### PR TITLE
Normalize Linux Pathing

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -1,0 +1,94 @@
+#
+# This file must be used by invoking "source activate.sh" from the command line.
+# You cannot run it directly.
+# To exit from the environment this creates, execute the 'deactivate' function.
+
+_RED="\033[0;31m"
+_MAGENTA="\033[0;95m"
+_YELLOW="\033[0;33m"
+_RESET="\033[0m"
+
+# This detects if a script was sourced or invoked directly
+# See https://stackoverflow.com/a/28776166/2526265
+sourced=0
+if [ -n "$ZSH_EVAL_CONTEXT" ]; then
+  case $ZSH_EVAL_CONTEXT in *:file) sourced=1;; esac
+  THIS_SCRIPT="${0:-}"
+elif [ -n "$KSH_VERSION" ]; then
+  [ "$(cd $(dirname -- $0) && pwd -P)/$(basename -- $0)" != "$(cd $(dirname -- ${.sh.file}) && pwd -P)/$(basename -- ${.sh.file})" ] && sourced=1
+  THIS_SCRIPT="${0:-}"
+elif [ -n "$BASH_VERSION" ]; then
+  (return 2>/dev/null) && sourced=1
+  THIS_SCRIPT="$BASH_SOURCE"
+else # All other shells: examine $0 for known shell binary filenames
+  # Detects `sh` and `dash`; add additional shell filenames as needed.
+  case ${0##*/} in sh|dash) sourced=1;; esac
+  THIS_SCRIPT="${0:-}"
+fi
+
+if [ $sourced -eq 0 ]; then
+    printf "${_RED}This script cannot be invoked directly.${_RESET}\n"
+    printf "${_RED}To function correctly, this script file must be sourced by calling \"source $0\".${_RESET}\n"
+    exit 1
+fi
+
+deactivate () {
+
+    # reset old environment variables
+    if [ ! -z "${_OLD_PATH:-}" ] ; then
+        export PATH="$_OLD_PATH"
+        unset _OLD_PATH
+    fi
+
+    if [ ! -z "${_OLD_PS1:-}" ] ; then
+        export PS1="$_OLD_PS1"
+        unset _OLD_PS1
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must
+    # be called to get it to forget past commands.  Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
+        hash -r 2>/dev/null
+    fi
+
+    unset DOTNET_ROOT
+    unset DOTNET_MULTILEVEL_LOOKUP
+    if [ ! "${1:-}" = "init" ] ; then
+        # Remove the deactivate function
+        unset -f deactivate
+    fi
+}
+
+# Cleanup the environment
+deactivate init
+
+DIR="$( cd "$( dirname "$THIS_SCRIPT" )" && pwd )"
+_OLD_PATH="$PATH"
+# Tell dotnet where to find itself
+export DOTNET_ROOT="$DIR/.dotnet"
+# Tell dotnet not to look beyond the DOTNET_ROOT folder for more dotnet things
+export DOTNET_MULTILEVEL_LOOKUP=0
+# Put dotnet first on PATH
+export PATH="$DOTNET_ROOT:$PATH"
+
+# Set the shell prompt
+if [ -z "${DISABLE_CUSTOM_PROMPT:-}" ] ; then
+    _OLD_PS1="$PS1"
+    export PS1="(`basename \"$DIR\"`) $PS1"
+fi
+
+# This should detect bash and zsh, which have a hash command that must
+# be called to get it to forget past commands.  Without forgetting
+# past commands the $PATH changes we made may not be respected
+if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
+    hash -r 2>/dev/null
+fi
+
+printf "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}\n"
+
+if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
+    printf "${_YELLOW}.NET Core has not been installed yet. Run $DIR/restore.sh to install it.${_RESET}\n"
+else
+    printf "dotnet = $DOTNET_ROOT/dotnet\n"
+fi

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpDocumentSnapshot.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     public sealed class OmniSharpDocumentSnapshot
     {
         private readonly DocumentSnapshot _documentSnapshot;
+        private readonly object _projectLock;
         private OmniSharpHostDocument _hostDocument;
         private OmniSharpProjectSnapshot _project;
-        private readonly object _projectLock;
 
         internal OmniSharpDocumentSnapshot(DocumentSnapshot documentSnapshot)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpDocumentSnapshot.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 
@@ -13,7 +12,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         private readonly DocumentSnapshot _documentSnapshot;
         private OmniSharpHostDocument _hostDocument;
         private OmniSharpProjectSnapshot _project;
-        private object _projectLock;
+        private readonly object _projectLock;
 
         internal OmniSharpDocumentSnapshot(DocumentSnapshot documentSnapshot)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostDocument.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostDocument.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
@@ -10,6 +11,15 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public OmniSharpHostDocument(string filePath, string targetPath, string kind)
         {
             InternalHostDocument = new HostDocument(filePath, targetPath, kind);
+
+            if (targetPath.Contains("/"))
+            {
+                throw new FormatException("TargetPath's must use '\\' instead of '/'");
+            }
+            if (targetPath.StartsWith("\\"))
+            {
+                throw new FormatException("TargetPath's can't start with '\\'");
+            }
         }
 
         public string FilePath => InternalHostDocument.FilePath;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostDocument.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpHostDocument.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             {
                 throw new FormatException("TargetPath's must use '\\' instead of '/'");
             }
+
             if (targetPath.StartsWith("\\"))
             {
                 throw new FormatException("TargetPath's can't start with '\\'");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         }
 
         /// <summary>
-        /// TargetPath is defined as using '\\' but some Tasks used to set that parameter don't respect that, so we normalize.
+        /// TargetPath is defined as using '\' but some Tasks used to set that parameter don't respect that, so we normalize.
         /// </summary>
         /// <param name="targetPath">The TargetPath to be normalized.</param>
         /// <returns>A normalized TargetPath</returns>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
@@ -220,8 +220,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         /// </summary>
         /// <param name="targetPath">The TargetPath to be normalized.</param>
         /// <returns>A normalized TargetPath</returns>
-        private static string NormalizeTargetPath(string targetPath)
+        internal static string NormalizeTargetPath(string targetPath)
         {
+            if (targetPath is null)
+            {
+                throw new ArgumentNullException(nameof(targetPath));
+            }
+
             var normalizedTargetPath = targetPath.Replace('/', '\\');
             normalizedTargetPath = normalizedTargetPath.TrimStart('\\');
             return normalizedTargetPath;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/LatestProjectConfigurationProvider.cs
@@ -107,23 +107,24 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 if (item.ItemType == RazorGenerateWithTargetPathItemType)
                 {
                     var filePath = Path.Combine(item.Project.Directory, item.EvaluatedInclude);
-                    var targetPath = item.GetMetadataValue(RazorTargetPathMetadataName);
-                    var hostDocument = new OmniSharpHostDocument(filePath, targetPath, FileKinds.Legacy);
+                    var originalTargetPath = item.GetMetadataValue(RazorTargetPathMetadataName);
+                    var normalizedTargetPath = NormalizeTargetPath(originalTargetPath);
+                    var hostDocument = new OmniSharpHostDocument(filePath, normalizedTargetPath, FileKinds.Legacy);
                     hostDocuments.Add(hostDocument);
                 }
                 else if (item.ItemType == RazorComponentWithTargetPathItemType)
                 {
                     var filePath = Path.Combine(item.Project.Directory, item.EvaluatedInclude);
-                    var targetPath = item.GetMetadataValue(RazorTargetPathMetadataName);
+                    var originalTargetPath = item.GetMetadataValue(RazorTargetPathMetadataName);
+                    var normalizedTargetPath = NormalizeTargetPath(originalTargetPath);
                     var fileKind = FileKinds.GetComponentFileKindFromFilePath(filePath);
-                    var hostDocument = new OmniSharpHostDocument(filePath, targetPath, fileKind);
+                    var hostDocument = new OmniSharpHostDocument(filePath, normalizedTargetPath, fileKind);
                     hostDocuments.Add(hostDocument);
                 }
             }
 
             return hostDocuments.ToList();
         }
-
 
         // Internal for testing
         internal static bool TryGetDefaultConfiguration(ProjectInstance projectInstance, out string defaultConfiguration)
@@ -212,6 +213,18 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             }
 
             return extensions.ToArray();
