### PR TITLE
Fix Visual Studio LSP client not associating documents with their proper project.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultProjectResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultProjectResolver.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                 }
 
                 var projectDirectory = _filePathNormalizer.GetDirectory(projects[i].FilePath);
-                if (normalizedDocumentPath.StartsWith(projectDirectory))
+                if (normalizedDocumentPath.StartsWith(projectDirectory, FilePathComparison.Instance))
                 {
                     projectSnapshot = projects[i];
                     return true;


### PR DESCRIPTION
- For some reason VS is sending differently cased URLs to our language server for documents and projects. This ended up exposing a bug in our code where we weren't using the appropriate file comparer when resolving what project a document belonged to.
- Added a test specifically for windows to verify that casing is ignored in our project resolver.