### PR TITLE
Suppress warnings about depending on non-stable versions of packages

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains common assets that are used in the Razor language server and other assemblies.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <!-- Suppress warnings about depending on non-stable version of Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `NU5104` warning in this project is a constant source of failures in stable builds of this branch. We should figure out if we're doing something wrong with this reference, but for now we can just suppress the warning. Example of a failing build: https://dev.azure.com/dnceng/internal/_build/results?buildId=522096

CC @dougbu @JunTaoLuo 

@Pilchie is this alright for 3.1.3 tell mode?

> F:\workspace_work\1\s.dotnet\sdk\3.1.100\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(198,5): error NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X [3.1.3-servicing.20114.2, )" or update the version field in the nuspec. [F:\workspace_work\1\s\src\Razor\src\Microsoft.AspNetCore.Razor.LanguageServer.Common\Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj]