### PR TITLE
Start Razor Language Server when new Razor LSP editor opens.

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -3,7 +3,7 @@
   <!--
     The `Condition` in this Import was added because publishing pipelines rely
     on importing this file but it doesn't import MPack.props.
-    The condition can be removed once this issue is fixed: 
+    The condition can be removed once this issue is fixed:
     https://github.com/dotnet/arcade/issues/2371
   -->
   <Import Project="MPack.props" Condition="Exists('MPack.props')" />
@@ -14,6 +14,11 @@
   -->
   <ItemGroup>
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MediatR.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MediatR.Extensions.Microsoft.DependencyInjection.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="OmniSharp.Extensions.JsonRpc.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="OmniSharp.Extensions.LanguageProtocol.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="OmniSharp.Extensions.LanguageServer.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -17,6 +17,13 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer.Common\Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj" />
   </ItemGroup>
 
+  <Target Name="_GetOutputPath" Returns="@(_ServerOutputPath)">
+    <ItemGroup>
+      <_ServerOutputPath Include="$(OutputPath)">
+      </_ServerOutputPath>
+    </ItemGroup>
+  </Target>
+
   <Target Name="_IncludeOmniSharpPlugin" Condition="Exists('$(PublishDir)')">
     <PropertyGroup>
       <TargetPluginOutputPath>$(PublishDir)\OmniSharpPlugin</TargetPluginOutputPath>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Export(typeof(ILanguageClient))]
+    [ContentType(RazorLSPContentTypeDefinition.Name)]
+    internal class RazorLanguageServerClient : ILanguageClient
+    {
+        public string Name => "Razor Language Server Client";
+
+        public IEnumerable<string> ConfigurationSections => null;
+
+        public object InitializationOptions => null;
+
+        public IEnumerable<string> FilesToWatch => null;
+
+        public event AsyncEventHandler<EventArgs> StartAsync;
+        public event AsyncEventHandler<EventArgs> StopAsync
+        {
+            add { }
+            remove { }
+        }
+
+        public async Task<Connection> ActivateAsync(CancellationToken token)
+        {
+            await Task.Yield();
+
+            var currentAssembly = typeof(RazorLanguageServerClient).Assembly;
+            var currentAssemblyLocation = currentAssembly.Location;
+            var extensionDirectory = Path.GetDirectoryName(currentAssemblyLocation);
+            var languageServerPath = Path.Combine(extensionDirectory, "LanguageServer", "rzls.exe");
+            var info = new ProcessStartInfo();
+            info.FileName = languageServerPath;
+            info.Arguments = "-lsp --logLevel Trace";
+            info.RedirectStandardInput = true;
+            info.RedirectStandardOutput = true;
+            info.UseShellExecute = false;
+            info.CreateNoWindow = true;
+
+            Process process = new Process();
+            process.StartInfo = info;
+
+            if (process.Start())
+            {
+                return new Connection(process.StandardOutput.BaseStream, process.StandardInput.BaseStream);
+            }
+
+            return null;
+        }
+
+        public async Task OnLoadedAsync()
+        {
+            await StartAsync.InvokeAsync(this, EventArgs.Empty);
+        }
+
+        public Task OnServerInitializeFailedAsync(Exception e)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OnServerInitializedAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -23,7 +23,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-    <!-- Include Razor SDK design time assets in the VSIX -->
+  <!-- Include Razor SDK design time assets in the VSIX -->
   <ItemGroup>
     <Content Include="..\Microsoft.NET.Sdk.Razor\build\netstandard2.0\Microsoft.NET.Sdk.Razor.DesignTime.targets">
       <IncludeInVsix>true</IncludeInVsix>
@@ -112,6 +112,29 @@
   <PropertyGroup>
     <_GeneratedVSIXBindingRedirectFile>$(IntermediateOutputPath)$(MSBuildProjectName).BindingRedirects.cs</_GeneratedVSIXBindingRedirectFile>
   </PropertyGroup>
+
+  <Target Name="_BuildLanguageServer">
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj"
+        Targets="Build" />
+  </Target>
+
+  <Target Name="_IncludeLanguageServer" DependsOnTargets="PrepareForBuild;_BuildLanguageServer"  BeforeTargets="CoreCompile">
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj"
+        Targets="_GetOutputPath">
+      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
+    </MSBuild>
+
+    <PropertyGroup>
+      <_ResolvedPackageVersionInfoProperty>@(_ResolvedPackageVersionInfo)</_ResolvedPackageVersionInfoProperty>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Content Include="$(_ResolvedPackageVersionInfoProperty)\*">
+        <IncludeInVsix>true</IncludeInVsix>
+        <VSIXSubPath>LanguageServer\</VSIXSubPath>
+      </Content>
+    </ItemGroup>
+  </Target>
 
   <Target Name="_GenerateVSIXBindingRedirects" DependsOnTargets="PrepareForBuild;GetAssemblyVersion" BeforeTargets="CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(_GeneratedVSIXBindingRedirectFile)">
     <ItemGroup>


### PR DESCRIPTION
- Included the LanguageServer core dlls as part of the VSIX install. To do this I had to expose the language server's output path via a target and then dynamically include its outputs in the VSIX output.
- Given how VSIX's are built I could not privately reference our language server to ensure that it's built when the VSIX is built. To work around this limitation I added a `_BuildLanguageServer` target that calls MSBuild directly on the language server as part of build.
- For now I'm dynamically booting the currently built language server that's deployed with the extension. I haven't given a lot of thought to what flavor of OS (x64 vs. x86) the server can run on; or if we need to ensure dotnet.exe is available.
- Found that the VS LSP client and the O# language server library that we use don't inter-operate as we'd expect. The server ends up telling the client that it doesn't care about text document change events (we do). I've created a separate PR in O# to fix this: https://github.com/OmniSharp/csharp-language-server-protocol/pull/199

aspnet/AspNetCore#17789