### PR TITLE
Load the netcoreapp3.1 compiled task when running in Core MSBuild

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -30,7 +30,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Paths to tools, tasks, and extensions are calculated relative to the RazorSdkDirectoryRoot. This can be modified to test a local build. -->
     <RazorSdkDirectoryRoot Condition="'$(RazorSdkDirectoryRoot)'==''">$(MSBuildThisFileDirectory)..\..\</RazorSdkDirectoryRoot>
     <RazorSdkBuildTasksDirectoryRoot Condition="'$(RazorSdkBuildTasksDirectoryRoot)'==''">$(RazorSdkDirectoryRoot)tasks\</RazorSdkBuildTasksDirectoryRoot>
-    <_RazorSdkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">$(DefaultNetCoreTargetFramework)</_RazorSdkTasksTFM>
+    <_RazorSdkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp3.1</_RazorSdkTasksTFM>
     <_RazorSdkTasksTFM Condition=" '$(_RazorSdkTasksTFM)' == ''">net46</_RazorSdkTasksTFM>
     <RazorSdkBuildTasksAssembly>$(RazorSdkBuildTasksDirectoryRoot)$(_RazorSdkTasksTFM)\Microsoft.NET.Sdk.Razor.Tasks.dll</RazorSdkBuildTasksAssembly>
   </PropertyGroup>

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntrospectionTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntrospectionTest.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
@@ -220,6 +223,50 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.BuildOutputContainsLine(result, $"Content: {launchSettingsPath} CopyToOutputDirectory= CopyToPublishDirectory=Never ExcludeFromSingleFile=true");
             Assert.BuildOutputContainsLine(result, "Content: appsettings.json CopyToOutputDirectory= CopyToPublishDirectory=PreserveNewest ExcludeFromSingleFile=true");
             Assert.BuildOutputContainsLine(result, "Content: appsettings.Development.json CopyToOutputDirectory= CopyToPublishDirectory=PreserveNewest ExcludeFromSingleFile=true");
+        }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task IntrospectRazorTasksDllPath()
+        {
+            // Regression test for https://github.com/aspnet/AspNetCore/issues/17308
+            var solutionRoot = GetType().Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+                .First(a => a.Key == "Testing.RepoRoot")
+                .Value;
+
+            var tfm =
+#if NETCOREAPP3_1
+                "netcoreapp3.1";
+#else
+#error Target framework needs to be updated.
+#endif
+
+            var expected = Path.Combine(solutionRoot, "artifacts", "bin", "Microsoft.NET.Sdk.Razor", Configuration, "sdk-output", "tasks", tfm, "Microsoft.NET.Sdk.Razor.Tasks.dll");
+
+            // Verifies the fix for https://github.com/aspnet/AspNetCore/issues/17308
+            var result = await DotnetMSBuild("_IntrospectRazorTasks");
+
+            Assert.BuildPassed(result);
+            Assert.BuildOutputContainsLine(result, $"RazorTasksPath: {expected}");
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task IntrospectRazorTasksDllPath_DesktopMsBuild()
+        {
+            var solutionRoot = GetType().Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+                .First(a => a.Key == "Testing.RepoRoot")
+                .Value;
+
+            var tfm = "net46";
+            var expected = Path.Combine(solutionRoot, "artifacts", "bin", "Microsoft.NET.Sdk.Razor", Configuration, "sdk-output", "tasks", tfm, "Microsoft.NET.Sdk.Razor.Tasks.dll");
+
+            // Verifies the fix for https://github.com/aspnet/AspNetCore/issues/17308
+            var result = await DotnetMSBuild("_IntrospectRazorTasks", msBuildProcessKind: MSBuildProcessKind.Desktop);
+
+            Assert.BuildPassed(result);
+            Assert.BuildOutputContainsLine(result, $"RazorTasksPath: {expected}");
         }
     }
 }

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/Microsoft.NET.Sdk.Razor.Test.csproj
@@ -53,6 +53,11 @@
       <_Parameter2>$(ProcDumpPath)</_Parameter2>
     </AssemblyAttribute>
 
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>Testing.RepoRoot</_Parameter1>
+      <_Parameter2>$(RepoRoot)</_Parameter2>
+    </AssemblyAttribute>
+
   </ItemGroup>
 
   <!-- The test projects rely on these binaries being available -->

--- a/src/Razor/test/testapps/RazorTest.Introspection.targets
+++ b/src/Razor/test/testapps/RazorTest.Introspection.targets
@@ -46,4 +46,11 @@
   <Target Name="_IntrospectContentItems">
     <Message Text="Content: %(Content.Identity) CopyToOutputDirectory=%(Content.CopyToOutputDirectory) CopyToPublishDirectory=%(Content.CopyToPublishDirectory) ExcludeFromSingleFile=%(Content.ExcludeFromSingleFile)" Importance="High" />
   </Target>
+
+  <Target Name="_IntrospectRazorTasks">
+    <PropertyGroup>
+      <_SdkTaskPath>$([System.IO.Path]::GetFullPath('$(RazorSdkBuildTasksAssembly)'))</_SdkTaskPath>
+    </PropertyGroup>
+    <Message Text="RazorTasksPath: $(_SdkTaskPath)" Importance="High" />
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/17308

--------------------------------------

#### Description:

The tasks assembly in the RazorSDK are cross-compiled between desktop and netcoreapp. The SDK is meant to load the appropriate task dll based on the flavor of MSBuild that's executing a build. However due to a bug, the 3.1 version of the Razor SDK always ends up loading the tasks dll compiled for `net46`. We haven't had any reports of this resulting in failures, but don't fully understand the ways in this may interact or fail with user's build systems.

#### Customer impact

None. However this does not preclude MSBuild failures depending on user's build setup.

#### Regression?

Yes. This is a regression introduced in the 3.1 SDK.

#### Risk

Low. Users do not directly interact with the tasks dll.