### PR TITLE
Add feature switch to use our new Razor LSP editor.

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -3,7 +3,7 @@
   <!--
     The `Condition` in this Import was added because publishing pipelines rely
     on importing this file but it doesn't import MPack.props.
-    The condition can be removed once this issue is fixed: 
+    The condition can be removed once this issue is fixed:
     https://github.com/dotnet/arcade/issues/2371
   -->
   <Import Project="MPack.props" Condition="Exists('MPack.props')" />
@@ -14,6 +14,11 @@
   -->
   <ItemGroup>
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MediatR.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MediatR.Extensions.Microsoft.DependencyInjection.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="OmniSharp.Extensions.JsonRpc.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="OmniSharp.Extensions.LanguageProtocol.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="OmniSharp.Extensions.LanguageServer.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,6 +90,7 @@
     <MicrosoftCodeAnalysisCommonPackageVersion>3.3.0</MicrosoftCodeAnalysisCommonPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>3.3.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.3.0</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
     <MicrosoftNETCoreApp50PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp50PackageVersion>
     <MicrosoftNETFrameworkReferenceAssemblies>1.0.0-alpha-5</MicrosoftNETFrameworkReferenceAssemblies>
     <MicrosoftNetRoslynDiagnosticsPackageVersion>2.6.3</MicrosoftNetRoslynDiagnosticsPackageVersion>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -17,6 +17,13 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer.Common\Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj" />
   </ItemGroup>
 
+  <Target Name="_GetOutputPath" Returns="@(_ServerOutputPath)">
+    <ItemGroup>
+      <_ServerOutputPath Include="$(OutputPath)">
+      </_ServerOutputPath>
+    </ItemGroup>
+  </Target>
+
   <Target Name="_IncludeOmniSharpPlugin" Condition="Exists('$(PublishDir)')">
     <PropertyGroup>
       <TargetPluginOutputPath>$(PublishDir)\OmniSharpPlugin</TargetPluginOutputPath>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(VS_NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="$(MicrosoftVisualStudioLanguageServerClientPackageVersion)" />
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime" Version="$(MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/README.md
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/README.md
@@ -1,0 +1,12 @@
+# Using the Razor LSP Editor
+
+To use the Razor LSP editor set an environment variable under the name `Razor.LSP.Editor` to `true` and then open Razor.sln. Running the `Microsoft.VisualStudio.RazorExtension` project will then result in `.razor` and `.cshtml` files being opened with our LSP editor.
+
+To set the environment variable in powershell you can use the following syntax: `${env:Razor.LSP.Editor}="true"`
+
+# FAQ
+
+**Opening a project results in my Razor file saying "waiting for IntelliSense to initialize", why does it never stop?**
+This is a combo issue dealing with how Visual Studio serializes project state after a feature flag / environment variable has been set. Basically, prior to setting `Razor.LSP.Editor` Visual Studio will have serialized project state that says a Razor file was opened with the WTE editor. Therefore, when you first open a project that Razor file will attempt to be opened under the WTE editor but the core editor will conflict saying it should be opened by our editor. This results in the endless behavior of "waiting for IntelliSense to initialize".
+
+Close and re-open the file and it shouldn't re-occur if you re-save the solution.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorEditorFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorEditorFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Runtime.InteropServices;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -13,7 +16,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     [Guid(EditorFactoryGuidString)]
-    public class RazorEditorFactory : EditorFactory
+    internal class RazorEditorFactory : EditorFactory
     {
         private const string EditorFactoryGuidString = "3dfdce9e-1799-4372-8aa6-d8e65182fdfc";
         private const string RazorLSPEditorFeatureFlag = "Razor.LSP.Editor";
@@ -45,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             });
         }
 
