### PR TITLE
Respect tabs vs spaces when generating code

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/CodeWriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/CodeWriter.cs
@@ -18,9 +18,16 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
         private int _currentLineIndex;
         private int _currentLineCharacterIndex;
 
-        public CodeWriter()
+        public CodeWriter() : this(Environment.NewLine, 4, false)
         {
-            NewLine = Environment.NewLine;
+        }
+
+        public CodeWriter(string newLine, int tabSize, bool indentWithTabs)
+        {
+            NewLine = newLine;
+            TabSize = tabSize;
+            IndentWithTabs = indentWithTabs;
+
             _builder = new StringBuilder();
         }
 
@@ -47,6 +54,10 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             }
         }
 
+        public int TabSize { get; set; }
+
+        public bool IndentWithTabs { get; set; }
+
         public SourceLocation Location => new SourceLocation(_absoluteIndex, _currentLineIndex, _currentLineCharacterIndex);
 
         public char this[int index]
@@ -62,15 +73,40 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             }
         }
 
-        // Internal for testing.
-        internal CodeWriter Indent(int size)
+        public CodeWriter Indent(int size)
         {
             if (Length == 0 || this[Length - 1] == '\n')
             {
-                _builder.Append(' ', size);
+                var actualSize = 0;
+                if (IndentWithTabs)
+                {
+                    // Avoid writing directly to the StringBuilder here, that will throw off the manual indexing 
+                    // done by the base class.
+                    var tabs = size / TabSize;
+                    actualSize += tabs;
+                    for (var i = 0; i < tabs; i++)
+                    {
+                        _builder.Append("\t");
+                    }
 
-                _currentLineCharacterIndex += size;
-                _absoluteIndex += size;
+                    var spaces = size % TabSize;
+                    actualSize += spaces;
+                    for (var i = 0; i < spaces; i++)
+                    {
+                        _builder.Append(" ");
+                    }
+                }
+                else
+                {
+                    actualSize = size;
+                    for (var i = 0; i < size; i++)
+                    {
+                        _builder.Append(" ");
+                    }
+                }
+
+                _currentLineCharacterIndex += actualSize;
+                _absoluteIndex += actualSize;
             }
 
             return this;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/CodeWriterExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/CodeWriterExtensions.cs
@@ -48,29 +48,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             var basePadding = CalculatePadding();
             var resolvedPadding = Math.Max(basePadding - offset, 0);
 
-            if (context.Options.IndentWithTabs)
-            {
-                // Avoid writing directly to the StringBuilder here, that will throw off the manual indexing 
-                // done by the base class.
-                var tabs = resolvedPadding / context.Options.IndentSize;
-                for (var i = 0; i < tabs; i++)
-                {
-                    writer.Write("\t");
-                }
-
-                var spaces = resolvedPadding % context.Options.IndentSize;
-                for (var i = 0; i < spaces; i++)
-                {
-                    writer.Write(" ");
-                }
-            }
-            else
-            {
-                for (var i = 0; i < resolvedPadding; i++)
-                {
-                    writer.Write(" ");
-                }
-            }
+            writer.Indent(resolvedPadding);
 
             return writer;
 
@@ -86,7 +64,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
                     }
                     else if (@char == '\t')
                     {
-                        spaceCount += context.Options.IndentSize;
+                        spaceCount += writer.TabSize;
                     }
                     else
                     {
@@ -569,11 +547,11 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             private int _tabSize;
             private int _startIndent;
 
-            public CSharpCodeWritingScope(CodeWriter writer, int tabSize = 4, bool autoSpace = true)
+            public CSharpCodeWritingScope(CodeWriter writer, bool autoSpace = true)
             {
                 _writer = writer;
                 _autoSpace = autoSpace;
-                _tabSize = tabSize;
+                _tabSize = writer.TabSize;
                 _startIndent = -1; // Set in WriteStartScope
 
                 WriteStartScope();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DefaultDocumentWriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DefaultDocumentWriter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             }
 
             var context = new DefaultCodeRenderingContext(
-                new CodeWriter(),
+                new CodeWriter(Environment.NewLine, _options.IndentSize, _options.IndentWithTabs),
                 _codeTarget.CreateNodeWriter(),
                 codeDocument,
                 documentNode,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
@@ -10,19 +10,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class RazorLSPOptions : IEquatable<RazorLSPOptions>
     {
-        public RazorLSPOptions(Trace trace, bool enableFormatting)
+        public RazorLSPOptions(Trace trace, bool enableFormatting, int tabSize, bool insertSpaces)
         {
             Trace = trace;
             EnableFormatting = enableFormatting;
+            TabSize = tabSize;
+            InsertSpaces = insertSpaces;
         }
 
-        public static RazorLSPOptions Default => new RazorLSPOptions(trace: default, enableFormatting: true);
+        public static RazorLSPOptions Default => new RazorLSPOptions(trace: default, enableFormatting: true, tabSize: 4, insertSpaces: true);
 
         public Trace Trace { get; }
 
         public LogLevel MinLogLevel => GetLogLevelForTrace(Trace);
 
         public bool EnableFormatting { get; }
+
+        public int TabSize { get; }
+
+        public bool InsertSpaces { get; }
 
         public static LogLevel GetLogLevelForTrace(Trace trace)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -15,8 +16,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public static readonly IFallbackProjectEngineFactory FallbackProjectEngineFactory = new FallbackProjectEngineFactory();
 
         private readonly FilePathNormalizer _filePathNormalizer;
+        private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
 
-        public RemoteProjectSnapshotProjectEngineFactory(FilePathNormalizer filePathNormalizer) : 
+        public RemoteProjectSnapshotProjectEngineFactory(FilePathNormalizer filePathNormalizer, IOptionsMonitor<RazorLSPOptions> optionsMonitor) : 
             base(FallbackProjectEngineFactory, ProjectEngineFactories.Factories)
         {
             if (filePathNormalizer == null)
@@ -24,7 +26,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(filePathNormalizer));
             }
 
+            if (optionsMonitor is null)
+            {
+                throw new ArgumentNullException(nameof(optionsMonitor));
+            }
+
             _filePathNormalizer = filePathNormalizer;
+            _optionsMonitor = optionsMonitor;
         }
 
         public override RazorProjectEngine Create(
@@ -39,7 +47,37 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             var remoteFileSystem = new RemoteRazorProjectFileSystem(defaultFileSystem.Root, _filePathNormalizer);
-            return base.Create(configuration, remoteFileSystem, configure);
+            return base.Create(configuration, remoteFileSystem, Configure);
+
+            void Configure(RazorProjectEngineBuilder builder)
+            {
+                configure(builder);
+                builder.Features.Add(new RemoteCodeGenerationOptionsFeature(_optionsMonitor));
+            }
+        }
+
+        private class RemoteCodeGenerationOptionsFeature : RazorEngineFeatureBase, IConfigureRazorCodeGenerationOptionsFeature
+        {
+            private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
+
+            public RemoteCodeGenerationOptionsFeature(IOptionsMonitor<RazorLSPOptions> optionsMonitor)
+            {
+                if (optionsMonitor is null)
+                {
+                    throw new ArgumentNullException(nameof(optionsMonitor));
+                }
+
+                _optionsMonitor = optionsMonitor;
+            }
+
+            public int Order { get; set; }
+
+            public void Configure(RazorCodeGenerationOptionsBuilder options)
+            {
+                // We don't need to explicitly subscribe to options changing because this method will be run on every parse.
+                options.IndentSize = _optionsMonitor.CurrentValue.TabSize;
+                options.IndentWithTabs = !_optionsMonitor.CurrentValue.InsertSpaces;
+            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -17,8 +17,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public async Task GetLatestOptionsAsync_ReturnsExpectedOptions()
         {
             // Arrange
-            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false);
-            var jsonString = @"
+            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false, tabSize: 8, insertSpaces: true);
+            var editorJsonString = @"
+{
+  ""tabSize"": 8,
+  ""insertSpaces"": ""true""
+}
+".Trim();
+            var razorJsonString = @"
 {
   ""trace"": ""Messages"",
   ""format"": {
@@ -26,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
   }
 }
 ".Trim();
-            var result = new object[] { jsonString };
+            var result = new object[] { editorJsonString, razorJsonString };
             var languageServer = GetLanguageServer(result);
             var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         private static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting)
         {
             var monitor = new Mock<IOptionsMonitor<RazorLSPOptions>>();
-            monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, enableFormatting));
+            monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, enableFormatting, tabSize: 4, insertSpaces: true));
             return monitor.Object;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public async Task UpdateAsync_Invokes_OnChangeRegistration()
         {
             // Arrange
-            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false);
+            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false, tabSize: 4, insertSpaces: true);
             var configService = Mock.Of<RazorConfigurationService>(f => f.GetLatestOptionsAsync() == Task.FromResult(expectedOptions));
             var optionsMonitor = new RazorLSPOptionsMonitor(configService, Cache);
             var called = false;
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public async Task UpdateAsync_DoesNotInvoke_OnChangeRegistration_AfterDispose()
         {
             // Arrange
-            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false);
+            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false, tabSize: 8, insertSpaces: false);
             var configService = Mock.Of<RazorConfigurationService>(f => f.GetLatestOptionsAsync() == Task.FromResult(expectedOptions));
             var optionsMonitor = new RazorLSPOptionsMonitor(configService, Cache);
             var called = false;

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.codegen.cs
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.codegen.cs
@@ -45,7 +45,7 @@ using Microsoft.AspNetCore.Components.RenderTree;
 #line default
 #line hidden
 #nullable disable
-                                      
+                          
 
         }
         #pragma warning restore 1998

--- a/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.mappings.txt
+++ b/src/Razor/test/RazorLanguage.Test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.mappings.txt
@@ -24,7 +24,7 @@ Generated Location: (1301:42,16 [6] )
 Source Location: (216:6,26 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |
 |
-Generated Location: (1398:47,38 [2] )
+Generated Location: (1386:47,26 [2] )
 |
 |
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/18996

- Made TabSize and IndentWithTabs first class properties on `CodeWriter` and actually use them when indenting.
- Wire it up with the options provided by the client in LSP scenarios