### PR TITLE
Add grammar support for Razor templates (@<p>...</p>).

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -9,6 +9,31 @@
       "include": "text.html.basic"
     }
   ],
+  "injections": {
+    "R:text.aspnetcorerazor": {
+      "patterns": [
+        {
+          "name": "meta.structure.template.razor",
+          "begin": "(@)(?=\\<)",
+          "beginCaptures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#transition"
+                }
+              ]
+            }
+          },
+          "patterns": [
+            {
+              "include": "#wellformed-html"
+            }
+          ],
+          "end": "(?<=\\>)"
+        }
+      ]
+    }
+  },
   "repository": {
     "razor-control-structures": {
       "patterns": [

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -4,6 +4,17 @@ patterns:
   - include: '#razor-control-structures'
   - include: 'text.html.basic'
 
+injections:
+  'R:text.aspnetcorerazor':
+    patterns:
+      - name: 'meta.structure.template.razor'
+        begin: '(@)(?=\<)'
+        beginCaptures:
+          1: { patterns: [ include: '#transition' ] }
+        patterns:
+          - include: '#wellformed-html'
+        end: '(?<=\>)'
+
 repository:
   razor-control-structures:
     patterns:

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/Directory.Build.props
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+<PropertyGroup>
+  <!--
+    The Oniguruma package for regex testing has its own Arcade & SDK independent build mechanisms that automatically look for hierarchical Directory.Build.props files.
+    Therefore, we have this file here in order to suppress the usage of the global SDK and arcade build system to enable yarn install to pass.
+
+    For context the Oniguruma contains C++ code that's dynamically compiled on install.
+  -->
+  <_SuppressSdkImports>true</_SuppressSdkImports>
+</PropertyGroup>
+</Project>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/GrammarTests.test.ts
@@ -24,6 +24,7 @@ import { RunModelDirectiveSuite } from './ModelDirective';
 import { RunNamespaceDirectiveSuite } from './NamespaceDirective';
 import { RunPageDirectiveSuite } from './PageDirective';
 import { RunRazorCommentSuite } from './RazorComment';
+import { RunRazorTemplateSuite } from './RazorTemplate';
 import { RunRemoveTagHelperDirectiveSuite } from './RemoveTagHelperDirective';
 import { RunSectionDirectiveSuite } from './SectionDirective';
 import { RunSwitchStatementSuite } from './SwitchStatement';
@@ -45,6 +46,7 @@ describe('Grammar tests', () => {
     RunImplicitExpressionSuite();
     RunCodeBlockSuite();
     RunRazorCommentSuite();
+    RunRazorTemplateSuite();
 
     // Directives
     RunCodeDirectiveSuite();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/RazorTemplate.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/RazorTemplate.ts
@@ -1,0 +1,193 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertMatchesSnapshot } from './infrastructure/TestUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunRazorTemplateSuite() {
+    describe('Razor templates @<p>....</p>', () => {
+        it('Malformed', async () => {
+            await assertMatchesSnapshot('@ <p></p>');
+        });
+
+        it('Incomplete', async () => {
+            await assertMatchesSnapshot('@<strong>');
+        });
+
+        it('Empty', async () => {
+            await assertMatchesSnapshot('@<p></p>');
+        });
+
+        it('Void', async () => {
+            await assertMatchesSnapshot('@<hr>');
+        });
+
+        it('Self-closing', async () => {
+            await assertMatchesSnapshot('@<hr>');
+        });
+
+        it('Single line local variable', async () => {
+            await assertMatchesSnapshot('@{ Action<object> abc = @<div>Hello World</p>; }');
+        });
+
+        it('Nested template', async () => {
+            await assertMatchesSnapshot('@{ Action<object> abc = @<div>@{ Action<object> def = @<p>Hello World</p>; }</div>; }');
+        });
+
+        it('Complex HTML tag structure non-template', async () => {
+            await assertMatchesSnapshot('@{@<p><input      /><strong>Hello <hr/> <br> World</strong></p>}');
+        });
+
+        it('Nested template in @code directive', async () => {
+            await assertMatchesSnapshot(
+                `@code {
+    public Action<int> GetTemplate()
+    {
+        Action<int> template = @<p>@item</p>;
+        return template;
+    }
+}`);
+        });
+
+        it('Nested template in @functions directive', async () => {
+            await assertMatchesSnapshot(
+                `@functions {
+    public Action<int> GetTemplate()
+    {
+        Action<int> template = @<p>@item</p>;
+        return template;
+    }
+}`);
+        });
+
+        it('Nested template in implicit expression', async () => {
+            await assertMatchesSnapshot(
+                `@CallSomeMethod(@<p>
+    The Template
+</p>)`);
+        });
+
+        it('Nested template in explicit expression', async () => {
+            await assertMatchesSnapshot(
+                `@(CallSomeMethod(@<p>
+    The Template
+</p>))`);
+        });
+
+        it('Nested for statement with templates', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    for (var i = 0; i % 2 == 0; i++)
+    {
+        Action<int> template = @<p>@item</p>;
+        @template(i)
+    }
+}`);
+        });
+
+        it('Nested foreach statement with template', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    foreach (var person in people)
+    {
+        Action<int> template = @<p>@item</p>;
+        @template(i)
+    }
+}`);
+        });
+
+        it('Nested do while statement with template', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    var i = 0;
+    do
+    {
+        Action<int> template = @<p>@item</p>;
+        @template(i)
+    } while (i++ != 10);
+}`);
+        });
+
+        it('Nested while statement with template', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    var i = 0;
+    while (i++ != 10)
+    {
+        Action<int> template = @<p>@item</p>;
+        @template(i)
+    }
+}`);
+        });
+
+        it('Nested lock statement with template', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    lock (someObject)
+    {
+        Action<string> template = @<p>@item</p>;
+        @template(someObject.ToString())
+    }
+}`);
+        });
+
+        it('Nested using statement with template', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    using (someDisposable)
+    {
+        Action<int> template = @<p>@item</p>;
+    }
+}`);
+        });
+
+        it('Nested try statement with template', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    try
+    {
+        Action<int> template = @<p>@item</p>;
+    } catch (Exception ex){}
+}`);
+        });
+
+        it('Nested switch statement with template', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    switch (something)
+    {
+        case true:
+            Action<int> template = @<p>@item</p>;
+            break;
+    }
+}`);
+        });
+
+        it('Complex with various nested statements', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    if (true) {
+        <div>
+        @using (someDisposable) {
+            <p>Foo!</p>
+            var x = 123;
+            while (i++ % 2 == 0)
+            {
+                Action<int> template = @<p>
+                    @item
+
+                    @{
+                        Action anotherTemplate = @<strong>LOUD</strong>;
+                    }
+                    </p>;
+            }
+        }
+        </div>
+    }
+}`);
+        });
+    });
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/RazorTemplate.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/RazorTemplate.ts
@@ -13,6 +13,10 @@ export function RunRazorTemplateSuite() {
             await assertMatchesSnapshot('@ <p></p>');
         });
 
+        it('Malformed attributes', async () => {
+            await assertMatchesSnapshot('@<p class="></p>');
+        });
+
         it('Incomplete', async () => {
             await assertMatchesSnapshot('@<strong>');
         });
@@ -26,7 +30,7 @@ export function RunRazorTemplateSuite() {
         });
 
         it('Self-closing', async () => {
-            await assertMatchesSnapshot('@<hr>');
+            await assertMatchesSnapshot('@<hr class="stuff" />');
         });
 
         it('Single line local variable', async () => {
@@ -34,7 +38,7 @@ export function RunRazorTemplateSuite() {
         });
 
         it('Nested template', async () => {
-            await assertMatchesSnapshot('@{ Action<object> abc = @<div>@{ Action<object> def = @<p>Hello World</p>; }</div>; }');
+            await assertMatchesSnapshot('@{ Action<object> abc = @<div>@{ Action<object> def = @<p class="john" onclick=\'someMethod\'>Hello World</p>; }</div>; }');
         });
 
         it('Complex HTML tag structure non-template', async () => {
@@ -65,7 +69,7 @@ export function RunRazorTemplateSuite() {
 
         it('Nested template in implicit expression', async () => {
             await assertMatchesSnapshot(
-                `@CallSomeMethod(@<p>
+                `@CallSomeMethod(@<p style="margin:1px;">
     The Template
 </p>)`);
         });