+        }
+
+        /// <summary>
+        /// TargetPath is defined as using '\\' but some Tasks used to set that parameter don't respect that, so we normalize.
+        /// </summary>
+        /// <param name="targetPath">The TargetPath to be normalized.</param>
+        /// <returns>A normalized TargetPath</returns>
+        private static string NormalizeTargetPath(string targetPath)
+        {
+            var normalizedTargetPath = targetPath.Replace('/', '\\');
+            normalizedTargetPath = normalizedTargetPath.TrimStart('\\');
+            return normalizedTargetPath;
         }
 
         private class ProjectSystemRazorConfiguration : RazorConfiguration

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -131,7 +131,6 @@
                         "null"
                     ],
                     "default": null,
-                    "scope": "machine",
                     "description": "Overrides the path to the Razor plugin dll."
                 },
                 "razor.languageServer.debug": {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             // Arrange
             var projectSnapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var hostProject = new OmniSharpHostProject("/path/to/unknownproject.csproj", RazorConfiguration.Default, rootNamespace: "TestRootNamespace");
-            var hostDocument = new OmniSharpHostDocument("/path/to/Counter.razor", "/path/to/Counter.razor", FileKinds.Component);
+            var hostDocument = new OmniSharpHostDocument("/path/to/Counter.razor", "path\\to\\Counter.razor", FileKinds.Component);
             await RunOnForegroundAsync(() =>
             {
                 projectSnapshotManager.ProjectAdded(hostProject);
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             // Arrange
             var projectSnapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var hostProject = new OmniSharpHostProject(Project.FilePath, RazorConfiguration.Default, rootNamespace: "TestRootNamespace");
-            var hostDocument = new OmniSharpHostDocument("/path/to/Counter.razor", "/path/to/Counter.razor", FileKinds.Component);
+            var hostDocument = new OmniSharpHostDocument("/path/to/Counter.razor", "path\\to\\Counter.razor", FileKinds.Component);
             await RunOnForegroundAsync(() =>
             {
                 projectSnapshotManager.ProjectAdded(hostProject);
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             // Arrange
             var projectSnapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var hostProject = new OmniSharpHostProject(Project.FilePath, RazorConfiguration.Default, rootNamespace: "TestRootNamespace");
-            var hostDocument = new OmniSharpHostDocument("/path/to/Counter.razor", "/path/to/Counter.razor", FileKinds.Component);
+            var hostDocument = new OmniSharpHostDocument("/path/to/Counter.razor", "path\\to\\Counter.razor", FileKinds.Component);
             await RunOnForegroundAsync(() =>
             {
                 projectSnapshotManager.ProjectAdded(hostProject);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/LatestProjectConfigurationProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/LatestProjectConfigurationProviderTest.cs
@@ -580,5 +580,28 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 extension => Assert.Equal(expectedExtension2Name, extension.ExtensionName));
             Assert.Equal(expectedRootNamespace, configuration.RootNamespace);
         }
+
+        [Theory]
+        [InlineData("//Views//_Import.cshtml", "Views\\\\_Import.cshtml")]
+        [InlineData("/Views/_Import.cshtml", "Views\\_Import.cshtml")]
+        [InlineData("Views/_Import.cshtml", "Views\\_Import.cshtml")]
+        [InlineData("\\Views\\_Import.cshtml", "Views\\_Import.cshtml")]
+        [InlineData("Views\\_Import.cshtml", "Views\\_Import.cshtml")]
+        [InlineData("_Import.cshtml", "_Import.cshtml")]
+        public void NormalizeTargetPath_BehavesAccordingToTargetPathSpec(string originalTargetPath, string expectedTargetPath)
+        {
+            // Arrange & Act
+            var normalizedPath = LatestProjectConfigurationProvider.NormalizeTargetPath(originalTargetPath);
+
+            // Assert
+            Assert.Equal(expectedTargetPath, normalizedPath);
+        }
+
+        [Fact]
+        public void NormalizeTargetPath_HandlesNull()
+        {
+            // Arrange, Act & Assert
+            Assert.Throws<ArgumentNullException>(() => LatestProjectConfigurationProvider.NormalizeTargetPath(null));
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/LatestProjectConfigurationProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/LatestProjectConfigurationProviderTest.cs
@@ -80,13 +80,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 hostDocument =>
                 {
                     Assert.Equal(Path.Combine(projectDirectory, "file.cshtml"), hostDocument.FilePath);
-                    Assert.Equal("path/file.cshtml", hostDocument.TargetPath);
+                    Assert.Equal("path\\file.cshtml", hostDocument.TargetPath);
                     Assert.Equal(FileKinds.Legacy, hostDocument.FileKind);
                 },
                 hostDocument =>
                 {
                     Assert.Equal(Path.Combine(projectDirectory, "otherfile.cshtml"), hostDocument.FilePath);
-                    Assert.Equal("other/path/otherfile.cshtml", hostDocument.TargetPath);
+                    Assert.Equal("other\\path\\otherfile.cshtml", hostDocument.TargetPath);
                     Assert.Equal(FileKinds.Legacy, hostDocument.FileKind);
                 });
         }
@@ -115,13 +115,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 hostDocument =>
                 {
                     Assert.Equal(Path.Combine(projectDirectory, "path/file.razor"), hostDocument.FilePath);
-                    Assert.Equal("path/file.razor", hostDocument.TargetPath);
+                    Assert.Equal("path\\file.razor", hostDocument.TargetPath);
                     Assert.Equal(FileKinds.Component, hostDocument.FileKind);
                 },
                 hostDocument =>
                 {
                     Assert.Equal(Path.Combine(projectDirectory, "other/path/otherfile.razor"), hostDocument.FilePath);
-                    Assert.Equal("other/path/otherfile.razor", hostDocument.TargetPath);
+                    Assert.Equal("other\\path\\otherfile.razor", hostDocument.TargetPath);
                     Assert.Equal(FileKinds.Component, hostDocument.FileKind);
                 });
         }
@@ -150,13 +150,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 hostDocument =>
                 {
                     Assert.Equal(Path.Combine(projectDirectory, "file.razor"), hostDocument.FilePath);
-                    Assert.Equal("path/file.razor", hostDocument.TargetPath);
+                    Assert.Equal("path\\file.razor", hostDocument.TargetPath);
                     Assert.Equal(FileKinds.Component, hostDocument.FileKind);
                 },
                 hostDocument =>
                 {
                     Assert.Equal(Path.Combine(projectDirectory, "otherfile.cshtml"), hostDocument.FilePath);
-                    Assert.Equal("other/path/otherfile.cshtml", hostDocument.TargetPath);
+                    Assert.Equal("other\\path\\otherfile.cshtml", hostDocument.TargetPath);
                     Assert.Equal(FileKinds.Legacy, hostDocument.FileKind);
                 });
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/14318.

- Added `activate.sh`. This was missing and I needed it to do my debugging in Linux, so I just added it here. It's an exact copy of what's in https://github.com/dotnet/aspnetcore
- OmniSharpHostDocument now throws is TargetPath doesn't meet the expected requirements.
- Normalize Document TargetPaths. We expected MSBuild to do this for us, but it's not (either correctly or wrongly.)
- Fix tests to reflect our expectations.
- Remove machine-scope of `razor.plugin.path` for local exception (It needs to stay machine-scoped in Omnisharp though). Again, needed this to debug in Linux.