### PR TITLE
Ensure result property always gets serialized

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Converters/ResponseRazorConverter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Converters/ResponseRazorConverter.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.JsonRpc.Client;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Converters
+{
+    internal class ResponseRazorConverter : JsonConverter<Response>
+    {
+        public override bool CanRead => false;
+        public override Response ReadJson(JsonReader reader, Type objectType, Response existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, Response value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+
+            writer.WritePropertyName("jsonrpc");
+            writer.WriteValue("2.0");
+
+            writer.WritePropertyName("id");
+            writer.WriteValue(value.Id);
+
+            writer.WritePropertyName("result");
+            // `null` is a valid value for some results, so we need to handle it properly
+            if (value.Result != null)
+            {
+                serializer.Serialize(writer, value.Result);
+            }
+            else
+            {
+                writer.WriteNull();
+            }
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Converters/ResponseRazorConverter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Converters/ResponseRazorConverter.cs
@@ -7,6 +7,8 @@ using OmniSharp.Extensions.JsonRpc.Client;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Converters
 {
+    // This is a temporary workaround for https://github.com/OmniSharp/csharp-language-server-protocol/issues/202
+    // The fix was not available on a non-alpha release, but this can be reverted once it is.
     internal class ResponseRazorConverter : JsonConverter<Response>
     {
         public override bool CanRead => false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,10 +19,9 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Editor.Razor;
-using System.Linq;
+using OmniSharp.Extensions.JsonRpc.Serialization.Converters;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharp.Extensions.LanguageServer.Server;
-using OmniSharp.Extensions.JsonRpc.Serialization.Converters;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/18370.

This is caused by https://github.com/OmniSharp/csharp-language-server-protocol/issues/202.

Basically the LSP spec (and the LSP package we're using on the TypeScript side) demand that a response contain either the `result` property or the `error` property. Currently Omnisharp isn't doing that. I'll eventually send them a PR with my suggested fix, but this will un-break us for now.