@@ -128,7 +132,7 @@ export function RunRazorTemplateSuite() {
                 `@{
     lock (someObject)
     {
-        Action<string> template = @<p>@item</p>;
+        Action<string> template = @<p class="world">@item</p>;
         @template(someObject.ToString())
     }
 }`);
@@ -180,7 +184,7 @@ export function RunRazorTemplateSuite() {
                     @item
 
                     @{
-                        Action anotherTemplate = @<strong>LOUD</strong>;
+                        Action anotherTemplate = @<strong class='really loud!'>LOUD</strong>;
                     }
                     </p>;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -4631,7 +4631,7 @@ Line:                     @{
  - token from 20 to 21 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
  - token from 21 to 22 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.razor.directive.codeblock.open
 
-Line:                         Action anotherTemplate = @<strong>LOUD</strong>;
+Line:                         Action anotherTemplate = @<strong class='really loud!'>LOUD</strong>;
  - token from 0 to 24 (                        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
  - token from 24 to 30 (Action) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, storage.type.cs
  - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
@@ -4642,12 +4642,18 @@ Line:                         Action anotherTemplate = @<strong>LOUD</strong>;
  - token from 49 to 50 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, keyword.control.cshtml.transition
  - token from 50 to 51 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
  - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
- - token from 57 to 58 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 58 to 62 (LOUD) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor
- - token from 62 to 64 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 64 to 70 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
- - token from 70 to 71 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 71 to 72 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.terminator.statement.cs
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor
+ - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 64 to 65 (') with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.begin.html
+ - token from 65 to 77 (really loud!) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html
+ - token from 77 to 78 (') with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.end.html
+ - token from 78 to 79 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 79 to 83 (LOUD) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor
+ - token from 83 to 85 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 85 to 91 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
+ - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 92 to 93 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.terminator.statement.cs
 
 Line:                     }
  - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
@@ -4714,6 +4720,19 @@ exports[`Grammar tests Razor templates @<p>....</p> Malformed 1`] = `
  - token from 5 to 7 (</) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.begin.html
  - token from 7 to 8 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, entity.name.tag.html
  - token from 8 to 9 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Malformed attributes 1`] = `
+"Line: @<p class=\\"></p>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (<) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
+ - token from 2 to 3 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, entity.name.tag.html
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html
+ - token from 4 to 9 (class) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 9 to 10 (=) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 10 to 11 (\\") with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 11 to 17 (></p>) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.class.html, string.quoted.double.html
 "
 `;
 
@@ -4948,7 +4967,7 @@ Line:     {
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
  - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
-Line:         Action<string> template = @<p>@item</p>;
+Line:         Action<string> template = @<p class=\\"world\\">@item</p>;
  - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
  - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
  - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
@@ -4962,13 +4981,19 @@ Line:         Action<string> template = @<p>@item</p>;
  - token from 34 to 35 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
  - token from 35 to 36 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
  - token from 36 to 37 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 37 to 38 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 38 to 39 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 39 to 43 (item) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 43 to 45 (</) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 45 to 46 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 46 to 47 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 47 to 48 (;) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 38 to 43 (class) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 43 to 44 (=) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 44 to 45 (\\") with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 45 to 50 (world) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html
+ - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 51 to 52 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 52 to 53 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 53 to 57 (item) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 57 to 59 (</) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 59 to 60 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 60 to 61 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 61 to 62 (;) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(someObject.ToString())
  - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
@@ -5052,7 +5077,7 @@ Line: }
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested template 1`] = `
-"Line: @{ Action<object> abc = @<div>@{ Action<object> def = @<p>Hello World</p>; }</div>; }
+"Line: @{ Action<object> abc = @<div>@{ Action<object> def = @<p class=\\"john\\" onclick='someMethod'>Hello World</p>; }</div>; }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
  - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
@@ -5084,20 +5109,32 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested template 1`] = `
  - token from 54 to 55 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, keyword.control.cshtml.transition
  - token from 55 to 56 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
  - token from 56 to 57 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
- - token from 57 to 58 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 58 to 69 (Hello World) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor
- - token from 69 to 71 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 71 to 72 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
- - token from 72 to 73 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 73 to 74 (;) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.terminator.statement.cs
- - token from 74 to 75 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
- - token from 75 to 76 (}) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.razor.directive.codeblock.close
- - token from 76 to 78 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 78 to 81 (div) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
- - token from 81 to 82 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 82 to 83 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
- - token from 83 to 84 ( ) with scopes text.aspnetcorerazor
- - token from 84 to 85 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor
+ - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 64 to 65 (\\") with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 65 to 69 (john) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html
+ - token from 69 to 70 (\\") with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 70 to 71 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor
+ - token from 71 to 78 (onclick) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, entity.other.attribute-name.html
+ - token from 78 to 79 (=) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, punctuation.separator.key-value.html
+ - token from 79 to 80 (') with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, punctuation.definition.string.begin.html
+ - token from 80 to 90 (someMethod) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, source.js, variable.other.readwrite.js
+ - token from 90 to 91 (') with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, punctuation.definition.string.end.html, source.js
+ - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 92 to 103 (Hello World) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor
+ - token from 103 to 105 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 105 to 106 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
+ - token from 106 to 107 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 107 to 108 (;) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.terminator.statement.cs
+ - token from 108 to 109 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
+ - token from 109 to 110 (}) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.razor.directive.codeblock.close
+ - token from 110 to 112 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 112 to 115 (div) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
+ - token from 115 to 116 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 116 to 117 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+ - token from 117 to 118 ( ) with scopes text.aspnetcorerazor
+ - token from 118 to 119 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -5249,14 +5286,20 @@ Line: </p>))
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested template in implicit expression 1`] = `
-"Line: @CallSomeMethod(@<p>
+"Line: @CallSomeMethod(@<p style=\\"margin:1px;\\">
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
  - token from 1 to 15 (CallSomeMethod) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
  - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
  - token from 16 to 17 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, keyword.control.cshtml.transition
  - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, punctuation.definition.tag.begin.html
  - token from 18 to 19 (p) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, entity.name.tag.html
- - token from 19 to 20 (>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor
+ - token from 20 to 25 (style) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, meta.attribute.style.html, entity.other.attribute-name.html
+ - token from 25 to 26 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, meta.attribute.style.html, punctuation.separator.key-value.html
+ - token from 26 to 27 (\\") with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, meta.attribute.style.html, meta.embedded.line.css, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 27 to 38 (margin:1px;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, meta.attribute.style.html, meta.embedded.line.css, string.quoted.double.html, source.css
+ - token from 38 to 39 (\\") with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, meta.attribute.style.html, meta.embedded.line.css, string.quoted.double.html, punctuation.definition.string.end.html, source.css
+ - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, punctuation.definition.tag.end.html
 
 Line:     The Template
  - token from 0 to 17 (    The Template) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor
@@ -5444,11 +5487,18 @@ Line: }
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Self-closing 1`] = `
-"Line: @<hr>
+"Line: @<hr class=\\"stuff\\" />
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
  - token from 1 to 2 (<) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
  - token from 2 to 4 (hr) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, entity.name.tag.html
- - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
+ - token from 4 to 5 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html
+ - token from 5 to 10 (class) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 11 to 12 (\\") with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 12 to 17 (stuff) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, meta.attribute.class.html, string.quoted.double.html
+ - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html
+ - token from 19 to 21 (/>) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -4494,6 +4494,999 @@ exports[`Grammar tests Razor comment Single line 1`] = `
 "
 `;
 
+exports[`Grammar tests Razor templates @<p>....</p> Complex HTML tag structure non-template 1`] = `
+"Line: @{@<p><input      /><strong>Hello <hr/> <br> World</strong></p>}
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 3 to 4 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
+ - token from 4 to 5 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 6 to 7 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
+ - token from 7 to 12 (input) with scopes text.aspnetcorerazor, entity.name.tag.html
+ - token from 12 to 18 (      ) with scopes text.aspnetcorerazor
+ - token from 18 to 20 (/>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 20 to 21 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
+ - token from 21 to 27 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
+ - token from 27 to 28 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 28 to 34 (Hello ) with scopes text.aspnetcorerazor
+ - token from 34 to 35 (<) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
+ - token from 35 to 37 (hr) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, entity.name.tag.html
+ - token from 37 to 39 (/>) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
+ - token from 41 to 43 (br) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
+ - token from 44 to 50 ( World) with scopes text.aspnetcorerazor
+ - token from 50 to 52 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
+ - token from 52 to 58 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
+ - token from 58 to 59 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 59 to 61 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
+ - token from 61 to 62 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
+ - token from 62 to 63 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 63 to 64 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Complex with various nested statements 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     if (true) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <div>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:         @using (someDisposable) {
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:             <p>Foo!</p>
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:             var x = 123;
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:             while (i++ % 2 == 0)
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+
+Line:             {
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:                 Action<int> template = @<p>
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 22 (Action) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 22 to 23 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 23 to 26 (int) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 28 to 36 (template) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 37 to 38 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 41 to 42 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+
+Line:                     @item
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 20 to 21 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 21 to 25 (item) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+
+Line:                     @{
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 20 to 21 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 21 to 22 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.razor.directive.codeblock.open
+
+Line:                         Action anotherTemplate = @<strong>LOUD</strong>;
+ - token from 0 to 24 (                        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 24 to 30 (Action) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, storage.type.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 31 to 46 (anotherTemplate) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.variable.local.cs
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 47 to 48 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.operator.assignment.cs
+ - token from 48 to 49 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 49 to 50 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 50 to 51 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
+ - token from 57 to 58 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 58 to 62 (LOUD) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor
+ - token from 62 to 64 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 64 to 70 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
+ - token from 70 to 71 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 71 to 72 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.terminator.statement.cs
+
+Line:                     }
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 20 to 21 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.razor.directive.codeblock.close
+
+Line:                     </p>;
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 20 to 22 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 22 to 23 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 24 to 25 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:             }
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line:         }
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line:         </div>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Empty 1`] = `
+"Line: @<p></p>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (<) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
+ - token from 2 to 3 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, entity.name.tag.html
+ - token from 3 to 4 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
+ - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.begin.html
+ - token from 6 to 7 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, entity.name.tag.html
+ - token from 7 to 8 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Incomplete 1`] = `
+"Line: @<strong>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (<) with scopes text.aspnetcorerazor, meta.tag.inline.strong.start.html, punctuation.definition.tag.begin.html
+ - token from 2 to 8 (strong) with scopes text.aspnetcorerazor, meta.tag.inline.strong.start.html, entity.name.tag.html
+ - token from 8 to 9 (>) with scopes text.aspnetcorerazor, meta.tag.inline.strong.start.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Malformed 1`] = `
+"Line: @ <p></p>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 ( ) with scopes text.aspnetcorerazor
+ - token from 2 to 3 (<) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
+ - token from 3 to 4 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
+ - token from 5 to 7 (</) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.begin.html
+ - token from 7 to 8 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, entity.name.tag.html
+ - token from 8 to 9 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested do while statement with template 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     var i = 0;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+
+Line:     do
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:         @template(i)
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+
+Line:     } while (i++ != 10);
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.terminator.statement.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested for statement with templates 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     for (var i = 0; i % 2 == 0; i++)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.control.loop.for.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.other.var.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.arithmetic.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.comparison.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.increment.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:         @template(i)
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested foreach statement with template 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     foreach (var person in people)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.other.var.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, entity.name.variable.local.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.in.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:         @template(i)
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested lock statement with template 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     lock (someObject)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.other.lock.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.open.cs
+ - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.statement.lock.razor, variable.other.readwrite.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<string> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 21 (string) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 23 to 31 (template) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 34 to 35 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 35 to 36 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 36 to 37 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 37 to 38 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 38 to 39 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 39 to 43 (item) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 43 to 45 (</) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 45 to 46 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 46 to 47 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 47 to 48 (;) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:         @template(someObject.ToString())
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 28 (someObject) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 29 to 37 (ToString) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 37 to 38 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 38 to 39 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 39 to 40 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested switch statement with template 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     switch (something)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.control.switch.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
+
+Line:         case true:
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
+
+Line:             Action<int> template = @<p>@item</p>;
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 18 (Action) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, storage.type.cs
+ - token from 18 to 19 (<) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.begin.cs
+ - token from 19 to 22 (int) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.type.cs
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.end.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 24 to 32 (template) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.variable.local.cs
+ - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 33 to 34 (=) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.assignment.cs
+ - token from 34 to 35 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 36 to 37 (<) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 37 to 38 (p) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, entity.name.tag.html
+ - token from 38 to 39 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 40 to 44 (item) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 44 to 46 (</) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 46 to 47 (p) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, entity.name.tag.html
+ - token from 47 to 48 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 48 to 49 (;) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+
+Line:             break;
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested template 1`] = `
+"Line: @{ Action<object> abc = @<div>@{ Action<object> def = @<p>Hello World</p>; }</div>; }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
+ - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, storage.type.cs
+ - token from 9 to 10 (<) with scopes text.aspnetcorerazor, punctuation.definition.typeparameters.begin.cs
+ - token from 10 to 16 (object) with scopes text.aspnetcorerazor, keyword.type.cs
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, punctuation.definition.typeparameters.end.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor
+ - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor
+ - token from 22 to 23 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor
+ - token from 24 to 25 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 30 to 31 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.razor.directive.codeblock.open
+ - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
+ - token from 33 to 39 (Action) with scopes text.aspnetcorerazor, meta.structure.template.razor, storage.type.cs
+ - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.typeparameters.begin.cs
+ - token from 40 to 46 (object) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.type.cs
+ - token from 46 to 47 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.typeparameters.end.cs
+ - token from 47 to 48 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
+ - token from 48 to 51 (def) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.variable.local.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
+ - token from 52 to 53 (=) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.operator.assignment.cs
+ - token from 53 to 54 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
+ - token from 54 to 55 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 55 to 56 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 56 to 57 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
+ - token from 57 to 58 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 58 to 69 (Hello World) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor
+ - token from 69 to 71 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 71 to 72 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
+ - token from 72 to 73 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 73 to 74 (;) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.terminator.statement.cs
+ - token from 74 to 75 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
+ - token from 75 to 76 (}) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.razor.directive.codeblock.close
+ - token from 76 to 78 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 78 to 81 (div) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
+ - token from 81 to 82 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 82 to 83 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+ - token from 83 to 84 ( ) with scopes text.aspnetcorerazor
+ - token from 84 to 85 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested template in @code directive 1`] = `
+"Line: @code {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
+
+Line:     public Action<int> GetTemplate()
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 10 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 11 to 17 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
+ - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 18 to 21 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 23 to 34 (GetTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
+ - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+
+Line:         return template;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 14 (return) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.flow.return.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 15 to 23 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested template in @functions directive 1`] = `
+"Line: @functions {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
+
+Line:     public Action<int> GetTemplate()
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 10 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 11 to 17 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
+ - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 18 to 21 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 23 to 34 (GetTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
+ - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+
+Line:         return template;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 14 (return) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.flow.return.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 15 to 23 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested template in explicit expression 1`] = `
+"Line: @(CallSomeMethod(@<p>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 2 to 16 (CallSomeMethod) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 17 to 18 (@) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 18 to 19 (<) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 19 to 20 (p) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, meta.structure.template.razor, entity.name.tag.html
+ - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, meta.structure.template.razor, punctuation.definition.tag.end.html
+
+Line:     The Template
+ - token from 0 to 17 (    The Template) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, meta.structure.template.razor
+
+Line: </p>))
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 2 to 3 (p) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, meta.structure.template.razor, entity.name.tag.html
+ - token from 3 to 4 (>) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 5 to 6 ()) with scopes text.aspnetcorerazor, meta.expression.explicit.cshtml, keyword.control.cshtml
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested template in implicit expression 1`] = `
+"Line: @CallSomeMethod(@<p>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 15 (CallSomeMethod) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 16 to 17 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 18 to 19 (p) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, entity.name.tag.html
+ - token from 19 to 20 (>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, punctuation.definition.tag.end.html
+
+Line:     The Template
+ - token from 0 to 17 (    The Template) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor
+
+Line: </p>)
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 2 to 3 (p) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, entity.name.tag.html
+ - token from 3 to 4 (>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested try statement with template 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     try
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:     } catch (Exception ex){}
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.statement.catch.razor, storage.type.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
+ - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested using statement with template 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     using (someDisposable)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Nested while statement with template 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+
+Line:     var i = 0;
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+
+Line:     while (i++ != 10)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<p>@item</p>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+
+Line:         @template(i)
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Self-closing 1`] = `
+"Line: @<hr>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (<) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
+ - token from 2 to 4 (hr) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Single line local variable 1`] = `
+"Line: @{ Action<object> abc = @<div>Hello World</p>; }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
+ - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, storage.type.cs
+ - token from 9 to 10 (<) with scopes text.aspnetcorerazor, punctuation.definition.typeparameters.begin.cs
+ - token from 10 to 16 (object) with scopes text.aspnetcorerazor, keyword.type.cs
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, punctuation.definition.typeparameters.end.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor
+ - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor
+ - token from 22 to 23 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor
+ - token from 24 to 25 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 30 to 41 (Hello World) with scopes text.aspnetcorerazor, meta.structure.template.razor
+ - token from 41 to 43 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 43 to 44 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
+ - token from 44 to 45 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 45 to 49 (; }) with scopes text.aspnetcorerazor, meta.structure.template.razor
+"
+`;
+
+exports[`Grammar tests Razor templates @<p>....</p> Void 1`] = `
+"Line: @<hr>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 1 to 2 (<) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
+ - token from 2 to 4 (hr) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
+"
+`;
+
 exports[`Grammar tests Transitions Escaped transitions 1`] = `
 "Line: @@
  - token from 0 to 2 (@@) with scopes text.aspnetcorerazor, constant.character.escape.razor.transition


### PR DESCRIPTION
- Utilized VSCode's grammar injection feature to enable Razor templates. Basically what's going on in this changeset is we describe an "injection" into the aspnetcorerazor grammar that states (`R:text.aspnetcorerazor`) if a previous Razor rule can't fulfill the current set of tokens to then allow our template rules to take precedence. This ends up also injecting itself in nested C# statements where we'd expect Razor templates.
- Arcade must have made a change restricting the VSCode grammar tests project from installing/building successfully on my box and I found that the way the SDK was being imported was breaking the way the Oniguruma library would compile itself. This didn't seem to happen on the CI but in an effort to ensure it can build everywhere I added a Directory.Build.props file that purposefully suppresses SDK imports (since it's an npmproj anyways) to avoid breaking the C++ build that takes place on install.
- Added tests to validate the new Razor template syntax.
- Updated snapshots for tests.

aspnet/AspNetCore#14287