### PR TITLE
Fix # in FilePath

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentFactory.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentFactory.ts
@@ -30,8 +30,9 @@ export function createDocument(uri: vscode.Uri) {
 function createProjectedHtmlDocument(hostDocumentUri: vscode.Uri) {
     // Index.cshtml => Index.cshtml__virtual.html
     const projectedPath = `${hostDocumentUri.path}${virtualHtmlSuffix}`;
-    const projectedUri = vscode.Uri.parse(`${HtmlProjectedDocumentContentProvider.scheme}://${projectedPath}`);
-    const projectedDocument = new HtmlProjectedDocument(projectedUri);
+    let uri = vscode.Uri.file(projectedPath);
+    uri = uri.with({ scheme: HtmlProjectedDocumentContentProvider.scheme });
+    const projectedDocument = new HtmlProjectedDocument(uri);
 
     return projectedDocument;
 }
@@ -39,8 +40,9 @@ function createProjectedHtmlDocument(hostDocumentUri: vscode.Uri) {
 function createProjectedCSharpDocument(hostDocumentUri: vscode.Uri) {
     // Index.cshtml => Index.cshtml__virtual.cs
     const projectedPath = `${hostDocumentUri.path}${virtualCSharpSuffix}`;
-    const projectedUri = vscode.Uri.parse(`${CSharpProjectedDocumentContentProvider.scheme}://${projectedPath}`);
-    const projectedDocument = new CSharpProjectedDocument(projectedUri);
+    let uri = vscode.Uri.file(projectedPath);
+    uri = uri.with({ scheme: CSharpProjectedDocumentContentProvider.scheme });
+    const projectedDocument = new CSharpProjectedDocument(uri);
 
     return projectedDocument;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptionsResolver.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerOptionsResolver.ts
@@ -6,7 +6,6 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { RazorLanguage } from './RazorLanguage';
 import { RazorLanguageServerOptions } from './RazorLanguageServerOptions';
 import { RazorLogger } from './RazorLogger';
 import { Trace } from './Trace';

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import { RazorLanguageServerClient } from './RazorLanguageServerClient';
-import { RazorLogger } from './RazorLogger';
 import { LanguageKind } from './RPC/LanguageKind';
 import { LanguageQueryRequest } from './RPC/LanguageQueryRequest';
 import { LanguageQueryResponse } from './RPC/LanguageQueryResponse';

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Completions.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Completions.test.ts
@@ -101,21 +101,6 @@ suite('Completions', () => {
         assertHasCompletion(completions, 'DateTimeOffset');
     });
 
-    test('Can perform Completions on file with "#" in the name', async () => {
-        const firstLine = new vscode.Position(1, 0);
-        const fileNamePath = path.join(homeDirectory, '#FileName.cshtml');
-        const fileNameDoc = await vscode.workspace.openTextDocument(fileNamePath);
-        const fileNameEditor = await vscode.window.showTextDocument(fileNameDoc);
-        await fileNameEditor.edit(edit => edit.insert(firstLine, '@Da'));
-
-        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
-            'vscode.executeCompletionItemProvider',
-            fileNameDoc.uri,
-            new vscode.Position(1, 2));
-
-        assertHasCompletion(completions, 'DateTime');
-    });
-
     test('Can complete imported C# in .cshtml', async () => {
         const lastLine = new vscode.Position(cshtmlDoc.lineCount - 1, 0);
         await editor.edit(edit => edit.insert(lastLine, '@'));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Completions.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Completions.test.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as assert from 'assert';
 import { afterEach, before, beforeEach } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {
+    assertHasCompletion,
+    assertHasNoCompletion,
     mvcWithComponentsRoot,
     pollUntil,
     waitForDocumentUpdate,
@@ -16,6 +17,7 @@ import {
 
 let cshtmlDoc: vscode.TextDocument;
 let editor: vscode.TextEditor;
+const homeDirectory = path.join(mvcWithComponentsRoot, 'Views', 'Home');
 
 suite('Completions', () => {
     before(async () => {
@@ -23,7 +25,7 @@ suite('Completions', () => {
     });
 
     beforeEach(async () => {
-        const filePath = path.join(mvcWithComponentsRoot, 'Views', 'Home', 'Index.cshtml');
+        const filePath = path.join(homeDirectory, 'Index.cshtml');
         cshtmlDoc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(cshtmlDoc);
     });
@@ -51,11 +53,9 @@ suite('Completions', () => {
             razorDoc.uri,
             new vscode.Position(0, 1));
 
-        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
-
-        assert.ok(hasCompletion('page'), 'Should have completion for "page"');
-        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
-        assert.ok(!hasCompletion('div'), 'Should not have completion for "div"');
+        assertHasCompletion(completions, 'page');
+        assertHasCompletion(completions, 'inject');
+        assertHasNoCompletion(completions, 'div');
     });
 
     test('Can complete Razor directive in .cshtml', async () => {
@@ -66,11 +66,9 @@ suite('Completions', () => {
             cshtmlDoc.uri,
             new vscode.Position(0, 1));
 
-        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
-
-        assert.ok(hasCompletion('page'), 'Should have completion for "page"');
-        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
-        assert.ok(!hasCompletion('div'), 'Should not have completion for "div"');
+        assertHasCompletion(completions, 'page');
+        assertHasCompletion(completions, 'inject');
+        assertHasNoCompletion(completions, 'div');
     });
 
     test('Can complete C# code blocks in .cshtml', async () => {
@@ -82,11 +80,10 @@ suite('Completions', () => {
             'vscode.executeCompletionItemProvider',
             cshtmlDoc.uri,
             new vscode.Position(cshtmlDoc.lineCount - 1, 2));
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText.startsWith('DateTime'))
-            .map(item => item.insertText as string);
 
-        assert.deepEqual(matchingCompletions, ['DateTime', 'DateTimeKind', 'DateTimeOffset']);
+        assertHasCompletion(completions, 'DateTime');
+        assertHasCompletion(completions, 'DateTimeKind');
+        assertHasCompletion(completions, 'DateTimeOffset');
     });
 
     test('Can complete C# implicit expressions in .cshtml', async () => {
@@ -98,11 +95,25 @@ suite('Completions', () => {
             'vscode.executeCompletionItemProvider',
             cshtmlDoc.uri,
             new vscode.Position(lastLine.line, 1));
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText.startsWith('DateTime'))
-            .map(item => item.insertText as string);
 
-        assert.deepEqual(matchingCompletions, ['DateTime', 'DateTimeKind', 'DateTimeOffset']);
+        assertHasCompletion(completions, 'DateTime');
+        assertHasCompletion(completions, 'DateTimeKind');
+        assertHasCompletion(completions, 'DateTimeOffset');
+    });
+
+    test('Can perform Completions on file with "#" in the name', async () => {
+        const firstLine = new vscode.Position(1, 0);
+        const fileNamePath = path.join(homeDirectory, '#FileName.cshtml');
+        const fileNameDoc = await vscode.workspace.openTextDocument(fileNamePath);
+        const fileNameEditor = await vscode.window.showTextDocument(fileNameDoc);
+        await fileNameEditor.edit(edit => edit.insert(firstLine, '@Da'));
+
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            fileNameDoc.uri,
+            new vscode.Position(1, 2));
+
+        assertHasCompletion(completions, 'DateTime');
     });
 
     test('Can complete imported C# in .cshtml', async () => {
@@ -114,11 +125,8 @@ suite('Completions', () => {
             'vscode.executeCompletionItemProvider',
             cshtmlDoc.uri,
             new vscode.Position(cshtmlDoc.lineCount - 1, 1));
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText.startsWith('TheTime'))
-            .map(item => item.insertText as string);
 
-        assert.deepEqual(matchingCompletions, ['TheTime']);
+        assertHasCompletion(completions, 'TheTime');
     });
 
     test('Can complete HTML tag in .cshtml', async () => {
@@ -128,10 +136,7 @@ suite('Completions', () => {
             'vscode.executeCompletionItemProvider',
             cshtmlDoc.uri,
             new vscode.Position(0, 4));
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText.startsWith('str'))
-            .map(item => item.insertText as string);
 
-        assert.deepEqual(matchingCompletions, ['strong']);
+        assertHasCompletion(completions, 'strong');
     });
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Completions2_1.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Completions2_1.test.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as assert from 'assert';
 import { afterEach, before, beforeEach } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {
+    assertHasCompletion,
+    assertHasNoCompletion,
     pollUntil,
     simpleMvc21Root,
     waitForDocumentUpdate,
@@ -52,11 +53,8 @@ suite('Completions 2.1', () => {
             'vscode.executeCompletionItemProvider',
             doc.uri,
             docPosition);
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText === 'iframe')
-            .map(item => item.insertText as string);
 
-        assert.deepEqual(matchingCompletions, ['iframe']);
+        assertHasCompletion(completions, 'iframe');
     });
 
     test('Can complete C# code blocks', async () => {
@@ -68,11 +66,10 @@ suite('Completions 2.1', () => {
             'vscode.executeCompletionItemProvider',
             doc.uri,
             new vscode.Position(doc.lineCount - 1, 2));
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText.startsWith('DateTime'))
-            .map(item => item.insertText as string);
 
-        assert.deepEqual(matchingCompletions, ['DateTime', 'DateTimeKind', 'DateTimeOffset']);
+        assertHasCompletion(completions, 'DateTime');
+        assertHasCompletion(completions, 'DateTimeKind');
+        assertHasCompletion(completions, 'DateTimeOffset');
     });
 
     test('Can complete C# implicit expressions', async () => {
@@ -84,11 +81,10 @@ suite('Completions 2.1', () => {
             'vscode.executeCompletionItemProvider',
             doc.uri,
             new vscode.Position(doc.lineCount - 1, 1));
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText.startsWith('DateTime'))
-            .map(item => item.insertText as string);
 
-        assert.deepEqual(matchingCompletions, ['DateTime', 'DateTimeKind', 'DateTimeOffset']);
+        assertHasCompletion(completions, 'DateTime');
+        assertHasCompletion(completions, 'DateTimeKind');
+        assertHasCompletion(completions, 'DateTimeOffset');
     });
 
     test('Can complete imported C#', async () => {
@@ -100,11 +96,8 @@ suite('Completions 2.1', () => {
             'vscode.executeCompletionItemProvider',
             doc.uri,
             new vscode.Position(doc.lineCount - 1, 1));
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText.startsWith('TheTime'))
-            .map(item => item.insertText as string);
 
-        assert.deepEqual(matchingCompletions, ['TheTime']);
+        assertHasCompletion(completions, 'TheTime');
     });
 
     test('Can complete Razor directive', async () => {
@@ -115,11 +108,9 @@ suite('Completions 2.1', () => {
             doc.uri,
             new vscode.Position(0, 1));
 
-        const hasCompletion = (text: string) => completions!.items.some(item => item.insertText === text);
-
-        assert.ok(hasCompletion('page'), 'Should have completion for "page"');
-        assert.ok(hasCompletion('inject'), 'Should have completion for "inject"');
-        assert.ok(!hasCompletion('div'), 'Should not have completion for "div"');
+        assertHasCompletion(completions, 'page');
+        assertHasCompletion(completions, 'inject');
+        assertHasNoCompletion(completions, 'div');
     });
 
     test('Can complete HTML tag', async () => {
@@ -129,10 +120,6 @@ suite('Completions 2.1', () => {
             'vscode.executeCompletionItemProvider',
             doc.uri,
             new vscode.Position(0, 4));
-        const matchingCompletions = completions!.items
-            .filter(item => (typeof item.insertText === 'string') && item.insertText.startsWith('str'))
-            .map(item => item.insertText as string);
-
-        assert.deepEqual(matchingCompletions, ['strong']);
+        assertHasCompletion(completions, 'strong');
     });
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/CompletionsComponents.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/CompletionsComponents.test.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as assert from 'assert';
 import { afterEach, before, beforeEach } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {
+    assertHasCompletion,
     componentRoot,
     pollUntil,
     waitForProjectReady,
@@ -15,6 +15,7 @@ import {
 
 let counterDoc: vscode.TextDocument;
 let counterEditor: vscode.TextEditor;
+const pagesDirectory = path.join(componentRoot, 'Components', 'Pages');
 
 suite('Completions Components', () => {
     before(async () => {
@@ -22,7 +23,7 @@ suite('Completions Components', () => {
     });
 
     beforeEach(async () => {
-        const counterPath = path.join(componentRoot, 'Components', 'Pages', 'Counter.razor');
+        const counterPath =  path.join(pagesDirectory, 'Counter.razor');
         counterDoc = await vscode.workspace.openTextDocument(counterPath);
         counterEditor = await vscode.window.showTextDocument(counterDoc);
     });
@@ -47,10 +48,7 @@ suite('Completions Components', () => {
             'vscode.executeCompletionItemProvider',
             counterDoc.uri,
             new vscode.Position(1, 50));
-        const matchingCompletions = completions!.items
-            .filter(item => item.label === 'OnValidSubmit')
-            .map(item => item.label as string);
 
-        assert.deepEqual(matchingCompletions, ['OnValidSubmit']);
+        assertHasCompletion(completions, 'OnValidSubmit');
     });
 });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Rename.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/Rename.test.ts
@@ -119,7 +119,6 @@ suite('Rename', () => {
     test('Rename symbol in .cs also changes .razor', async () => {
         const expectedNewText = 'Oof';
         const csDoc = await vscode.workspace.openTextDocument(csPath);
-        const csEditor = await vscode.window.showTextDocument(csDoc);
 
         await new Promise(r => setTimeout(r, 3000));
         const renames = await vscode.commands.executeCommand<vscode.WorkspaceEdit>(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/TestUtil.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.FunctionalTest/tests/TestUtil.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import * as assert from 'assert';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as glob from 'glob';
@@ -42,6 +43,16 @@ export async function pollUntil(fn: () => (boolean | Promise<boolean>), timeoutM
         timeWaited += resolvedPollInterval;
     }
     while (!fnEval);
+}
+
+export function assertHasNoCompletion(completions: vscode.CompletionList | undefined, name: string) {
+    const ok = completions!.items.some(item => item.label === name);
+    assert.ok(!ok, `Should not have had completion "${name}"`);
+}
+
+export function assertHasCompletion(completions: vscode.CompletionList | undefined, name: string) {
+    const ok = completions!.items.some(item => item.label === name);
+    assert.ok(ok, `Should have had completion "${name}"`);
 }
 
 export async function ensureNoChangesFor(documentUri: vscode.Uri, durationMs: number) {
@@ -149,13 +160,11 @@ export async function waitForProjectsConfigured() {
 
 async function removeOldProjectRazorJsons() {
     const folders = fs.readdirSync(testAppsRoot);
-    let count = 0;
     for (const folder of folders) {
         const objDir = path.join(testAppsRoot, folder, 'obj');
         if (findInDir(objDir, projectConfigFile)) {
             const projFile = findInDir(objDir, projectConfigFile) as string;
             fs.unlinkSync(projFile);
-            count++;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/RazorLogger.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/RazorLogger.test.ts
@@ -31,6 +31,7 @@ describe('RazorLogger', () => {
         const log = getAndAssertLog(sink);
         const logContent = log.join('LF');
         assert.ok(logContent.indexOf('currently set to \'Off\'') > 0);
+        logger.dispose();
     });
 
     it('logAlways logs when trace is Off', () => {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/ReportIssueDataCollector.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/ReportIssueDataCollector.test.ts
@@ -28,6 +28,7 @@ describe('ReportIssueDataCollector', () => {
         // Assert
         const lastLog = razorOutputChannel[razorOutputChannel.length - 1];
         assert.ok(lastLog.indexOf('Starting') > 0);
+        dataCollector.stop();
     });
 
     it('stop always logs the stopping of data collection', async () => {

--- a/src/Razor/test/testapps/MvcWithComponents/Views/Home/#FileName.cshtml
+++ b/src/Razor/test/testapps/MvcWithComponents/Views/Home/#FileName.cshtml
@@ -1,0 +1,1 @@
+@page "/filename"

--- a/src/Razor/tsconfig.json
+++ b/src/Razor/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "strict": true,
     "moduleResolution": "node",
+    "noUnusedLocals": true,
     "sourceMap": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/14323.

vscode.Uri.parse treats anything after `#` as a uri fragment, so instead I used vscode.Uri.file then set the scheme after. `file` doesn't try to parse out the fragment, so the file is handled properly.