### PR TITLE
Fix _Imports.razor deletion causing exceptions in language server scenarios.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -440,6 +440,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             foreach (var importItem in importItems)
             {
                 var itemTargetPath = importItem.FilePath.Replace('/', '\\').TrimStart('\\');
+
+                if (FilePathComparer.Instance.Equals(itemTargetPath, hostDocument.TargetPath))
+                {
+                    // If an import change it can't impact itself. The above filepath normalization occasionally results in something like _Imports.razor mapping to /_Imports.razor because the leading / is trimmed.
+                    continue;
+                }
+
                 targetPaths.Add(itemTargetPath);
             }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -443,7 +443,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
                 if (FilePathComparer.Instance.Equals(itemTargetPath, hostDocument.TargetPath))
                 {
-                    // If an import change it can't impact itself. The above filepath normalization occasionally results in something like _Imports.razor mapping to /_Imports.razor because the leading / is trimmed.
+                    // We've normalized the original importItem.FilePath into the HostDocument.TargetPath. For instance, if the HostDocument.TargetPath
+                    // was '/_Imports.razor' it'd be normalized down into '_Imports.razor'. The purpose of this method is to get the associated document
+                    // paths for a given import file (_Imports.razor / _ViewImports.cshtml); therefore, an import importing itself doesn't make sense.
                     continue;
                 }
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -70,6 +70,19 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [Fact]
+        public void GetImportDocumentTargetPaths_DoesNotIncludeCurrentImport()
+        {
+            // Arrange
+            var state = ProjectState.Create(Workspace.Services, HostProject, ProjectWorkspaceState);
+
+            // Act
+            var paths = state.GetImportDocumentTargetPaths(TestProjectData.SomeProjectComponentImportFile1);
+
+            // Assert
+            Assert.DoesNotContain(TestProjectData.SomeProjectComponentImportFile1.TargetPath, paths);
+        }
+
+        [Fact]
         public void ProjectState_ConstructedNew()
         {
             // Arrange


### PR DESCRIPTION
- Due to how the Language Server normalizes paths there are situations when ProjectState can end up in situations where it thinks `_Imports.razor` file changes impact themselves (recursion!!). Because of this, when we remove an `_Imports.razor` file from a project the removal process ends up trying to clean up the project states understanding import -> dependent file mappings and when it tries to re-lookup itself in the dependent file mapping it no longer exists (it was removed from the document list) therefore you get a missing key exception.
- Added a test to validate the scenario.

https://github.com/dotnet/aspnetcore/issues/18487