### PR TITLE
TSLint prevent floating promises

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "clean": "rimraf out && rimraf dist",
     "build": "yarn run clean && yarn run lint && tsc -p ./",
-    "lint": "tslint ./src/**/*.ts",
+    "lint": "tslint ./src/**/*.ts --project ./",
     "watch": "tsc -watch -p ./"
   }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ProvisionalCompletionOrchestrator.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ProvisionalCompletionOrchestrator.ts
@@ -44,9 +44,9 @@ export class ProvisionalCompletionOrchestrator {
 
             await this.tryRemoveProvisionalDot(args.document);
         });
-        const onDidChangeActiveEditorRegistration = vscode.window.onDidChangeActiveTextEditor(args => {
+        const onDidChangeActiveEditorRegistration = vscode.window.onDidChangeActiveTextEditor(async args => {
             if (this.currentActiveDocument) {
-                this.tryRemoveProvisionalDot(this.currentActiveDocument);
+                await this.tryRemoveProvisionalDot(this.currentActiveDocument);
             }
 
             if (args) {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -106,11 +106,12 @@ export class RazorDocumentManager implements IRazorDocumentManager {
                 return;
             }
 
-            this.documentChanged(args.document.uri);
+            await this.documentChanged(args.document.uri);
         });
+        // tslint:disable-next-line: no-floating-promises
         this.serverClient.onRequest(
             'updateCSharpBuffer',
-            updateBufferRequest => this.updateCSharpBuffer(updateBufferRequest));
+            async updateBufferRequest => this.updateCSharpBuffer(updateBufferRequest));
 
         return vscode.Disposable.from(
             watcher,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
@@ -136,6 +136,7 @@ export class RazorLanguageServerClient implements vscode.Disposable {
             const startDisposable = this.client.start();
             this.startDisposable = vscode.Disposable.from(startDisposable, didChangeStateDisposable);
             this.logger.logMessage('Server started, waiting for client to be ready...');
+            // tslint:disable-next-line: no-floating-promises
             this.client.onReady().then(async () => {
                 if (currentState !== State.Running) {
                     // Unexpected scenario, if we fall into this scenario the above onDidChangeState

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/runTest.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/runTest.ts
@@ -27,4 +27,5 @@ async function main() {
     }
 }
 
+// tslint:disable-next-line: no-floating-promises
 main();

--- a/src/Razor/tslint.json
+++ b/src/Razor/tslint.json
@@ -6,6 +6,7 @@
         "file-header": [true, "------"],
         "interface-name": false,
         "no-console": false,
+        "no-floating-promises": true,
         "no-return-await": true,
         "no-inferrable-types": true,
         "object-literal-sort-keys": false,


### PR DESCRIPTION
I wanted to add a tslint rule for "floating promises" because I made a silly mistake which could have been easily caught by it. There are a couple of existing places which violate this rule, I've added exceptions where I'm reasonably certain they're intended, and async/await where I figure it was just a mistake. If I'm wrong about any of those instances I'm super interested in why.