### PR TITLE
Out of workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ node_modules/
 # VSCode extension outputs
 dist/
 out/
+
+# Test generated
+src/Razor/test/OutOfWorkspaceFile.cshtml

--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,4 @@ dist/
 out/
 
 # Test generated
-src/Razor/test/OutOfWorkspaceFile.cshtml
+src/Razor/test/OutOfWorkspaceFile.razor

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -128,6 +128,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
 
         // This might happen in the case that a file is opened outside the workspace
         if (!document) {
+            this.logger.logMessage(`File '${path}' didn't exist in the Razor document list. This is likely because it's from outside the workspace.`);
             document = this.addDocument(uri);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -154,6 +154,13 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         csharpProjectedDocument.reset();
         htmlProjectedDocument.reset();
 
+        // Files outside of the workspace will return undefined from getWorkspaceFolder
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+        if (!workspaceFolder) {
+            // Out of workspace files should be removed once they're closed
+            this.removeDocument(uri);
+        }
+
         this.notifyDocumentChange(document, RazorDocumentChangeKind.closed);
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -124,10 +124,11 @@ export class RazorDocumentManager implements IRazorDocumentManager {
 
     private _getDocument(uri: vscode.Uri) {
         const path = getUriPath(uri);
-        const document = this.razorDocuments[path];
+        let document = this.razorDocuments[path];
 
+        // This might happen in the case that a file is opened outside the workspace
         if (!document) {
-            throw new Error('Requested document does not exist.');
+            document = this.addDocument(uri);
         }
 
         return document;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Completions2_1.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Completions2_1.test.ts
@@ -120,6 +120,7 @@ suite('Completions 2.1', () => {
             'vscode.executeCompletionItemProvider',
             doc.uri,
             new vscode.Position(0, 4));
+
         assertHasCompletion(completions, 'strong');
     });
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/OutOfWorkspaceCompletion.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/OutOfWorkspaceCompletion.test.ts
@@ -1,0 +1,49 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+import { afterEach, before, beforeEach } from 'mocha';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    mvcWithComponentsRoot,
+    pollUntil,
+    testAppsRoot,
+    waitForProjectReady,
+} from './TestUtil';
+
+suite('Completions', () => {
+    before(async () => {
+        await waitForProjectReady(mvcWithComponentsRoot);
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await pollUntil(async () => {
+            await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+            if (vscode.window.visibleTextEditors.length === 0) {
+                return true;
+            }
+
+            return false;
+        }, /* timeout */ 3000, /* pollInterval */ 500, true /* suppress timeout */);
+    });
+
+    test('Completions out of Workspace work', async () => {
+        const outOfWorkspace = path.join(testAppsRoot, '..', 'OutOfWorkspaceFile.cshtml');
+        const outOfWorkspaceDoc = await vscode.workspace.openTextDocument(outOfWorkspace);
+        const outOfWorkspaceEditor = await vscode.window.showTextDocument(outOfWorkspaceDoc);
+        const firstLine = new vscode.Position(0, 0);
+        await outOfWorkspaceEditor.edit(edit => edit.insert(firstLine, '<a'));
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            outOfWorkspaceDoc.uri,
+            new vscode.Position(0, 2));
+
+        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
+
+        assert.ok(hasCompletion('a'), 'Should have completion for "a"');
+    });
+});

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/OutOfWorkspaceCompletion.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/OutOfWorkspaceCompletion.test.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as assert from 'assert';
 import * as fs from 'fs';
 import { after, afterEach, before } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {
+    assertHasCompletion,
     mvcWithComponentsRoot,
     pollUntil,
     testAppsRoot,
@@ -50,9 +50,7 @@ suite('Out of workspace Completions', () => {
             outOfWorkspaceDoc.uri,
             new vscode.Position(0, 3));
 
-        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
-
-        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
+        assertHasCompletion(completions, 'inject');
     });
 
     test('C# completions out of Workspace work', async () => {
@@ -65,9 +63,7 @@ suite('Out of workspace Completions', () => {
             outOfWorkspaceDoc.uri,
             new vscode.Position(0, 2));
 
-        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
-
-        assert.ok(hasCompletion('DateTime'), 'Should have completion for "DateTime"');
+        assertHasCompletion(completions, 'DateTime');
     });
 
     test('HTML completions out of Workspace work', async () => {
@@ -80,8 +76,6 @@ suite('Out of workspace Completions', () => {
             outOfWorkspaceDoc.uri,
             new vscode.Position(0, 2));
 
-        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
-
-        assert.ok(hasCompletion('a'), 'Should have completion for "a"');
+        assertHasCompletion(completions, 'a');
     });
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/OutOfWorkspaceCompletion.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/OutOfWorkspaceCompletion.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as fs from 'fs';
-import { afterEach, before, beforeEach } from 'mocha';
+import { after, afterEach, before } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {
@@ -15,9 +15,9 @@ import {
     waitForProjectReady,
 } from './TestUtil';
 
-const outsideWorkspaceFile = path.join(testAppsRoot, '..', 'OutOfWorkspaceFile.cshtml');
+const outsideWorkspaceFile = path.join(testAppsRoot, '..', 'OutOfWorkspaceFile.razor');
 
-suite('Completions', () => {
+suite('Out of workspace Completions', () => {
     before(async () => {
         await waitForProjectReady(mvcWithComponentsRoot);
         fs.writeFileSync(outsideWorkspaceFile, /* data */ '');
@@ -43,16 +43,16 @@ suite('Completions', () => {
         const outOfWorkspaceDoc = await vscode.workspace.openTextDocument(outsideWorkspaceFile);
         const outOfWorkspaceEditor = await vscode.window.showTextDocument(outOfWorkspaceDoc);
         const firstLine = new vscode.Position(0, 0);
-        await outOfWorkspaceEditor.edit(edit => edit.insert(firstLine, '<input @bi'));
+        await outOfWorkspaceEditor.edit(edit => edit.insert(firstLine, '@inje'));
 
         const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
             'vscode.executeCompletionItemProvider',
             outOfWorkspaceDoc.uri,
-            new vscode.Position(0, 9));
+            new vscode.Position(0, 3));
 
         const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
 
-        assert.ok(hasCompletion('bind'), 'Should have completion for "bind"');
+        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
     });
 
     test('C# completions out of Workspace work', async () => {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/14304.

So what happens here is that documents get added by the file watcher, which only watches the work-space folder, so when you open a file outside of the work-space it calls in to` _getDocument`, where it throws the error bellow. Since there's no reason we shouldn't have out-of-work-space files in the document list I've modified `_getDocument` to create and insert the document if it doesn't already exist.

Since the Workspace for the functional tests is the testapps folder I did have to pollute the test directory with a cshtml file which shouldn't normally be there to write a test. I'm open to suggestions on avoiding that.