### PR TITLE
Fix directive attribute @... completion item not being available on incomplete tags.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperCompletionService.cs
@@ -199,8 +199,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return elementCompletions;
             }
 
-            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out var selectedAttributeName, out attributes) &&
-                attributes.Span.IntersectsWith(location.AbsoluteIndex))
+            if (_htmlFactsService.TryGetAttributeInfo(
+                    parent,
+                    out containingTagNameToken,
+                    out var prefixLocation,
+                    out var selectedAttributeName,
+                    out var selectedAttributeNameLocation,
+                    out attributes) &&
+                (selectedAttributeName == null ||
+                selectedAttributeNameLocation.Value.IntersectsWith(location.AbsoluteIndex) ||
+                prefixLocation.Value.IntersectsWith(location.AbsoluteIndex)))
             {
                 var stringifiedAttributes = _tagHelperFactsService.StringifyAttributes(attributes);
                 var attributeCompletions = GetAttributeCompletions(parent, containingTagNameToken.Content, selectedAttributeName, stringifiedAttributes, codeDocument);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -53,20 +53,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return Completions;
             }
 
-            if (!TryGetAttributeInfo(attribute, out var name, out var nameLocation, out _, out _))
+            if (!TryGetAttributeInfo(owner, out var prefixLocation, out var name, out var nameLocation, out _, out _))
             {
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            if (name.StartsWith("@"))
+            if (nameLocation.IntersectsWith(location.AbsoluteIndex) && name.StartsWith("@"))
             {
-                // The transition is already provided
+                // The transition is already provided for the name
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            if (!nameLocation.IntersectsWith(location.AbsoluteIndex))
+            if (!IntersectsWithAttributeNameOrPrefix(location, prefixLocation, nameLocation))
             {
-                // Not operating in the name section
+                // Not operating in the name area
                 return Array.Empty<RazorCompletionItem>();
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
@@ -101,8 +101,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 }
             }
 
-            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out _, out var selectedAttributeName, out _, out attributes) &&
-                attributes.Span.IntersectsWith(location.AbsoluteIndex))
+            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out _, out var selectedAttributeName, out var selectedAttributeNameLocation, out attributes) &&
+                selectedAttributeNameLocation?.IntersectsWith(location.AbsoluteIndex) == true)
             {
                 // Hovering over HTML attribute name
                 var stringifiedAttributes = _tagHelperFactsService.StringifyAttributes(attributes);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 }
             }
 
