### PR TITLE
Restricted TagHelper attribute hovers to only show when over a name.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
@@ -101,8 +101,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 }
             }
 
-            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out _, out var selectedAttributeName, out _, out attributes) &&
-                attributes.Span.IntersectsWith(location.AbsoluteIndex))
+            if (_htmlFactsService.TryGetAttributeInfo(parent, out containingTagNameToken, out _, out var selectedAttributeName, out var selectedAttributeNameLocation, out attributes) &&
+                selectedAttributeNameLocation?.IntersectsWith(location.AbsoluteIndex) == true)
             {
                 // Hovering over HTML attribute name
                 var stringifiedAttributes = _tagHelperFactsService.StringifyAttributes(attributes);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -51,6 +51,54 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
         }
 
         [Fact]
+        public void GetHoverInfo_TagHelper_AttributeValue_ReturnsNull()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true'></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var service = GetDefaultRazorHoverInfoService();
+            var location = new SourceSpan(txt.IndexOf("true"), 0);
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location);
+
+            // Assert
+            Assert.Null(hover);
+        }
+
+        [Fact]
+        public void GetHoverInfo_TagHelper_AfterAttributeEquals_ReturnsNull()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true'></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var service = GetDefaultRazorHoverInfoService();
+            var location = new SourceSpan(txt.IndexOf("=") + 1, 0);
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location);
+
+            // Assert
+            Assert.Null(hover);
+        }
+
+        [Fact]
+        public void GetHoverInfo_TagHelper_AttributeEnd_ReturnsNull()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true'></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var service = GetDefaultRazorHoverInfoService();
+            var location = new SourceSpan(txt.IndexOf("true'") + 5, 0);
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location);
+
+            // Assert
+            Assert.Null(hover);
+        }
+
+        [Fact]
         public void GetHoverInfo_TagHelper_MinimizedAttribute()
         {
             // Arrange


### PR DESCRIPTION
- Prior to this we were doing attribute intersection checks on the entire attribute ranges of an HTML element to determine if we should show an attribute hover. In reality we should only allow TagHelper attribute hovers on an attribute's name.
- Added tests for the new failure cases. Testing this was primarily handled by existing tests because we had to ensure that we didn't break new scenarios by adding new restrictions when completions show up. Aka, prior tests not exploding show the quality of the change.

aspnet/AspNetCore#18432