### PR TITLE
[StaticWebAssets][Fixes #AspNetCore/17426] Publish no build doesn't copy static web assets from referenced projects

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -54,23 +54,19 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(GetCurrentProjectStaticWebAssetsDependsOn)
     </GetCurrentProjectStaticWebAssetsDependsOn>
 
-    <AssignTargetPathsDependsOn>
+    <GetCopyToOutputDirectoryItemsDependsOn>
+      $(GetCopyToOutputDirectoryItemsDependsOn);
       GenerateStaticWebAssetsManifest;
-      $(AssignTargetPathsDependsOn)
-    </AssignTargetPathsDependsOn>
+    </GetCopyToOutputDirectoryItemsDependsOn>
 
     <ResolveStaticWebAssetsInputsDependsOn>
       ResolveCurrentProjectStaticWebAssetsInputs;
-      $(ResolveStaticWebAssetsInputsDependsOn)
-    </ResolveStaticWebAssetsInputsDependsOn>
-
-    <ResolveStaticWebAssetsInputsDependsOn Condition="$(NoBuild) != 'true'">
       ResolveReferencedProjectsStaticWebAssets;
       $(ResolveStaticWebAssetsInputsDependsOn)
     </ResolveStaticWebAssetsInputsDependsOn>
 
     <ResolveReferencedProjectsStaticWebAssetsDependsOn>
-      ResolveReferences;
+      PrepareProjectReferences;
       $(ResolveReferencedProjectsStaticWebAssetsDependsOn)
     </ResolveReferencedProjectsStaticWebAssetsDependsOn>
 
@@ -187,14 +183,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <!-- This is the list of inputs that will be used for generating the manifest used during development. -->
     <ItemGroup>
-      <Content
+      <ContentWithTargetPath
         Include="$(_GeneratedStaticWebAssetsDevelopmentManifest)"
-        Condition="'@(_ExternalStaticWebAsset->Count())' != '0'"
-        Link="$(TargetName).StaticWebAssets.xml">
+        Condition="'@(_ExternalStaticWebAsset->Count())' != '0'">
 
+        <TargetPath>$(TargetName).StaticWebAssets.xml</TargetPath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-      </Content>
+      </ContentWithTargetPath>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
@@ -104,6 +104,26 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "PackageLibraryTransitiveDependency", "js", "pkg-transitive-dep.js"));
         }
 
+        [Fact]
+        [InitializeTestProject("AppWithPackageAndP2PReference", additionalProjects: new[] { "ClassLibrary", "ClassLibrary2" })]
+        public async Task Publish_NoBuild_CopiesStaticWebAssetsToDestinationFolder()
+        {
+            var build = await DotnetMSBuild("Build", "/restore");
+
+            Assert.BuildPassed(build);
+
+            var publish = await DotnetMSBuild("Publish", "/p:NoBuild=true");
+
+            Assert.BuildPassed(publish);
+
+            Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "ClassLibrary", "js", "project-transitive-dep.js"));
+            Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "ClassLibrary", "js", "project-transitive-dep.v4.js"));
+            Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "ClassLibrary2", "css", "site.css"));
+            Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "ClassLibrary2", "js", "project-direct-dep.js"));
+            Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "PackageLibraryDirectDependency", "css", "site.css"));
+            Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "PackageLibraryDirectDependency", "js", "pkg-direct-dep.js"));
+            Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "PackageLibraryTransitiveDependency", "js", "pkg-transitive-dep.js"));
+        }
 
         [Fact]
         [InitializeTestProject("SimpleMvc")]


### PR DESCRIPTION
### Description
Static web assets don't work properly with `--no-build` as they depend on AssignTargetPath which is not necessary.

I've updated when the targets get executed to avoid relying on something that will cause NoBuild to fails.

### Customer Impact
Customers can't do `dotnet publish --no-build` if they have referenced projects that contain static web assets

The issue was customer reported https://github.com/aspnet/AspNetCore/issues/17426

### Regression?
No

### Risk
Low. It simply moves some MSBuild extensibility around and there are tests to cover the scenario

**Implementation details**
The problem was with a previous implementation that relied on embedding the manifest on the assembly.

The fix redefines when some of the targets get executed.