### PR TITLE
Skip Publish_CopiesStaticWebAssetsToDestinationFolder_PublishSingleFile.

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileDoesNotExist(result, PublishOutputPath, "AppWithPackageAndP2PReference.StaticWebAssets.xml");
         }
 
-        [ConditionalFact(Skip = "Flakey test: https://github.com/dotnet/aspnetcore/issues/18543")]
+        [ConditionalFact(Skip = "Flaky test: https://github.com/dotnet/aspnetcore/issues/18543")]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         [InitializeTestProject("AppWithPackageAndP2PReferenceAndRID", additionalProjects: new[] { "ClassLibrary", "ClassLibrary2" })]
         public async Task Publish_CopiesStaticWebAssetsToDestinationFolder_PublishSingleFile()

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileDoesNotExist(result, PublishOutputPath, "AppWithPackageAndP2PReference.StaticWebAssets.xml");
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Flakey test: https://github.com/dotnet/aspnetcore/issues/18543")]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         [InitializeTestProject("AppWithPackageAndP2PReferenceAndRID", additionalProjects: new[] { "ClassLibrary", "ClassLibrary2" })]
         public async Task Publish_CopiesStaticWebAssetsToDestinationFolder_PublishSingleFile()


### PR DESCRIPTION
This test has around a 50% pass rate. Always find myself having to retry builds to work around this. Skipping for now until flakyness can be resolved.

dotnet/AspNetCore#18543