### PR TITLE
Fix language server logging.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -63,7 +63,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 options
                     .WithInput(Console.OpenStandardInput())
                     .WithOutput(Console.OpenStandardOutput())
-                    .ConfigureLogging(builder => builder.SetMinimumLevel(logLevel))
+                    .ConfigureLogging(builder => builder
+                        .AddLanguageServer()
+                        .SetMinimumLevel(logLevel))
                     .OnInitialized(async (languageServer, request, response) =>
                     {
                         var fileChangeDetectorManager = languageServer.Services.GetRequiredService<RazorFileChangeDetectorManager>();


### PR DESCRIPTION
- When I moved the LanguageServer over to the new OmniSharp library version it added the requirement to add a specific LangaugeServer logger. Given that we weren't doing that all logs from the server were being swallowed.