### PR TITLE
Add /p:DotNetPublishUsingPipelines=value setting for Win Debug builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,6 +165,7 @@ stages:
           matrix:
             debug:
               _BuildConfig: Debug
+              _PublishArgs: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
             release:
               _BuildConfig: Release
               ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Addresses #dotnet/aspnetcore-internal#3516

duplicating fixes described in https://github.com/dotnet/extensions/pull/3016