### PR TITLE
Basic LSP Razor formatting

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/ClassifiedSpanVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/ClassifiedSpanVisitor.cs
@@ -18,6 +18,11 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public ClassifiedSpanVisitor(RazorSourceDocument source)
         {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
             _source = source;
             _spans = new List<ClassifiedSpanInternal>();
             _currentBlockKind = BlockKindInternal.Markup;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultRazorDocumentMappingService : RazorDocumentMappingService
+    {
+        public override bool TryMapFromProjectedDocumentRange(RazorCodeDocument codeDocument, Range projectedRange, out Range originalRange)
+        {
+            originalRange = default;
+            if (codeDocument.IsUnsupported())
+            {
+                // All mapping requests on unsupported documents return undefined ranges. This is equivalent to what pre-VSCode Razor was capable of.
+                return false;
+            }
+
+            var csharpSourceText = SourceText.From(codeDocument.GetCSharpDocument().GeneratedCode);
+            var range = projectedRange;
+            var startPosition = range.Start;
+            var lineStartPosition = new LinePosition((int)startPosition.Line, (int)startPosition.Character);
+            var startIndex = csharpSourceText.Lines.GetPosition(lineStartPosition);
+            if (!TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out var _))
+            {
+                return false;
+            }
+
+            var endPosition = range.End;
+            var lineEndPosition = new LinePosition((int)endPosition.Line, (int)endPosition.Character);
+            var endIndex = csharpSourceText.Lines.GetPosition(lineEndPosition);
+            if (!TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out var _))
+            {
+                return false;
+            }
+
+            originalRange = new Range(
+                hostDocumentStart,
+                hostDocumentEnd);
+
+            return true;
+        }
+
+        public override bool TryMapToProjectedDocumentRange(RazorCodeDocument codeDocument, Range originalRange, out Range projectedRange)
+        {
+            projectedRange = default;
+            var source = codeDocument.Source;
+            var charBuffer = new char[source.Length];
+            source.CopyTo(0, charBuffer, 0, source.Length);
+            var sourceText = SourceText.From(new string(charBuffer));
+            var range = originalRange;
+
+            var startPosition = range.Start;
+            var lineStartPosition = new LinePosition((int)startPosition.Line, (int)startPosition.Character);
+            var startIndex = sourceText.Lines.GetPosition(lineStartPosition);
+            if (!TryMapToProjectedDocumentPosition(codeDocument, startIndex, out var projectedStart, out var _))
+            {
+                return false;
+            }
+
+            var endPosition = range.End;
+            var lineEndPosition = new LinePosition((int)endPosition.Line, (int)endPosition.Character);
+            var endIndex = sourceText.Lines.GetPosition(lineEndPosition);
+            if (!TryMapToProjectedDocumentPosition(codeDocument, endIndex, out var projectedEnd, out var _))
+            {
+                return false;
+            }
+
+            projectedRange = new Range(
+                projectedStart,
+                projectedEnd);
+
+            return true;
+        }
+
+        public override bool TryMapFromProjectedDocumentPosition(RazorCodeDocument codeDocument, int csharpAbsoluteIndex, out Position originalPosition, out int originalIndex)
+        {
+            var csharpDoc = codeDocument.GetCSharpDocument();
+            foreach (var mapping in csharpDoc.SourceMappings)
+            {
+                var generatedSpan = mapping.GeneratedSpan;
+                var generatedAbsoluteIndex = generatedSpan.AbsoluteIndex;
+                if (generatedAbsoluteIndex <= csharpAbsoluteIndex)
+                {
+                    // Treat the mapping as owning the edge at its end (hence <= originalSpan.Length),
+                    // otherwise we wouldn't handle the cursor being right after the final C# char
+                    var distanceIntoGeneratedSpan = csharpAbsoluteIndex - generatedAbsoluteIndex;
+                    if (distanceIntoGeneratedSpan <= generatedSpan.Length)
+                    {
+                        // Found the generated span that contains the csharp absolute index
+
+                        originalIndex = mapping.OriginalSpan.AbsoluteIndex + distanceIntoGeneratedSpan;
+                        var originalLocation = codeDocument.Source.Lines.GetLocation(originalIndex);
+                        originalPosition = new Position(originalLocation.LineIndex, originalLocation.CharacterIndex);
+                        return true;
+                    }
+                }
+            }
+
+            originalPosition = default;
+            originalIndex = default;
+            return false;
+        }
+
+        public override bool TryMapToProjectedDocumentPosition(RazorCodeDocument codeDocument, int absoluteIndex, out Position projectedPosition, out int projectedIndex)
+        {
+            var csharpDoc = codeDocument.GetCSharpDocument();
+            foreach (var mapping in csharpDoc.SourceMappings)
+            {
+                var originalSpan = mapping.OriginalSpan;
+                var originalAbsoluteIndex = originalSpan.AbsoluteIndex;
+                if (originalAbsoluteIndex <= absoluteIndex)
+                {
+                    // Treat the mapping as owning the edge at its end (hence <= originalSpan.Length),
+                    // otherwise we wouldn't handle the cursor being right after the final C# char
+                    var distanceIntoOriginalSpan = absoluteIndex - originalAbsoluteIndex;
+                    if (distanceIntoOriginalSpan <= originalSpan.Length)
+                    {
+                        var generatedSource = SourceText.From(csharpDoc.GeneratedCode);
+                        projectedIndex = mapping.GeneratedSpan.AbsoluteIndex + distanceIntoOriginalSpan;
+                        var generatedLinePosition = generatedSource.Lines.GetLinePosition(projectedIndex);
+                        projectedPosition = new Position(generatedLinePosition.Line, generatedLinePosition.Character);
+                        return true;
+                    }
+                }
+            }
+
+            projectedPosition = default;
+            projectedIndex = default;
+            return false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -1,0 +1,287 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using RoslynFormattingOptions = Microsoft.CodeAnalysis.Formatting.FormattingOptions;
+using OmniSharpFormattingOptions = OmniSharp.Extensions.LanguageServer.Protocol.Models.FormattingOptions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class DefaultRazorFormattingService : RazorFormattingService
+    {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly RazorDocumentMappingService _documentMappingService;
+        private readonly FilePathNormalizer _filePathNormalizer;
+        private readonly ProjectSnapshotManagerAccessor _projectSnapshotManagerAccessor;
+        private readonly ILanguageServer _server;
+
+        public DefaultRazorFormattingService(
+            ForegroundDispatcher foregroundDispatcher,
+            RazorDocumentMappingService documentMappingService,
+            FilePathNormalizer filePathNormalizer,
+            ProjectSnapshotManagerAccessor projectSnapshotManagerAccessor,
+            ILanguageServer server)
+        {
+            if (foregroundDispatcher is null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (documentMappingService is null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingService));
+            }
+
+            if (filePathNormalizer is null)
+            {
+                throw new ArgumentNullException(nameof(filePathNormalizer));
+            }
+
+            if (projectSnapshotManagerAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(projectSnapshotManagerAccessor));
+            }
+
+            if (server is null)
+            {
+                throw new ArgumentNullException(nameof(server));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _documentMappingService = documentMappingService;
+            _filePathNormalizer = filePathNormalizer;
+            _projectSnapshotManagerAccessor = projectSnapshotManagerAccessor;
+            _server = server;
+        }
+
+        public override Task<TextEdit[]> FormatAsync(Uri uri, RazorCodeDocument codeDocument, Range range, OmniSharpFormattingOptions options)
+        {
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var formattingSpans = syntaxTree.GetFormattingSpans();
+            var indentations = GetLineIndentationMap(codeDocument.Source, formattingSpans);
+
+            var edits = new List<TextEdit>();
+            for (var i = (int)range.Start.Line; i <= (int)range.End.Line; i++)
+            {
+                var context = indentations[i];
+                if (context.IndentationLevel == -1)
+                {
+                    // Couldn't determine the desired indentation. Leave this line alone.
+                    continue;
+                }
+
+                var desiredIndentation = context.IndentationLevel * options.TabSize;
+
+                if (context.FirstSpan.Kind == FormattingSpanKind.Code &&
+                    context.ExistingIndentation >= desiredIndentation)
+                {
+                    // This is C# and it is already indented at least the minimum amount we require.
+                    // Since we don't understand the structure of C#, it is better to leave this line alone.
+                    continue;
+                }
+
+                var effectiveIndentation = desiredIndentation - context.ExistingIndentation;
+                if (effectiveIndentation > 0)
+                {
+                    var indentationChar = options.InsertSpaces ? ' ' : '\t';
+                    var indentationString = new string(indentationChar, (int)effectiveIndentation);
+                    var edit = new TextEdit()
+                    {
+                        Range = new Range(new Position(i, 0), new Position(i, 0)),
+                        NewText = indentationString,
+                    };
+
+                    edits.Add(edit);
+                }
+                else if (effectiveIndentation < 0)
+                {
+                    var edit = new TextEdit()
+                    {
+                        Range = new Range(new Position(i, 0), new Position(i, -effectiveIndentation)),
+                        NewText = string.Empty,
+                    };
+
+                    edits.Add(edit);
+                }
+            }
+
+            return Task.FromResult(edits.ToArray());
+        }
+
+        internal static Dictionary<int, IndentationContext> GetLineIndentationMap(RazorSourceDocument source, IReadOnlyList<FormattingSpan> formattingSpans)
+        {
+            var result = new Dictionary<int, IndentationContext>();
+            var total = 0;
+            for (var i = 0; i < source.Lines.Count; i++)
+            {
+                // Get first non-whitespace character position
+                var lineLength = source.Lines.GetLineLength(i);
+                var nonWsChar = 0;
+                for (var j = 0; j < lineLength; j++)
+                {
+                    var ch = source[total + j];
+                    if (!char.IsWhiteSpace(ch) && !ParserHelpers.IsNewLine(ch))
+                    {
+                        nonWsChar = j;
+                        break;
+                    }
+                }
+
+                // position now contains the first non-whitespace character or 0. Get the corresponding FormattingSpan.
+                if (TryGetFormattingSpanIndex(total + nonWsChar, formattingSpans, out var index))
+                {
+                    var span = formattingSpans[index];
+                    result[i] = new IndentationContext
+                    {
+                        Line = i,
+                        IndentationLevel = span.IndentationLevel,
+                        ExistingIndentation = nonWsChar,
+                        FirstSpan = span,
+                    };
+                }
+                else
+                {
+                    // Couldn't find a corresponding FormattingSpan.
+                    result[i] = new IndentationContext
+                    {
+                        Line = i,
+                        IndentationLevel = -1,
+                        ExistingIndentation = nonWsChar,
+                    };
+                }
+
+                total += lineLength;
+            }
+
+            return result;
+        }
+
+        internal static bool TryGetFormattingSpanIndex(int absoluteIndex, IReadOnlyList<FormattingSpan> formattingspans, out int index)
+        {
+            index = -1;
+            for (var i = 0; i < formattingspans.Count; i++)
+            {
+                var formattingspan = formattingspans[i];
+                var span = formattingspan.Span;
+
+                if (span.Start <= absoluteIndex)
+                {
+                    if (span.End >= absoluteIndex)
+                    {
+                        if (span.End == absoluteIndex && span.Length > 0)
+                        {
+                            // We're at an edge.
+                            // Non-marker spans do not own the edges after it
+                            continue;
+                        }
+
+                        index = i;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private async Task<TextEdit[]> FormatProjectedHtmlDocument(
+            RazorCodeDocument codeDocument,
+            Range range,
+            string documentPath,
+            OmniSharpFormattingOptions options)
+        {
+            var @params = new RazorDocumentRangeFormattingParams()
+            {
+                Kind = RazorLanguageKind.CSharp,
+                ProjectedRange = range,
+                HostDocumentFilePath = _filePathNormalizer.Normalize(documentPath),
+                Options = options
+            };
+
+            var result = await _server.Client.SendRequest<RazorDocumentRangeFormattingParams, RazorDocumentRangeFormattingResponse>(
+                "razor/rangeFormatting", @params);
+
+            return result.Edits;
+        }
+
+        private async Task<TextEdit[]> FormatProjectedCSharpDocument(RazorCodeDocument codeDocument, OmniSharpFormattingOptions options)
+        {
+            var workspace = _projectSnapshotManagerAccessor.Instance.Workspace;
+
+            var cSharpOptions = workspace.Options
+                .WithChangedOption(RoslynFormattingOptions.TabSize, LanguageNames.CSharp, (int)options.TabSize)
+                .WithChangedOption(RoslynFormattingOptions.UseTabs, LanguageNames.CSharp, !options.InsertSpaces);
+            
+            var csharpSpans = new List<TextSpan>();
+            var csharpDocument = codeDocument.GetCSharpDocument();
+            var syntaxTree = CSharpSyntaxTree.ParseText(csharpDocument.GeneratedCode);
+            var sourceText = SourceText.From(csharpDocument.GeneratedCode);
+            var root = await syntaxTree.GetRootAsync();
+            foreach (var mapping in csharpDocument.SourceMappings)
+            {
+                var span = new TextSpan(mapping.GeneratedSpan.AbsoluteIndex, mapping.GeneratedSpan.Length);
+                csharpSpans.Add(span);
+            }
+
+            // Actually format all the C# parts of the document.
+            var textChanges = Formatter.GetFormattedTextChanges(root, csharpSpans, workspace, options: cSharpOptions);
+
+            var csharpEdits = new List<TextEdit>();
+            foreach (var change in textChanges)
+            {
+                csharpEdits.Add(change.AsTextEdit(sourceText));
+            }
+
+            // We now have the edits for the projected C# document. We need to map these back to the original razor document.
+            var actualEdits = MapProjectedCSharpEdits(codeDocument, csharpEdits);
+            return actualEdits;
+        }
+
+        private TextEdit[] MapProjectedCSharpEdits(RazorCodeDocument codeDocument, List<TextEdit> csharpEdits)
+        {
+            var actualEdits = new List<TextEdit>();
+            foreach (var edit in csharpEdits)
+            {
+                if (_documentMappingService.TryMapFromProjectedDocumentRange(codeDocument, edit.Range, out var newRange))
+                {
+                    actualEdits.Add(new TextEdit()
+                    {
+                        NewText = edit.NewText,
+                        Range = newRange,
+                    });
+                }
+            }
+
+            return actualEdits.ToArray();
+        }
+
+        internal class IndentationContext
+        {
+            public int Line { get; set; }
+
+            public int IndentationLevel { get; set; }
+
+            public int ExistingIndentation { get; set; }
+
+            public FormattingSpan FirstSpan { get; set; }
+
+            public override string ToString()
+            {
+                return $"Line: {Line}, Indentation Level: {IndentationLevel}, ExistingIndentation: {ExistingIndentation}";
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingBlockKind.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingBlockKind.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal enum FormattingBlockKind
+    {
+        // Code
+        Statement,
+        Directive,
+        Expression,
+
+        // Markup
+        Markup,
+        Template,
+
+        // Special
+        Comment,
+        Tag,
+        HtmlComment
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingSpan.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingSpan.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class FormattingSpan
+    {
+        public FormattingSpan(TextSpan span, TextSpan blockSpan, FormattingSpanKind spanKind, FormattingBlockKind blockKind, int indentationLevel)
+        {
+            Span = span;
+            BlockSpan = blockSpan;
+            Kind = spanKind;
+            BlockKind = blockKind;
+            IndentationLevel = indentationLevel;
+        }
+
+        public TextSpan Span { get; }
+
+        public TextSpan BlockSpan { get; }
+
+        public FormattingBlockKind BlockKind { get; }
+
+        public FormattingSpanKind Kind { get; }
+
+        public int IndentationLevel { get; }
+    }
+
+    internal enum FormattingBlockKind
+    {
+        // Code
+        Statement,
+        Directive,
+        Expression,
+
+        // Markup
+        Markup,
+        Template,
+
+        // Special
+        Comment,
+        Tag,
+        HtmlComment
+    }
+
+    internal enum FormattingSpanKind
+    {
+        Transition,
+        MetaCode,
+        Comment,
+        Code,
+        Markup,
+        None
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingSpan.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingSpan.cs
@@ -26,31 +26,4 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public int IndentationLevel { get; }
     }
-
-    internal enum FormattingBlockKind
-    {
-        // Code
-        Statement,
-        Directive,
-        Expression,
-
-        // Markup
-        Markup,
-        Template,
-
-        // Special
-        Comment,
-        Tag,
-        HtmlComment
-    }
-
-    internal enum FormattingSpanKind
-    {
-        Transition,
-        MetaCode,
-        Comment,
-        Code,
-        Markup,
-        None
-    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingSpanKind.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingSpanKind.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal enum FormattingSpanKind
+    {
+        Transition,
+        MetaCode,
+        Comment,
+        Code,
+        Markup,
+        None
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -1,0 +1,416 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class FormattingVisitor : SyntaxWalker
+    {
+        private RazorSourceDocument _source;
+        private List<FormattingSpan> _spans;
+        private FormattingBlockKind _currentBlockKind;
+        private SyntaxNode _currentBlock;
+        private int _currentIndentationLevel = 0;
+
+        public FormattingVisitor(RazorSourceDocument source)
+        {
+            _source = source;
+            _spans = new List<FormattingSpan>();
+            _currentBlockKind = FormattingBlockKind.Markup;
+        }
+
+        public IReadOnlyList<FormattingSpan> FormattingSpans => _spans;
+
+        public override void VisitRazorCommentBlock(RazorCommentBlockSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Comment, razorCommentSyntax =>
+            {
+                WriteSpan(razorCommentSyntax.StartCommentTransition, FormattingSpanKind.Transition);
+                WriteSpan(razorCommentSyntax.StartCommentStar, FormattingSpanKind.MetaCode);
+
+                var comment = razorCommentSyntax.Comment;
+                if (comment.IsMissing)
+                {
+                    // We need to generate a formatting span at this position. So insert a marker in its place.
+                    comment = (SyntaxToken)SyntaxFactory.Token(SyntaxKind.Marker, string.Empty).Green.CreateRed(razorCommentSyntax, razorCommentSyntax.StartCommentStar.EndPosition);
+                }
+                WriteSpan(comment, FormattingSpanKind.Comment);
+
+                WriteSpan(razorCommentSyntax.EndCommentStar, FormattingSpanKind.MetaCode);
+                WriteSpan(razorCommentSyntax.EndCommentTransition, FormattingSpanKind.Transition);
+            });
+        }
+
+        public override void VisitCSharpCodeBlock(CSharpCodeBlockSyntax node)
+        {
+            if (node.Parent is CSharpStatementBodySyntax ||
+                node.Parent is CSharpExplicitExpressionBodySyntax ||
+                node.Parent is CSharpImplicitExpressionBodySyntax ||
+                node.Parent is RazorDirectiveBodySyntax ||
+                (_currentBlockKind == FormattingBlockKind.Directive &&
+                node.Children.Count == 1 &&
+                node.Children[0] is CSharpStatementLiteralSyntax))
+            {
+                if (!(node.Parent is RazorDirectiveBodySyntax))
+                {
+                    _currentIndentationLevel++;
+                }
+                base.VisitCSharpCodeBlock(node);
+                if (!(node.Parent is RazorDirectiveBodySyntax))
+                {
+                    _currentIndentationLevel--;
+                }
+                return;
+            }
+
+            WriteBlock(node, FormattingBlockKind.Statement, base.VisitCSharpCodeBlock);
+        }
+
+        public override void VisitCSharpStatement(CSharpStatementSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Statement, base.VisitCSharpStatement);
+        }
+
+        public override void VisitCSharpExplicitExpression(CSharpExplicitExpressionSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Expression, base.VisitCSharpExplicitExpression);
+        }
+
+        public override void VisitCSharpImplicitExpression(CSharpImplicitExpressionSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Expression, base.VisitCSharpImplicitExpression);
+        }
+
+        public override void VisitRazorDirective(RazorDirectiveSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Directive, base.VisitRazorDirective);
+        }
+
+        public override void VisitCSharpTemplateBlock(CSharpTemplateBlockSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Template, base.VisitCSharpTemplateBlock);
+        }
+
+        public override void VisitMarkupBlock(MarkupBlockSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Markup, base.VisitMarkupBlock);
+        }
+
+        public override void VisitMarkupElement(MarkupElementSyntax node)
+        {
+            _currentIndentationLevel++;
+            base.VisitMarkupElement(node);
+            _currentIndentationLevel--;
+        }
+
+        public override void VisitMarkupStartTag(MarkupStartTagSyntax node)
+        {
+            _currentIndentationLevel--;
+            WriteBlock(node, FormattingBlockKind.Tag, n =>
+            {
+                var children = GetRewrittenMarkupStartTagChildren(node);
+                foreach (var child in children)
+                {
+                    Visit(child);
+                }
+            });
+            _currentIndentationLevel++;
+        }
+
+        public override void VisitMarkupEndTag(MarkupEndTagSyntax node)
+        {
+            _currentIndentationLevel--;
+            WriteBlock(node, FormattingBlockKind.Tag, n =>
+            {
+                var children = GetRewrittenMarkupEndTagChildren(node);
+                foreach (var child in children)
+                {
+                    Visit(child);
+                }
+            });
+            _currentIndentationLevel++;
+        }
+
+        public override void VisitMarkupTagHelperElement(MarkupTagHelperElementSyntax node)
+        {
+            _currentIndentationLevel++;
+            WriteBlock(node, FormattingBlockKind.Tag, base.VisitMarkupTagHelperElement);
+            _currentIndentationLevel--;
+        }
+
+        public override void VisitMarkupTagHelperStartTag(MarkupTagHelperStartTagSyntax node)
+        {
+            _currentIndentationLevel--;
+            WriteBlock(node, FormattingBlockKind.Tag, n =>
+            {
+                foreach (var child in n.Children)
+                {
+                    Visit(child);
+                }
+            });
+            _currentIndentationLevel++;
+        }
+
+        public override void VisitMarkupTagHelperEndTag(MarkupTagHelperEndTagSyntax node)
+        {
+            _currentIndentationLevel--;
+            WriteBlock(node, FormattingBlockKind.Tag, n =>
+            {
+                foreach (var child in n.Children)
+                {
+                    Visit(child);
+                }
+            });
+            _currentIndentationLevel++;
+        }
+
+        public override void VisitMarkupAttributeBlock(MarkupAttributeBlockSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Markup, n =>
+            {
+                var equalsSyntax = SyntaxFactory.MarkupTextLiteral(new SyntaxList<SyntaxToken>(node.EqualsToken));
+                var mergedAttributePrefix = SyntaxUtilities.MergeTextLiterals(node.NamePrefix, node.Name, node.NameSuffix, equalsSyntax, node.ValuePrefix);
+                Visit(mergedAttributePrefix);
+                Visit(node.Value);
+                Visit(node.ValueSuffix);
+            });
+        }
+
+        public override void VisitMarkupTagHelperAttribute(MarkupTagHelperAttributeSyntax node)
+        {
+            Visit(node.Value);
+        }
+
+        public override void VisitMarkupTagHelperDirectiveAttribute(MarkupTagHelperDirectiveAttributeSyntax node)
+        {
+            Visit(node.Transition);
+            Visit(node.Colon);
+            Visit(node.Value);
+        }
+
+        public override void VisitMarkupMinimizedTagHelperDirectiveAttribute(MarkupMinimizedTagHelperDirectiveAttributeSyntax node)
+        {
+            Visit(node.Transition);
+            Visit(node.Colon);
+        }
+
+        public override void VisitMarkupMinimizedAttributeBlock(MarkupMinimizedAttributeBlockSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Markup, n =>
+            {
+                var mergedAttributePrefix = SyntaxUtilities.MergeTextLiterals(node.NamePrefix, node.Name);
+                Visit(mergedAttributePrefix);
+            });
+        }
+
+        public override void VisitMarkupCommentBlock(MarkupCommentBlockSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.HtmlComment, base.VisitMarkupCommentBlock);
+        }
+
+        public override void VisitMarkupDynamicAttributeValue(MarkupDynamicAttributeValueSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Markup, base.VisitMarkupDynamicAttributeValue);
+        }
+
+        public override void VisitMarkupTagHelperAttributeValue(MarkupTagHelperAttributeValueSyntax node)
+        {
+            WriteBlock(node, FormattingBlockKind.Markup, base.VisitMarkupTagHelperAttributeValue);
+        }
+
+        public override void VisitRazorMetaCode(RazorMetaCodeSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.MetaCode);
+            base.VisitRazorMetaCode(node);
+        }
+
+        public override void VisitCSharpTransition(CSharpTransitionSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.Transition);
+            base.VisitCSharpTransition(node);
+        }
+
+        public override void VisitMarkupTransition(MarkupTransitionSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.Transition);
+            base.VisitMarkupTransition(node);
+        }
+
+        public override void VisitCSharpStatementLiteral(CSharpStatementLiteralSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.Code);
+            base.VisitCSharpStatementLiteral(node);
+        }
+
+        public override void VisitCSharpExpressionLiteral(CSharpExpressionLiteralSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.Code);
+            base.VisitCSharpExpressionLiteral(node);
+        }
+
+        public override void VisitCSharpEphemeralTextLiteral(CSharpEphemeralTextLiteralSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.Code);
+            base.VisitCSharpEphemeralTextLiteral(node);
+        }
+
+        public override void VisitUnclassifiedTextLiteral(UnclassifiedTextLiteralSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.None);
+            base.VisitUnclassifiedTextLiteral(node);
+        }
+
+        public override void VisitMarkupLiteralAttributeValue(MarkupLiteralAttributeValueSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.Markup);
+            base.VisitMarkupLiteralAttributeValue(node);
+        }
+
+        public override void VisitMarkupTextLiteral(MarkupTextLiteralSyntax node)
+        {
+            if (node.Parent is MarkupLiteralAttributeValueSyntax)
+            {
+                base.VisitMarkupTextLiteral(node);
+                return;
+            }
+
+            WriteSpan(node, FormattingSpanKind.Markup);
+            base.VisitMarkupTextLiteral(node);
+        }
+
+        public override void VisitMarkupEphemeralTextLiteral(MarkupEphemeralTextLiteralSyntax node)
+        {
+            WriteSpan(node, FormattingSpanKind.Markup);
+            base.VisitMarkupEphemeralTextLiteral(node);
+        }
+
+        private void WriteBlock<TNode>(TNode node, FormattingBlockKind kind, Action<TNode> handler) where TNode : SyntaxNode
+        {
+            var previousBlock = _currentBlock;
+            var previousKind = _currentBlockKind;
+
+            _currentBlock = node;
+            _currentBlockKind = kind;
+
+            handler(node);
+
+            _currentBlock = previousBlock;
+            _currentBlockKind = previousKind;
+        }
+
+        private void WriteSpan(SyntaxNode node, FormattingSpanKind kind)
+        {
+            if (node.IsMissing)
+            {
+                return;
+            }
+
+            var spanSource = new TextSpan(node.Position, node.FullWidth);
+            var blockSource = new TextSpan(_currentBlock.Position, _currentBlock.FullWidth);
+
+            var span = new FormattingSpan(spanSource, blockSource, kind, _currentBlockKind, _currentIndentationLevel);
+            _spans.Add(span);
+        }
+
+        private static SyntaxList<RazorSyntaxNode> GetRewrittenMarkupStartTagChildren(MarkupStartTagSyntax node)
+        {
+            // Rewrites the children of the start tag to look like the legacy syntax tree.
+            if (node.IsMarkupTransition)
+            {
+                var tokens = node.DescendantNodes().Where(n => n is SyntaxToken token && !token.IsMissing).Cast<SyntaxToken>().ToArray();
+                var tokenBuilder = SyntaxListBuilder<SyntaxToken>.Create();
+                tokenBuilder.AddRange(tokens, 0, tokens.Length);
+                var markupTransition = SyntaxFactory.MarkupTransition(tokenBuilder.ToList()).Green.CreateRed(node, node.Position);
+                var spanContext = node.GetSpanContext();
+                if (spanContext != null)
+                {
+                    markupTransition = markupTransition.WithSpanContext(spanContext);
+                }
+
+                var builder = new SyntaxListBuilder(1);
+                builder.Add(markupTransition);
+                return new SyntaxList<RazorSyntaxNode>(builder.ToListNode().CreateRed(node, node.Position));
+            }
+
+            SpanContext latestSpanContext = null;
+            var children = node.Children;
+            var newChildren = new SyntaxListBuilder(children.Count);
+            var literals = new List<MarkupTextLiteralSyntax>();
+            foreach (var child in children)
+            {
+                if (child is MarkupTextLiteralSyntax literal)
+                {
+                    literals.Add(literal);
+                    latestSpanContext = literal.GetSpanContext() ?? latestSpanContext;
+                }
+                else if (child is MarkupMiscAttributeContentSyntax miscContent)
+                {
+                    foreach (var contentChild in miscContent.Children)
+                    {
+                        if (contentChild is MarkupTextLiteralSyntax contentLiteral)
+                        {
+                            literals.Add(contentLiteral);
+                            latestSpanContext = contentLiteral.GetSpanContext() ?? latestSpanContext;
+                        }
+                        else
+                        {
+                            // Pop stack
+                            AddLiteralIfExists();
+                            newChildren.Add(contentChild);
+                        }
+                    }
+                }
+                else
+                {
+                    AddLiteralIfExists();
+                    newChildren.Add(child);
+                }
+            }
+
+            AddLiteralIfExists();
+
+            return new SyntaxList<RazorSyntaxNode>(newChildren.ToListNode().CreateRed(node, node.Position));
+
+            void AddLiteralIfExists()
+            {
+                if (literals.Count > 0)
+                {
+                    var mergedLiteral = SyntaxUtilities.MergeTextLiterals(literals.ToArray());
+                    mergedLiteral = mergedLiteral.WithSpanContext(latestSpanContext);
+                    literals.Clear();
+                    latestSpanContext = null;
+                    newChildren.Add(mergedLiteral);
+                }
+            }
+        }
+
+        private static SyntaxList<RazorSyntaxNode> GetRewrittenMarkupEndTagChildren(MarkupEndTagSyntax node)
+        {
+            // Rewrites the children of the end tag to look like the legacy syntax tree.
+            if (node.IsMarkupTransition)
+            {
+                var tokens = node.DescendantNodes().Where(n => n is SyntaxToken token && !token.IsMissing).Cast<SyntaxToken>().ToArray();
+                var tokenBuilder = SyntaxListBuilder<SyntaxToken>.Create();
+                tokenBuilder.AddRange(tokens, 0, tokens.Length);
+                var markupTransition = SyntaxFactory.MarkupTransition(tokenBuilder.ToList()).Green.CreateRed(node, node.Position);
+                var spanContext = node.GetSpanContext();
+                if (spanContext != null)
+                {
+                    markupTransition = markupTransition.WithSpanContext(spanContext);
+                }
+
+                var builder = new SyntaxListBuilder(1);
+                builder.Add(markupTransition);
+                return new SyntaxList<RazorSyntaxNode>(builder.ToListNode().CreateRed(node, node.Position));
+            }
+
+            return node.Children;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingParams.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using MediatR;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class RazorDocumentRangeFormattingParams : IRequest<RazorDocumentRangeFormattingResponse>
+    {
+        public RazorLanguageKind Kind { get; set; }
+
+        public string HostDocumentFilePath { get; set; }
+
+        public Range ProjectedRange { get; set; }
+
+        public FormattingOptions Options { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingResponse.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class RazorDocumentRangeFormattingResponse
+    {
+        public TextEdit[] Edits { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -4,31 +4,28 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using HoverModel = OmniSharp.Extensions.LanguageServer.Protocol.Models.Hover;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
-    internal class RazorHoverEndpoint : IHoverHandler
+    internal class RazorFormattingEndpoint : IDocumentRangeFormattingHandler
     {
-        private HoverCapability _capability;
-        private readonly ILogger _logger;
+        private DocumentRangeFormattingCapability _capability;
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentResolver _documentResolver;
-        private readonly RazorHoverInfoService _hoverInfoService;
+        private readonly RazorFormattingService _razorFormattingService;
+        private readonly ILogger _logger;
 
-        public RazorHoverEndpoint(
+        public RazorFormattingEndpoint(
             ForegroundDispatcher foregroundDispatcher,
             DocumentResolver documentResolver,
-            RazorHoverInfoService hoverInfoService,
+            RazorFormattingService razorFormattingService,
             ILoggerFactory loggerFactory)
         {
             if (foregroundDispatcher is null)
@@ -41,9 +38,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 throw new ArgumentNullException(nameof(documentResolver));
             }
 
-            if (hoverInfoService is null)
+            if (razorFormattingService is null)
             {
-                throw new ArgumentNullException(nameof(hoverInfoService));
+                throw new ArgumentNullException(nameof(razorFormattingService));
             }
 
             if (loggerFactory is null)
@@ -53,25 +50,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
 
             _foregroundDispatcher = foregroundDispatcher;
             _documentResolver = documentResolver;
-            _hoverInfoService = hoverInfoService;
-            _logger = loggerFactory.CreateLogger<RazorHoverEndpoint>();
+            _razorFormattingService = razorFormattingService;
+            _logger = loggerFactory.CreateLogger<RazorFormattingEndpoint>();
         }
 
         public TextDocumentRegistrationOptions GetRegistrationOptions()
         {
             return new TextDocumentRegistrationOptions()
             {
-                DocumentSelector = RazorDefaults.Selector
+                DocumentSelector = RazorDefaults.Selector,
             };
         }
 
-        public async Task<HoverModel> Handle(HoverParams request, CancellationToken cancellationToken)
+        public async Task<TextEditContainer> Handle(DocumentRangeFormattingParams request, CancellationToken cancellationToken)
         {
-            if (request is null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
-
             var document = await Task.Factory.StartNew(() =>
             {
                 _documentResolver.TryResolveDocument(request.TextDocument.Uri.AbsolutePath, out var documentSnapshot);
@@ -90,21 +82,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 return null;
             }
 
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+            var edits = await _razorFormattingService.FormatAsync(request.TextDocument.Uri, codeDocument, request.Range, request.Options);
 
-            var sourceText = await document.GetTextAsync();
-            var linePosition = new LinePosition((int)request.Position.Line, (int)request.Position.Character);
-            var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
-            var location = new SourceLocation(hostDocumentIndex, (int)request.Position.Line, (int)request.Position.Character);
-
-            var hoverItem = _hoverInfoService.GetHoverInfo(codeDocument, location);
-
-            _logger.LogTrace($"Found hover info items.");
-
-            return hoverItem;
+            var editContainer = new TextEditContainer(edits);
+            return editContainer;
         }
 
-        public void SetCapability(HoverCapability capability)
+        public void SetCapability(DocumentRangeFormattingCapability capability)
         {
             _capability = capability;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal abstract class RazorFormattingService
+    {
+        public abstract Task<TextEdit[]> FormatAsync(Uri uri, RazorCodeDocument codeDocument, Range range, FormattingOptions options);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorSyntaxTreeExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal static class RazorSyntaxTreeExtensions
+    {
+        public static IReadOnlyList<FormattingSpan> GetFormattingSpans(this RazorSyntaxTree syntaxTree)
+        {
+            if (syntaxTree == null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            var visitor = new FormattingVisitor(syntaxTree.Source);
+            visitor.Visit(syntaxTree.Root);
+
+            return visitor.FormattingSpans;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
             _htmlFactsService = htmlFactsService;
         }
 
-        public override HoverModel GetHoverInfo(RazorCodeDocument codeDocument, SourceSpan location)
+        public override HoverModel GetHoverInfo(RazorCodeDocument codeDocument, SourceLocation location)
         {
             if (codeDocument is null)
             {
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
             }
 
             var syntaxTree = codeDocument.GetSyntaxTree();
-            var change = new SourceChange(location, "");
+            var change = new SourceChange(location.AbsoluteIndex, length: 0, newText: "");
             var owner = syntaxTree.Root.LocateOwner(change);
 
             if (owner == null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverInfoService.cs
@@ -8,6 +8,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
 {
     internal abstract class RazorHoverInfoService
     {
-        public abstract HoverModel GetHoverInfo(RazorCodeDocument codeDocument, SourceSpan location);
+        public abstract HoverModel GetHoverInfo(RazorCodeDocument codeDocument, SourceLocation location);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="$(OmniSharpExtensionsLanguageServerPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/PositionExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class PositionExtensions
+    {
+        public static int GetAbsoluteIndex(this Position position, SourceText sourceText)
+        {
+            if (position is null)
+            {
+                throw new ArgumentNullException(nameof(position));
+            }
+
+            if (sourceText is null)
+            {
+                throw new ArgumentNullException(nameof(sourceText));
+            }
+
+            var linePosition = new LinePosition((int)position.Line, (int)position.Character);
+            var index = sourceText.Lines.GetPosition(linePosition);
+            return index;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -91,7 +90,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RazorFileChangeDetectorManager>();
 
                         // File change listeners
-                      services.AddSingleton<IProjectConfigurationFileChangeListener, ProjectConfigurationStateSynchronizer>();
+                        services.AddSingleton<IProjectConfigurationFileChangeListener, ProjectConfigurationStateSynchronizer>();
                         services.AddSingleton<IProjectFileChangeListener, ProjectFileSynchronizer>();
 
                         // File Change detectors

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using Position = OmniSharp.Extensions.LanguageServer.Protocol.Models.Position;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class RazorDocumentMappingService
+    {
+        public abstract bool TryMapFromProjectedDocumentRange(RazorCodeDocument codeDocument, Range projectedRange, out Range originalRange);
+
+        public abstract bool TryMapToProjectedDocumentRange(RazorCodeDocument codeDocument, Range originalRange, out Range projectedRange);
+
+        public abstract bool TryMapFromProjectedDocumentPosition(RazorCodeDocument codeDocument, int csharpAbsoluteIndex, out Position originalPosition, out int originalIndex);
+
+        public abstract bool TryMapToProjectedDocumentPosition(RazorCodeDocument codeDocument, int absoluteIndex, out Position projectedPosition, out int projectedIndex);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -29,12 +29,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentResolver _documentResolver;
         private readonly DocumentVersionCache _documentVersionCache;
+        private readonly RazorDocumentMappingService _documentMappingservice;
         private readonly ILogger _logger;
 
         public RazorLanguageEndpoint(
             ForegroundDispatcher foregroundDispatcher,
             DocumentResolver documentResolver,
             DocumentVersionCache documentVersionCache,
+            RazorDocumentMappingService documentMappingService,
             ILoggerFactory loggerFactory)
         {
             if (foregroundDispatcher == null)
@@ -52,6 +54,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(documentVersionCache));
             }
 
+            if (documentMappingService == null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingService));
+            }
+
             if (loggerFactory == null)
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
@@ -60,6 +67,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _foregroundDispatcher = foregroundDispatcher;
             _documentResolver = documentResolver;
             _documentVersionCache = documentVersionCache;
+            _documentMappingservice = documentMappingService;
             _logger = loggerFactory.CreateLogger<RazorLanguageEndpoint>();
         }
 
@@ -106,7 +114,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             if (languageKind == RazorLanguageKind.CSharp)
             {
-                if (TryGetCSharpProjectedPosition(codeDocument, hostDocumentIndex, out var projectedPosition, out var projectedIndex))
+                if (_documentMappingservice.TryMapToProjectedDocumentPosition(codeDocument, hostDocumentIndex, out var projectedPosition, out var projectedIndex))
                 {
                     // For C# locations, we attempt to return the corresponding position
                     // within the projected document
@@ -165,22 +173,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
-            if (codeDocument.IsUnsupported())
-            {
-                // All maping requests on unsupported documents return undefined ranges. This is equivalent to what pre-VSCode Razor was capable of.
-                return new RazorMapToDocumentRangeResponse()
-                {
-                    Range = UndefinedRange,
-                    HostDocumentVersion = documentVersion,
-                };
-            }
-
-            var csharpSourceText = SourceText.From(codeDocument.GetCSharpDocument().GeneratedCode);
-            var range = request.ProjectedRange;
-            var startPosition = range.Start;
-            var lineStartPosition = new LinePosition((int)startPosition.Line, (int)startPosition.Character);
-            var startIndex = csharpSourceText.Lines.GetPosition(lineStartPosition);
-            if (!TryGetHostDocumentPosition(codeDocument, startIndex, out var hostDocumentStart))
+            if (!_documentMappingservice.TryMapFromProjectedDocumentRange(codeDocument, request.ProjectedRange, out var originalRange))
             {
                 return new RazorMapToDocumentRangeResponse()
                 {
@@ -188,26 +181,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     HostDocumentVersion = documentVersion,
                 };
             }
-
-            var endPosition = range.End;
-            var lineEndPosition = new LinePosition((int)endPosition.Line, (int)endPosition.Character);
-            var endIndex = csharpSourceText.Lines.GetPosition(lineEndPosition);
-            if (!TryGetHostDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd))
-            {
-                return new RazorMapToDocumentRangeResponse()
-                {
-                    Range = UndefinedRange,
-                    HostDocumentVersion = documentVersion,
-                };
-            }
-
-            var remappedDocumentRange = new Range(
-                hostDocumentStart,
-                hostDocumentEnd);
 
             return new RazorMapToDocumentRangeResponse()
             {
-                Range = remappedDocumentRange,
+                Range = originalRange,
                 HostDocumentVersion = documentVersion,
             };
         }
@@ -280,64 +257,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Default to Razor
             return RazorLanguageKind.Razor;
-        }
-
-        // Internal for testing
-        internal static bool TryGetCSharpProjectedPosition(RazorCodeDocument codeDocument, int absoluteIndex, out Position projectedPosition, out int projectedIndex)
-        {
-            var csharpDoc = codeDocument.GetCSharpDocument();
-            foreach (var mapping in csharpDoc.SourceMappings)
-            {
-                var originalSpan = mapping.OriginalSpan;
-                var originalAbsoluteIndex = originalSpan.AbsoluteIndex;
-                if (originalAbsoluteIndex <= absoluteIndex)
-                {
-                    // Treat the mapping as owning the edge at its end (hence <= originalSpan.Length),
-                    // otherwise we wouldn't handle the cursor being right after the final C# char
-                    var distanceIntoOriginalSpan = absoluteIndex - originalAbsoluteIndex;
-                    if (distanceIntoOriginalSpan <= originalSpan.Length)
-                    {
-                        var generatedSource = SourceText.From(csharpDoc.GeneratedCode);
-                        projectedIndex = mapping.GeneratedSpan.AbsoluteIndex + distanceIntoOriginalSpan;
-                        var generatedLinePosition = generatedSource.Lines.GetLinePosition(projectedIndex);
-                        projectedPosition = new Position(generatedLinePosition.Line, generatedLinePosition.Character);
-                        return true;
-                    }
-                }
-            }
-
-            projectedPosition = default;
-            projectedIndex = default;
-            return false;
-        }
-
-        // Internal for testing
-        internal static bool TryGetHostDocumentPosition(RazorCodeDocument codeDocument, int csharpAbsoluteIndex, out Position hostDocumentPosition)
-        {
-            var csharpDoc = codeDocument.GetCSharpDocument();
-            foreach (var mapping in csharpDoc.SourceMappings)
-            {
-                var generatedSpan = mapping.GeneratedSpan;
-                var generatedAbsoluteIndex = generatedSpan.AbsoluteIndex;
-                if (generatedAbsoluteIndex <= csharpAbsoluteIndex)
-                {
-                    // Treat the mapping as owning the edge at its end (hence <= originalSpan.Length),
-                    // otherwise we wouldn't handle the cursor being right after the final C# char
-                    var distanceIntoGeneratedSpan = csharpAbsoluteIndex - generatedAbsoluteIndex;
-                    if (distanceIntoGeneratedSpan <= generatedSpan.Length)
-                    {
-                        // Found the generated span that contains the csharp absolute index
-
-                        var hostDocumentIndex = mapping.OriginalSpan.AbsoluteIndex + distanceIntoGeneratedSpan;
-                        var originalLocation = codeDocument.Source.Lines.GetLocation(hostDocumentIndex);
-                        hostDocumentPosition = new Position(originalLocation.LineIndex, originalLocation.CharacterIndex);
-                        return true;
-                    }
-                }
-            }
-
-            hostDocumentPosition = default;
-            return false;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextChangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextChangeExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class TextChangeExtensions
+    {
+        public static TextEdit AsTextEdit(this TextChange textChange, SourceText sourceText)
+        {
+            if (sourceText is null)
+            {
+                throw new ArgumentNullException(nameof(sourceText));
+            }
+
+            var lineSpan = sourceText.Lines.GetLinePositionSpan(textChange.Span);
+            var range = new Range(
+                new Position(lineSpan.Start.Line, lineSpan.Start.Character),
+                new Position(lineSpan.End.Line, lineSpan.End.Character));
+
+            return new TextEdit()
+            {
+                NewText = textChange.NewText,
+                Range = range
+            };
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextEditExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextEditExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class TextEditExtensions
+    {
+        public static TextChange AsTextChange(this TextEdit textEdit, SourceText sourceText)
+        {
+            if (textEdit is null)
+            {
+                throw new ArgumentNullException(nameof(textEdit));
+            }
+
+            if (sourceText is null)
+            {
+                throw new ArgumentNullException(nameof(sourceText));
+            }
+
+            var start = sourceText.Lines[(int)textEdit.Range.Start.Line].Start + (int)textEdit.Range.Start.Character;
+            var end = sourceText.Lines[(int)textEdit.Range.End.Line].Start + (int)textEdit.Range.End.Character;
+            var span = new TextSpan(start, end - start);
+
+            return new TextChange(span, textEdit.NewText);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/RazorDocumentRangeFormattingRequest.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/RazorDocumentRangeFormattingRequest.ts
@@ -1,0 +1,15 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { LanguageKind } from './LanguageKind';
+import { SerializableRange } from './SerializableRange';
+
+export interface RazorDocumentRangeFormattingRequest {
+    kind: LanguageKind;
+    hostDocumentFilePath: string;
+    projectedRange: SerializableRange;
+    options: vscode.FormattingOptions;
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/RazorDocumentRangeFormattingResponse.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/RazorDocumentRangeFormattingResponse.ts
@@ -1,0 +1,11 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { SerializableTextEdit } from './SerializableTextEdit';
+
+export class RazorDocumentRangeFormattingResponse {
+    constructor(public readonly edits: SerializableTextEdit[]) {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/SerializableTextEdit.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/SerializableTextEdit.ts
@@ -1,0 +1,26 @@
+/* --------------------------------------------------------------------------------------------
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT License. See License.txt in the project root for license information.
+* ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { convertRangeFromSerializable, convertRangeToSerializable, SerializableRange } from './SerializableRange';
+
+// We'd typically just use vscode.TextEdit here; however, that type doesn't serialize properly over the wire.
+export interface SerializableTextEdit {
+    readonly range: SerializableRange;
+    readonly newText: string;
+}
+
+export function convertTextEditToSerializable(textEdit: vscode.TextEdit): SerializableTextEdit {
+    return {
+        range: convertRangeToSerializable(textEdit.range),
+        newText: textEdit.newText,
+    };
+}
+
+export function convertTextEditFromSerializable(textEdit: SerializableTextEdit): vscode.TextEdit {
+    return new vscode.TextEdit(
+        convertRangeFromSerializable(textEdit.range),
+        textEdit.newText);
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorFormattingFeature.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorFormattingFeature.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { CancellationToken, RequestType } from 'vscode-languageclient';
+import { RazorDocumentManager } from './RazorDocumentManager';
+import { RazorLanguageServerClient } from './RazorLanguageServerClient';
+import { RazorLogger } from './RazorLogger';
+import { LanguageKind } from './RPC/LanguageKind';
+import { RazorDocumentRangeFormattingRequest } from './RPC/RazorDocumentRangeFormattingRequest';
+import { RazorDocumentRangeFormattingResponse } from './RPC/RazorDocumentRangeFormattingResponse';
+import { convertRangeFromSerializable } from './RPC/SerializableRange';
+import { convertTextEditToSerializable } from './RPC/SerializableTextEdit';
+
+export class RazorFormattingFeature {
+
+    private rangeFormattingRequestType: RequestType<RazorDocumentRangeFormattingRequest, RazorDocumentRangeFormattingResponse, any, any> = new RequestType('razor/rangeFormatting');
+    private emptyRangeFormattingResponse: RazorDocumentRangeFormattingResponse = new RazorDocumentRangeFormattingResponse([]);
+
+    constructor(
+        private readonly serverClient: RazorLanguageServerClient,
+        private readonly documentManager: RazorDocumentManager,
+        private readonly logger: RazorLogger) {
+    }
+
+    public register() {
+        // tslint:disable-next-line: no-floating-promises
+        this.serverClient.onRequest2<RazorDocumentRangeFormattingRequest, RazorDocumentRangeFormattingResponse, any, any>(
+            this.rangeFormattingRequestType,
+            async (request, token) => this.handleRangeFormatting(request, token));
+    }
+
+    private async handleRangeFormatting(request: RazorDocumentRangeFormattingRequest, token: CancellationToken) {
+        if (request.kind === LanguageKind.Razor) {
+            // We shouldn't attempt to format the actual Razor document here.
+            // Doing so could potentially lead to an infinite loop.
+            return this.emptyRangeFormattingResponse;
+        }
+
+        try {
+            const uri = vscode.Uri.file(request.hostDocumentFilePath);
+            const razorDocument = await this.documentManager.getDocument(uri);
+            if (!razorDocument) {
+                return this.emptyRangeFormattingResponse;
+            }
+
+            let documentUri = uri;
+            if (request.kind === LanguageKind.CSharp) {
+                documentUri = razorDocument.csharpDocument.uri;
+            } else {
+                documentUri = razorDocument.htmlDocument.uri;
+            }
+
+            // Get the edits
+            const textEdits = await vscode.commands.executeCommand<vscode.TextEdit[]>(
+                'vscode.executeFormatRangeProvider',
+                documentUri,
+                convertRangeFromSerializable(request.projectedRange),
+                request.options);
+
+            if (textEdits) {
+                const edits = textEdits.map(item => convertTextEditToSerializable(item));
+                return new RazorDocumentRangeFormattingResponse(edits);
+            }
+        } catch (error) {
+            this.logger.logWarning(`razor/rangeFormatting failed with ${error}`);
+        }
+
+        return this.emptyRangeFormattingResponse;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
@@ -9,6 +9,8 @@ import {
     GenericRequestHandler,
     LanguageClient,
     LanguageClientOptions,
+    RequestHandler,
+    RequestType,
     ServerOptions,
     State,
 } from 'vscode-languageclient/lib/main';
@@ -178,7 +180,15 @@ export class RazorLanguageServerClient implements vscode.Disposable {
         return this.client.sendRequest<TResponseType>(method, param);
     }
 
-    public async onRequest<TRequest, TReturn>(method: string, handler: GenericRequestHandler<TRequest, TReturn>) {
+    public async onRequest<TResponse, TError>(method: string, handler: GenericRequestHandler<TResponse, TError>) {
+        if (!this.isStarted) {
+            throw new Error('Tried to bind on request logic while server is not started.');
+        }
+
+        this.client.onRequest(method, handler);
+    }
+
+    public async onRequest2<P, R, E, RO>(method: RequestType<P, R, E, RO>, handler: RequestHandler<P, R, E>) {
         if (!this.isStarted) {
             throw new Error('Tried to bind on request logic while server is not started.');
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -23,6 +23,7 @@ import { RazorDefinitionProvider } from './RazorDefinitionProvider';
 import { RazorDocumentManager } from './RazorDocumentManager';
 import { RazorDocumentSynchronizer } from './RazorDocumentSynchronizer';
 import { RazorDocumentTracker } from './RazorDocumentTracker';
+import { RazorFormattingFeature } from './RazorFormattingFeature';
 import { RazorHoverProvider } from './RazorHoverProvider';
 import { RazorImplementationProvider } from './RazorImplementationProvider';
 import { RazorLanguage } from './RazorLanguage';
@@ -67,6 +68,7 @@ export async function activate(context: ExtensionContext, languageServerDir: str
         const documentTracker = new RazorDocumentTracker(documentManager, languageServiceClient);
         const localRegistrations: vscode.Disposable[] = [];
         const reportIssueCommand = new ReportIssueCommand(vscode, documentManager, logger);
+        const razorFormattingFeature = new RazorFormattingFeature(languageServerClient, documentManager, logger);
 
         const onStartRegistration = languageServerClient.onStart(() => {
             vscode.commands.executeCommand<void>('omnisharp.registerLanguageMiddleware', razorLanguageMiddleware);
@@ -163,6 +165,8 @@ export async function activate(context: ExtensionContext, languageServerDir: str
                 htmlFeature.register(),
                 documentSynchronizer.register(),
                 reportIssueCommand.register());
+
+            razorFormattingFeature.register();
         });
 
         const onStopRegistration = languageServerClient.onStop(() => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class DefaultRazorDocumentMappingServiceTest
+    {
+        [Fact]
+        public void TryMapToProjectedDocumentPosition_NotMatchingAnyMapping()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "test razor source",
+                "test C# source",
+                new[] { new SourceMapping(new SourceSpan(2, 100), new SourceSpan(0, 100)) });
+
+            // Act
+            var result = service.TryMapToProjectedDocumentPosition(
+                codeDoc,
+                1,
+                out var projectedPosition,
+                out var projectedPositionIndex);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, projectedPosition);
+            Assert.Equal(default, projectedPositionIndex);
+        }
+
+        [Fact]
+        public void TryMapToProjectedDocumentPosition_CSharp_OnLeadingEdge()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "Line 1\nLine 2 @{ var abc;\nvar def; }",
+                "\n// Prefix\n var abc;\nvar def; \n// Suffix",
+                new[] {
+                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
+                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
+                });
+
+            // Act
+            var result = service.TryMapToProjectedDocumentPosition(
+                codeDoc,
+                16,
+                out var projectedPosition,
+                out var projectedPositionIndex);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(2, projectedPosition.Line);
+            Assert.Equal(0, projectedPosition.Character);
+            Assert.Equal(11, projectedPositionIndex);
+        }
+
+        [Fact]
+        public void TryMapToProjectedDocumentPosition_CSharp_InMiddle()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "Line 1\nLine 2 @{ var abc;\nvar def; }",
+                "\n// Prefix\n var abc;\nvar def; \n// Suffix",
+                new[] {
+                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
+                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
+                });
+
+            // Act
+            var result = service.TryMapToProjectedDocumentPosition(
+                codeDoc,
+                28,
+                out var projectedPosition,
+                out var projectedPositionIndex);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(3, projectedPosition.Line);
+            Assert.Equal(2, projectedPosition.Character);
+            Assert.Equal(23, projectedPositionIndex);
+        }
+
+        [Fact]
+        public void TryMapToProjectedDocumentPosition_CSharp_OnTrailingEdge()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "Line 1\nLine 2 @{ var abc;\nvar def; }",
+                "\n// Prefix\n var abc;\nvar def; \n// Suffix",
+                new[] {
+                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
+                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
+                });
+
+            // Act
+            var result = service.TryMapToProjectedDocumentPosition(
+                codeDoc,
+                35,
+                out var projectedPosition,
+                out var projectedPositionIndex);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(3, projectedPosition.Line);
+            Assert.Equal(9, projectedPosition.Character);
+            Assert.Equal(30, projectedPositionIndex);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentPosition_NotMatchingAnyMapping()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                razorSource: "test razor source",
+                projectedCSharpSource: "projectedCSharpSource: test C# source",
+                new[] { new SourceMapping(new SourceSpan(2, 100), new SourceSpan(2, 100)) });
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentPosition(
+                codeDoc,
+                1,
+                out var hostDocumentPosition,
+                out var hostDocumentIndex);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, hostDocumentPosition);
+            Assert.Equal(default, hostDocumentIndex);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentPosition_CSharp_OnLeadingEdge()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                razorSource: "Line 1\nLine 2 @{ var abc;\nvar def; }",
+                projectedCSharpSource: "\n// Prefix\n var abc;\nvar def; \n// Suffix",
+                new[] {
+                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
+                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
+                });
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentPosition(
+                codeDoc,
+                11, // @{|
+                out var hostDocumentPosition,
+                out var hostDocumentIndex);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(1, hostDocumentPosition.Line);
+            Assert.Equal(9, hostDocumentPosition.Character);
+            Assert.Equal(16, hostDocumentIndex);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentPosition_CSharp_InMiddle()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                razorSource: "Line 1\nLine 2 @{ var abc;\nvar def; }",
+                projectedCSharpSource: "\n// Prefix\n var abc;\nvar def; \n// Suffix",
+                new[] {
+                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
+                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
+                });
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentPosition(
+                codeDoc,
+                21, // |var def
+                out var hostDocumentPosition,
+                out var hostDocumentIndex);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(2, hostDocumentPosition.Line);
+            Assert.Equal(0, hostDocumentPosition.Character);
+            Assert.Equal(26, hostDocumentIndex);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentPosition_CSharp_OnTrailingEdge()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                razorSource: "Line 1\nLine 2 @{ var abc;\nvar def; }",
+                projectedCSharpSource: "\n// Prefix\n var abc;\nvar def; \n// Suffix",
+                new[] {
+                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
+                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
+                });
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentPosition(
+                codeDoc,
+                30, // def; |}
+                out var hostDocumentPosition,
+                out var hostDocumentIndex);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(2, hostDocumentPosition.Line);
+            Assert.Equal(9, hostDocumentPosition.Character);
+            Assert.Equal(35, hostDocumentIndex);
+        }
+
+        private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
+        {
+            tagHelpers = tagHelpers ?? Array.Empty<TagHelperDescriptor>();
+            var sourceDocument = TestRazorSourceDocument.Create(text);
+            var projectEngine = RazorProjectEngine.Create(builder => { });
+            var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, "mvc", Array.Empty<RazorSourceDocument>(), tagHelpers);
+            return codeDocument;
+        }
+
+        private static RazorCodeDocument CreateCodeDocumentWithCSharpProjection(string razorSource, string projectedCSharpSource, IEnumerable<SourceMapping> sourceMappings)
+        {
+            var codeDocument = CreateCodeDocument(razorSource, Array.Empty<TagHelperDescriptor>());
+            var csharpDocument = RazorCSharpDocument.Create(
+                    projectedCSharpSource,
+                    RazorCodeGenerationOptions.CreateDefault(),
+                    Enumerable.Empty<RazorDiagnostic>(),
+                    sourceMappings,
+                    Enumerable.Empty<LinePragma>());
+            codeDocument.SetCSharpDocument(csharpDocument);
+            return codeDocument;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using Xunit;
+using Microsoft.CodeAnalysis.Razor;
+using Moq;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Microsoft.CodeAnalysis.Text;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    public class DefaultRazorFormattingServiceTest
+    {
+        [Fact]
+        public async Task FormatAsync_FormatsDocument()
+        {
+            // Arrange
+            var path = "file:///path/to/document.razor";
+            var uri = new Uri(path);
+            var source = SourceText.From(@"
+@{
+var x = ""foo"";
+}
+<div>
+<span>
+                Hello
+ </span>
+        </div>
+");
+            var codeDocument = CreateCodeDocument(source, path);
+            var range = new Range(new Position(0, 0), new Position(source.Lines.Count-1, 0));
+            var options = new FormattingOptions()
+            {
+                TabSize = 2,
+                InsertSpaces = true,
+            };
+            var formattingService = CreateService();
+
+            // Act
+            var edits = await formattingService.FormatAsync(uri, codeDocument, range, options);
+
+            // Assert
+            var edited = ApplyEdits(source, edits);
+            Assert.Equal(@"
+@{
+  var x = ""foo"";
+}
+<div>
+  <span>
+    Hello
+  </span>
+</div>
+", edited.ToString());
+        }
+
+        private SourceText ApplyEdits(SourceText source, TextEdit[] edits)
+        {
+            var changes = edits.Select(e => e.AsTextChange(source));
+            return source.WithChanges(changes);
+        }
+
+        private static RazorCodeDocument CreateCodeDocument(SourceText text, string path, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
+        {
+            tagHelpers = tagHelpers ?? Array.Empty<TagHelperDescriptor>();
+            var sourceDocument = text.GetRazorSourceDocument(path, path);
+            var projectEngine = RazorProjectEngine.Create(builder => { });
+            var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Legacy, Array.Empty<RazorSourceDocument>(), tagHelpers);
+            return codeDocument;
+        }
+
+        private RazorFormattingService CreateService()
+        {
+            var foregroundDispatcher = Mock.Of<ForegroundDispatcher>();
+            var mappingService = new DefaultRazorDocumentMappingService();
+            var filePathNormalizer = new FilePathNormalizer();
+            var projectSnapshotManagerAccessor = Mock.Of<ProjectSnapshotManagerAccessor>();
+            var languageServer = Mock.Of<ILanguageServer>();
+
+            return new DefaultRazorFormattingService(foregroundDispatcher, mappingService, filePathNormalizer, projectSnapshotManagerAccessor, languageServer);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
@@ -2,18 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
-using Xunit;
-using Microsoft.CodeAnalysis.Razor;
-using Moq;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Text;
-using System.Linq;
-using System.Collections.Generic;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
-            var location = new SourceSpan(txt.IndexOf("test1"), 0);
+            var location = new SourceLocation(txt.IndexOf("test1"), -1, -1);
 
             // Act
             var hover = service.GetHoverInfo(codeDocument, location);
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true'></test1>";
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
-            var location = new SourceSpan(txt.IndexOf("bool-val"), 0);
+            var location = new SourceLocation(txt.IndexOf("bool-val"), -1, -1);
 
             // Act
             var hover = service.GetHoverInfo(codeDocument, location);
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val></test1>";
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
-            var location = new SourceSpan(txt.IndexOf("bool-val"), 0);
+            var location = new SourceLocation(txt.IndexOf("bool-val"), -1, -1);
 
             // Act
             var hover = service.GetHoverInfo(codeDocument, location);
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1<hello";
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
-            var location = new SourceSpan(txt.IndexOf("test1"), 0);
+            var location = new SourceLocation(txt.IndexOf("test1"), -1, -1);
 
             // Act
             var hover = service.GetHoverInfo(codeDocument, location);
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val=\"aslj alsk<strong>";
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
-            var location = new SourceSpan(txt.IndexOf("bool-val"), 0);
+            var location = new SourceLocation(txt.IndexOf("bool-val"), -1, -1);
 
             // Act
             var hover = service.GetHoverInfo(codeDocument, location);
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<p><strong></strong></p>";
             var codeDocument = CreateCodeDocument(txt);
             var service = GetDefaultRazorHoverInfoService();
-            var location = new SourceSpan(txt.IndexOf("strong"), 0);
+            var location = new SourceLocation(txt.IndexOf("strong"), -1, -1);
 
             // Act
             var hover = service.GetHoverInfo(codeDocument, location);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -30,9 +30,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 .Returns(true);
 
             DocumentVersionCache = documentVersionCache.Object;
+            MappingService = new DefaultRazorDocumentMappingService();
         }
 
         private DocumentVersionCache DocumentVersionCache { get; }
+
+        private RazorDocumentMappingService MappingService { get; }
 
         // These are more integration tests to validate that all the pieces work together
         [Fact]
@@ -49,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorMapToDocumentRangeParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -80,7 +83,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorMapToDocumentRangeParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -110,7 +113,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorMapToDocumentRangeParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -140,7 +143,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorMapToDocumentRangeParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -163,7 +166,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentPath = "C:/path/to/document.cshtml";
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorMapToDocumentRangeParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -186,7 +189,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentPath = "C:/path/to/document.cshtml";
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorMapToDocumentRangeParams()
             {
                 Kind = RazorLanguageKind.Razor,
@@ -217,7 +220,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 });
             codeDocument.SetUnsupported();
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorMapToDocumentRangeParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -240,7 +243,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentPath = "C:/path/to/document.cshtml";
             var codeDocument = CreateCodeDocument("@{}");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = new Uri(documentPath),
@@ -264,7 +267,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentPath = "C:/path/to/document.cshtml";
             var codeDocument = CreateCodeDocument("<s");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = new Uri(documentPath),
@@ -291,7 +294,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 "/* CSharp */",
                 new[] { new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 12)) });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = new Uri(documentPath),
@@ -320,7 +323,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 new[] { new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 12)) });
             codeDocument.SetUnsupported();
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, LoggerFactory);
+            var languageEndpoint = new RazorLanguageEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = new Uri(documentPath),
@@ -490,198 +493,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, languageKind);
-        }
-
-        [Fact]
-        public void TryGetCSharpProjectedPosition_NotMatchingAnyMapping()
-        {
-            // Arrange
-            var codeDoc = CreateCodeDocumentWithCSharpProjection(
-                "test razor source",
-                "test C# source",
-                new[] { new SourceMapping(new SourceSpan(2, 100), new SourceSpan(0, 100)) });
-
-            // Act
-            var result = RazorLanguageEndpoint.TryGetCSharpProjectedPosition(
-                codeDoc,
-                1,
-                out var projectedPosition,
-                out var projectedPositionIndex);
-
-            // Assert
-            Assert.False(result);
-            Assert.Equal(default, projectedPosition);
-            Assert.Equal(default, projectedPositionIndex);
-        }
-
-        [Fact]
-        public void TryGetCSharpProjectedPosition_CSharp_OnLeadingEdge()
-        {
-            // Arrange
-            var codeDoc = CreateCodeDocumentWithCSharpProjection(
-                "Line 1\nLine 2 @{ var abc;\nvar def; }",
-                "\n// Prefix\n var abc;\nvar def; \n// Suffix",
-                new[] {
-                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
-                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
-                });
-
-            // Act
-            var result = RazorLanguageEndpoint.TryGetCSharpProjectedPosition(
-                codeDoc,
-                16,
-                out var projectedPosition,
-                out var projectedPositionIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(2, projectedPosition.Line);
-            Assert.Equal(0, projectedPosition.Character);
-            Assert.Equal(11, projectedPositionIndex);
-        }
-
-        [Fact]
-        public void TryGetCSharpProjectedPosition_CSharp_InMiddle()
-        {
-            // Arrange
-            var codeDoc = CreateCodeDocumentWithCSharpProjection(
-                "Line 1\nLine 2 @{ var abc;\nvar def; }",
-                "\n// Prefix\n var abc;\nvar def; \n// Suffix",
-                new[] {
-                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
-                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
-                });
-
-            // Act
-            var result = RazorLanguageEndpoint.TryGetCSharpProjectedPosition(
-                codeDoc,
-                28,
-                out var projectedPosition,
-                out var projectedPositionIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(3, projectedPosition.Line);
-            Assert.Equal(2, projectedPosition.Character);
-            Assert.Equal(23, projectedPositionIndex);
-        }
-
-        [Fact]
-        public void TryGetCSharpProjectedPosition_CSharp_OnTrailingEdge()
-        {
-            // Arrange
-            var codeDoc = CreateCodeDocumentWithCSharpProjection(
-                "Line 1\nLine 2 @{ var abc;\nvar def; }",
-                "\n// Prefix\n var abc;\nvar def; \n// Suffix",
-                new[] {
-                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
-                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
-                });
-
-            // Act
-            var result = RazorLanguageEndpoint.TryGetCSharpProjectedPosition(
-                codeDoc,
-                35,
-                out var projectedPosition,
-                out var projectedPositionIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(3, projectedPosition.Line);
-            Assert.Equal(9, projectedPosition.Character);
-            Assert.Equal(30, projectedPositionIndex);
-        }
-
-        [Fact]
-        public void TryGetHostDocumentPosition_NotMatchingAnyMapping()
-        {
-            // Arrange
-            var codeDoc = CreateCodeDocumentWithCSharpProjection(
-                razorSource: "test razor source",
-                projectedCSharpSource: "projectedCSharpSource: test C# source",
-                new[] { new SourceMapping(new SourceSpan(2, 100), new SourceSpan(2, 100)) });
-
-            // Act
-            var result = RazorLanguageEndpoint.TryGetHostDocumentPosition(
-                codeDoc,
-                1,
-                out var hostDocumentPosition);
-
-            // Assert
-            Assert.False(result);
-            Assert.Equal(default, hostDocumentPosition);
-        }
-
-        [Fact]
-        public void TryGetHostDocumentPosition_CSharp_OnLeadingEdge()
-        {
-            // Arrange
-            var codeDoc = CreateCodeDocumentWithCSharpProjection(
-                razorSource: "Line 1\nLine 2 @{ var abc;\nvar def; }",
-                projectedCSharpSource: "\n// Prefix\n var abc;\nvar def; \n// Suffix",
-                new[] {
-                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
-                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
-                });
-
-            // Act
-            var result = RazorLanguageEndpoint.TryGetHostDocumentPosition(
-                codeDoc,
-                11, // @{|
-                out var hostDocumentPosition);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(1, hostDocumentPosition.Line);
-            Assert.Equal(9, hostDocumentPosition.Character);
-        }
-
-        [Fact]
-        public void TryGetHostDocumentPosition_CSharp_InMiddle()
-        {
-            // Arrange
-            var codeDoc = CreateCodeDocumentWithCSharpProjection(
-                razorSource: "Line 1\nLine 2 @{ var abc;\nvar def; }",
-                projectedCSharpSource: "\n// Prefix\n var abc;\nvar def; \n// Suffix",
-                new[] {
-                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
-                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
-                });
-
-            // Act
-            var result = RazorLanguageEndpoint.TryGetHostDocumentPosition(
-                codeDoc,
-                21, // |var def
-                out var hostDocumentPosition);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(2, hostDocumentPosition.Line);
-            Assert.Equal(0, hostDocumentPosition.Character);
-        }
-
-        [Fact]
-        public void TryGetHostDocumentPosition_CSharp_OnTrailingEdge()
-        {
-            // Arrange
-            var codeDoc = CreateCodeDocumentWithCSharpProjection(
-                razorSource: "Line 1\nLine 2 @{ var abc;\nvar def; }",
-                projectedCSharpSource: "\n// Prefix\n var abc;\nvar def; \n// Suffix",
-                new[] {
-                    new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
-                    new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
-                });
-
-            // Act
-            var result = RazorLanguageEndpoint.TryGetHostDocumentPosition(
-                codeDoc,
-                30, // def; |}
-                out var hostDocumentPosition);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(2, hostDocumentPosition.Line);
-            Assert.Equal(9, hostDocumentPosition.Character);
         }
 
         private (IReadOnlyList<ClassifiedSpanInternal> classifiedSpans, IReadOnlyList<TagHelperSpanInternal> tagHelperSpans) GetClassifiedSpans(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/14271

![basic-formatting](https://user-images.githubusercontent.com/1579269/72793253-155f2180-3bef-11ea-843b-469c008d74c0.gif)

- Basic support for Razor formatting
  o Indent Razor blocks
  o Indent Html tags
  o Indent Tag helpers
  o No support for C#, JavaScript or css formatting
- Added a custom `razor/rangeFormatting` command that the server can use to ask the client to format a range of the projected C# or HTML document
- Added `FormattingSpan` and its corresponding visitor to represent Razor understanding of indentation. This is currently almost the same as classified spans but will change in the future.
- Moved the document mapping code to a separate `RazorDocumentMappingService` service for ease of use
- Added support for calling Roslyn formatting APIs directly to format the backing C# document. This is currently not being used by the formatter but will be used in the future.
- Added necessary extension methods for convenience
- Some cleanup
- Added tests (a lot more coming soon)