-        private bool IsLSPRazorEditorEnabled
+        private bool IsRazorLSPEditorEnabled
         {
             get
             {
@@ -74,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             out Guid cmdUI,
             out int cancelled)
         {
-            if (!IsLSPRazorEditorEnabled)
+            if (!IsRazorLSPEditorEnabled)
             {
                 docView = default;
                 docData = default;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorEditorFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorEditorFactory.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Package;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Guid(EditorFactoryGuidString)]
+    public class RazorEditorFactory : EditorFactory
+    {
+        private const string EditorFactoryGuidString = "3dfdce9e-1799-4372-8aa6-d8e65182fdfc";
+        private const string RazorLSPEditorFeatureFlag = "Razor.LSP.Editor";
+        private readonly Lazy<IVsEditorAdaptersFactoryService> _adaptersFactory;
+        private readonly Lazy<IContentType> _razorLSPContentType;
+        private readonly Lazy<IVsFeatureFlags> _featureFlags;
+
+        public RazorEditorFactory(AsyncPackage package) : base(package)
+        {
+            _adaptersFactory = new Lazy<IVsEditorAdaptersFactoryService>(() =>
+            {
+                var componentModel = (IComponentModel)AsyncPackage.GetGlobalService(typeof(SComponentModel));
+                var adaptersFactory = componentModel.GetService<IVsEditorAdaptersFactoryService>();
+                return adaptersFactory;
+            });
+
+            _razorLSPContentType = new Lazy<IContentType>(() =>
+            {
+                var componentModel = (IComponentModel)AsyncPackage.GetGlobalService(typeof(SComponentModel));
+                var contentTypeService = componentModel.GetService<IContentTypeRegistryService>();
+                var contentType = contentTypeService.GetContentType(RazorLSPContentTypeDefinition.Name);
+                return contentType;
+            });
+
+            _featureFlags = new Lazy<IVsFeatureFlags>(() =>
+            {
+                var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+                return featureFlags;
+            });
+        }
+
+        private bool IsLSPRazorEditorEnabled
+        {
+            get
+            {
+                var lspRazorEnabledString = Environment.GetEnvironmentVariable(RazorLSPEditorFeatureFlag);
+                bool.TryParse(lspRazorEnabledString, out var enabled);
+                if (enabled)
+                {
+                    return true;
+                }
+
+                enabled = _featureFlags.Value.IsFeatureEnabled(RazorLSPEditorFeatureFlag, defaultValue: false);
+                return enabled;
+            }
+        }
+
+        public override int CreateEditorInstance(
+            uint createDocFlags,
+            string moniker,
+            string physicalView,
+            IVsHierarchy pHier,
+            uint itemid,
+            IntPtr existingDocData,
+            out IntPtr docView,
+            out IntPtr docData,
+            out string editorCaption,
+            out Guid cmdUI,
+            out int cancelled)
+        {
+            if (!IsLSPRazorEditorEnabled)
+            {
+                docView = default;
+                docData = default;
+                editorCaption = null;
+                cmdUI = default;
+                cancelled = 0;
+
+                // Razor LSP is not enabled, allow another editor to handle this document
+                return VSConstants.VS_E_UNSUPPORTEDFORMAT;
+            }
+
+            var editorInstance = base.CreateEditorInstance(createDocFlags, moniker, physicalView, pHier, itemid, existingDocData, out docView, out docData, out editorCaption, out cmdUI, out cancelled);
+            var textLines = (IVsTextLines)Marshal.GetObjectForIUnknown(docData);
+
+            SetTextBufferContentType(textLines);
+
+            return editorInstance;
+        }
+
+        private void SetTextBufferContentType(IVsTextLines textLines)
+        {
+            var textBufferDataEventsGuid = typeof(IVsTextBufferDataEvents).GUID;
+            var connectionPointContainer = textLines as IConnectionPointContainer;
+            connectionPointContainer.FindConnectionPoint(textBufferDataEventsGuid, out var connectionPoint);
+            var contentTypeSetter = new TextBufferContentTypeSetter(
+                textLines,
+                _adaptersFactory.Value,
+                _razorLSPContentType.Value);
+            contentTypeSetter.Attach(connectionPoint);
+
+            // Next, the editor typically resets the ContentType after TextBuffer creation. We need to let them know
+            // to not update the content type.
+            var userData = textLines as IVsUserData;
+            var hresult = userData.SetData(VSConstants.VsTextBufferUserDataGuid.VsBufferDetectLangSID_guid, false);
+
+            ErrorHandler.ThrowOnFailure(hresult);
+        }
+
+        private class TextBufferContentTypeSetter : IVsTextBufferDataEvents
+        {
+            private readonly IVsTextLines _textLines;
+            private readonly IVsEditorAdaptersFactoryService _adaptersFactory;
+            private readonly IContentType _razorLSPContentType;
+            private IConnectionPoint _connectionPoint;
+            private uint _connectionPointCookie;
+
+            public TextBufferContentTypeSetter(
+                IVsTextLines textLines,
+                IVsEditorAdaptersFactoryService adaptersFactory,
+                IContentType razorLSPContentType)
+            {
+                _textLines = textLines;
+                _adaptersFactory = adaptersFactory;
+                _razorLSPContentType = razorLSPContentType;
+            }
+
+            public void Attach(IConnectionPoint connectionPoint)
+            {
+                if (connectionPoint is null)
+                {
+                    throw new ArgumentNullException(nameof(connectionPoint));
+                }
+
+                _connectionPoint = connectionPoint;
+
+                connectionPoint.Advise(this, out _connectionPointCookie);
+            }
+
+            public void OnFileChanged(uint grfChange, uint dwFileAttrs)
+            {
+            }
+
+            public int OnLoadCompleted(int fReload)
+            {
+                try
+                {
+                    var diskBuffer = _adaptersFactory.GetDocumentBuffer(_textLines);
+                    diskBuffer.ChangeContentType(_razorLSPContentType, editTag: null);
+                }
+                finally
+                {
+                    _connectionPoint.Unadvise(_connectionPointCookie);
+                }
+
+                return VSConstants.S_OK;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPContentTypeDefinition.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPContentTypeDefinition.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal sealed class RazorLSPContentTypeDefinition
+    {
+        public const string Name = "RazorLSP";
+        public const string CSHTMLFileExtension = ".cshtml";
+        public const string RazorFileExtension = ".razor";
+
+        /// <summary>
+        /// Exports the Razor LSP content type
+        /// </summary>
+        [Export]
+        [Name(Name)]
+        [BaseDefinition(CodeRemoteContentDefinition.CodeRemoteContentTypeName)]
+        public ContentTypeDefinition RazorLSPContentType { get; set; }
+
+        // We can't assocaite the Razor LSP content type with the above file extensions because there's already a content type
+        // associated with them. Instead, we utilize our RazorEditorFactory to assign the RazorLSPContentType to .razor/.cshtml
+        // files.
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPContentTypeDefinition.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPContentTypeDefinition.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.Composition;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.Utilities;
 
@@ -18,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         [BaseDefinition(CodeRemoteContentDefinition.CodeRemoteContentTypeName)]
         public ContentTypeDefinition RazorLSPContentType { get; set; }
 
-        // We can't assocaite the Razor LSP content type with the above file extensions because there's already a content type
+        // We can't associate the Razor LSP content type with the above file extensions because there's already a content type
         // associated with them. Instead, we utilize our RazorEditorFactory to assign the RazorLSPContentType to .razor/.cshtml
         // files.
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Export(typeof(ILanguageClient))]
+    [ContentType(RazorLSPContentTypeDefinition.Name)]
+    internal class RazorLanguageServerClient : ILanguageClient
+    {
+        public string Name => "Razor Language Server Client";
+
+        public IEnumerable<string> ConfigurationSections => null;
+
+        public object InitializationOptions => null;
+
+        public IEnumerable<string> FilesToWatch => null;
+
+        public event AsyncEventHandler<EventArgs> StartAsync;
+        public event AsyncEventHandler<EventArgs> StopAsync
+        {
+            add { }
+            remove { }
+        }
+
+        public async Task<Connection> ActivateAsync(CancellationToken token)
+        {
+            await Task.Yield();
+
+            var currentAssembly = typeof(RazorLanguageServerClient).Assembly;
+            var currentAssemblyLocation = currentAssembly.Location;
+            var extensionDirectory = Path.GetDirectoryName(currentAssemblyLocation);
+            var languageServerPath = Path.Combine(extensionDirectory, "LanguageServer", "rzls.exe");
+            var info = new ProcessStartInfo();
+            info.FileName = languageServerPath;
+            info.Arguments = "-lsp --logLevel Trace";
+            info.RedirectStandardInput = true;
+            info.RedirectStandardOutput = true;
+            info.UseShellExecute = false;
+            info.CreateNoWindow = true;
+
+            Process process = new Process();
+            process.StartInfo = info;
+
+            if (process.Start())
+            {
+                return new Connection(process.StandardOutput.BaseStream, process.StandardInput.BaseStream);
+            }
+
+            return null;
+        }
+
+        public async Task OnLoadedAsync()
+        {
+            await StartAsync.InvokeAsync(this, EventArgs.Empty);
+        }
+
+        public Task OnServerInitializeFailedAsync(Exception e)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OnServerInitializedAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -23,7 +23,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-    <!-- Include Razor SDK design time assets in the VSIX -->
+  <!-- Include Razor SDK design time assets in the VSIX -->
   <ItemGroup>
     <Content Include="..\Microsoft.NET.Sdk.Razor\build\netstandard2.0\Microsoft.NET.Sdk.Razor.DesignTime.targets">
       <IncludeInVsix>true</IncludeInVsix>
@@ -112,6 +112,29 @@
   <PropertyGroup>
     <_GeneratedVSIXBindingRedirectFile>$(IntermediateOutputPath)$(MSBuildProjectName).BindingRedirects.cs</_GeneratedVSIXBindingRedirectFile>
   </PropertyGroup>
+
+  <Target Name="_BuildLanguageServer">
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj"
+        Targets="Build" />
+  </Target>
+
+  <Target Name="_IncludeLanguageServer" DependsOnTargets="PrepareForBuild;_BuildLanguageServer"  BeforeTargets="CoreCompile">
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj"
+        Targets="_GetOutputPath">
+      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
+    </MSBuild>
+
+    <PropertyGroup>
+      <_ResolvedPackageVersionInfoProperty>@(_ResolvedPackageVersionInfo)</_ResolvedPackageVersionInfoProperty>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Content Include="$(_ResolvedPackageVersionInfoProperty)\*">
+        <IncludeInVsix>true</IncludeInVsix>
+        <VSIXSubPath>LanguageServer\</VSIXSubPath>
+      </Content>
+    </ItemGroup>
+  </Target>
 
   <Target Name="_GenerateVSIXBindingRedirects" DependsOnTargets="PrepareForBuild;GetAssemblyVersion" BeforeTargets="CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(_GeneratedVSIXBindingRedirectFile)">
     <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -65,6 +65,10 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources.resx">
+      <GenerateSource>true</GenerateSource>
+      <Generator>MSBuild:_GenerateResxSource</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Include="VSPackage.resx">
       <MergeWithCTO>true</MergeWithCTO>
       <ManifestResourceName>VSPackage</ManifestResourceName>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -4,21 +4,32 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.VisualStudio.LanguageServerClient.Razor;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.RazorExtension
 {
-    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    // We attach to the 51st priority order because the traditional Web + XML editors have priority 50. We need to be loaded prior to them
+    // since we want to have the option to own the experience for Razor files
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.CSHTMLFileExtension, 52, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.RazorFileExtension, 52, NameResourceID = 101)]
+    [ProvideEditorFactory(typeof(RazorEditorFactory), 101)]
+    [PackageRegistration(UseManagedResourcesOnly = true)]
     [AboutDialogInfo(PackageGuidString, "ASP.NET Core Razor Language Services", "#110", "#112", IconResourceID = "#400")]
     [Guid(PackageGuidString)]
     public sealed class RazorPackage : AsyncPackage
     {
         public const string PackageGuidString = "13b72f58-279e-49e0-a56d-296be02f0805";
 
+        private RazorEditorFactory _editorFactory;
+
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            _editorFactory = new RazorEditorFactory(this);
+            RegisterEditorFactory(_editorFactory);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -12,8 +12,8 @@ namespace Microsoft.VisualStudio.RazorExtension
 {
     // We attach to the 51st priority order because the traditional Web + XML editors have priority 50. We need to be loaded prior to them
     // since we want to have the option to own the experience for Razor files
-    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.CSHTMLFileExtension, 52, NameResourceID = 101)]
-    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.RazorFileExtension, 52, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.CSHTMLFileExtension, 51, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.RazorFileExtension, 51, NameResourceID = 101)]
     [ProvideEditorFactory(typeof(RazorEditorFactory), 101)]
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [AboutDialogInfo(PackageGuidString, "ASP.NET Core Razor Language Services", "#110", "#112", IconResourceID = "#400")]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Resources.resx
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Resources.resx
@@ -117,17 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="101" xml:space="preserve">
-    <value>IDS_EDITORNAME</value>
-  </data>
-  <data name="110" xml:space="preserve">
-    <value>ASP.NET Core Razor Language Services</value>
-  </data>
-  <data name="112" xml:space="preserve">
-    <value>Provides languages services for ASP.NET Core Razor.</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Resources\RazorPackage.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="IDS_EDITORNAME" xml:space="preserve">
+    <value>LSP Razor Editor</value>
   </data>
 </root>


### PR DESCRIPTION
- Added a new Razor LSP content type to identify our new Razor editor experience.
- Given that there are already content type associations for the .cshtml/.razor file paths I had to build a RazorEditorFactory that takes precedence over WTE's editor factories and if our feature flags are `true` to change the content type on created editors.
- Added a `README.md` to the LanguageServerClient project to indicate how to use the new Razor LSP editor (no functionality currently).
- For a feature flag I took a two pronged approach of allowing environment variables or VS' first class feature flag support. We haven't yet made the changes to Visual Studio necessary to surface our feature flag as a properly settable feature flag. Once that is done our feature flag will be toggable via the `Enable Preview Features` dialog.
- Didn't feel there was a ton of value in adding tests for our EditorFactory since it acts on things like environment variables and internal VS feature flag functionalities.

aspnet/AspNetCore#17787