### PR TITLE
 Supply the `PropertyName` for Context TagHelper results.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor/ComponentTagHelperDescriptorProvider.cs
@@ -301,6 +301,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 b.Name = ComponentMetadata.ChildContent.ParameterAttributeName;
                 b.TypeName = typeof(string).FullName;
                 b.Metadata.Add(ComponentMetadata.Component.ChildContentParameterNameKey, bool.TrueString);
+                b.Metadata.Add(TagHelperMetadata.Common.PropertyName, b.Name);
 
                 if (childContentName == null)
                 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/CompletionsComponents.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/CompletionsComponents.test.ts
@@ -1,0 +1,56 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import { afterEach, before, beforeEach } from 'mocha';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    componentRoot,
+    pollUntil,
+    waitForProjectReady,
+} from './TestUtil';
+
+let counterDoc: vscode.TextDocument;
+let counterEditor: vscode.TextEditor;
+
+suite('Completions Components', () => {
+    before(async () => {
+        await waitForProjectReady(componentRoot);
+    });
+
+    beforeEach(async () => {
+        const counterPath = path.join(componentRoot, 'Components', 'Pages', 'Counter.razor');
+        counterDoc = await vscode.workspace.openTextDocument(counterPath);
+        counterEditor = await vscode.window.showTextDocument(counterDoc);
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await pollUntil(async () => {
+            await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+            if (vscode.window.visibleTextEditors.length === 0) {
+                return true;
+            }
+
+            return false;
+        }, /* timeout */ 3000, /* pollInterval */ 500, true /* suppress timeout */);
+    });
+
+    test('Can perform Completions on directive attributes', async () => {
+        const firstLine = new vscode.Position(1, 0);
+        await counterEditor.edit(edit => edit.insert(firstLine, '<Microsoft.AspNetCore.Components.Forms.EditForm OnV'));
+
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            counterDoc.uri,
+            new vscode.Position(1, 50));
+        const matchingCompletions = completions!.items
+            .filter(item => item.label === 'OnValidSubmit')
+            .map(item => item.label as string);
+
+        assert.deepEqual(matchingCompletions, ['OnValidSubmit']);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/14322

Not having this caused exceptions to be thrown downstream which resulted in no TagHelper Completions being available.