### PR TITLE
Add Razor colorization grammar to Visual Studio.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -1,6 +1,10 @@
 {
   "name": "ASP.NET Razor",
   "scopeName": "text.aspnetcorerazor",
+  "fileTypes": [
+    "razor",
+    "cshtml"
+  ],
   "patterns": [
     {
       "include": "#razor-control-structures"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -1,5 +1,8 @@
 name: ASP.NET Razor
 scopeName: text.aspnetcorerazor
+fileTypes:
+  - 'razor'
+  - 'cshtml'
 patterns:
   - include: '#razor-control-structures'
   - include: 'text.html.basic'

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -1,0 +1,2 @@
+﻿[$RootKey$\TextMate\Repositories]
+"AspNetCoreRazor"="$PackageFolder$\Grammars"

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -55,6 +55,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Microsoft.VisualStudio.RazorExtension.Custom.pkgdef">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -132,6 +137,21 @@
       <Content Include="$(_ResolvedPackageVersionInfoProperty)\*">
         <IncludeInVsix>true</IncludeInVsix>
         <VSIXSubPath>LanguageServer\</VSIXSubPath>
+      </Content>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_BuildRazorGrammar">
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.VSCode.Extension\Microsoft.AspNetCore.Razor.VSCode.Extension.npmproj"
+        Targets="Build" />
+  </Target>
+
+  <Target Name="_IncludeRazorGrammar" DependsOnTargets="PrepareForBuild;_BuildRazorGrammar"  BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Content Include="..\Microsoft.AspNetCore.Razor.VSCode.Extension\syntaxes\aspnetcorerazor.tmLanguage.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <IncludeInVSIX>true</IncludeInVSIX>
+        <VSIXSubPath>Grammars\</VSIXSubPath>
       </Content>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
- The new grammar will apply to our LSP editor Razor files.
- Had to update our grammar to specifically apply to razor/cshtml files so VS would pick up the mapping
- The grammar doesn't look to colorize the embedded languages correctly. Have reached out to the VS editor team to investigate the issue further.
- Couldn't add tests because this was more of an end-to-end scenario.
- Added a new pkdef to our extension to allow us to hand-edit pkdef's (ours are usually auto-generated) for features that do not have a code-first model (TextMate).
- Expanded the VSIX extension to build the grammar project on run to ensure we always get the latest grammar.
- Does not include "proper" colorization of Razor constructs, that's tracked at https://github.com/dotnet/aspnetcore/issues/18769

dotnet/aspnetcore#17801