### PR TITLE
Add tests for the VS LSP document manager.

### DIFF
--- a/src/Razor/Razor.sln
+++ b/src/Razor/Razor.sln
@@ -108,6 +108,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.LanguageServerClient.Razor", "src\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.csproj", "{70E70B52-EB70-42D1-B785-8618BD0B950E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.LanguageServerClient.Razor.Test", "test\Microsoft.VisualStudio.LanguageServerClient.Razor.Test\Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj", "{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -500,6 +502,14 @@ Global
 		{70E70B52-EB70-42D1-B785-8618BD0B950E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{70E70B52-EB70-42D1-B785-8618BD0B950E}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{70E70B52-EB70-42D1-B785-8618BD0B950E}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -553,6 +563,7 @@ Global
 		{305354FD-5ED7-4E89-8B1D-58FCCA3E08AD} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 		{4ED6CC87-11C4-4ECD-B9A1-AFC5C2DACABE} = {92463391-81BE-462B-AC3C-78C6C760741F}
 		{70E70B52-EB70-42D1-B785-8618BD0B950E} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
+		{F6E8EEA2-BDD8-4AAF-A0CE-9E33A9A7CE8E} = {92463391-81BE-462B-AC3C-78C6C760741F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0035341D-175A-4D05-95E6-F1C2785A1E26}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class CSharpVirtualDocument : VirtualDocument
+    {
+        private readonly ITextBuffer _textBuffer;
+
+        public CSharpVirtualDocument(Uri uri, ITextBuffer textBuffer)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            Uri = uri;
+            _textBuffer = textBuffer;
+        }
+
+        public override Uri Uri { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(VirtualDocumentFactory))]
+    internal class CSharpVirtualDocumentFactory : VirtualDocumentFactory
+    {
+        // Internal for testing
+        internal const string CSharpLSPContentTypeName = "C#_LSP";
+        internal const string VirtualCSharpFileNameSuffix = "__virtual.cs";
+
+        private readonly IContentTypeRegistryService _contentTypeRegistry;
+        private readonly ITextBufferFactoryService _textBufferFactory;
+        private readonly FileUriProvider _fileUriProvider;
+        private IContentType _csharpLSPContentType;
+
+        [ImportingConstructor]
+        public CSharpVirtualDocumentFactory(
+            IContentTypeRegistryService contentTypeRegistry,
+            ITextBufferFactoryService textBufferFactory,
+            FileUriProvider fileUriProvider)
+        {
+            if (contentTypeRegistry is null)
+            {
+                throw new ArgumentNullException(nameof(contentTypeRegistry));
+            }
+
+            if (textBufferFactory is null)
+            {
+                throw new ArgumentNullException(nameof(textBufferFactory));
+            }
+
+            if (fileUriProvider is null)
+            {
+                throw new ArgumentNullException(nameof(fileUriProvider));
+            }
+
+            _contentTypeRegistry = contentTypeRegistry;
+            _textBufferFactory = textBufferFactory;
+            _fileUriProvider = fileUriProvider;
+        }
+
+        private IContentType CSharpLSPContentType
+        {
+            get
+            {
+                if (_csharpLSPContentType == null)
+                {
+                    _csharpLSPContentType = _contentTypeRegistry.GetContentType(CSharpLSPContentTypeName);
+                }
+
+                return _csharpLSPContentType;
+            }
+        }
+
+        public override bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument)
+        {
+            if (hostDocumentBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(hostDocumentBuffer));
+            }
+
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            {
+                // Another content type we don't care about.
+                virtualDocument = null;
+                return false;
+            }
+
+            var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
+
+            // Index.cshtml => Index.cshtml__virtual.cs
+            var virtualCSharpFilePath = hostDocumentUri.AbsolutePath + VirtualCSharpFileNameSuffix;
+            var virtualCSharpUri = new Uri(virtualCSharpFilePath);
+
+            var csharpBuffer = _textBufferFactory.CreateTextBuffer(CSharpLSPContentType);
+            virtualDocument = new CSharpVirtualDocument(virtualCSharpUri, csharpBuffer);
+            return true;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class HtmlVirtualDocument : VirtualDocument
+    {
+        private readonly ITextBuffer _textBuffer;
+
+        public HtmlVirtualDocument(Uri uri, ITextBuffer textBuffer)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            Uri = uri;
+            _textBuffer = textBuffer;
+        }
+
+        public override Uri Uri { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(VirtualDocumentFactory))]
+    internal class HtmlVirtualDocumentFactory : VirtualDocumentFactory
+    {
+        // Internal for testing
+        internal const string HtmlLSPContentTypeName = "htmlyLSP";
+        internal const string VirtualHtmlFileNameSuffix = "__virtual.html";
+
+        private readonly IContentTypeRegistryService _contentTypeRegistry;
+        private readonly ITextBufferFactoryService _textBufferFactory;
+        private readonly FileUriProvider _fileUriProvider;
+        private IContentType _htmlLSPContentType;
+
+        [ImportingConstructor]
+        public HtmlVirtualDocumentFactory(
+            IContentTypeRegistryService contentTypeRegistry,
+            ITextBufferFactoryService textBufferFactory,
+            FileUriProvider filePathProvider)
+        {
+            if (contentTypeRegistry is null)
+            {
+                throw new ArgumentNullException(nameof(contentTypeRegistry));
+            }
+
+            if (textBufferFactory is null)
+            {
+                throw new ArgumentNullException(nameof(textBufferFactory));
+            }
+
+            if (filePathProvider is null)
+            {
+                throw new ArgumentNullException(nameof(filePathProvider));
+            }
+
+            _contentTypeRegistry = contentTypeRegistry;
+            _textBufferFactory = textBufferFactory;
+            _fileUriProvider = filePathProvider;
+        }
+
+        private IContentType HtmlLSPContentType
+        {
+            get
+            {
+                if (_htmlLSPContentType == null)
+                {
+                    _htmlLSPContentType = _contentTypeRegistry.GetContentType(HtmlLSPContentTypeName);
+                }
+
+                return _htmlLSPContentType;
+            }
+        }
+
+        public override bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument)
+        {
+            if (hostDocumentBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(hostDocumentBuffer));
+            }
+
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            {
+                // Another content type we don't care about.
+                virtualDocument = null;
+                return false;
+            }
+
+            var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
+
+            // Index.cshtml => Index.cshtml__virtual.html
+            var virtualHtmlFilePath = hostDocumentUri + VirtualHtmlFileNameSuffix;
+            var virtualHtmlUri = new Uri(virtualHtmlFilePath);
+
+            var htmlBuffer = _textBufferFactory.CreateTextBuffer(HtmlLSPContentType);
+            virtualDocument = new HtmlVirtualDocument(virtualHtmlUri, htmlBuffer);
+            return true;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class CSharpVirtualDocumentFactoryTest
+    {
+        public CSharpVirtualDocumentFactoryTest()
+        {
+            var csharpContentType = Mock.Of<IContentType>();
+            ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
+                registry => registry.GetContentType(CSharpVirtualDocumentFactory.CSharpLSPContentTypeName) == csharpContentType);
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(csharpContentType) == Mock.Of<ITextBuffer>());
+
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        private IContentTypeRegistryService ContentTypeRegistry { get; }
+
+        private ITextBufferFactoryService TextBufferFactory { get; }
+
+        [Fact]
+        public void TryCreateFor_NonRazorLSPBuffer_ReturnsFalse()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri);
+            var factory = new CSharpVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(NonRazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryCreateFor_RazorLSPBuffer_ReturnsCSharpVirtualDocumentAndTrue()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(RazorLSPBuffer) == uri);
+            var factory = new CSharpVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(RazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(virtualDocument);
+            Assert.EndsWith(CSharpVirtualDocumentFactory.VirtualCSharpFileNameSuffix, virtualDocument.Uri.OriginalString);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultFileUriProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultFileUriProviderTest.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultFileUriProviderTest
+    {
+        [Fact]
+        public void GetOrCreate_NoTextDocument_Creates()
+        {
+            // Arrange
+            var uriProvider = new DefaultFileUriProvider(Mock.Of<ITextDocumentFactoryService>());
+            var textBuffer = Mock.Of<ITextBuffer>();
+
+            // Act
+            var uri = uriProvider.GetOrCreate(textBuffer);
+
+            // Assert
+            Assert.NotNull(uri);
+        }
+
+        [Fact]
+        public void GetOrCreate_TurnsTextDocumentFilePathIntoUri()
+        {
+            // Arrange
+            var factory = new Mock<ITextDocumentFactoryService>();
+            var textBuffer = Mock.Of<ITextBuffer>();
+            var expectedFilePath = "C:/path/to/file.razor";
+            var textDocument = Mock.Of<ITextDocument>(document => document.FilePath == expectedFilePath);
+            factory.Setup(f => f.TryGetTextDocument(textBuffer, out textDocument))
+                .Returns(true);
+            var uriProvider = new DefaultFileUriProvider(factory.Object);
+
+            // Act
+            var uri = uriProvider.GetOrCreate(textBuffer);
+
+            // Assert
+            Assert.Equal(expectedFilePath, uri.OriginalString);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultFileUriProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultFileUriProviderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
 using Moq;
 using Xunit;
 
@@ -9,18 +10,39 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     public class DefaultFileUriProviderTest
     {
+        public DefaultFileUriProviderTest()
+        {
+            TextBuffer = Mock.Of<ITextBuffer>(buffer => buffer.Properties == new PropertyCollection());
+        }
+
+        private ITextBuffer TextBuffer { get; }
+
         [Fact]
         public void GetOrCreate_NoTextDocument_Creates()
         {
             // Arrange
             var uriProvider = new DefaultFileUriProvider(Mock.Of<ITextDocumentFactoryService>());
-            var textBuffer = Mock.Of<ITextBuffer>();
 
             // Act
-            var uri = uriProvider.GetOrCreate(textBuffer);
+            var uri = uriProvider.GetOrCreate(TextBuffer);
 
             // Assert
             Assert.NotNull(uri);
+        }
+
+        [Fact]
+        public void GetOrCreate_NoTextDocument_MemoizesGeneratedUri()
+        {
+            // Arrange
+            var uriProvider = new DefaultFileUriProvider(Mock.Of<ITextDocumentFactoryService>());
+
+            // Act
+            var uri1 = uriProvider.GetOrCreate(TextBuffer);
+            var uri2 = uriProvider.GetOrCreate(TextBuffer);
+
+            // Assert
+            Assert.NotNull(uri1);
+            Assert.Same(uri1, uri2);
         }
 
         [Fact]
@@ -28,15 +50,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var factory = new Mock<ITextDocumentFactoryService>();
-            var textBuffer = Mock.Of<ITextBuffer>();
             var expectedFilePath = "C:/path/to/file.razor";
             var textDocument = Mock.Of<ITextDocument>(document => document.FilePath == expectedFilePath);
-            factory.Setup(f => f.TryGetTextDocument(textBuffer, out textDocument))
+            factory.Setup(f => f.TryGetTextDocument(TextBuffer, out textDocument))
                 .Returns(true);
             var uriProvider = new DefaultFileUriProvider(factory.Object);
 
             // Act
-            var uri = uriProvider.GetOrCreate(textBuffer);
+            var uri = uriProvider.GetOrCreate(TextBuffer);
 
             // Assert
             Assert.Equal(expectedFilePath, uri.OriginalString);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentFactoryTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultLSPDocumentFactoryTest
+    {
+        [Fact]
+        public void Create_BuildsLSPDocumentWithTextBufferURI()
+        {
+            // Arrange
+            var textBuffer = Mock.Of<ITextBuffer>();
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(p => p.GetOrCreate(textBuffer) == uri);
+            var factory = new DefaultLSPDocumentFactory(uriProvider, Enumerable.Empty<VirtualDocumentFactory>());
+
+            // Act
+            var lspDocument = factory.Create(textBuffer);
+
+            // Assert
+            Assert.Same(uri, lspDocument.Uri);
+        }
+
+        [Fact]
+        public void Create_MultipleFactories_CreatesLSPDocumentWithVirtualDocuments()
+        {
+            // Arrange
+            var textBuffer = Mock.Of<ITextBuffer>();
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(p => p.GetOrCreate(textBuffer) == uri);
+            var virtualDocument1 = Mock.Of<VirtualDocument>();
+            var factory1 = Mock.Of<VirtualDocumentFactory>(f => f.TryCreateFor(textBuffer, out virtualDocument1) == true);
+            var virtualDocument2 = Mock.Of<VirtualDocument>();
+            var factory2 = Mock.Of<VirtualDocumentFactory>(f => f.TryCreateFor(textBuffer, out virtualDocument2) == true);
+            var factory = new DefaultLSPDocumentFactory(uriProvider, new[] { factory1, factory2 });
+
+            // Act
+            var lspDocument = factory.Create(textBuffer);
+
+            // Assert
+            Assert.Collection(
+                lspDocument.VirtualDocuments,
+                virtualDocument => Assert.Same(virtualDocument1, virtualDocument),
+                virtualDocument => Assert.Same(virtualDocument2, virtualDocument));
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentManagerTest.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultLSPDocumentManagerTest
+    {
+        public DefaultLSPDocumentManagerTest()
+        {
+            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
+            JoinableTaskContext = joinableTaskContext.Context;
+            TextBuffer = Mock.Of<ITextBuffer>();
+            Uri = new Uri("C:/path/to/file.razor");
+            UriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(TextBuffer) == Uri);
+            LSPDocument = Mock.Of<LSPDocument>(document => document.Uri == Uri);
+            LSPDocumentFactory = Mock.Of<LSPDocumentFactory>(factory => factory.Create(TextBuffer) == LSPDocument);
+        }
+
+        public JoinableTaskContext JoinableTaskContext { get; }
+
+        private ITextBuffer TextBuffer { get; }
+
+        private Uri Uri { get; }
+
+        private FileUriProvider UriProvider { get; }
+
+        private LSPDocumentFactory LSPDocumentFactory { get; }
+
+        public LSPDocument LSPDocument { get; }
+
+        [Fact]
+        public void TryGetDocument_TrackedDocument_ReturnsTrue()
+        {
+            // Arrange
+            var textView = Mock.Of<ITextView>();
+            var manager = new DefaultLSPDocumentManager(JoinableTaskContext, UriProvider, LSPDocumentFactory);
+            manager.TrackDocumentView(TextBuffer, textView);
+
+            // Act
+            var result = manager.TryGetDocument(Uri, out var lspDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(LSPDocument, lspDocument);
+        }
+
+        [Fact]
+        public void TryGetDocument_UnknownDocument_ReturnsFalse()
+        {
+            // Arrange
+            var manager = new DefaultLSPDocumentManager(JoinableTaskContext, UriProvider, LSPDocumentFactory);
+
+            // Act
+            var result = manager.TryGetDocument(Uri, out var lspDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(lspDocument);
+        }
+
+        [Fact]
+        public void TryGetDocument_UntrackedDocument_ReturnsFalse()
+        {
+            // Arrange
+            var textView = Mock.Of<ITextView>();
+            var manager = new DefaultLSPDocumentManager(JoinableTaskContext, UriProvider, LSPDocumentFactory);
+            manager.TrackDocumentView(TextBuffer, textView);
+            manager.UntrackDocumentView(TextBuffer, textView);
+
+            // Act
+            var result = manager.TryGetDocument(Uri, out var lspDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(lspDocument);
+        }
+
+        [Fact]
+        public void TryGetDocument_TrackDocumentMultipleViews_ReturnsTrue()
+        {
+            // Arrange
+            var textView1 = Mock.Of<ITextView>();
+            var textView2 = Mock.Of<ITextView>();
+            var manager = new DefaultLSPDocumentManager(JoinableTaskContext, UriProvider, LSPDocumentFactory);
+            manager.TrackDocumentView(TextBuffer, textView1);
+            manager.TrackDocumentView(TextBuffer, textView2);
+            manager.UntrackDocumentView(TextBuffer, textView1);
+
+            // Act
+            var result = manager.TryGetDocument(Uri, out var lspDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(LSPDocument, lspDocument);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class HtmlVirtualDocumentFactoryTest
+    {
+        public HtmlVirtualDocumentFactoryTest()
+        {
+            var htmlContentType = Mock.Of<IContentType>();
+            ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
+                registry => registry.GetContentType(HtmlVirtualDocumentFactory.HtmlLSPContentTypeName) == htmlContentType);
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(htmlContentType) == Mock.Of<ITextBuffer>());
+
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        private IContentTypeRegistryService ContentTypeRegistry { get; }
+
+        private ITextBufferFactoryService TextBufferFactory { get; }
+
+        [Fact]
+        public void TryCreateFor_NonRazorLSPBuffer_ReturnsFalse()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri);
+            var factory = new HtmlVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(NonRazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryCreateFor_RazorLSPBuffer_ReturnsHtmlVirtualDocumentAndTrue()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(RazorLSPBuffer) == uri);
+            var factory = new HtmlVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(RazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(virtualDocument);
+            Assert.EndsWith(HtmlVirtualDocumentFactory.VirtualHtmlFileNameSuffix, virtualDocument.Uri.OriginalString);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class LSPDocumentTest
+    {
+        public LSPDocumentTest()
+        {
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public void TryGetVirtualDocument_NoCSharpDocument_ReturnsFalse()
+        {
+            // Arrange
+            var lspDocument = new DefaultLSPDocument(Uri, new[] { Mock.Of<VirtualDocument>() });
+
+            // Act
+            var result = lspDocument.TryGetVirtualDocument<TestVirtualDocument>(out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryGetVirtualCSharpDocument_CSharpDocument_ReturnsTrue()
+        {
+            // Arrange
+            var testVirtualDocument = new TestVirtualDocument();
+            var lspDocument = new DefaultLSPDocument(Uri, new[] { Mock.Of<VirtualDocument>(), testVirtualDocument });
+
+            // Act
+            var result = lspDocument.TryGetVirtualDocument<TestVirtualDocument>(out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(testVirtualDocument, virtualDocument);
+        }
+
+        private class TestVirtualDocument : VirtualDocument
+        {
+            public override Uri Uri => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472</TargetFrameworks>
+    <NoWarn>$(NoWarn);VSSDK005</NoWarn>
+    <CodeAnalysisRuleSet>..\..\src\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextViewConnectionListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextViewConnectionListenerTest.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Documents;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class RazorLSPTextViewConnectionListenerTest
+    {
+        public RazorLSPTextViewConnectionListenerTest()
+        {
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        [Fact]
+        public void SubjectBuffersConnected_NoLSPRazorBuffers_Noops()
+        {
+            // Arrange
+            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
+            var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer };
+            var textView = Mock.Of<ITextView>();
+
+            // Act
+            listener.SubjectBuffersConnected(textView, ConnectionReason.TextViewLifetime, subjectBuffers);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+
+        [Fact]
+        public void SubjectBuffersConnected_TracksLSPRazorBuffers()
+        {
+            // Arrange
+            var textView = Mock.Of<ITextView>();
+            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            lspDocumentManager.Setup(manager => manager.TrackDocumentView(RazorLSPBuffer, textView))
+                .Verifiable();
+            var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
+            var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer, RazorLSPBuffer };
+
+            // Act
+            listener.SubjectBuffersConnected(textView, ConnectionReason.TextViewLifetime, subjectBuffers);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+
+        [Fact]
+        public void SubjectBuffersDisconnected_NoLSPRazorBuffers_Noops()
+        {
+            // Arrange
+            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
+            var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer };
+            var textView = Mock.Of<ITextView>();
+
+            // Act
+            listener.SubjectBuffersDisconnected(textView, ConnectionReason.TextViewLifetime, subjectBuffers);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+
+        [Fact]
+        public void SubjectBuffersDisconnected_UntracksLSPRazorBuffers()
+        {
+            // Arrange
+            var textView = Mock.Of<ITextView>();
+            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            lspDocumentManager.Setup(manager => manager.UntrackDocumentView(RazorLSPBuffer, textView))
+                .Verifiable();
+            var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
+            var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer, RazorLSPBuffer };
+
+            // Act
+            listener.SubjectBuffersDisconnected(textView, ConnectionReason.TextViewLifetime, subjectBuffers);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextViewConnectionListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextViewConnectionListenerTest.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Documents;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
@@ -32,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void SubjectBuffersConnected_NoLSPRazorBuffers_Noops()
         {
             // Arrange
-            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
             var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
             var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer };
             var textView = Mock.Of<ITextView>();
@@ -49,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textView = Mock.Of<ITextView>();
-            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
             lspDocumentManager.Setup(manager => manager.TrackDocumentView(RazorLSPBuffer, textView))
                 .Verifiable();
             var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
@@ -66,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void SubjectBuffersDisconnected_NoLSPRazorBuffers_Noops()
         {
             // Arrange
-            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
             var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);
             var subjectBuffers = new List<ITextBuffer>() { NonRazorLSPBuffer };
             var textView = Mock.Of<ITextView>();
@@ -83,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textView = Mock.Of<ITextView>();
-            var lspDocumentManager = new Mock<LSPDocumentManagerBase>(MockBehavior.Strict);
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
             lspDocumentManager.Setup(manager => manager.UntrackDocumentView(RazorLSPBuffer, textView))
                 .Verifiable();
             var listener = new RazorLSPTextViewConnectionListener(lspDocumentManager.Object);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/xunit.runner.json
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "methodDisplay": "method",
+  "shadowCopy": false
+}


### PR DESCRIPTION
- This changeset adds the Razor LanguageServerClient testing project as well as some tests for the VS document  manager APIs.
- Inherited the `src` LanguageServerClient's ruleset to avoid unimportant VS rules from applying to our test project.
- Added tests for https://github.com/dotnet/aspnetcore-tooling/pull/1602

dotnet/aspnetcore#17791
dotnet/aspnetcore#17748