-            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out var selectedAttributeName, out attributes) &&
+            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out _, out var selectedAttributeName, out _, out attributes) &&
                 attributes.Span.IntersectsWith(location.AbsoluteIndex))
             {
                 // Hovering over HTML attribute name

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.VisualStudio.Editor.Razor;
+using TextSpan = Microsoft.AspNetCore.Razor.Language.Syntax.TextSpan;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {
@@ -54,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            if (!TryGetAttributeInfo(owner, out var attributeName, out var attributeNameLocation, out _, out _))
+            if (!TryGetAttributeInfo(owner, out _, out var attributeName, out var attributeNameLocation, out _, out _))
             {
                 // Either we're not in an attribute or the attribute is so malformed that we can't provide proper completions.
                 return Array.Empty<RazorCompletionItem>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProviderBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProviderBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using RazorSyntaxList = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxList<Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode>;
 using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
@@ -11,8 +12,34 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     internal abstract class DirectiveAttributeCompletionItemProviderBase : RazorCompletionItemProvider
     {
         // Internal for testing
+        internal static bool IntersectsWithAttributeNameOrPrefix(SourceSpan location, TextSpan prefixLocation, TextSpan attributeNameLocation)
+        {
+            if (location.AbsoluteIndex == prefixLocation.Start)
+            {
+                // <input| class="test" />
+                // Starts of prefix locations belong to the previous SyntaxNode. It could be the end of an attribute value, the tag name, C# etc.
+                return false;
+            }
+
+            if (prefixLocation.IntersectsWith(location.AbsoluteIndex))
+            {
+                // <input   |  class="test" />
+                return true;
+            }
+
+            if (attributeNameLocation.IntersectsWith(location.AbsoluteIndex))
+            {
+                // <input cl|ass="test" />
+                return true;
+            }
+
+            return false;
+        }
+
+        // Internal for testing
         internal static bool TryGetAttributeInfo(
             RazorSyntaxNode attributeLeafOwner,
+            out TextSpan prefixLocation,
             out string name,
             out TextSpan nameLocation,
             out string parameterName,
@@ -23,6 +50,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             switch (attribute)
             {
                 case MarkupMinimizedAttributeBlockSyntax minimizedMarkupAttribute:
+                    prefixLocation = minimizedMarkupAttribute.NamePrefix.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         minimizedMarkupAttribute.Name.GetContent(),
                         minimizedMarkupAttribute.Name.Span,
@@ -33,6 +61,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 
                     return true;
                 case MarkupAttributeBlockSyntax markupAttribute:
+                    prefixLocation = markupAttribute.NamePrefix.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         markupAttribute.Name.GetContent(),
                         markupAttribute.Name.Span,
@@ -42,6 +71,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         out parameterLocation);
                     return true;
                 case MarkupMinimizedTagHelperAttributeSyntax minimizedTagHelperAttribute:
+                    prefixLocation = minimizedTagHelperAttribute.NamePrefix.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         minimizedTagHelperAttribute.Name.GetContent(),
                         minimizedTagHelperAttribute.Name.Span,
@@ -51,6 +81,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         out parameterLocation);
                     return true;
                 case MarkupTagHelperAttributeSyntax tagHelperAttribute:
+                    prefixLocation = tagHelperAttribute.NamePrefix.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         tagHelperAttribute.Name.GetContent(),
                         tagHelperAttribute.Name.Span,
@@ -65,6 +96,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         var directiveAttributeTransition = directiveAttribute.Transition;
                         var nameStart = directiveAttributeTransition?.SpanStart ?? attributeName.SpanStart;
                         var nameEnd = attributeName?.Span.End ?? directiveAttributeTransition.Span.End;
+                        prefixLocation = directiveAttribute.NamePrefix.Span;
                         name = string.Concat(directiveAttributeTransition?.GetContent(), attributeName?.GetContent());
                         nameLocation = new TextSpan(nameStart, nameEnd - nameStart);
                         parameterName = directiveAttribute.ParameterName?.GetContent();
@@ -77,6 +109,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         var directiveAttributeTransition = minimizedDirectiveAttribute.Transition;
                         var nameStart = directiveAttributeTransition?.SpanStart ?? attributeName.SpanStart;
                         var nameEnd = attributeName?.Span.End ?? directiveAttributeTransition.Span.End;
+                        prefixLocation = minimizedDirectiveAttribute.NamePrefix.Span;
                         name = string.Concat(directiveAttributeTransition?.GetContent(), attributeName?.GetContent());
                         nameLocation = new TextSpan(nameStart, nameEnd - nameStart);
                         parameterName = minimizedDirectiveAttribute.ParameterName?.GetContent();
@@ -85,6 +118,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     }
             }
 
+            prefixLocation = default;
             name = null;
             nameLocation = default;
             parameterName = null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            if (!TryGetAttributeInfo(owner, out var attributeName, out _, out var parameterName, out var parameterNameLocation))
+            if (!TryGetAttributeInfo(owner, out _, out var attributeName, out _, out var parameterName, out var parameterNameLocation))
             {
                 // Either we're not in an attribute or the attribute is so malformed that we can't provide proper completions.
                 return Array.Empty<RazorCompletionItem>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
@@ -28,54 +28,78 @@ namespace Microsoft.VisualStudio.Editor.Razor
             return false;
         }
 
-        public override bool TryGetAttributeInfo(SyntaxNode attribute, out SyntaxToken containingTagNameToken, out string selectedAttributeName, out SyntaxList<RazorSyntaxNode> attributeNodes)
+        public override bool TryGetAttributeInfo(
+            SyntaxNode attribute,
+            out SyntaxToken containingTagNameToken,
+            out TextSpan? prefixLocation,
+            out string selectedAttributeName,
+            out TextSpan? selectedAttributeNameLocation,
+            out SyntaxList<RazorSyntaxNode> attributeNodes)
         {
             if (!TryGetElementInfo(attribute.Parent, out containingTagNameToken, out attributeNodes))
             {
                 containingTagNameToken = null;
+                prefixLocation = null;
                 selectedAttributeName = null;
+                selectedAttributeNameLocation = null;
                 attributeNodes = default;
                 return false;
             }
 
             if (attribute is MarkupMinimizedAttributeBlockSyntax minimizedAttributeBlock)
             {
+                prefixLocation = minimizedAttributeBlock.NamePrefix.Span;
                 selectedAttributeName = minimizedAttributeBlock.Name.GetContent();
+                selectedAttributeNameLocation = minimizedAttributeBlock.Name.Span;
                 return true;
             }
             else if (attribute is MarkupAttributeBlockSyntax attributeBlock)
             {
+                prefixLocation = attributeBlock.NamePrefix.Span;
                 selectedAttributeName = attributeBlock.Name.GetContent();
+                selectedAttributeNameLocation = attributeBlock.Name.Span;
                 return true;
             }
             else if (attribute is MarkupTagHelperAttributeSyntax tagHelperAttribute)
             {
+                prefixLocation = tagHelperAttribute.NamePrefix.Span;
                 selectedAttributeName = tagHelperAttribute.Name.GetContent();
+                selectedAttributeNameLocation = tagHelperAttribute.Name.Span;
                 return true;
             }
             else if (attribute is MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute)
             {
+                prefixLocation = minimizedAttribute.NamePrefix.Span;
                 selectedAttributeName = minimizedAttribute.Name.GetContent();
+                selectedAttributeNameLocation = minimizedAttribute.Name.Span;
                 return true;
             }
             else if (attribute is MarkupTagHelperDirectiveAttributeSyntax tagHelperDirectiveAttribute)
             {
+                prefixLocation = tagHelperDirectiveAttribute.NamePrefix.Span;
                 selectedAttributeName = tagHelperDirectiveAttribute.Name.GetContent();
+                selectedAttributeNameLocation = tagHelperDirectiveAttribute.Name.Span;
                 return true;
             }
             else if (attribute is MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedTagHelperDirectiveAttribute)
             {
+                prefixLocation = minimizedTagHelperDirectiveAttribute.NamePrefix.Span;
                 selectedAttributeName = minimizedTagHelperDirectiveAttribute.Name.GetContent();
+                selectedAttributeNameLocation = minimizedTagHelperDirectiveAttribute.Name.Span;
                 return true;
             }
             else if (attribute is MarkupMiscAttributeContentSyntax)
             {
+                prefixLocation = null;
                 selectedAttributeName = null;
+                selectedAttributeNameLocation = null;
                 return true;
             }
 
             // Not an attribute type that we know of
+            prefixLocation = null;
             selectedAttributeName = null;
+            selectedAttributeNameLocation = null;
             return false;
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFactsService.cs
@@ -8,6 +8,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
     internal abstract class HtmlFactsService
     {
         public abstract bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes);
-        public abstract bool TryGetAttributeInfo(SyntaxNode attribute, out SyntaxToken containingTagNameToken, out string selectedAttributeName, out SyntaxList<RazorSyntaxNode> attributeNodes);
+
+        public abstract bool TryGetAttributeInfo(
+            SyntaxNode attribute,
+            out SyntaxToken containingTagNameToken,
+            out TextSpan? prefixLocation,
+            out string selectedAttributeName,
+            out TextSpan? nameLocation,
+            out SyntaxList<RazorSyntaxNode> attributeNodes);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperCompletionServiceTest.cs
@@ -353,5 +353,39 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 completion => Assert.Equal("bool-val", completion.FilterText),
                 completion => Assert.Equal("int-val", completion.FilterText));
         }
+
+        [Fact]
+        public void GetCompletionAt_HtmlAttributeValue_DoesNotReturnCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(43 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionsAt_AttributePrefix_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2        class=''>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("bool-val", completion.FilterText),
+                completion => Assert.Equal("int-val", completion.FilterText));
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -93,6 +93,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Same(item, TransitionCompletionItem);
         }
 
+        [Fact]
+        public void GetCompletionItems_AttributeAreaInIncompleteComponent_ReturnsTransitionCompletionItem()
+        {
+            // Arrange
+            var syntaxTree = GetSyntaxTree("<input   @{");
+            var location = new SourceSpan(7, 0);
+
+            // Act
+            var result = Provider.GetCompletionItems(syntaxTree, TagHelperDocumentContext, location);
+
+            // Assert
+            var item = Assert.Single(result);
+            Assert.Same(item, TransitionCompletionItem);
+        }
+
         private static RazorSyntaxTree GetSyntaxTree(string text, string fileKind = null)
         {
             fileKind = fileKind ?? FileKinds.Component;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -51,6 +51,54 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
         }
 
         [Fact]
+        public void GetHoverInfo_TagHelper_AttributeValue_ReturnsNull()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true'></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var service = GetDefaultRazorHoverInfoService();
+            var location = new SourceSpan(txt.IndexOf("true"), 0);
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location);
+
+            // Assert
+            Assert.Null(hover);
+        }
+
+        [Fact]
+        public void GetHoverInfo_TagHelper_AfterAttributeEquals_ReturnsNull()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true'></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var service = GetDefaultRazorHoverInfoService();
+            var location = new SourceSpan(txt.IndexOf("=") + 1, 0);
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location);
+
+            // Assert
+            Assert.Null(hover);
+        }
+
+        [Fact]
+        public void GetHoverInfo_TagHelper_AttributeEnd_ReturnsNull()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true'></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var service = GetDefaultRazorHoverInfoService();
+            var location = new SourceSpan(txt.IndexOf("true'") + 5, 0);
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location);
+
+            // Assert
+            Assert.Null(hover);
+        }
+
+        [Fact]
         public void GetHoverInfo_TagHelper_MinimizedAttribute()
         {
             // Arrange


### PR DESCRIPTION
- The core issue was that we weren't taking into consideration an attributes "prefix" text, aka the content prior to the attribute name. This area is typically where users are typing when doing `<InputText                  @{...` because our parser thinks the attribute name is `@{` and the prefix is all the leading whitespace. We now do a two fold check
  - Ensure we're overlapping the attribute name if we're checking the content of the attribute name
  - Also allow typing in the prefix section when determining if we should show the `@...` completion item
- Added tests for all new API.

![image](https://user-images.githubusercontent.com/2008729/72652931-a60ed680-393d-11ea-9bf6-9cfa50b1c9d4.png)


dotnet/AspNetCore#14334