### PR TITLE
Create Virtual C# document for LSP Razor document.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class CSharpVirtualDocument : VirtualDocument
+    {
+        private readonly ITextBuffer _textBuffer;
+
+        public CSharpVirtualDocument(Uri uri, ITextBuffer textBuffer)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            Uri = uri;
+            _textBuffer = textBuffer;
+        }
+
+        public override Uri Uri { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(VirtualDocumentFactory))]
+    internal class CSharpVirtualDocumentFactory : VirtualDocumentFactory
+    {
+        // Internal for testing
+        internal const string CSharpLSPContentTypeName = "C#_LSP";
+        internal const string VirtualCSharpFileNameSuffix = "__virtual.cs";
+
+        private readonly IContentTypeRegistryService _contentTypeRegistry;
+        private readonly ITextBufferFactoryService _textBufferFactory;
+        private readonly FileUriProvider _fileUriProvider;
+        private IContentType _csharpLSPContentType;
+
+        [ImportingConstructor]
+        public CSharpVirtualDocumentFactory(
+            IContentTypeRegistryService contentTypeRegistry,
+            ITextBufferFactoryService textBufferFactory,
+            FileUriProvider fileUriProvider)
+        {
+            if (contentTypeRegistry is null)
+            {
+                throw new ArgumentNullException(nameof(contentTypeRegistry));
+            }
+
+            if (textBufferFactory is null)
+            {
+                throw new ArgumentNullException(nameof(textBufferFactory));
+            }
+
+            if (fileUriProvider is null)
+            {
+                throw new ArgumentNullException(nameof(fileUriProvider));
+            }
+
+            _contentTypeRegistry = contentTypeRegistry;
+            _textBufferFactory = textBufferFactory;
+            _fileUriProvider = fileUriProvider;
+        }
+
+        private IContentType CSharpLSPContentType
+        {
+            get
+            {
+                if (_csharpLSPContentType == null)
+                {
+                    _csharpLSPContentType = _contentTypeRegistry.GetContentType(CSharpLSPContentTypeName);
+                }
+
+                return _csharpLSPContentType;
+            }
+        }
+
+        public override bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument)
+        {
+            if (hostDocumentBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(hostDocumentBuffer));
+            }
+
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            {
+                // Another content type we don't care about.
+                virtualDocument = null;
+                return false;
+            }
+
+            var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
+
+            // Index.cshtml => Index.cshtml__virtual.cs
+            var virtualCSharpFilePath = hostDocumentUri.AbsolutePath + VirtualCSharpFileNameSuffix;
+            var virtualCSharpUri = new Uri(virtualCSharpFilePath);
+
+            var csharpBuffer = _textBufferFactory.CreateTextBuffer(CSharpLSPContentType);
+            virtualDocument = new CSharpVirtualDocument(virtualCSharpUri, csharpBuffer);
+            return true;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class HtmlVirtualDocument : VirtualDocument
+    {
+        private readonly ITextBuffer _textBuffer;
+
+        public HtmlVirtualDocument(Uri uri, ITextBuffer textBuffer)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            Uri = uri;
+            _textBuffer = textBuffer;
+        }
+
+        public override Uri Uri { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(VirtualDocumentFactory))]
+    internal class HtmlVirtualDocumentFactory : VirtualDocumentFactory
+    {
+        // Internal for testing
+        internal const string HtmlLSPContentTypeName = "htmlyLSP";
+        internal const string VirtualHtmlFileNameSuffix = "__virtual.html";
+
+        private readonly IContentTypeRegistryService _contentTypeRegistry;
+        private readonly ITextBufferFactoryService _textBufferFactory;
+        private readonly FileUriProvider _fileUriProvider;
+        private IContentType _htmlLSPContentType;
+
+        [ImportingConstructor]
+        public HtmlVirtualDocumentFactory(
+            IContentTypeRegistryService contentTypeRegistry,
+            ITextBufferFactoryService textBufferFactory,
+            FileUriProvider filePathProvider)
+        {
+            if (contentTypeRegistry is null)
+            {
+                throw new ArgumentNullException(nameof(contentTypeRegistry));
+            }
+
+            if (textBufferFactory is null)
+            {
+                throw new ArgumentNullException(nameof(textBufferFactory));
+            }
+
+            if (filePathProvider is null)
+            {
+                throw new ArgumentNullException(nameof(filePathProvider));
+            }
+
+            _contentTypeRegistry = contentTypeRegistry;
+            _textBufferFactory = textBufferFactory;
+            _fileUriProvider = filePathProvider;
+        }
+
+        private IContentType HtmlLSPContentType
+        {
+            get
+            {
+                if (_htmlLSPContentType == null)
+                {
+                    _htmlLSPContentType = _contentTypeRegistry.GetContentType(HtmlLSPContentTypeName);
+                }
+
+                return _htmlLSPContentType;
+            }
+        }
+
+        public override bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument)
+        {
+            if (hostDocumentBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(hostDocumentBuffer));
+            }
+
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            {
+                // Another content type we don't care about.
+                virtualDocument = null;
+                return false;
+            }
+
+            var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
+
+            // Index.cshtml => Index.cshtml__virtual.html
+            var virtualHtmlFilePath = hostDocumentUri + VirtualHtmlFileNameSuffix;
+            var virtualHtmlUri = new Uri(virtualHtmlFilePath);
+
+            var htmlBuffer = _textBufferFactory.CreateTextBuffer(HtmlLSPContentType);
+            virtualDocument = new HtmlVirtualDocument(virtualHtmlUri, htmlBuffer);
+            return true;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class CSharpVirtualDocumentFactoryTest
+    {
+        public CSharpVirtualDocumentFactoryTest()
+        {
+            var csharpContentType = Mock.Of<IContentType>();
+            ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
+                registry => registry.GetContentType(CSharpVirtualDocumentFactory.CSharpLSPContentTypeName) == csharpContentType);
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(csharpContentType) == Mock.Of<ITextBuffer>());
+
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        private IContentTypeRegistryService ContentTypeRegistry { get; }
+
+        private ITextBufferFactoryService TextBufferFactory { get; }
+
+        [Fact]
+        public void TryCreateFor_NonRazorLSPBuffer_ReturnsFalse()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri);
+            var factory = new CSharpVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(NonRazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryCreateFor_RazorLSPBuffer_ReturnsCSharpVirtualDocumentAndTrue()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(RazorLSPBuffer) == uri);
+            var factory = new CSharpVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(RazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(virtualDocument);
+            Assert.EndsWith(CSharpVirtualDocumentFactory.VirtualCSharpFileNameSuffix, virtualDocument.Uri.OriginalString);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class HtmlVirtualDocumentFactoryTest
+    {
+        public HtmlVirtualDocumentFactoryTest()
+        {
+            var htmlContentType = Mock.Of<IContentType>();
+            ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
+                registry => registry.GetContentType(HtmlVirtualDocumentFactory.HtmlLSPContentTypeName) == htmlContentType);
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(htmlContentType) == Mock.Of<ITextBuffer>());
+
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        private IContentTypeRegistryService ContentTypeRegistry { get; }
+
+        private ITextBufferFactoryService TextBufferFactory { get; }
+
+        [Fact]
+        public void TryCreateFor_NonRazorLSPBuffer_ReturnsFalse()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri);
+            var factory = new HtmlVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(NonRazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryCreateFor_RazorLSPBuffer_ReturnsHtmlVirtualDocumentAndTrue()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(RazorLSPBuffer) == uri);
+            var factory = new HtmlVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(RazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(virtualDocument);
+            Assert.EndsWith(HtmlVirtualDocumentFactory.VirtualHtmlFileNameSuffix, virtualDocument.Uri.OriginalString);
+        }
+    }
+}


### PR DESCRIPTION
- We hook into the `VirtualDocumentFactory` sub-system and when we're asked to create a virtual document for a Razor file we will now create a virtual C# document backed by a `C#_LSP` content typed buffer.
- Eventually our `CSharpVirtualDocument` type will have the logic to update its underlying `ITextBuffer`. We don't expose this at the `VirtualDocument` layer to ensure that no one else can unintentionally update the backing buffer. When we want to add the logic to update the buffer we'll cast the virtual document and update it that way.
- This code still does not handle adding that C# buffer and its context to the C# workspace under the correct project etc. This will have to be a follow up.
- Added an `LSPDocumentExtensions` class as a way to pick out a specific C# document from our LSP document. This way another system (WTE) could build on the same `LSPDocument` by having their own extension methods that extract their virtual documents.
- Added tests for the new APIs

dotnet/aspnetcore#17792

/cc @ToddGrun @alexgav @jimmylewis 