### PR TITLE
[StaticWebAssets] Updates manifest generation to allow multiple content roots under the same base path for a single project

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/ValidateStaticWebAssetsUniquePaths.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/ValidateStaticWebAssetsUniquePaths.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.AspNetCore.Razor.Tasks
+{
+    public class ValidateStaticWebAssetsUniquePaths : Task
+    {
+        private const string BasePath = "BasePath";
+        private const string RelativePath = "RelativePath";
+        private const string TargetPath = "TargetPath";
+
+        [Required]
+        public ITaskItem[] StaticWebAssets { get; set; }
+
+        [Required]
+        public ITaskItem[] WebRootFiles { get; set; }
+
+        public override bool Execute()
+        {
+            var assetsByWebRootPaths = new Dictionary<string, ITaskItem>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < StaticWebAssets.Length; i++)
+            {
+                var contentRootDefinition = StaticWebAssets[i];
+                if (!EnsureRequiredMetadata(contentRootDefinition, BasePath) ||
+                    !EnsureRequiredMetadata(contentRootDefinition, RelativePath))
+                {
+                    return false;
+                }
+                else
+                {
+                    var webRootPath = GetWebRootPath(
+                        contentRootDefinition.GetMetadata(BasePath),
+                        contentRootDefinition.GetMetadata(RelativePath));
+
+                    if (assetsByWebRootPaths.TryGetValue(webRootPath, out var existingWebRootPath))
+                    {
+                        if (!string.Equals(contentRootDefinition.ItemSpec, existingWebRootPath.ItemSpec, StringComparison.OrdinalIgnoreCase))
+                        {
+                            Log.LogError($"Conflicting assets with the same path '{webRootPath}' for content root paths '{contentRootDefinition.ItemSpec}' and '{existingWebRootPath.ItemSpec}'.");
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        assetsByWebRootPaths.Add(webRootPath, contentRootDefinition);
+                    }
+                }
+            }
+
+            for (var i = 0; i < WebRootFiles.Length; i++)
+            {
+                var webRootFile = WebRootFiles[i];
+                var relativePath = webRootFile.GetMetadata(TargetPath);
+                var webRootFileWebRootPath = GetWebRootPath("/", relativePath);
+                if (assetsByWebRootPaths.TryGetValue(webRootFileWebRootPath, out var existingAsset))
+                {
+                    Log.LogError($"The static web asset '{existingAsset.ItemSpec}' has a conflicting web root path '{webRootFileWebRootPath}' with the project file '{webRootFile.ItemSpec}'.");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Normalizes /base/relative \base\relative\ base\relative and so on to /base/relative
+        private string GetWebRootPath(string basePath, string relativePath) => $"/{Path.Combine(basePath, relativePath.TrimStart('.').TrimStart('/')).Replace("\\", "/").Trim('/')}";
+
+        private bool EnsureRequiredMetadata(ITaskItem item, string metadataName)
+        {
+            var value = item.GetMetadata(metadataName);
+            if (string.IsNullOrEmpty(value))
+            {
+                Log.LogError($"Missing required metadata '{metadataName}' for '{item.ItemSpec}'.");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -33,6 +33,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
   <UsingTask
+    TaskName="Microsoft.AspNetCore.Razor.Tasks.ValidateStaticWebAssetsUniquePaths"
+    AssemblyFile="$(RazorSdkBuildTasksAssembly)"
+    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
+
+  <UsingTask
     TaskName="Microsoft.AspNetCore.Razor.Tasks.GenerateStaticWebAsssetsPropsFile"
     AssemblyFile="$(RazorSdkBuildTasksAssembly)"
     Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
@@ -145,11 +150,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'%(SourceType)' != ''">
           <BasePath>%(StaticWebAsset.BasePath)</BasePath>
           <ContentRoot>%(StaticWebAsset.ContentRoot)</ContentRoot>
+          <SourceId>%(StaticWebAsset.SourceId)</SourceId>
       </_ExternalStaticWebAsset>
     </ItemGroup>
 
     <!-- We need a transform here to make sure we hash the metadata -->
-    <Hash ItemsToHash="@(_ExternalStaticWebAsset->'%(Identity)%(BasePath)%(ContentRoot)')">
+    <Hash ItemsToHash="@(_ExternalStaticWebAsset->'%(Identity)%(SourceId)%(BasePath)%(ContentRoot)')">
       <Output TaskParameter="HashResult" PropertyName="_StaticWebAssetsCacheHash" />
     </Hash>
 
@@ -180,6 +186,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     Inputs="$(_GeneratedStaticWebAssetsInputsCacheFile)"
     Outputs="$(_GeneratedStaticWebAssetsDevelopmentManifest)"
     DependsOnTargets="$(GenerateStaticWebAssetsManifestDependsOn)">
+
+    <ItemGroup>
+      <_WebRootFiles Include="@(ContentWithTargetPath)" Condition="$([System.String]::Copy('%(TargetPath)').Replace('\','/').StartsWith('wwwroot/'))" />
+      <_ReferencedStaticWebAssets Include="@(StaticWebAsset)" Condition="'%(SourceType)' != ''" />
+    </ItemGroup>
+
+    <ValidateStaticWebAssetsUniquePaths
+      StaticWebAssets="@(_ReferencedStaticWebAssets)"
+      WebRootFiles="@(_WebRootFiles)" />
 
     <GenerateStaticWebAssetsManifest
       ContentRootDefinitions="@(_ExternalStaticWebAsset)"
@@ -273,7 +288,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_ThisProjectStaticWebAsset
         Include="@(Content)"
-        Condition="$([System.String]::Copy('%(Identity)').StartsWith('wwwroot'))">
+        Condition="$([System.String]::Copy('%(Identity)').Replace('\','/').StartsWith('wwwroot/'))">
 
         <!-- Remove the wwwroot\ prefix -->
         <RelativePath>$([System.String]::Copy('%(Identity)').Substring(8))</RelativePath>

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/ValidateStaticWebAssetsUniquePathsTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/ValidateStaticWebAssetsUniquePathsTest.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Tasks
+{
+    public class ValidateStaticWebAssetsUniquePathsTest
+    {
+        [Fact]
+        public void ReturnsError_WhenStaticWebAssetsWebRootPathMatchesExistingContentItemPath()
+        {
+            // Arrange
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+            var task = new ValidateStaticWebAssetsUniquePaths
+            {
+                BuildEngine = buildEngine.Object,
+                StaticWebAssets = new TaskItem[]
+                {
+                    CreateItem(Path.Combine(".", "Library", "wwwroot", "sample.js"), new Dictionary<string,string>
+                    {
+                        ["BasePath"] = "/",
+                        ["RelativePath"] = "/sample.js",
+                    })
+                },
+                WebRootFiles = new TaskItem[]
+                {
+                    CreateItem(Path.Combine(".", "App", "wwwroot", "sample.js"), new Dictionary<string,string>
+                    {
+                        ["TargetPath"] = "/SAMPLE.js",
+                    })
+                }
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.False(result);
+            var message = Assert.Single(errorMessages);
+            Assert.Equal($"The static web asset '{Path.Combine(".", "Library", "wwwroot", "sample.js")}' has a conflicting web root path '/SAMPLE.js' with the project file '{Path.Combine(".", "App", "wwwroot", "sample.js")}'.", message);
+        }
+
+        [Fact]
+        public void ReturnsError_WhenMultipleStaticWebAssetsHaveTheSameWebRootPath()
+        {
+            // Arrange
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+            var task = new ValidateStaticWebAssetsUniquePaths
+            {
+                BuildEngine = buildEngine.Object,
+                StaticWebAssets = new TaskItem[]
+                {
+                    CreateItem(Path.Combine(".", "Library", "wwwroot", "sample.js"), new Dictionary<string,string>
+                    {
+                        ["BasePath"] = "/",
+                        ["RelativePath"] = "/sample.js",
+                    }),
+                    CreateItem(Path.Combine(".", "Library", "bin", "dist", "sample.js"), new Dictionary<string,string>
+                    {
+                        ["BasePath"] = "/",
+                        ["RelativePath"] = "/sample.js",
+                    })
+                }
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.False(result);
+            var message = Assert.Single(errorMessages);
+            Assert.Equal($"Conflicting assets with the same path '/sample.js' for content root paths '{Path.Combine(".", "Library", "bin", "dist", "sample.js")}' and '{Path.Combine(".", "Library", "wwwroot", "sample.js")}'.", message);
+        }
+
+        [Fact]
+        public void ReturnsSuccess_WhenStaticWebAssetsDontConflictWithApplicationContentItems()
+        {
+            // Arrange
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+
+            var task = new ValidateStaticWebAssetsUniquePaths
+            {
+                BuildEngine = buildEngine.Object,
+                StaticWebAssets = new TaskItem[]
+                {
+                    CreateItem(Path.Combine(".", "Library", "wwwroot", "sample.js"), new Dictionary<string,string>
+                    {
+                        ["BasePath"] = "/_library",
+                        ["RelativePath"] = "/sample.js",
+                    }),
+                    CreateItem(Path.Combine(".", "Library", "wwwroot", "sample.js"), new Dictionary<string,string>
+                    {
+                        ["BasePath"] = "/_library",
+                        ["RelativePath"] = "/sample.js",
+                    })
+                },
+                WebRootFiles = new TaskItem[]
+                {
+                    CreateItem(Path.Combine(".", "App", "wwwroot", "sample.js"), new Dictionary<string,string>
+                    {
+                        ["TargetPath"] = "/SAMPLE.js",
+                    })
+                }
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+        }
+
+        private static TaskItem CreateItem(
+            string spec,
+            IDictionary<string, string> metadata)
+        {
+            var result = new TaskItem(spec);
+            foreach (var (key, value) in metadata)
+            {
+                result.SetMetadata(key, value);
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
### Description
We had a restriction in place that prevented a project from exposing static web assets under the same base path from different locations on disk.
This was done in order to avoid potential conflicting files.
It turns out that for a scenario we want to enable on Blazor webassembly we need to support exposing two folder locations from the same base path, so that we can expose the files under the wwwroot folder and the compiled dlls that get sent to the browser without having to copy files around.

Fixes https://github.com/aspnet/AspNetCore/issues/17375

### Customer Impact
It blocks us from moving Blazor wasm to use static web assets.

### Regression?
No

### Risk
Low. We are relaxing a requirement/precondition but we still do a check to make sure that you don't have conflicting assets exposed at runtime.

**Implementation details**
We relaxed the limitation and added an additional check to make sure static web assets don't conflict with assets from the main project or with other static web assets from the app.