### PR TITLE
[Static web assets][Fixes #AspNetCore/17079] PublishSingleFile results in 404 errors for Nuget components

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -506,14 +506,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <RelativePath>$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)','$([MSBuild]::NormalizePath('wwwroot\%(BasePath)\%(RelativePath)'))'))</RelativePath>
-
       </_ExternalPublishStaticWebAsset>
 
       <!-- Remove any existing external static web asset that might have been added as part of the
            regular publish pipeline. -->
       <ResolvedFileToPublish Remove="@(_ExternalPublishStaticWebAsset)" />
 
-      <ResolvedFileToPublish Include="@(_ExternalPublishStaticWebAsset)" />
+      <ResolvedFileToPublish Include="@(_ExternalPublishStaticWebAsset)">
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      </ResolvedFileToPublish>
     </ItemGroup>
 
   </Target>

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
@@ -40,6 +40,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         protected string PublishOutputPath => Path.Combine(OutputPath, "publish");
 
+        protected string GetRidSpecificPublishOutputPath(string rid) => Path.Combine(OutputPath, rid, "publish");
+
         // Used by the test framework to set the project that we're working with
         internal static ProjectDirectory Project
         {


### PR DESCRIPTION
## Description

Static web assets don't work properly with PublishSingleFile as they aren't excluded (like the rest of the web content is).

This fix simply adds a property and the tests necessary to make sure the assets are excluded when published.

## Customer Impact
This blocks customers trying to publish ASP.NET Core apps as single files when the app uses static web assets.

The issue was customer reported https://github.com/aspnet/AspNetCore/issues/17079

## Regression?
No, but we broke this really close to 3.0 RTM and used to work before.

## Risk
Low. It's a one line change and we've included a test that validates the fix.

#### Implementation details
Just adds the ExcludeFromSingleFile property to the resolved static web assets to publish.