### PR TITLE
Create Virtual Html document for LSP Razor document.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class HtmlVirtualDocument : VirtualDocument
+    {
+        private readonly ITextBuffer _textBuffer;
+
+        public HtmlVirtualDocument(Uri uri, ITextBuffer textBuffer)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            Uri = uri;
+            _textBuffer = textBuffer;
+        }
+
+        public override Uri Uri { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(VirtualDocumentFactory))]
+    internal class HtmlVirtualDocumentFactory : VirtualDocumentFactory
+    {
+        // Internal for testing
+        internal const string HtmlLSPContentTypeName = "htmlyLSP";
+        internal const string VirtualHtmlFileNameSuffix = "__virtual.html";
+
+        private readonly IContentTypeRegistryService _contentTypeRegistry;
+        private readonly ITextBufferFactoryService _textBufferFactory;
+        private readonly FileUriProvider _fileUriProvider;
+        private IContentType _htmlLSPContentType;
+
+        [ImportingConstructor]
+        public HtmlVirtualDocumentFactory(
+            IContentTypeRegistryService contentTypeRegistry,
+            ITextBufferFactoryService textBufferFactory,
+            FileUriProvider filePathProvider)
+        {
+            if (contentTypeRegistry is null)
+            {
+                throw new ArgumentNullException(nameof(contentTypeRegistry));
+            }
+
+            if (textBufferFactory is null)
+            {
+                throw new ArgumentNullException(nameof(textBufferFactory));
+            }
+
+            if (filePathProvider is null)
+            {
+                throw new ArgumentNullException(nameof(filePathProvider));
+            }
+
+            _contentTypeRegistry = contentTypeRegistry;
+            _textBufferFactory = textBufferFactory;
+            _fileUriProvider = filePathProvider;
+        }
+
+        private IContentType HtmlLSPContentType
+        {
+            get
+            {
+                if (_htmlLSPContentType == null)
+                {
+                    _htmlLSPContentType = _contentTypeRegistry.GetContentType(HtmlLSPContentTypeName);
+                }
+
+                return _htmlLSPContentType;
+            }
+        }
+
+        public override bool TryCreateFor(ITextBuffer hostDocumentBuffer, out VirtualDocument virtualDocument)
+        {
+            if (hostDocumentBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(hostDocumentBuffer));
+            }
+
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            {
+                // Another content type we don't care about.
+                virtualDocument = null;
+                return false;
+            }
+
+            var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
+
+            // Index.cshtml => Index.cshtml__virtual.html
+            var virtualHtmlFilePath = hostDocumentUri + VirtualHtmlFileNameSuffix;
+            var virtualHtmlUri = new Uri(virtualHtmlFilePath);
+
+            var htmlBuffer = _textBufferFactory.CreateTextBuffer(HtmlLSPContentType);
+            virtualDocument = new HtmlVirtualDocument(virtualHtmlUri, htmlBuffer);
+            return true;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class HtmlVirtualDocumentFactoryTest
+    {
+        public HtmlVirtualDocumentFactoryTest()
+        {
+            var htmlContentType = Mock.Of<IContentType>();
+            ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
+                registry => registry.GetContentType(HtmlVirtualDocumentFactory.HtmlLSPContentTypeName) == htmlContentType);
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(htmlContentType) == Mock.Of<ITextBuffer>());
+
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
+
+            var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
+            NonRazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == nonRazorLSPContentType);
+        }
+
+        private ITextBuffer NonRazorLSPBuffer { get; }
+
+        private ITextBuffer RazorLSPBuffer { get; }
+
+        private IContentTypeRegistryService ContentTypeRegistry { get; }
+
+        private ITextBufferFactoryService TextBufferFactory { get; }
+
+        [Fact]
+        public void TryCreateFor_NonRazorLSPBuffer_ReturnsFalse()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri);
+            var factory = new HtmlVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(NonRazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(virtualDocument);
+        }
+
+        [Fact]
+        public void TryCreateFor_RazorLSPBuffer_ReturnsHtmlVirtualDocumentAndTrue()
+        {
+            // Arrange
+            var uri = new Uri("C:/path/to/file.razor");
+            var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(RazorLSPBuffer) == uri);
+            var factory = new HtmlVirtualDocumentFactory(ContentTypeRegistry, TextBufferFactory, uriProvider);
+
+            // Act
+            var result = factory.TryCreateFor(RazorLSPBuffer, out var virtualDocument);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(virtualDocument);
+            Assert.EndsWith(HtmlVirtualDocumentFactory.VirtualHtmlFileNameSuffix, virtualDocument.Uri.OriginalString);
+        }
+    }
+}


### PR DESCRIPTION
- We hook into the `VirtualDocumentFactory` sub-system and when we're asked to create a virtual document for a Razor file we will now create a virtual Html document backed by a `htmly` content typed buffer.
- Eventually our `HtmlVirtualDocument` type will have the logic to update its underlying `ITextBuffer`. We don't expose this at the `VirtualDocument` layer to ensure that no one else can unintentionally update the backing buffer. When we want to add the logic to update the buffer we'll cast the virtual document and update it that way.
- Added a specific `TryGetVirtualHtmlDocument` to our lsp document extensions to enable the extraction of the Html buffer.
- Added tests for the new APIs

dotnet/aspnetcore#17793

/cc @ToddGrun @alexgav @jimmylewis 