### PR TITLE
Add Visual Studio LSP document tracking manager.

### DIFF
--- a/src/Razor/Razor.sln
+++ b/src/Razor/Razor.sln
@@ -108,6 +108,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.LanguageServerClient.Razor", "src\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.csproj", "{70E70B52-EB70-42D1-B785-8618BD0B950E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.LanguageServerClient.Razor.Test", "test\Microsoft.VisualStudio.LanguageServerClient.Razor.Test\Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj", "{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -500,6 +502,14 @@ Global
 		{70E70B52-EB70-42D1-B785-8618BD0B950E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{70E70B52-EB70-42D1-B785-8618BD0B950E}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{70E70B52-EB70-42D1-B785-8618BD0B950E}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -553,6 +563,7 @@ Global
 		{305354FD-5ED7-4E89-8B1D-58FCCA3E08AD} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 		{4ED6CC87-11C4-4ECD-B9A1-AFC5C2DACABE} = {92463391-81BE-462B-AC3C-78C6C760741F}
 		{70E70B52-EB70-42D1-B785-8618BD0B950E} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E} = {92463391-81BE-462B-AC3C-78C6C760741F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0035341D-175A-4D05-95E6-F1C2785A1E26}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class CSharpVirtualDocument : VirtualDocument
+    {
+        private readonly ITextBuffer _textBuffer;
+
+        public CSharpVirtualDocument(Uri uri, ITextBuffer textBuffer)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            Uri = uri;
+            _textBuffer = textBuffer;
+        }
+
+        public override Uri Uri { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(VirtualDocumentFactory))]
+    internal class CSharpVirtualDocumentFactory : VirtualDocumentFactory
+    {
+        // Internal for testing
+        internal const string CSharpLSPContentTypeName = "C#_LSP";
+        internal const string VirtualCSharpFileNameSuffix = "__virtual.cs";
+
+        private readonly IContentTypeRegistryService _contentTypeRegistry;
+        private readonly ITextBufferFactoryService _textBufferFactory;
+        private readonly FileUriProvider _fileUriProvider;
+        private IContentType _csharpLSPContentType;
+
+        [ImportingConstructor]
+        public CSharpVirtualDocumentFactory(
+            IContentTypeRegistryService contentTypeRegistry,
+            ITextBufferFactoryService textBufferFactory,
+            FileUriProvider fileUriProvider)
+        {
+            if (contentTypeRegistry is null)
+            {
+                throw new ArgumentNullException(nameof(contentTypeRegistry));
+            }
+
+            if (textBufferFactory is null)
+            {
+                throw new ArgumentNullException(nameof(textBufferFactory));
+            }
+
+            if (fileUriProvider is null)
+            {
+                throw new ArgumentNullException(nameof(fileUriProvider));
+            }
+
+            _contentTypeRegistry = contentTypeRegistry;
+            _textBufferFactory = textBufferFactory;
+            _fileUriProvider = fileUriProvider;
+        }
+
+        private IContentType CSharpLSPContentType
+        {
+            get
+            {
+                if (_csharpLSPContentType == null)
+                {
+                    _csharpLSPContentType = _contentTypeRegistry.GetContentType(CSharpLSPContentTypeName);
+                }
+
+                return _csharpLSPContentType;
+            }
+        }
+
+        public override bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument)
+        {
+            if (hostDocumentBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(hostDocumentBuffer));
+            }
+
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            {
+                // Another content type we don't care about.
+                virtualDocument = null;
+                return false;
+            }
+
+            var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
+
+            // Index.cshtml => Index.cshtml__virtual.cs
+            var virtualCSharpFilePath = hostDocumentUri.AbsolutePath + VirtualCSharpFileNameSuffix;
+            var virtualCSharpUri = new Uri(virtualCSharpFilePath);
+
+            var csharpBuffer = _textBufferFactory.CreateTextBuffer(CSharpLSPContentType);
+            virtualDocument = new CSharpVirtualDocument(virtualCSharpUri, csharpBuffer);
+            return true;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultFileUriProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultFileUriProvider.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.IO;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(FileUriProvider))]
+    internal class DefaultFileUriProvider : FileUriProvider
+    {
+        private readonly ITextDocumentFactoryService _textDocumentFactory;
+
+        [ImportingConstructor]
+        public DefaultFileUriProvider(ITextDocumentFactoryService textDocumentFactory)
+        {
+            if (textDocumentFactory is null)
+            {
+                throw new ArgumentNullException(nameof(textDocumentFactory));
+            }
+
+            _textDocumentFactory = textDocumentFactory;
+        }
+
+        public override Uri GetOrCreate(ITextBuffer textBuffer)
+        {
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            string filePath;
+            if (_textDocumentFactory.TryGetTextDocument(textBuffer, out var textDocument))
+            {
+                filePath = textDocument.FilePath;
+            }
+            else
+            {
+                // TextBuffer doesn't have a file path, we need to fabricate one.
+                filePath = Uri.UriSchemeFile + Uri.SchemeDelimiter + Guid.NewGuid().ToString();
+            }
+
+            var uri = new Uri(filePath, UriKind.Absolute);
+            return uri;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class DefaultLSPDocument : LSPDocument
+    {
+        public DefaultLSPDocument(Uri uri, IReadOnlyList<VirtualDocument> virtualDocuments)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (virtualDocuments is null)
+            {
+                throw new ArgumentNullException(nameof(virtualDocuments));
+            }
+
+            Uri = uri;
+            VirtualDocuments = virtualDocuments;
+        }
+
+        public override Uri Uri { get; }
+
+        public override IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentFactory.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(LSPDocumentFactory))]
+    internal class DefaultLSPDocumentFactory : LSPDocumentFactory
+    {
+        private readonly FileUriProvider _fileUriProvider;
+        private readonly IEnumerable<VirtualDocumentFactory> _virtualDocumentFactories;
+
+        [ImportingConstructor]
+        public DefaultLSPDocumentFactory(
+            FileUriProvider fileUriProvider,
+            [ImportMany] IEnumerable<VirtualDocumentFactory> virtualBufferFactories)
+        {
+            if (fileUriProvider is null)
+            {
+                throw new ArgumentNullException(nameof(fileUriProvider));
+            }
+
+            if (virtualBufferFactories is null)
+            {
+                throw new ArgumentNullException(nameof(virtualBufferFactories));
+            }
+
+            _fileUriProvider = fileUriProvider;
+            _virtualDocumentFactories = virtualBufferFactories;
+        }
+
+        public override LSPDocument Create(ITextBuffer buffer)
+        {
+            if (buffer is null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            var uri = _fileUriProvider.GetOrCreate(buffer);
+            var virtualDocuments = CreateVirtualDocuments(buffer);
+            var lspDocument = new DefaultLSPDocument(uri, virtualDocuments);
+
+            return lspDocument;
+        }
+
+        private IReadOnlyList<VirtualDocument> CreateVirtualDocuments(ITextBuffer hostDocumentBuffer)
+        {
+            var virtualDocuments = new List<VirtualDocument>();
+            foreach (var factory in _virtualDocumentFactories)
+            {
+                if (factory.TryCreateFor(hostDocumentBuffer, out var virtualDocument))
+                {
+                    virtualDocuments.Add(virtualDocument);
+                }
+            }
+
+            return virtualDocuments;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentFactory.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    [Shared]
     [Export(typeof(LSPDocumentFactory))]
     internal class DefaultLSPDocumentFactory : LSPDocumentFactory
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Diagnostics;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(LSPDocumentManager))]
+    internal class DefaultLSPDocumentManager : LSPDocumentManagerBase
+    {
+        private readonly JoinableTaskContext _joinableTaskContext;
+        private readonly FileUriProvider _fileUriProvider;
+        private readonly LSPDocumentFactory _documentFactory;
+        private readonly Dictionary<Uri, DocumentTracker> _documents;
+
+        [ImportingConstructor]
+        public DefaultLSPDocumentManager(
+            JoinableTaskContext joinableTaskContext,
+            FileUriProvider fileUriProvider,
+            LSPDocumentFactory documentFactory)
+        {
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            if (fileUriProvider is null)
+            {
+                throw new ArgumentNullException(nameof(fileUriProvider));
+            }
+
+            if (documentFactory is null)
+            {
+                throw new ArgumentNullException(nameof(documentFactory));
+            }
+
+            _joinableTaskContext = joinableTaskContext;
+            _fileUriProvider = fileUriProvider;
+            _documentFactory = documentFactory;
+            _documents = new Dictionary<Uri, DocumentTracker>();
+        }
+
+        public override void TrackDocumentView(ITextBuffer buffer, ITextView textView)
+        {
+            if (buffer is null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (textView is null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            Debug.Assert(_joinableTaskContext.IsOnMainThread);
+
+            var uri = _fileUriProvider.GetOrCreate(buffer);
+            if (!_documents.TryGetValue(uri, out var documentTracker))
+            {
+                var lspDocument = _documentFactory.Create(buffer);
+                documentTracker = new DocumentTracker(lspDocument);
+                _documents[uri] = documentTracker;
+            }
+
+            documentTracker.TextViews.Add(textView);
+        }
+
+        public override void UntrackDocumentView(ITextBuffer buffer, ITextView textView)
+        {
+            if (buffer is null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (textView is null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            Debug.Assert(_joinableTaskContext.IsOnMainThread);
+
+            var uri = _fileUriProvider.GetOrCreate(buffer);
+            if (!_documents.TryGetValue(uri, out var documentTracker))
+            {
+                // We don't know about this document, noop.
+                return;
+            }
+
+            documentTracker.TextViews.Remove(textView);
+
+            if (documentTracker.TextViews.Count == 0)
+            {
+                _documents.Remove(uri);
+            }
+        }
+
+        public override bool TryGetDocument(Uri uri, out LSPDocument lspDocument)
+        {
+            Debug.Assert(_joinableTaskContext.IsOnMainThread);
+
+            if (!_documents.TryGetValue(uri, out var documentTracker))
+            {
+                // This should never happen in practice but return `null` so our tests can validate
+                lspDocument = null;
+                return false;
+            }
+
+            lspDocument = documentTracker.Document;
+            return true;
+        }
+
+        private class DocumentTracker
+        {
+            public DocumentTracker(LSPDocument document)
+            {
+                Document = document;
+                TextViews = new HashSet<ITextView>();
+            }
+
+            public LSPDocument Document { get; }
+
+            public HashSet<ITextView> TextViews { get; }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
@@ -5,16 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    [Shared]
     [Export(typeof(LSPDocumentManager))]
-    internal class DefaultLSPDocumentManager : LSPDocumentManagerBase
+    internal class DefaultLSPDocumentManager : TrackingLSPDocumentManager
     {
         private readonly JoinableTaskContext _joinableTaskContext;
         private readonly FileUriProvider _fileUriProvider;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/FileUriProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/FileUriProvider.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal abstract class FileUriProvider
+    {
+        public abstract Uri GetOrCreate(ITextBuffer textBuffer);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/FileUriProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/FileUriProvider.cs
@@ -6,8 +6,19 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
+    /// <summary>
+    /// The purpose of the <see cref="FileUriProvider"/> is to take something that's not always addressable (an <see cref="ITextBuffer"/>) and make it addressable.
+    /// This is required in LSP scenarios because everything operates off of the assumption that a document can be addressable via a <see cref="Uri"/>.
+    /// </summary>
     internal abstract class FileUriProvider
     {
+        /// <summary>
+        /// Gets or creates an addressable <see cref="Uri"/> for the provided <paramref name="textBuffer"/>.
+        ///
+        /// In the case that the <paramref name="textBuffer"/> is not currently addressable via a <see cref="Uri"/>, we create one.
+        /// </summary>
+        /// <param name="textBuffer">A text buffer</param>
+        /// <returns>A <see cref="Uri"/> that can be used to locate the provided <paramref name="textBuffer"/>.</returns>
         public abstract Uri GetOrCreate(ITextBuffer textBuffer);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class HtmlVirtualDocument : VirtualDocument
+    {
+        private readonly ITextBuffer _textBuffer;
+
+        public HtmlVirtualDocument(Uri uri, ITextBuffer textBuffer)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            Uri = uri;
+            _textBuffer = textBuffer;
+        }
+
+        public override Uri Uri { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(VirtualDocumentFactory))]
+    internal class HtmlVirtualDocumentFactory : VirtualDocumentFactory
+    {
+        // Internal for testing
+        internal const string HtmlLSPContentTypeName = "htmlyLSP";
+        internal const string VirtualHtmlFileNameSuffix = "__virtual.html";
+
+        private readonly IContentTypeRegistryService _contentTypeRegistry;
+        private readonly ITextBufferFactoryService _textBufferFactory;
+        private readonly FileUriProvider _fileUriProvider;
+        private IContentType _htmlLSPContentType;
+
+        [ImportingConstructor]
+        public HtmlVirtualDocumentFactory(
+            IContentTypeRegistryService contentTypeRegistry,
+            ITextBufferFactoryService textBufferFactory,
+            FileUriProvider filePathProvider)
+        {
+            if (contentTypeRegistry is null)
+            {
+                throw new ArgumentNullException(nameof(contentTypeRegistry));
+            }
+
+            if (textBufferFactory is null)
+            {
+                throw new ArgumentNullException(nameof(textBufferFactory));
+            }
+
+            if (filePathProvider is null)
+            {
+                throw new ArgumentNullException(nameof(filePathProvider));
+            }
+
+            _contentTypeRegistry = contentTypeRegistry;
+            _textBufferFactory = textBufferFactory;
+            _fileUriProvider = filePathProvider;
+        }
+
+        private IContentType HtmlLSPContentType
+        {
+            get
+            {
+                if (_htmlLSPContentType == null)
+                {
+                    _htmlLSPContentType = _contentTypeRegistry.GetContentType(HtmlLSPContentTypeName);
+                }
+
+                return _htmlLSPContentType;
+            }
+        }
+
+        public override bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument)
+        {
+            if (hostDocumentBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(hostDocumentBuffer));
+            }
+
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            {
+                // Another content type we don't care about.
+                virtualDocument = null;
+                return false;
+            }
+
+            var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
+
+            // Index.cshtml => Index.cshtml__virtual.html
+            var virtualHtmlFilePath = hostDocumentUri + VirtualHtmlFileNameSuffix;
+            var virtualHtmlUri = new Uri(virtualHtmlFilePath);
+
+            var htmlBuffer = _textBufferFactory.CreateTextBuffer(HtmlLSPContentType);
+            virtualDocument = new HtmlVirtualDocument(virtualHtmlUri, htmlBuffer);
+            return true;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
@@ -6,10 +6,22 @@ using System.Collections.Generic;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
+    /// <summary>
+    /// An <see cref="LSPDocument"/> represents a top-level document that has embedded languages in it. For instance a Razor document has embedded
+    /// C# and HTML. The purpose of the <see cref="LSPDocument"/> is to provide a mechanism through which consumers can address a given document
+    /// via the <see cref="Uri"/> and based on calculated information such as "what language is being operated on?" extract virtual documents
+    /// from the <see cref="VirtualDocuments"/> list in an effort to re-invoke LSP requests.
+    /// </summary>
     public abstract class LSPDocument
     {
+        /// <summary>
+        /// The address to use to refer to the current <see cref="LSPDocument"/>.
+        /// </summary>
         public abstract Uri Uri { get; }
 
+        /// <summary>
+        /// A collection of <see cref="VirtualDocument"/>s that represent the embedded documents for the top level <see cref="LSPDocument"/>.
+        /// </summary>
         public abstract IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public abstract class LSPDocument
+    {
+        public abstract Uri Uri { get; }
+
+        public abstract IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
@@ -23,5 +23,26 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         /// A collection of <see cref="VirtualDocument"/>s that represent the embedded documents for the top level <see cref="LSPDocument"/>.
         /// </summary>
         public abstract IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
+
+        /// <summary>
+        /// Retrieves a virtual document of the provided <typeparamref name="TDocument"/> type.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of <see cref="VirtualDocument"/> to find.</typeparam>
+        /// <param name="virtualDocument">The virtual document of the provided <typeparamref name="TDocument"/> type.</param>
+        /// <returns><c>true</c> if <see cref="VirtualDocuments"/> contains a <see cref="VirtualDocument"/> of the provided <typeparamref name="TDocument"/> type; <c>false</c> otherwise.</returns>
+        public bool TryGetVirtualDocument<TDocument>(out TDocument virtualDocument) where TDocument : VirtualDocument
+        {
+            for (var i = 0; i < VirtualDocuments.Count; i++)
+            {
+                if (VirtualDocuments[i] is TDocument actualVirtualDocument)
+                {
+                    virtualDocument = actualVirtualDocument;
+                    return true;
+                }
+            }
+
+            virtualDocument = null;
+            return false;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal abstract class LSPDocumentFactory
+    {
+        public abstract LSPDocument Create(ITextBuffer buffer);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManager.cs
@@ -5,8 +5,20 @@ using System;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
+    /// <summary>
+    /// There are two primary purposes of the <see cref="LSPDocumentManager"/>.
+    ///
+    /// 1. Track <see cref="LSPDocument"/> lifecycles.
+    /// 2. Allow known <see cref="LSPDocument"/>s to be looked up via <see cref="TryGetDocument(Uri, out LSPDocument)"/>.
+    /// </summary>
     public abstract class LSPDocumentManager
     {
+        /// <summary>
+        /// Retrieves the <see cref="LSPDocument"/> associated with the <paramref name="uri"/>.
+        /// </summary>
+        /// <param name="uri">The address of the document to look up.</param>
+        /// <param name="lspDocument">The resolved <see cref="LSPDocument"/>.</param>
+        /// <returns><c>true</c> if the <see cref="LSPDocument"/> could be resolved for the given <paramref name="uri"/>, <c>false</c> otherwise.</returns>
         public abstract bool TryGetDocument(Uri uri, out LSPDocument lspDocument);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManager.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public abstract class LSPDocumentManager
+    {
+        public abstract bool TryGetDocument(Uri uri, out LSPDocument lspDocument);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManagerBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManagerBase.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal abstract class LSPDocumentManagerBase : LSPDocumentManager
+    {
+        public abstract void TrackDocumentView(ITextBuffer buffer, ITextView textView);
+
+        public abstract void UntrackDocumentView(ITextBuffer buffer, ITextView textView);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.Editor.Razor\Microsoft.VisualStudio.Editor.Razor.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [ContentType(RazorLSPContentTypeDefinition.Name)]
+    [TextViewRole(PredefinedTextViewRoles.Document)]
+    [Export(typeof(ITextViewConnectionListener))]
+    internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
+    {
+        private readonly LSPDocumentManagerBase _lspDocumentManager;
+
+        [ImportingConstructor]
+        public RazorLSPTextViewConnectionListener(
+            LSPDocumentManager lspDocumentManager)
+        {
+            if (lspDocumentManager is null)
+            {
+                throw new ArgumentNullException(nameof(lspDocumentManager));
+            }
+
+            _lspDocumentManager = lspDocumentManager as LSPDocumentManagerBase;
+
+            Debug.Assert(_lspDocumentManager != null);
+        }
+
+        public void SubjectBuffersConnected(ITextView textView, ConnectionReason reason, IReadOnlyCollection<ITextBuffer> subjectBuffers)
+        {
+            foreach (var textBuffer in subjectBuffers)
+            {
+                if (!textBuffer.IsRazorLSPBuffer())
+                {
+                    continue;
+                }
+
+                // This initializes the Razor LSP world and constructs C#/HTML buffers for the embedded language parts of the Razor document.
+                _lspDocumentManager.TrackDocumentView(textBuffer, textView);
+            }
+        }
+
+        public void SubjectBuffersDisconnected(ITextView textView, ConnectionReason reason, IReadOnlyCollection<ITextBuffer> subjectBuffers)
+        {
+            foreach (var textBuffer in subjectBuffers)
+            {
+                if (!textBuffer.IsRazorLSPBuffer())
+                {
+                    continue;
+                }
+
+                // This initializes the Razor LSP world and constructs C#/HTML buffers for the embedded language parts of the Razor document.
+                _lspDocumentManager.UntrackDocumentView(textBuffer, textView);
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (_lspDocumentManager is null)
             {
-                throw new ArgumentNullException(nameof(_lspDocumentManager));
+                throw new ArgumentException("The LSP document manager should be of type " + typeof(TrackingLSPDocumentManager).FullName, nameof(_lspDocumentManager));
             }
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [Export(typeof(ITextViewConnectionListener))]
     internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
     {
-        private readonly LSPDocumentManagerBase _lspDocumentManager;
+        private readonly TrackingLSPDocumentManager _lspDocumentManager;
 
         [ImportingConstructor]
         public RazorLSPTextViewConnectionListener(
@@ -27,9 +27,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(lspDocumentManager));
             }
 
-            _lspDocumentManager = lspDocumentManager as LSPDocumentManagerBase;
+            _lspDocumentManager = lspDocumentManager as TrackingLSPDocumentManager;
 
-            Debug.Assert(_lspDocumentManager != null);
+            if (_lspDocumentManager is null)
+            {
+                throw new ArgumentNullException(nameof(_lspDocumentManager));
+            }
         }
 
         public void SubjectBuffersConnected(ITextView textView, ConnectionReason reason, IReadOnlyCollection<ITextBuffer> subjectBuffers)
@@ -55,7 +58,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     continue;
                 }
 
-                // This initializes the Razor LSP world and constructs C#/HTML buffers for the embedded language parts of the Razor document.
                 _lspDocumentManager.UntrackDocumentView(textBuffer, textView);
             }
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.LanguageServerClient.Razor;
+
+namespace Microsoft.VisualStudio.Text
+{
+    internal static class TextBufferExtensions
+    {
+        public static bool IsRazorLSPBuffer(this ITextBuffer textBuffer)
+        {
+            if (textBuffer == null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            var matchesContentType = textBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name);
+            return matchesContentType;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TrackingLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TrackingLSPDocumentManager.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    internal abstract class LSPDocumentManagerBase : LSPDocumentManager
+    internal abstract class TrackingLSPDocumentManager : LSPDocumentManager
     {
         public abstract void TrackDocumentView(ITextBuffer buffer, ITextView textView);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
@@ -5,8 +5,19 @@ using System;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
+    /// <summary>
+    /// The core purpose of a virtual document is to represent an embedded language LSP document that is addressable to make re-invoking
+    /// LSP requests possible.
+    ///
+    /// For instance, when we want to invoke an LSP request on a virtual document we'll go through the <see cref="LSPDocumentManager"/>
+    /// to locate the top level <see cref="LSPDocument"/>, find the <see cref="VirtualDocument"/> we care about, invoke the LSP request
+    /// with the new <see cref="Uri"/>.
+    /// </summary>
     public abstract class VirtualDocument
     {
+        /// <summary>
+        /// The address to use to refer to the current <see cref="VirtualDocument"/>.
+        /// </summary>
         public abstract Uri Uri { get; }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public abstract class VirtualDocument
+    {
+        public abstract Uri Uri { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocumentFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public abstract class VirtualDocumentFactory
+    {
+        public abstract bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocumentFactory.cs
@@ -5,8 +5,20 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
+    /// <summary>
+    /// The <see cref="VirtualDocumentFactory"/>'s purpose is to create a <see cref="VirtualDocument"/> for a given <see cref="ITextBuffer"/>.
+    /// These <see cref="VirtualDocument"/>s are addressable via their <see cref="VirtualDocument.Uri"/>'s and represnt an embedded, addressable LSP
+    /// document for a provided <see cref="ITextBuffer"/>.
+    /// </summary>
     public abstract class VirtualDocumentFactory
     {
+        /// <summary>
+        /// Attempts to create a <see cref="VirtualDocument"/> for the provided <paramref name="hostDocumentBuffer"/>.
+        /// </summary>
+        /// <param name="hostDocumentBuffer">The top-level LSP document buffer.</param>
+        /// <param name="virtualDocument">The resultant <see cref="VirtualDocument"/> for the top-level <paramref name="hostDocumentBuffer"/>.</param>
+        /// <returns><c>true</c> if a <see cref="VirtualDocument"/> could be created, <c>false</c> otherwise. A result of <c>false</c> typically indicates
+        /// that a <see cref="VirtualDocumentFactory"/> was not meant to be called for the given <paramref name="hostDocumentBuffer"/>.</returns>
         public abstract bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class CSharpVirtualDocumentFactoryTest
+    {
+        public CSharpVirtualDocumentFactoryTest()
+        {
+            var csharpContentType = Mock.Of<IContentType>();
+            ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
+                registry => registry.GetContentType(CSharpVirtualDocumentFactory.CSharpLSPContentTypeName) == csharpContentType);
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(csharpContentType) == Mock.Of<ITextBuffer>());
+
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        private IContentTypeRegistryService ContentTypeRegistry { get; }
+
+        private ITextBufferFactoryService TextBufferFactory { get; }
+
+        [Fact]
+        public void TryCreateFor_NonRazorLSPBuffer_ReturnsFalse()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri);
+            var factory = new CSharpVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(NonRazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryCreateFor_RazorLSPBuffer_ReturnsCSharpVirtualDocumentAndTrue()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(RazorLSPBuffer) == uri);
+            var factory = new CSharpVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(RazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(virtualDocument);
+            Assert.EndsWith(CSharpVirtualDocumentFactory.VirtualCSharpFileNameSuffix, virtualDocument.Uri.OriginalString);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultFileUriProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultFileUriProviderTest.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultFileUriProviderTest
+    {
+        [Fact]
+        public void GetOrCreate_NoTextDocument_Creates()
+        {
+            // Arrange
+            var uriProvider = new DefaultFileUriProvider(Mock.Of<ITextDocumentFactoryService>());
+            var textBuffer = Mock.Of<ITextBuffer>();
+
+            // Act
+            var uri = uriProvider.GetOrCreate(textBuffer);
+
+            // Assert
+            Assert.NotNull(uri);
+        }
+
+        [Fact]
+        public void GetOrCreate_TurnsTextDocumentFilePathIntoUri()
+        {
+            // Arrange
+            var factory = new Mock<ITextDocumentFactoryService>();
+            var textBuffer = Mock.Of<ITextBuffer>();
+            var expectedFilePath = "C:/path/to/file.razor";
+            var textDocument = Mock.Of<ITextDocument>(document => document.FilePath == expectedFilePath);
+            factory.Setup(f => f.TryGetTextDocument(textBuffer, out textDocument))
+                .Returns(true);
+            var uriProvider = new DefaultFileUriProvider(factory.Object);
+
+            // Act
+            var uri = uriProvider.GetOrCreate(textBuffer);
+
+            // Assert
+            Assert.Equal(expectedFilePath, uri.OriginalString);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultFileUriProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultFileUriProviderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
 using Moq;
 using Xunit;
 
@@ -9,18 +10,39 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     public class DefaultFileUriProviderTest
     {
+        public DefaultFileUriProviderTest()
+        {
+            TextBuffer = Mock.Of<ITextBuffer>(buffer => buffer.Properties == new PropertyCollection());
+        }
+
+        private ITextBuffer TextBuffer { get; }
+
         [Fact]
         public void GetOrCreate_NoTextDocument_Creates()
         {
             // Arrange
             var uriProvider = new DefaultFileUriProvider(Mock.Of<ITextDocumentFactoryService>());
-            var textBuffer = Mock.Of<ITextBuffer>();
 
             // Act
-            var uri = uriProvider.GetOrCreate(textBuffer);
+            var uri = uriProvider.GetOrCreate(TextBuffer);
 
             // Assert
             Assert.NotNull(uri);
+        }
+
+        [Fact]
+        public void GetOrCreate_NoTextDocument_MemoizesGeneratedUri()
+        {
+            // Arrange
+            var uriProvider = new DefaultFileUriProvider(Mock.Of<ITextDocumentFactoryService>());
+
+            // Act
+            var uri1 = uriProvider.GetOrCreate(TextBuffer);
+            var uri2 = uriProvider.GetOrCreate(TextBuffer);
+
+            // Assert
+            Assert.NotNull(uri1);
+            Assert.Same(uri1, uri2);
         }
 
         [Fact]
@@ -28,15 +50,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var factory = new Mock<ITextDocumentFactoryService>();
-            var textBuffer = Mock.Of<ITextBuffer>();
             var expectedFilePath = "C:/path/to/file.razor";
             var textDocument = Mock.Of<ITextDocument>(document => document.FilePath == expectedFilePath);
-            factory.Setup(f => f.TryGetTextDocument(textBuffer, out textDocument))
+            factory.Setup(f => f.TryGetTextDocument(TextBuffer, out textDocument))
                 .Returns(true);
             var uriProvider = new DefaultFileUriProvider(factory.Object);
 
             // Act
-            var uri = uriProvider.GetOrCreate(textBuffer);
+            var uri = uriProvider.GetOrCreate(TextBuffer);
 
             // Assert
             Assert.Equal(expectedFilePath, uri.OriginalString);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentFactoryTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultLSPDocumentFactoryTest
+    {
+        [Fact]
+        public void Create_BuildsLSPDocumentWithTextBufferURI()
+        {
+            // Arrange
+            var textBuffer = Mock.Of<ITextBuffer>();
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(p => p.GetOrCreate(textBuffer) == uri);
+            var factory = new DefaultLSPDocumentFactory(uriProvider, Enumerable.Empty<VirtualDocumentFactory>());
+
+            // Act
+            var lspDocument = factory.Create(textBuffer);
+
+            // Assert
+            Assert.Same(uri, lspDocument.Uri);
+        }
+
+        [Fact]
+        public void Create_MultipleFactories_CreatesLSPDocumentWithVirtualDocuments()
+        {
+            // Arrange
+            var textBuffer = Mock.Of<ITextBuffer>();
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(p => p.GetOrCreate(textBuffer) == uri);
+            var virtualDocument1 = Mock.Of<VirtualDocument>();
+            var factory1 = Mock.Of<VirtualDocumentFactory>(f => f.TryCreateFor(textBuffer, out virtualDocument1) == true);
+            var virtualDocument2 = Mock.Of<VirtualDocument>();
+            var factory2 = Mock.Of<VirtualDocumentFactory>(f => f.TryCreateFor(textBuffer, out virtualDocument2) == true);
+            var factory = new DefaultLSPDocumentFactory(uriProvider, new[] { factory1, factory2 });
+
+            // Act
+            var lspDocument = factory.Create(textBuffer);
+
+            // Assert
+            Assert.Collection(
+                lspDocument.VirtualDocuments,
+                virtualDocument => Assert.Same(virtualDocument1, virtualDocument),
+                virtualDocument => Assert.Same(virtualDocument2, virtualDocument));
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentManagerTest.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultLSPDocumentManagerTest
+    {
+        public DefaultLSPDocumentManagerTest()
+        {
+            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
+            JoinableTaskContext = joinableTaskContext.Context;
+            TextBuffer = Mock.Of<ITextBuffer>();
+            Uri = new Uri("C:/path/to/file.razor");
+            UriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(TextBuffer) == Uri);
+            LSPDocument = Mock.Of<LSPDocument>(document => document.Uri == Uri);
+            LSPDocumentFactory = Mock.Of<LSPDocumentFactory>(factory => factory.Create(TextBuffer) == LSPDocument);
+        }
+
+        public JoinableTaskContext JoinableTaskContext { get; }
+
+        private ITextBuffer TextBuffer { get; }
+
+        private Uri Uri { get; }
+
+        private FileUriProvider UriProvider { get; }
+
+        private LSPDocumentFactory LSPDocumentFactory { get; }
+
+        public LSPDocument LSPDocument { get; }
+
+        [Fact]
+        public void TryGetDocument_TrackedDocument_ReturnsTrue()
+        {
+            // Arrange
+            var textView = Mock.Of<ITextView>();
+            var manager = new DefaultLSPDocumentManager(JoinableTaskContext, UriProvider, LSPDocumentFactory);
+            manager.TrackDocumentView(TextBuffer, textView);
+
+            // Act
+            var result = manager.TryGetDocument(Uri, out var lspDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(LSPDocument, lspDocument);
+        }
+
+        [Fact]
+        public void TryGetDocument_UnknownDocument_ReturnsFalse()
+        {
+            // Arrange
+            var manager = new DefaultLSPDocumentManager(JoinableTaskContext, UriProvider, LSPDocumentFactory);
+
+            // Act
+            var result = manager.TryGetDocument(Uri, out var lspDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(lspDocument);
+        }
+
+        [Fact]
+        public void TryGetDocument_UntrackedDocument_ReturnsFalse()
+        {
+            // Arrange
+            var textView = Mock.Of<ITextView>();
+            var manager = new DefaultLSPDocumentManager(JoinableTaskContext, UriProvider, LSPDocumentFactory);
+            manager.TrackDocumentView(TextBuffer, textView);
+            manager.UntrackDocumentView(TextBuffer, textView);
+
+            // Act
+            var result = manager.TryGetDocument(Uri, out var lspDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(lspDocument);
+        }
+
+        [Fact]
+        public void TryGetDocument_TrackDocumentMultipleViews_ReturnsTrue()
+        {
+            // Arrange
+            var textView1 = Mock.Of<ITextView>();
+            var textView2 = Mock.Of<ITextView>();
+            var manager = new DefaultLSPDocumentManager(JoinableTaskContext, UriProvider, LSPDocumentFactory);
+            manager.TrackDocumentView(TextBuffer, textView1);
+            manager.TrackDocumentView(TextBuffer, textView2);
+            manager.UntrackDocumentView(TextBuffer, textView1);
+
+            // Act
+            var result = manager.TryGetDocument(Uri, out var lspDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(LSPDocument, lspDocument);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class HtmlVirtualDocumentFactoryTest
+    {
+        public HtmlVirtualDocumentFactoryTest()
+        {
+            var htmlContentType = Mock.Of<IContentType>();
+            ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
+                registry => registry.GetContentType(HtmlVirtualDocumentFactory.HtmlLSPContentTypeName) == htmlContentType);
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(htmlContentType) == Mock.Of<ITextBuffer>());
+
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        private IContentTypeRegistryService ContentTypeRegistry { get; }
+
+        private ITextBufferFactoryService TextBufferFactory { get; }
+
+        [Fact]
+        public void TryCreateFor_NonRazorLSPBuffer_ReturnsFalse()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri);
+            var factory = new HtmlVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(NonRazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryCreateFor_RazorLSPBuffer_ReturnsHtmlVirtualDocumentAndTrue()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(RazorLSPBuffer) == uri);
+            var factory = new HtmlVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(RazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(virtualDocument);
+            Assert.EndsWith(HtmlVirtualDocumentFactory.VirtualHtmlFileNameSuffix, virtualDocument.Uri.OriginalString);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class LSPDocumentTest
+    {
+        public LSPDocumentTest()
+        {
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public void TryGetVirtualDocument_NoCSharpDocument_ReturnsFalse()
+        {
+            // Arrange
+            var lspDocument = new DefaultLSPDocument(Uri, new[] { Mock.Of<VirtualDocument>() });
+
+            // Act
+            var result = lspDocument.TryGetVirtualDocument<TestVirtualDocument>(out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryGetVirtualCSharpDocument_CSharpDocument_ReturnsTrue()
+        {
+            // Arrange
+            var testVirtualDocument = new TestVirtualDocument();
+            var lspDocument = new DefaultLSPDocument(Uri, new[] { Mock.Of<VirtualDocument>(), testVirtualDocument });
+
+            // Act
+            var result = lspDocument.TryGetVirtualDocument<TestVirtualDocument>(out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(testVirtualDocument, virtualDocument);
+        }
+
+        private class TestVirtualDocument : VirtualDocument
+        {
+            public override Uri Uri => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472</TargetFrameworks>
+    <NoWarn>$(NoWarn);VSSDK005</NoWarn>
+    <CodeAnalysisRuleSet>..\..\src\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextViewConnectionListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextViewConnectionListenerTest.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Documents;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class RazorLSPTextViewConnectionListenerTest
+    {
+        public RazorLSPTextViewConnectionListenerTest()
+        {
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        [Fact]
+        public void SubjectBuffersConnected_NoLSPRazorBuffers_Noops()
+        {
+            // Arrange
+            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
+            var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer };
+            var textView = Mock.Of<ITextView>();
+
+            // Act
+            listener.SubjectBuffersConnected(textView, ConnectionReason.TextViewLifetime, subjectBuffers);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+
+        [Fact]
+        public void SubjectBuffersConnected_TracksLSPRazorBuffers()
+        {
+            // Arrange
+            var textView = Mock.Of<ITextView>();
+            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            lspDocumentManager.Setup(manager => manager.TrackDocumentView(RazorLSPBuffer, textView))
+                .Verifiable();
+            var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
+            var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer, RazorLSPBuffer };
+
+            // Act
+            listener.SubjectBuffersConnected(textView, ConnectionReason.TextViewLifetime, subjectBuffers);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+
+        [Fact]
+        public void SubjectBuffersDisconnected_NoLSPRazorBuffers_Noops()
+        {
+            // Arrange
+            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
+            var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer };
+            var textView = Mock.Of<ITextView>();
+
+            // Act
+            listener.SubjectBuffersDisconnected(textView, ConnectionReason.TextViewLifetime, subjectBuffers);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+
+        [Fact]
+        public void SubjectBuffersDisconnected_UntracksLSPRazorBuffers()
+        {
+            // Arrange
+            var textView = Mock.Of<ITextView>();
+            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            lspDocumentManager.Setup(manager => manager.UntrackDocumentView(RazorLSPBuffer, textView))
+                .Verifiable();
+            var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
+            var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer, RazorLSPBuffer };
+
+            // Act
+            listener.SubjectBuffersDisconnected(textView, ConnectionReason.TextViewLifetime, subjectBuffers);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextViewConnectionListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextViewConnectionListenerTest.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Documents;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
@@ -32,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void SubjectBuffersConnected_NoLSPRazorBuffers_Noops()
         {
             // Arrange
-            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
             var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
             var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer };
             var textView = Mock.Of<ITextView>();
@@ -49,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textView = Mock.Of<ITextView>();
-            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
             lspDocumentManager.Setup(manager => manager.TrackDocumentView(RazorLSPBuffer, textView))
                 .Verifiable();
             var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
@@ -66,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void SubjectBuffersDisconnected_NoLSPRazorBuffers_Noops()
         {
             // Arrange
-            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
             var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
             var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer };
             var textView = Mock.Of<ITextView>();
@@ -83,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textView = Mock.Of<ITextView>();
-            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
             lspDocumentManager.Setup(manager => manager.UntrackDocumentView(RazorLSPBuffer, textView))
                 .Verifiable();
             var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/xunit.runner.json
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "methodDisplay": "method",
+  "shadowCopy": false
+}


### PR DESCRIPTION
- Built out the document management infrastructure that will be responsible for understanding all LSP related documents in the VS IDE. The core purpose of this system is to
  1. Understand an LSP documents lifecycle, aka know when it starts/ends
  2. Allow all LSP documents to be looked up in an LSP friendly format. LSP friendly formats are via URIs.
  3. Create addressable virtual documents for a top level documents. In our case our top level document is a .razor/.cshtml file and we'll be creating two virtual documents per top-level document (C#/HTML).
- I also had a sub-goal to build this system out with minimal Razor dependencies. WTE will need to have a similar system where they can turn an HTML document into a top level document with a JavaScript/CSS virtual document associated.
- Utilized the VS `ITextViewConnectionListener` concept to track when an LSP documents life starts and ends.
- Found that our `LanguageServerClient.Razor` project depended on our old VS.Editor binary. Changed this to point to our common LanguageServer dependency (CodeAnalysis.Razor.Workspaces). This dependency might be entirely moved later if we find we don't need it.
- Tests are in [another PR](https://github.com/dotnet/aspnetcore-tooling/pull/1603) to limit the amount of content in this PR for 1 but also because we have a separate issue tracking the creation of the test project.

dotnet/aspnetcore#17791

/cc @ToddGrun @alexgav @jimmylewis  I built these bits with the intent to keep our contained language bits as independent from Razor as possible (take a look at the initial public contracts here). I'll have the C#/HTML implementations that sit ontop of this out in a bit and i'll cc you there as well.