### PR TITLE
Restricted TagHelper attribute completion to not show in values.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperCompletionService.cs
@@ -199,8 +199,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return elementCompletions;
             }
 
-            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out var selectedAttributeName, out attributes) &&
-                attributes.Span.IntersectsWith(location.AbsoluteIndex))
+            if (_htmlFactsService.TryGetAttributeInfo(
+                    parent,
+                    out containingTagNameToken,
+                    out var prefixLocation,
+                    out var selectedAttributeName,
+                    out var selectedAttributeNameLocation,
+                    out attributes) &&
+                (selectedAttributeName == null ||
+                selectedAttributeNameLocation.Value.IntersectsWith(location.AbsoluteIndex) ||
+                prefixLocation.Value.IntersectsWith(location.AbsoluteIndex)))
             {
                 var stringifiedAttributes = _tagHelperFactsService.StringifyAttributes(attributes);
                 var attributeCompletions = GetAttributeCompletions(parent, containingTagNameToken.Content, selectedAttributeName, stringifiedAttributes, codeDocument);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 }
             }
 
-            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out var selectedAttributeName, out attributes) &&
+            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out _, out var selectedAttributeName, out _, out attributes) &&
                 attributes.Span.IntersectsWith(location.AbsoluteIndex))
             {
                 // Hovering over HTML attribute name

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
@@ -28,54 +28,78 @@ namespace Microsoft.VisualStudio.Editor.Razor
             return false;
         }
 
-        public override bool TryGetAttributeInfo(SyntaxNode attribute, out SyntaxToken containingTagNameToken, out string selectedAttributeName, out SyntaxList<RazorSyntaxNode> attributeNodes)
+        public override bool TryGetAttributeInfo(
+            SyntaxNode attribute,
+            out SyntaxToken containingTagNameToken,
+            out TextSpan? prefixLocation,
+            out string selectedAttributeName,
+            out TextSpan? selectedAttributeNameLocation,
+            out SyntaxList<RazorSyntaxNode> attributeNodes)
         {
             if (!TryGetElementInfo(attribute.Parent, out containingTagNameToken, out attributeNodes))
             {
                 containingTagNameToken = null;
+                prefixLocation = null;
                 selectedAttributeName = null;
+                selectedAttributeNameLocation = null;
                 attributeNodes = default;
                 return false;
             }
 
             if (attribute is MarkupMinimizedAttributeBlockSyntax minimizedAttributeBlock)
             {
+                prefixLocation = minimizedAttributeBlock.NamePrefix.Span;
                 selectedAttributeName = minimizedAttributeBlock.Name.GetContent();
+                selectedAttributeNameLocation = minimizedAttributeBlock.Name.Span;
                 return true;
             }
             else if (attribute is MarkupAttributeBlockSyntax attributeBlock)
             {
+                prefixLocation = attributeBlock.NamePrefix.Span;
                 selectedAttributeName = attributeBlock.Name.GetContent();
+                selectedAttributeNameLocation = attributeBlock.Name.Span;
                 return true;
             }
             else if (attribute is MarkupTagHelperAttributeSyntax tagHelperAttribute)
             {
+                prefixLocation = tagHelperAttribute.NamePrefix.Span;
                 selectedAttributeName = tagHelperAttribute.Name.GetContent();
+                selectedAttributeNameLocation = tagHelperAttribute.Name.Span;
                 return true;
             }
             else if (attribute is MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute)
             {
+                prefixLocation = minimizedAttribute.NamePrefix.Span;
                 selectedAttributeName = minimizedAttribute.Name.GetContent();
+                selectedAttributeNameLocation = minimizedAttribute.Name.Span;
                 return true;
             }
             else if (attribute is MarkupTagHelperDirectiveAttributeSyntax tagHelperDirectiveAttribute)
             {
+                prefixLocation = tagHelperDirectiveAttribute.NamePrefix.Span;
                 selectedAttributeName = tagHelperDirectiveAttribute.Name.GetContent();
+                selectedAttributeNameLocation = tagHelperDirectiveAttribute.Name.Span;
                 return true;
             }
             else if (attribute is MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedTagHelperDirectiveAttribute)
             {
+                prefixLocation = minimizedTagHelperDirectiveAttribute.NamePrefix.Span;
                 selectedAttributeName = minimizedTagHelperDirectiveAttribute.Name.GetContent();
+                selectedAttributeNameLocation = minimizedTagHelperDirectiveAttribute.Name.Span;
                 return true;
             }
             else if (attribute is MarkupMiscAttributeContentSyntax)
             {
+                prefixLocation = null;
                 selectedAttributeName = null;
+                selectedAttributeNameLocation = null;
                 return true;
             }
 
             // Not an attribute type that we know of
+            prefixLocation = null;
             selectedAttributeName = null;
+            selectedAttributeNameLocation = null;
             return false;
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFactsService.cs
@@ -8,6 +8,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
     internal abstract class HtmlFactsService
     {
         public abstract bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes);
-        public abstract bool TryGetAttributeInfo(SyntaxNode attribute, out SyntaxToken containingTagNameToken, out string selectedAttributeName, out SyntaxList<RazorSyntaxNode> attributeNodes);
+
+        public abstract bool TryGetAttributeInfo(
+            SyntaxNode attribute,
+            out SyntaxToken containingTagNameToken,
+            out TextSpan? prefixLocation,
+            out string selectedAttributeName,
+            out TextSpan? nameLocation,
+            out SyntaxList<RazorSyntaxNode> attributeNodes);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperCompletionServiceTest.cs
@@ -353,5 +353,39 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 completion => Assert.Equal("bool-val", completion.FilterText),
                 completion => Assert.Equal("int-val", completion.FilterText));
         }
+
+        [Fact]
+        public void GetCompletionAt_HtmlAttributeValue_DoesNotReturnCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(43 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Empty(completions);
+        }
+
+        [Fact]
+        public void GetCompletionsAt_AttributePrefix_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2        class=''>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+
+            // Act
+            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion => Assert.Equal("bool-val", completion.FilterText),
+                completion => Assert.Equal("int-val", completion.FilterText));
+        }
     }
 }


### PR DESCRIPTION
- Prior to this we were doing attribute intersection checks on the entire attribute ranges of an HTML element. In reality we should only allow TagHelper completion in an attribute's prefix or name. To get this new information I had to expand on the `HtmlFactsService` to extract extra information from the attributes it introspects on.
- Added tests for the new failure cases. Testing this was primarily handled by existing tests because we had to ensure that we didn't break new scenarios by adding new restrictions when completions show up. Aka, prior tests not exploding show the quality of the change.

dotnet/AspNetCore#18431