### PR TITLE
Skip Publish_NoBuild_CopiesStaticWebAssetsToDestinationFolder.

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "PackageLibraryTransitiveDependency", "js", "pkg-transitive-dep.js"));
         }
 
-        [Fact]
+        [Fact(Skip = "Flaky test: https://github.com/dotnet/aspnetcore/issues/18561")]
         [InitializeTestProject("AppWithPackageAndP2PReference", additionalProjects: new[] { "ClassLibrary", "ClassLibrary2" })]
         public async Task Publish_NoBuild_CopiesStaticWebAssetsToDestinationFolder()
         {


### PR DESCRIPTION
- This test has around a pretty high failure rate. Always find myself having to retry builds to work around this. Skipping for now until flakyness can be resolved.

dotnet/aspnetcore#18561
