### PR TITLE
Update FileSystemWatcher monitoring to listen for CreationTime changes.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _watcher = new FileSystemWatcher(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile)
             {
-                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                 IncludeSubdirectories = true,
             };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _watcher = new FileSystemWatcher(workspaceDirectory, ProjectFileExtensionPattern)
             {
-                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                 IncludeSubdirectories = true,
             };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 var extension = RazorFileExtensions[i];
                 var watcher = new FileSystemWatcher(workspaceDirectory, "*" + extension)
                 {
-                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                     IncludeSubdirectories = true,
                 };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectDocumentChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectDocumentChangeDetector.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             {
                 var documentWatcher = new FileSystemWatcher(projectDirectory, "*" + RazorFileExtensions[i])
                 {
-                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                     IncludeSubdirectories = true,
                 };
 


### PR DESCRIPTION
- Some clients "save" files by re-creating the files on every save. VS seems to be an example of this because our existing file watcher infrastructure wasn't picking up VisualStudio file system changes. I found that by also monitoring `CreationTime` we got the proper notifications.
- Can't add tests for these because we don't test the file watchers directly (they're an external component).