### PR TITLE
Add grammar support for Razor markup in functions.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -69,6 +69,7 @@
       "name": "keyword.control.cshtml.transition"
     },
     "razor-codeblock": {
+      "name": "meta.structure.razor.codeblock",
       "begin": "(@)(\\{)",
       "beginCaptures": {
         "1": {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -32,6 +32,29 @@
           "end": "(?<=\\>)"
         }
       ]
+    },
+    "L:meta.structure.razor.codeblock - (meta.statement | string.quoted | comment), L:meta.structure.razor.directive.codeblock - (meta.statement | string.quoted | comment)": {
+      "patterns": [
+        {
+          "begin": "(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.curlybrace.open.cs"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#razor-codeblock-body"
+            }
+          ],
+          "end": "(\\})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.curlybrace.close.cs"
+            }
+          }
+        }
+      ]
     }
   },
   "repository": {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -37,6 +37,7 @@ repository:
 # ----------  Razor Code Block ------------
 
   razor-codeblock:
+    name: 'meta.structure.razor.codeblock'
     begin: '(@)(\{)'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
@@ -141,12 +142,12 @@ repository:
     patterns:
       - include: '#wellformed-html'
       - include: '$self'
-    end: (?=\</)
+    end: '(?=\</)'
 
   balanced-open-close-tag-end:
     match: '(</)(!?)([^/\s>]+)\s*(>)'
     captures:
-      1: { name: 'punctuation.definition.tag.begin.html'}
+      1: { name: 'punctuation.definition.tag.begin.html' }
       2: { name: 'constant.character.escape.razor.tagHelperOptOut' }
       3: { name: 'entity.name.tag.html' }
       4: { name: 'punctuation.definition.tag.end.html' }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -14,6 +14,16 @@ injections:
         patterns:
           - include: '#wellformed-html'
         end: '(?<=\>)'
+  'L:meta.structure.razor.codeblock - (meta.statement | string.quoted | comment), L:meta.structure.razor.directive.codeblock - (meta.statement | string.quoted | comment)':
+    patterns:
+      - begin: '(\{)'
+        beginCaptures:
+          1: { name: 'punctuation.curlybrace.open.cs' }
+        patterns:
+          - include: '#razor-codeblock-body'
+        end: '(\})'
+        endCaptures:
+          1: { name: 'punctuation.curlybrace.close.cs' }
 
 repository:
   razor-control-structures:

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeBlock.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeBlock.ts
@@ -87,11 +87,27 @@ export function RunCodeBlockSuite() {
     @: <strong> <-- This is incomplete @DateTime.Now
 
     <input class="hello world">
+
+    void SomeMethod(int value)
+    {
+        Action<int> template = @<strong>Value: @item</strong>;
+        <section>
+            This section is rendered when called: @template(1337)
+        </section>
+    }
+
     <p>aHello</p>
 
     if (true) {
         <p>alksdjfl</p>
     }
+}`);
+        });
+
+        it('Nested local function with markup', async () => {
+            await assertMatchesSnapshot(
+                `@{
+    void SomeMethod() { <p class="priority"><strong>Hello World</strong></p> }
 }`);
         });
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeDirective.ts
@@ -21,6 +21,17 @@ export function RunCodeDirectiveSuite() {
             await assertMatchesSnapshot('@code { public void Foo() {} }');
         });
 
+        it('Single-line comment with curly braces', async () => {
+            await assertMatchesSnapshot(`
+@code {
+    // { var ThisShouldNotBeCSharp = true; }
+}`);
+        });
+
+        it('Multi-line comment with curly braces', async () => {
+            await assertMatchesSnapshot('@code { /* { var ThisShouldNotBeCSharp = true; } */ }');
+        });
+
         it('Multi line', async () => {
             await assertMatchesSnapshot(
                 `@code {
@@ -28,7 +39,27 @@ export function RunCodeDirectiveSuite() {
 
     private void IncrementCount()
     {
+        var someString = "{ var ThisShouldNotBeCSharp = true; }";
         currentCount++;
+    }
+}`);
+        });
+
+        it('With Razor and markup', async () => {
+            await assertMatchesSnapshot(
+                `@code {
+    private void SomeMethod()
+    {
+        <p>This method <strong>is really</strong> nice!
+
+            @if(true) {
+                <input type="checkbox" value="true" name="Something" />
+            }
+        </p>
+
+        @DateTime.Now
+
+        <input type="hidden" value=" { true }" name="Something">
     }
 }`);
         });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/FunctionsDirective.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/FunctionsDirective.ts
@@ -21,6 +21,17 @@ export function RunFunctionsDirectiveSuite() {
             await assertMatchesSnapshot('@functions { public void Foo() {} }');
         });
 
+        it('Single-line comment with curly braces', async () => {
+            await assertMatchesSnapshot(`
+@functions {
+    // { var ThisShouldNotBeCSharp = true; }
+}`);
+        });
+
+        it('Multi-line comment with curly braces', async () => {
+            await assertMatchesSnapshot('@functions { /* { var ThisShouldNotBeCSharp = true; } */ }');
+        });
+
         it('Multi line', async () => {
             await assertMatchesSnapshot(
                 `@functions {
@@ -28,7 +39,27 @@ export function RunFunctionsDirectiveSuite() {
 
     private void IncrementCount()
     {
+        var someString = "{ var ThisShouldNotBeCSharp = true; }";
         currentCount++;
+    }
+}`);
+        });
+
+        it('With Razor and markup', async () => {
+            await assertMatchesSnapshot(
+                `@functions {
+    private void SomeMethod()
+    {
+        <p>This method <strong>is really</strong> nice!
+
+            @if(true) {
+                <input type="checkbox" value="true" name="Something" />
+            }
+        </p>
+
+        @DateTime.Now
+
+        <input type="hidden" value=" { true }" name="Something">
     }
 }`);
         });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -3513,156 +3513,156 @@ exports[`Grammar tests Implicit Expressions Single line simple 1`] = `
 
 exports[`Grammar tests Razor code blocks @{ ... } Complex HTML tag structures 1`] = `
 "Line: @{<p><input      /><strong>Hello <hr/> <br> World</strong></p>}
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 3 to 4 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 4 to 5 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 5 to 6 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 6 to 11 (input) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 11 to 17 (      ) with scopes text.aspnetcorerazor
- - token from 17 to 19 (/>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 19 to 20 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 20 to 26 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 26 to 27 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 27 to 33 (Hello ) with scopes text.aspnetcorerazor
- - token from 33 to 34 (<) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
- - token from 34 to 36 (hr) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, entity.name.tag.html
- - token from 36 to 38 (/>) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
- - token from 38 to 39 ( ) with scopes text.aspnetcorerazor
- - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
- - token from 40 to 42 (br) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, entity.name.tag.html
- - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
- - token from 43 to 49 ( World) with scopes text.aspnetcorerazor
- - token from 49 to 51 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 57 to 58 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 58 to 60 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 60 to 61 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 61 to 62 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 62 to 63 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 3 to 4 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 5 to 6 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 6 to 11 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 11 to 17 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 17 to 19 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 19 to 20 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 20 to 26 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 27 to 33 (Hello ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 33 to 34 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
+ - token from 34 to 36 (hr) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, entity.name.tag.html
+ - token from 36 to 38 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
+ - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
+ - token from 40 to 42 (br) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, entity.name.tag.html
+ - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
+ - token from 43 to 49 ( World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 49 to 51 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 57 to 58 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 58 to 60 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 60 to 61 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 61 to 62 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 62 to 63 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Complex with various nested statements 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     if (true) {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <div>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:         @using (someDisposable) {
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
- - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
- - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
- - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:             <p>Foo!</p>
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:             var x = 123;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:             while (i++ % 2 == 0)
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
- - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
 
 Line:             {
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:                 <strong>Bar</strong>
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 17 to 23 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 24 to 27 (Bar) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 27 to 29 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 29 to 35 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 35 to 36 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 17 to 23 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 24 to 27 (Bar) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 27 to 29 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 29 to 35 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 35 to 36 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:             }
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:         }
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:         </div>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Empty code block 1`] = `
 "Line: @{}
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Incomplete code block 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 "
 `;
 
@@ -3675,778 +3675,778 @@ exports[`Grammar tests Razor code blocks @{ ... } Malformed code block 1`] = `
 
 exports[`Grammar tests Razor code blocks @{ ... } Multi line complex 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var x = true;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (x) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
- - token from 12 to 16 (true) with scopes text.aspnetcorerazor, constant.language.boolean.true.cs
- - token from 16 to 17 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 12 to 16 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.language.boolean.true.cs
+ - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
 
 Line:     <text>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 10 (<text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.open
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 10 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.open
 
 Line:         @{
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 9 to 10 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 9 to 10 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:             @DateTime.Now
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor
- - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 13 to 21 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 21 to 22 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 22 to 25 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 13 to 21 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 21 to 22 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.expression.implicit.cshtml
+ - token from 22 to 25 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
 
 Line:             @{
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor
- - token from 12 to 13 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 13 to 14 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 13 to 14 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:                 @{
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor
- - token from 16 to 17 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 17 to 18 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+ - token from 16 to 17 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 17 to 18 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line: 
- - token from 0 to 1 () with scopes text.aspnetcorerazor
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock
 
 Line:                 }
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor
- - token from 16 to 17 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+ - token from 16 to 17 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 
 Line:             }
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor
- - token from 12 to 13 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 
 Line:         }
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 
 Line:     </text>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 11 (</text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.close
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 11 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.close
 
 Line: 
- - token from 0 to 1 () with scopes text.aspnetcorerazor
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
 
 Line:     <p></p>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 5 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 5 to 6 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 6 to 7 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 7 to 9 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 5 to 6 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 6 to 7 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 7 to 9 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
 
 Line: <p class=\\"hello <world></p>\\" @DateTime.Now> Foo<strong @{ <text> can't believe this works </text>}>Bar</strong> Baz
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 1 to 2 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
- - token from 3 to 8 (class) with scopes text.aspnetcorerazor, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 8 to 9 (=) with scopes text.aspnetcorerazor, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 9 to 10 (\\") with scopes text.aspnetcorerazor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 10 to 27 (hello <world></p>) with scopes text.aspnetcorerazor, meta.attribute.class.html, string.quoted.double.html
- - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor
- - token from 29 to 30 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 30 to 38 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 38 to 39 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 39 to 42 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
- - token from 42 to 43 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 43 to 47 ( Foo) with scopes text.aspnetcorerazor
- - token from 47 to 48 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 48 to 54 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 54 to 55 ( ) with scopes text.aspnetcorerazor
- - token from 55 to 56 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 56 to 57 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 57 to 58 ( ) with scopes text.aspnetcorerazor
- - token from 58 to 64 (<text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.open
- - token from 64 to 90 ( can't believe this works ) with scopes text.aspnetcorerazor
- - token from 90 to 97 (</text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.close
- - token from 97 to 98 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
- - token from 98 to 99 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 99 to 102 (Bar) with scopes text.aspnetcorerazor
- - token from 102 to 104 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 104 to 110 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 110 to 111 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 111 to 116 ( Baz) with scopes text.aspnetcorerazor
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 1 to 2 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 3 to 8 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 8 to 9 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 9 to 10 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 10 to 27 (hello <world></p>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html
+ - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 29 to 30 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 30 to 38 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 38 to 39 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml
+ - token from 39 to 42 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 43 to 47 ( Foo) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 47 to 48 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 48 to 54 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 54 to 55 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 55 to 56 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 56 to 57 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+ - token from 58 to 64 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.open
+ - token from 64 to 90 ( can't believe this works ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+ - token from 90 to 97 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.close
+ - token from 97 to 98 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
+ - token from 98 to 99 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 99 to 102 (Bar) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 102 to 104 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 104 to 110 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 110 to 111 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 111 to 116 ( Baz) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
 
 Line:         <p class=\\"hello world\\">
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
- - token from 11 to 16 (class) with scopes text.aspnetcorerazor, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 29 (hello world) with scopes text.aspnetcorerazor, meta.attribute.class.html, string.quoted.double.html
- - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 30 to 31 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 11 to 16 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 18 to 29 (hello world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html
+ - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
 
 Line:             Below is an incomplete tag
- - token from 0 to 39 (            Below is an incomplete tag) with scopes text.aspnetcorerazor
+ - token from 0 to 39 (            Below is an incomplete tag) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
 
 Line:             </strong>
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor
- - token from 12 to 14 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 14 to 20 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 20 to 21 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 12 to 14 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 14 to 20 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
 
 Line:         </p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor
- - token from 8 to 10 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 10 to 11 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 11 to 12 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
 
 Line: 
- - token from 0 to 1 () with scopes text.aspnetcorerazor
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
 
 Line:         <text>This is not a special transition tag</text>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 9 to 13 (text) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 13 to 14 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 14 to 50 (This is not a special transition tag) with scopes text.aspnetcorerazor
- - token from 50 to 52 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 52 to 56 (text) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 56 to 57 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 13 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 14 to 50 (This is not a special transition tag) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 50 to 52 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 52 to 56 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 56 to 57 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
 
 Line:         Hello World
- - token from 0 to 20 (        Hello World) with scopes text.aspnetcorerazor
+ - token from 0 to 20 (        Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
 
 Line:     </p>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 6 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 6 to 7 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 7 to 8 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 6 to 7 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 7 to 8 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
 
 Line:     @: <strong> <-- This is incomplete @DateTime.Now
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, keyword.control.razor.singleLineMarkup
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor
- - token from 7 to 8 (<) with scopes text.aspnetcorerazor, meta.tag.inline.strong.start.html, punctuation.definition.tag.begin.html
- - token from 8 to 14 (strong) with scopes text.aspnetcorerazor, meta.tag.inline.strong.start.html, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.tag.inline.strong.start.html, punctuation.definition.tag.end.html
- - token from 15 to 39 ( <-- This is incomplete ) with scopes text.aspnetcorerazor
- - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 40 to 48 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 48 to 49 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 49 to 52 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.singleLineMarkup
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 7 to 8 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.inline.strong.start.html, punctuation.definition.tag.begin.html
+ - token from 8 to 14 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.inline.strong.start.html, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.inline.strong.start.html, punctuation.definition.tag.end.html
+ - token from 15 to 39 ( <-- This is incomplete ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 40 to 48 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 48 to 49 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml
+ - token from 49 to 52 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
 
 Line: 
- - token from 0 to 1 () with scopes text.aspnetcorerazor
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
 
 Line:     <input class=\\"hello world\\">
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
- - token from 5 to 10 (input) with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html, entity.name.tag.html
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html
- - token from 11 to 16 (class) with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 29 (hello world) with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html
- - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
+ - token from 5 to 10 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, entity.name.tag.html
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html
+ - token from 11 to 16 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 18 to 29 (hello world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html
+ - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
 
 Line:     <p>aHello</p>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 5 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 5 to 6 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 6 to 7 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 7 to 13 (aHello) with scopes text.aspnetcorerazor
- - token from 13 to 15 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 15 to 16 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 5 to 6 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 6 to 7 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 7 to 13 (aHello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
 
 Line: 
- - token from 0 to 1 () with scopes text.aspnetcorerazor
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
 
 Line:     if (true) {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>alksdjfl</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 19 (alksdjfl) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 19 (alksdjfl) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested do while statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var i = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (i) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
- - token from 12 to 13 (0) with scopes text.aspnetcorerazor, constant.numeric.decimal.cs
- - token from 13 to 14 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
 
 Line:     do
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
- - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor
+ - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, keyword.control.loop.do.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>@i</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     } while (i++ != 10);
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.terminator.statement.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested for statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     for (var i = 0; i % 2 == 0; i++)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.control.loop.for.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.open.cs
- - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.other.var.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, entity.name.variable.local.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.assignment.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.terminator.statement.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.arithmetic.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.comparison.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.terminator.statement.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.increment.cs
- - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.control.loop.for.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.other.var.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.arithmetic.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.comparison.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.increment.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>@i</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested foreach statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     foreach (var person in people)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
- - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.other.var.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, entity.name.variable.local.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.in.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
- - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.other.var.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, entity.name.variable.local.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.control.loop.in.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>@person</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 12 to 18 (person) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 18 to 20 (</) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 20 to 21 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 18 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 18 to 20 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 20 to 21 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested if statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     if (true)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>Hello World!</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 23 (Hello World!) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 23 to 25 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 25 to 26 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 23 (Hello World!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 23 to 25 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 25 to 26 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested lock statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     lock (someObject)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.other.lock.cs
- - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.open.cs
- - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.statement.lock.razor, variable.other.readwrite.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
+ - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, keyword.other.lock.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
+ - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, punctuation.parenthesis.open.cs
+ - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, variable.other.readwrite.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>Hello World</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested switch statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     switch (something)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.control.switch.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.open.cs
- - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
- - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
+ - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, keyword.control.switch.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
 
 Line:         case true:
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
- - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
 
 Line:             <p>Hello World</p>
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
- - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
- - token from 15 to 26 (Hello World) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 26 to 28 (</) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
- - token from 28 to 29 (p) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
- - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
+ - token from 15 to 26 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 26 to 28 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
+ - token from 28 to 29 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
 
 Line:             break;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
- - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested text tag 1`] = `
 "Line: @{ <p><text>Hello</text></p> }
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
- - token from 3 to 4 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 4 to 5 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 6 to 7 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 7 to 11 (text) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 11 to 12 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 12 to 17 (Hello) with scopes text.aspnetcorerazor
- - token from 17 to 19 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 19 to 23 (text) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 23 to 24 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 24 to 26 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 26 to 27 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 27 to 28 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor
- - token from 29 to 30 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 3 to 4 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 4 to 5 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 6 to 7 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 7 to 11 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 12 to 17 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 17 to 19 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 19 to 23 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 24 to 26 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 26 to 27 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 27 to 28 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 29 to 30 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested text text tag 1`] = `
 "Line: @{ <text><text>Hello</text></text> }
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
- - token from 3 to 9 (<text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.open
- - token from 9 to 10 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 10 to 14 (text) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 15 to 20 (Hello) with scopes text.aspnetcorerazor
- - token from 20 to 22 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 22 to 26 (text) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 26 to 27 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 27 to 34 (</text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.close
- - token from 34 to 35 ( ) with scopes text.aspnetcorerazor
- - token from 35 to 36 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 3 to 9 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.open
+ - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 14 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 20 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 20 to 22 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 22 to 26 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 27 to 34 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.close
+ - token from 34 to 35 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 35 to 36 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested try statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     try
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor
+ - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, keyword.control.try.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>Hello World</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     } catch (Exception ex){}
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
- - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.control.try.catch.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.open.cs
- - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.statement.catch.razor, storage.type.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
- - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, entity.name.variable.local.cs
- - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.close.cs
- - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
- - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
+ - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, storage.type.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
+ - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested using statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     using (someDisposable)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
+ - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>Hello World</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Nested while statement with markup 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var i = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (i) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
- - token from 12 to 13 (0) with scopes text.aspnetcorerazor, constant.numeric.decimal.cs
- - token from 13 to 14 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
 
 Line:     while (i++ != 10)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>@i</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Pure C# 1`] = `
 "Line: @{var x = true; Console.WriteLine(\\"Hello World\\");}
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 5 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
- - token from 6 to 7 (x) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
- - token from 10 to 14 (true) with scopes text.aspnetcorerazor, constant.language.boolean.true.cs
- - token from 14 to 15 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor
- - token from 16 to 23 (Console) with scopes text.aspnetcorerazor, variable.other.object.cs
- - token from 23 to 24 (.) with scopes text.aspnetcorerazor, punctuation.accessor.cs
- - token from 24 to 33 (WriteLine) with scopes text.aspnetcorerazor, entity.name.function.cs
- - token from 33 to 34 (() with scopes text.aspnetcorerazor, punctuation.parenthesis.open.cs
- - token from 34 to 35 (\\") with scopes text.aspnetcorerazor, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 35 to 46 (Hello World) with scopes text.aspnetcorerazor, string.quoted.double.cs
- - token from 46 to 47 (\\") with scopes text.aspnetcorerazor, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 47 to 48 ()) with scopes text.aspnetcorerazor, punctuation.parenthesis.close.cs
- - token from 48 to 49 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
- - token from 49 to 50 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 5 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 6 to 7 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 10 to 14 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.language.boolean.true.cs
+ - token from 14 to 15 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 16 to 23 (Console) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.object.cs
+ - token from 23 to 24 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.accessor.cs
+ - token from 24 to 33 (WriteLine) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
+ - token from 33 to 34 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
+ - token from 34 to 35 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 35 to 46 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs
+ - token from 46 to 47 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 47 to 48 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
+ - token from 48 to 49 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 49 to 50 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Single line local function 1`] = `
 "Line: @{ void Foo() {} }
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
- - token from 3 to 7 (void) with scopes text.aspnetcorerazor, keyword.type.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
- - token from 8 to 11 (Foo) with scopes text.aspnetcorerazor, entity.name.function.cs
- - token from 11 to 12 (() with scopes text.aspnetcorerazor, punctuation.parenthesis.open.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, punctuation.curlybrace.open.cs
- - token from 15 to 16 (}) with scopes text.aspnetcorerazor, punctuation.curlybrace.close.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor
- - token from 17 to 18 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 3 to 7 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 11 (Foo) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.open.cs
+ - token from 15 to 16 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.close.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 17 to 18 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Single line markup complex 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     @:@DateTime.Now <text>Nope</text>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, keyword.control.razor.singleLineMarkup
- - token from 6 to 7 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 7 to 15 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 15 to 16 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 16 to 19 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor
- - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.tag.other.text.html, punctuation.definition.tag.begin.html
- - token from 21 to 25 (text) with scopes text.aspnetcorerazor, meta.tag.other.text.html, entity.name.tag.html, invalid.illegal.unrecognized-tag.html
- - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.tag.other.text.html, punctuation.definition.tag.end.html
- - token from 26 to 30 (Nope) with scopes text.aspnetcorerazor
- - token from 30 to 32 (</) with scopes text.aspnetcorerazor, meta.tag.other.text.html, punctuation.definition.tag.begin.html
- - token from 32 to 36 (text) with scopes text.aspnetcorerazor, meta.tag.other.text.html, entity.name.tag.html, invalid.illegal.unrecognized-tag.html
- - token from 36 to 37 (>) with scopes text.aspnetcorerazor, meta.tag.other.text.html, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.singleLineMarkup
+ - token from 6 to 7 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 7 to 15 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 15 to 16 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml
+ - token from 16 to 19 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, punctuation.definition.tag.begin.html
+ - token from 21 to 25 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, entity.name.tag.html, invalid.illegal.unrecognized-tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, punctuation.definition.tag.end.html
+ - token from 26 to 30 (Nope) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 30 to 32 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, punctuation.definition.tag.begin.html
+ - token from 32 to 36 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, entity.name.tag.html, invalid.illegal.unrecognized-tag.html
+ - token from 36 to 37 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, punctuation.definition.tag.end.html
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Single line markup simple 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     @: <p> Incomplete
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, keyword.control.razor.singleLineMarkup
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor
- - token from 7 to 8 (<) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
- - token from 8 to 9 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, entity.name.tag.html
- - token from 9 to 10 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
- - token from 10 to 22 ( Incomplete) with scopes text.aspnetcorerazor
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.singleLineMarkup
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 7 to 8 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
+ - token from 8 to 9 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.p.start.html, entity.name.tag.html
+ - token from 9 to 10 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
+ - token from 10 to 22 ( Incomplete) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor code blocks @{ ... } Top level text tag 1`] = `
 "Line: @{ <text>Hello</text> }
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
- - token from 3 to 9 (<text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.open
- - token from 9 to 14 (Hello) with scopes text.aspnetcorerazor
- - token from 14 to 21 (</text>) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition.textTag.close
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor
- - token from 22 to 23 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 3 to 9 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.open
+ - token from 9 to 14 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 14 to 21 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.close
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 22 to 23 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -4496,196 +4496,196 @@ exports[`Grammar tests Razor comment Single line 1`] = `
 
 exports[`Grammar tests Razor templates @<p>....</p> Complex HTML tag structure non-template 1`] = `
 "Line: @{@<p><input      /><strong>Hello <hr/> <br> World</strong></p>}
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 3 to 4 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 4 to 5 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 6 to 7 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 7 to 12 (input) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 12 to 18 (      ) with scopes text.aspnetcorerazor
- - token from 18 to 20 (/>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 20 to 21 (<) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 21 to 27 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 27 to 28 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 28 to 34 (Hello ) with scopes text.aspnetcorerazor
- - token from 34 to 35 (<) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
- - token from 35 to 37 (hr) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, entity.name.tag.html
- - token from 37 to 39 (/>) with scopes text.aspnetcorerazor, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
- - token from 39 to 40 ( ) with scopes text.aspnetcorerazor
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
- - token from 41 to 43 (br) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, entity.name.tag.html
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
- - token from 44 to 50 ( World) with scopes text.aspnetcorerazor
- - token from 50 to 52 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 52 to 58 (strong) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 58 to 59 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 59 to 61 (</) with scopes text.aspnetcorerazor, punctuation.definition.tag.begin.html
- - token from 61 to 62 (p) with scopes text.aspnetcorerazor, entity.name.tag.html
- - token from 62 to 63 (>) with scopes text.aspnetcorerazor, punctuation.definition.tag.end.html
- - token from 63 to 64 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 3 to 4 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 4 to 5 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 6 to 7 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 7 to 12 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 12 to 18 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 18 to 20 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 27 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 27 to 28 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 28 to 34 (Hello ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 34 to 35 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
+ - token from 35 to 37 (hr) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, entity.name.tag.html
+ - token from 37 to 39 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
+ - token from 41 to 43 (br) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
+ - token from 44 to 50 ( World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 50 to 52 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 52 to 58 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 58 to 59 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 59 to 61 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 61 to 62 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 62 to 63 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 63 to 64 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Complex with various nested statements 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     if (true) {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <div>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:         @using (someDisposable) {
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
- - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
- - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
- - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:             <p>Foo!</p>
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:             var x = 123;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:             while (i++ % 2 == 0)
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
- - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
 
 Line:             {
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:                 Action<int> template = @<p>
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 16 to 22 (Action) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 22 to 23 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 23 to 26 (int) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 28 to 36 (template) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 37 to 38 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 41 to 42 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 22 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 22 to 23 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 23 to 26 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 28 to 36 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 37 to 38 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 41 to 42 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
 
 Line:                     @item
- - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 20 to 21 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 21 to 25 (item) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 20 to 21 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 21 to 25 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
 
 Line: 
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
 
 Line:                     @{
- - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 20 to 21 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 21 to 22 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 20 to 21 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 21 to 22 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:                         Action anotherTemplate = @<strong class='really loud!'>LOUD</strong>;
- - token from 0 to 24 (                        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 24 to 30 (Action) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, storage.type.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 31 to 46 (anotherTemplate) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.variable.local.cs
- - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 47 to 48 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.operator.assignment.cs
- - token from 48 to 49 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 49 to 50 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 50 to 51 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
- - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor
- - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 64 to 65 (') with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 65 to 77 (really loud!) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html
- - token from 77 to 78 (') with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.end.html
- - token from 78 to 79 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 79 to 83 (LOUD) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor
- - token from 83 to 85 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 85 to 91 (strong) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
- - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 92 to 93 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.terminator.statement.cs
+ - token from 0 to 24 (                        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 24 to 30 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, storage.type.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 31 to 46 (anotherTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 47 to 48 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 48 to 49 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 49 to 50 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 50 to 51 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor
+ - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 64 to 65 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.begin.html
+ - token from 65 to 77 (really loud!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html
+ - token from 77 to 78 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.end.html
+ - token from 78 to 79 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 79 to 83 (LOUD) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor
+ - token from 83 to 85 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 85 to 91 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 92 to 93 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
 
 Line:                     }
- - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 20 to 21 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 20 to 21 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 
 Line:                     </p>;
- - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 20 to 22 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 22 to 23 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 24 to 25 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 20 to 22 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 22 to 23 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 24 to 25 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:             }
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:         }
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:         </div>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -4738,403 +4738,403 @@ exports[`Grammar tests Razor templates @<p>....</p> Malformed attributes 1`] = `
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested do while statement with template 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var i = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (i) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
- - token from 12 to 13 (0) with scopes text.aspnetcorerazor, constant.numeric.decimal.cs
- - token from 13 to 14 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
 
 Line:     do
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
- - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor
+ - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, keyword.control.loop.do.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(i)
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     } while (i++ != 10);
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.terminator.statement.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested for statement with templates 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     for (var i = 0; i % 2 == 0; i++)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.control.loop.for.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.open.cs
- - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.other.var.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, entity.name.variable.local.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.assignment.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.terminator.statement.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.arithmetic.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.comparison.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.terminator.statement.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.increment.cs
- - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.control.loop.for.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.other.var.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.arithmetic.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.comparison.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.increment.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(i)
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested foreach statement with template 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     foreach (var person in people)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
- - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.other.var.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, entity.name.variable.local.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.in.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
- - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.other.var.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, entity.name.variable.local.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.control.loop.in.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(i)
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested lock statement with template 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     lock (someObject)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.other.lock.cs
- - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.open.cs
- - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.statement.lock.razor, variable.other.readwrite.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
+ - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, keyword.other.lock.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
+ - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, punctuation.parenthesis.open.cs
+ - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, variable.other.readwrite.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<string> template = @<p class=\\"world\\">@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 21 (string) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 23 to 31 (template) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 34 to 35 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 35 to 36 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 36 to 37 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
- - token from 38 to 43 (class) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 43 to 44 (=) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 44 to 45 (\\") with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 45 to 50 (world) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html
- - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 51 to 52 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 52 to 53 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 53 to 57 (item) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 57 to 59 (</) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 59 to 60 (p) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 60 to 61 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 61 to 62 (;) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 21 (string) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 23 to 31 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 34 to 35 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 35 to 36 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 36 to 37 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor
+ - token from 38 to 43 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 43 to 44 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 44 to 45 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 45 to 50 (world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html
+ - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 51 to 52 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 52 to 53 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 53 to 57 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 57 to 59 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 59 to 60 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 60 to 61 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 61 to 62 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(someObject.ToString())
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 28 (someObject) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.object.cs
- - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.accessor.cs
- - token from 29 to 37 (ToString) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
- - token from 37 to 38 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 38 to 39 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 39 to 40 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 28 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 29 to 37 (ToString) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 37 to 38 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 38 to 39 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 39 to 40 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested switch statement with template 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     switch (something)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.control.switch.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.open.cs
- - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
- - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
+ - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, keyword.control.switch.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
 
 Line:         case true:
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
- - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
 
 Line:             Action<int> template = @<p>@item</p>;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 12 to 18 (Action) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, storage.type.cs
- - token from 18 to 19 (<) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.begin.cs
- - token from 19 to 22 (int) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.type.cs
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.end.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 24 to 32 (template) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.variable.local.cs
- - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 33 to 34 (=) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.assignment.cs
- - token from 34 to 35 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 36 to 37 (<) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 37 to 38 (p) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, entity.name.tag.html
- - token from 38 to 39 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 40 to 44 (item) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 44 to 46 (</) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 46 to 47 (p) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, entity.name.tag.html
- - token from 47 to 48 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 48 to 49 (;) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 18 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, storage.type.cs
+ - token from 18 to 19 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.begin.cs
+ - token from 19 to 22 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.type.cs
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.end.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 24 to 32 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.variable.local.cs
+ - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 33 to 34 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.assignment.cs
+ - token from 34 to 35 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 36 to 37 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 37 to 38 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, entity.name.tag.html
+ - token from 38 to 39 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 40 to 44 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 44 to 46 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 46 to 47 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, entity.name.tag.html
+ - token from 47 to 48 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 48 to 49 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
 
 Line:             break;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
- - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested template 1`] = `
 "Line: @{ Action<object> abc = @<div>@{ Action<object> def = @<p class=\\"john\\" onclick='someMethod'>Hello World</p>; }</div>; }
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
- - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, storage.type.cs
- - token from 9 to 10 (<) with scopes text.aspnetcorerazor, punctuation.definition.typeparameters.begin.cs
- - token from 10 to 16 (object) with scopes text.aspnetcorerazor, keyword.type.cs
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, punctuation.definition.typeparameters.end.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor
- - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor
- - token from 22 to 23 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor
- - token from 24 to 25 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
- - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 30 to 31 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.razor.directive.codeblock.open
- - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
- - token from 33 to 39 (Action) with scopes text.aspnetcorerazor, meta.structure.template.razor, storage.type.cs
- - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.typeparameters.begin.cs
- - token from 40 to 46 (object) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.type.cs
- - token from 46 to 47 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.typeparameters.end.cs
- - token from 47 to 48 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
- - token from 48 to 51 (def) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.variable.local.cs
- - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
- - token from 52 to 53 (=) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.operator.assignment.cs
- - token from 53 to 54 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
- - token from 54 to 55 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 55 to 56 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 56 to 57 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
- - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor
- - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 64 to 65 (\\") with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 65 to 69 (john) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html
- - token from 69 to 70 (\\") with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 70 to 71 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor
- - token from 71 to 78 (onclick) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, entity.other.attribute-name.html
- - token from 78 to 79 (=) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, punctuation.separator.key-value.html
- - token from 79 to 80 (') with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 80 to 90 (someMethod) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, source.js, variable.other.readwrite.js
- - token from 90 to 91 (') with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, punctuation.definition.string.end.html, source.js
- - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 92 to 103 (Hello World) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor
- - token from 103 to 105 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 105 to 106 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, entity.name.tag.html
- - token from 106 to 107 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 107 to 108 (;) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.terminator.statement.cs
- - token from 108 to 109 ( ) with scopes text.aspnetcorerazor, meta.structure.template.razor
- - token from 109 to 110 (}) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.razor.directive.codeblock.close
- - token from 110 to 112 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 112 to 115 (div) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
- - token from 115 to 116 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 116 to 117 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
- - token from 117 to 118 ( ) with scopes text.aspnetcorerazor
- - token from 118 to 119 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, storage.type.cs
+ - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 10 to 16 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 22 to 23 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 24 to 25 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 30 to 31 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 33 to 39 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, storage.type.cs
+ - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 40 to 46 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.type.cs
+ - token from 46 to 47 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 47 to 48 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 48 to 51 (def) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 52 to 53 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 53 to 54 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 54 to 55 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 55 to 56 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 56 to 57 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor
+ - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 64 to 65 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 65 to 69 (john) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html
+ - token from 69 to 70 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 70 to 71 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor
+ - token from 71 to 78 (onclick) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.event-handler.click.html, entity.other.attribute-name.html
+ - token from 78 to 79 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.event-handler.click.html, punctuation.separator.key-value.html
+ - token from 79 to 80 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, punctuation.definition.string.begin.html
+ - token from 80 to 90 (someMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, source.js, variable.other.readwrite.js
+ - token from 90 to 91 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.attribute.event-handler.click.html, meta.embedded.line.js, string.quoted.single.html, punctuation.definition.string.end.html, source.js
+ - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 92 to 103 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor
+ - token from 103 to 105 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 105 to 106 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 106 to 107 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 107 to 108 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 108 to 109 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock
+ - token from 109 to 110 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
+ - token from 110 to 112 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 112 to 115 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 115 to 116 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 116 to 117 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 117 to 118 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 118 to 119 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -5314,175 +5314,175 @@ Line: </p>)
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested try statement with template 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     try
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor
+ - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, keyword.control.try.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:     } catch (Exception ex){}
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
- - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.statement.catch.razor, keyword.control.try.catch.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.open.cs
- - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.statement.catch.razor, storage.type.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
- - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.statement.catch.razor, entity.name.variable.local.cs
- - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.catch.razor, punctuation.parenthesis.close.cs
- - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
- - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
+ - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, storage.type.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
+ - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested using statement with template 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     using (someDisposable)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
+ - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests Razor templates @<p>....</p> Nested while statement with template 1`] = `
 "Line: @{
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var i = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor
- - token from 8 to 9 (i) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor
- - token from 12 to 13 (0) with scopes text.aspnetcorerazor, constant.numeric.decimal.cs
- - token from 13 to 14 (;) with scopes text.aspnetcorerazor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
 
 Line:     while (i++ != 10)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 35 to 36 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 36 to 40 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(i)
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -5504,27 +5504,27 @@ exports[`Grammar tests Razor templates @<p>....</p> Self-closing 1`] = `
 
 exports[`Grammar tests Razor templates @<p>....</p> Single line local variable 1`] = `
 "Line: @{ Action<object> abc = @<div>Hello World</p>; }
- - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
- - token from 1 to 2 ({) with scopes text.aspnetcorerazor, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor
- - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, storage.type.cs
- - token from 9 to 10 (<) with scopes text.aspnetcorerazor, punctuation.definition.typeparameters.begin.cs
- - token from 10 to 16 (object) with scopes text.aspnetcorerazor, keyword.type.cs
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, punctuation.definition.typeparameters.end.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor
- - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, entity.name.variable.local.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor
- - token from 22 to 23 (=) with scopes text.aspnetcorerazor, keyword.operator.assignment.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor
- - token from 24 to 25 (@) with scopes text.aspnetcorerazor, meta.structure.template.razor, keyword.control.cshtml.transition
- - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
- - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 30 to 41 (Hello World) with scopes text.aspnetcorerazor, meta.structure.template.razor
- - token from 41 to 43 (</) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.begin.html
- - token from 43 to 44 (p) with scopes text.aspnetcorerazor, meta.structure.template.razor, entity.name.tag.html
- - token from 44 to 45 (>) with scopes text.aspnetcorerazor, meta.structure.template.razor, punctuation.definition.tag.end.html
- - token from 45 to 49 (; }) with scopes text.aspnetcorerazor, meta.structure.template.razor
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, storage.type.cs
+ - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 10 to 16 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 22 to 23 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 24 to 25 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 30 to 41 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor
+ - token from 41 to 43 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 43 to 44 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 44 to 45 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 45 to 49 (; }) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -202,6 +202,19 @@ Line:     {
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
  - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
 
+Line:         var someString = \\"{ var ThisShouldNotBeCSharp = true; }\\";
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 11 (var) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.other.var.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 12 to 22 (someString) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 23 to 24 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 25 to 26 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 26 to 63 ({ var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
+ - token from 63 to 64 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 64 to 65 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+
 Line:         currentCount++;
  - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
  - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
@@ -214,6 +227,21 @@ Line:     }
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @code directive Multi-line comment with curly braces 1`] = `
+"Line: @code { /* { var ThisShouldNotBeCSharp = true; } */ }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 10 (/*) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs, punctuation.definition.comment.cs
+ - token from 10 to 49 ( { var ThisShouldNotBeCSharp = true; } ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs
+ - token from 49 to 51 (*/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs, punctuation.definition.comment.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 52 to 53 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -243,6 +271,156 @@ exports[`Grammar tests @code directive Single line 1`] = `
  - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
  - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
  - token from 29 to 30 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @code directive Single-line comment with curly braces 1`] = `
+"Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor
+
+Line: @code {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
+
+Line:     // { var ThisShouldNotBeCSharp = true; }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.whitespace.comment.leading.cs
+ - token from 4 to 6 (//) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.line.double-slash.cs, punctuation.definition.comment.cs
+ - token from 6 to 44 ( { var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.line.double-slash.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @code directive With Razor and markup 1`] = `
+"Line: @code {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
+ - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
+
+Line:     private void SomeMethod()
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 17 to 27 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
+ - token from 27 to 28 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
+ - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>This method <strong>is really</strong> nice!
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 23 (This method ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 23 to 24 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 30 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.tag.html
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.end.html
+ - token from 31 to 40 (is really) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.begin.html
+ - token from 42 to 48 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.tag.html
+ - token from 48 to 49 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.end.html
+ - token from 49 to 56 ( nice!) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+
+Line:             @if(true) {
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 13 to 15 (if) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 20 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor
+ - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:                 <input type=\\"checkbox\\" value=\\"true\\" name=\\"Something\\" />
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
+ - token from 17 to 22 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, entity.name.tag.html
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html
+ - token from 23 to 27 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, entity.other.attribute-name.html
+ - token from 27 to 28 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, punctuation.separator.key-value.html
+ - token from 28 to 29 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 29 to 37 (checkbox) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html
+ - token from 37 to 38 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html
+ - token from 39 to 44 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, entity.other.attribute-name.html
+ - token from 44 to 45 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, punctuation.separator.key-value.html
+ - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 46 to 50 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html
+ - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html
+ - token from 52 to 56 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, entity.other.attribute-name.html
+ - token from 56 to 57 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, punctuation.separator.key-value.html
+ - token from 57 to 58 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 58 to 67 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html
+ - token from 67 to 68 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 68 to 69 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html
+ - token from 69 to 71 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
+
+Line:             }
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line:         </p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.tag.html
+ - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.end.html
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+
+Line:         @DateTime.Now
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.expression.implicit.cshtml
+ - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+
+Line:         <input type=\\"hidden\\" value=\\" { true }\\" name=\\"Something\\">
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
+ - token from 9 to 14 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, entity.name.tag.html
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html
+ - token from 15 to 19 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, entity.other.attribute-name.html
+ - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, punctuation.separator.key-value.html
+ - token from 20 to 21 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 21 to 27 (hidden) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html
+ - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html
+ - token from 29 to 34 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, entity.other.attribute-name.html
+ - token from 34 to 35 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, punctuation.separator.key-value.html
+ - token from 35 to 36 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 36 to 45 ( { true }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html
+ - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html
+ - token from 47 to 51 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, entity.other.attribute-name.html
+ - token from 51 to 52 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, punctuation.separator.key-value.html
+ - token from 52 to 53 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 53 to 62 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html
+ - token from 62 to 63 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 63 to 64 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -1016,6 +1194,19 @@ Line:     {
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
  - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
 
+Line:         var someString = \\"{ var ThisShouldNotBeCSharp = true; }\\";
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 11 (var) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.other.var.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 12 to 22 (someString) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 23 to 24 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 25 to 26 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 26 to 63 ({ var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
+ - token from 63 to 64 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 64 to 65 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+
 Line:         currentCount++;
  - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
  - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
@@ -1028,6 +1219,21 @@ Line:     }
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @functions directive Multi-line comment with curly braces 1`] = `
+"Line: @functions { /* { var ThisShouldNotBeCSharp = true; } */ }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 13 to 15 (/*) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs, punctuation.definition.comment.cs
+ - token from 15 to 54 ( { var ThisShouldNotBeCSharp = true; } ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs
+ - token from 54 to 56 (*/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs, punctuation.definition.comment.cs
+ - token from 56 to 57 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 57 to 58 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -1057,6 +1263,156 @@ exports[`Grammar tests @functions directive Single line 1`] = `
  - token from 32 to 33 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
  - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
  - token from 34 to 35 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @functions directive Single-line comment with curly braces 1`] = `
+"Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor
+
+Line: @functions {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
+
+Line:     // { var ThisShouldNotBeCSharp = true; }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.whitespace.comment.leading.cs
+ - token from 4 to 6 (//) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.line.double-slash.cs, punctuation.definition.comment.cs
+ - token from 6 to 44 ( { var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.line.double-slash.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests @functions directive With Razor and markup 1`] = `
+"Line: @functions {
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, keyword.control.cshtml.transition
+ - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
+ - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
+
+Line:     private void SomeMethod()
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 17 to 27 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
+ - token from 27 to 28 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
+ - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p>This method <strong>is really</strong> nice!
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 23 (This method ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 23 to 24 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 30 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.tag.html
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.end.html
+ - token from 31 to 40 (is really) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.begin.html
+ - token from 42 to 48 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.tag.html
+ - token from 48 to 49 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.end.html
+ - token from 49 to 56 ( nice!) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+
+Line:             @if(true) {
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 13 to 15 (if) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 20 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor
+ - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:                 <input type=\\"checkbox\\" value=\\"true\\" name=\\"Something\\" />
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
+ - token from 17 to 22 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, entity.name.tag.html
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html
+ - token from 23 to 27 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, entity.other.attribute-name.html
+ - token from 27 to 28 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, punctuation.separator.key-value.html
+ - token from 28 to 29 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 29 to 37 (checkbox) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html
+ - token from 37 to 38 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html
+ - token from 39 to 44 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, entity.other.attribute-name.html
+ - token from 44 to 45 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, punctuation.separator.key-value.html
+ - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 46 to 50 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html
+ - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html
+ - token from 52 to 56 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, entity.other.attribute-name.html
+ - token from 56 to 57 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, punctuation.separator.key-value.html
+ - token from 57 to 58 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 58 to 67 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html
+ - token from 67 to 68 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 68 to 69 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html
+ - token from 69 to 71 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
+
+Line:             }
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line:         </p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.tag.html
+ - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.tag.end.html
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+
+Line:         @DateTime.Now
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.expression.implicit.cshtml
+ - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+
+Line:         <input type=\\"hidden\\" value=\\" { true }\\" name=\\"Something\\">
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
+ - token from 9 to 14 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, entity.name.tag.html
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html
+ - token from 15 to 19 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, entity.other.attribute-name.html
+ - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, punctuation.separator.key-value.html
+ - token from 20 to 21 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 21 to 27 (hidden) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html
+ - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.type.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html
+ - token from 29 to 34 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, entity.other.attribute-name.html
+ - token from 34 to 35 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, punctuation.separator.key-value.html
+ - token from 35 to 36 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 36 to 45 ( { true }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html
+ - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.value.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html
+ - token from 47 to 51 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, entity.other.attribute-name.html
+ - token from 51 to 52 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, punctuation.separator.key-value.html
+ - token from 52 to 53 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 53 to 62 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html
+ - token from 62 to 63 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, meta.attribute.name.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 63 to 64 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
@@ -3856,6 +4212,74 @@ Line:     <input class=\\"hello world\\">
  - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
 
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+
+Line:     void SomeMethod(int value)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 8 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 9 to 19 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
+ - token from 20 to 23 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 24 to 29 (value) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.parameter.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
+
+Line:     {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.open.cs
+
+Line:         Action<int> template = @<strong>Value: @item</strong>;
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 31 to 32 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, keyword.control.cshtml.transition
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 33 to 39 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 40 to 47 (Value: ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor
+ - token from 47 to 48 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 48 to 52 (item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 52 to 54 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.begin.html
+ - token from 54 to 60 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, entity.name.tag.html
+ - token from 60 to 61 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.template.razor, punctuation.definition.tag.end.html
+ - token from 61 to 62 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+
+Line:         <section>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 16 (section) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+
+Line:             This section is rendered when called: @template(1337)
+ - token from 0 to 50 (            This section is rendered when called: ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 50 to 51 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 51 to 59 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
+ - token from 59 to 60 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 60 to 64 (1337) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 64 to 65 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+
+Line:         </section>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 17 (section) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 17 to 18 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.close.cs
+
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+
 Line:     <p>aHello</p>
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
  - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
@@ -4085,6 +4509,48 @@ Line:         <p>Hello World!</p>
 Line:     }
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
  - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
+exports[`Grammar tests Razor code blocks @{ ... } Nested local function with markup 1`] = `
+"Line: @{
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+
+Line:     void SomeMethod() { <p class=\\"priority\\"><strong>Hello World</strong></p> }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 4 to 8 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 9 to 19 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.open.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 24 to 25 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 25 to 26 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 27 to 32 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 33 to 34 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 34 to 42 (priority) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html
+ - token from 42 to 43 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 44 to 45 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 45 to 51 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 51 to 52 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 52 to 63 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 63 to 65 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 65 to 71 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 71 to 72 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 72 to 74 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
+ - token from 74 to 75 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
+ - token from 75 to 76 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 76 to 77 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 77 to 78 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close


### PR DESCRIPTION
- Utilized VSCode's grammar injection feature to enable Razor markup in functions. Basically what's going on in this changeset is we describe an "injection" into the code/functions directive and Razor code blocks grammar that states if we encounter a { inside of a Razor C# block that's not a string or comment, then tokenize the contents of the {} as typical C#. This ends up also injecting itself in nested C# statements where we'd allow nested markup.
- Updated existing tests and added a lot of new ones to cover several edge cases.
- Marked Razor code blocks with `meta.structure.razor.codeblock` so we can inject our own markup allowing grammar into the C# pieces that we call into.

dotnet/AspNetCore#14287