### PR TITLE
Run Razor Language Server in-proc in VS.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ILanguageServerExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ILanguageServerExtensions.cs
@@ -12,8 +12,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         public static Task InitializedAsync(this ILanguageServer languageServer, CancellationToken cancellationToken)
         {
-            var assembly = Assembly.Load("OmniSharp.Extensions.LanguageServer");
-            var type = assembly.GetType("OmniSharp.Extensions.LanguageServer.Server.LanguageServer");
+            var type = typeof(OmniSharp.Extensions.LanguageServer.Server.LanguageServer);
             var method = type.GetMethod("Initialize", BindingFlags.NonPublic | BindingFlags.Instance);
             var task = (Task)method.Invoke(languageServer, new object[] { cancellationToken });
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/BindingRedirects.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/BindingRedirects.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.VisualStudio.Shell;
+
+[assembly: ProvideBindingRedirection(
+    AssemblyName="OmniSharp.Extensions.JsonRpc",
+    CodeBase = @"$PackageFolder$\OmniSharp.Extensions.JsonRpc.dll",
+    OldVersionLowerBound = "0.14.0.0", OldVersionUpperBound = "0.14.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "OmniSharp.Extensions.LanguageProtocol",
+    CodeBase = @"$PackageFolder$\OmniSharp.Extensions.LanguageProtocol.dll",
+    OldVersionLowerBound = "0.14.0.0", OldVersionUpperBound = "0.14.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "OmniSharp.Extensions.LanguageServer",
+    CodeBase = @"$PackageFolder$\OmniSharp.Extensions.LanguageServer.dll",
+    OldVersionLowerBound = "0.14.0.0", OldVersionUpperBound = "0.14.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "MediatR",
+    CodeBase = @"$PackageFolder$\MediatR.dll",
+    OldVersionLowerBound = "7.0.0.0", OldVersionUpperBound = "7.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "MediatR.Extensions.Microsoft.DependencyInjection",
+    CodeBase = @"$PackageFolder$\MediatR.Extensions.Microsoft.DependencyInjection.dll",
+    OldVersionLowerBound = "7.0.0.0", OldVersionUpperBound = "7.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.Options",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.Options.dll",
+    OldVersionLowerBound = "2.0.0.0", OldVersionUpperBound = "2.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.DependencyInjection",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.DependencyInjection.dll",
+    OldVersionLowerBound = "2.0.0.0", OldVersionUpperBound = "2.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.DependencyInjection.Abstractions.dll",
+    OldVersionLowerBound = "2.0.0.0", OldVersionUpperBound = "2.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.Configuration.Json",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.Configuration.Json.dll",
+    OldVersionLowerBound = "5.0.0.0", OldVersionUpperBound = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.Configuration.FileExtensions",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.Configuration.FileExtensions.dll",
+    OldVersionLowerBound = "5.0.0.0", OldVersionUpperBound = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.Configuration",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.Configuration.dll",
+    OldVersionLowerBound = "5.0.0.0", OldVersionUpperBound = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.Configuration.Abstractions",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.Configuration.Abstractions.dll",
+    OldVersionLowerBound = "5.0.0.0", OldVersionUpperBound = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.Logging",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.Logging.dll",
+    OldVersionLowerBound = "2.0.0.0", OldVersionUpperBound = "2.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.Logging.Abstractions",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.Logging.Abstractions.dll",
+    OldVersionLowerBound = "2.0.0.0", OldVersionUpperBound = "2.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.FileSystemGlobbing",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileSystemGlobbing.dll",
+    OldVersionLowerBound = "5.0.0.0", OldVersionUpperBound = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.FileProviders.Abstractions",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileProviders.Abstractions.dll",
+    OldVersionLowerBound = "5.0.0.0", OldVersionUpperBound = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.FileProviders.Physical",
+    CodeBase = @"$PackageFolder$\Microsoft.Extensions.FileProviders.Physical.dll",
+    OldVersionLowerBound = "5.0.0.0", OldVersionUpperBound = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "System.Reactive",
+    CodeBase = @"$PackageFolder$\System.Reactive.dll",
+    OldVersionLowerBound = "4.1.0.0", OldVersionUpperBound = "4.1.0.0")]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -73,6 +73,27 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <VSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.JsonRpc.dll" />
+    <VSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.LanguageProtocol.dll" />
+    <VSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.LanguageServer.dll" />
+    <VSIXSourceItem Include="$(OutputPath)MediatR.dll" />
+    <VSIXSourceItem Include="$(OutputPath)MediatR.Extensions.Microsoft.DependencyInjection.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Options.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.DependencyInjection.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.Json.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.FileExtensions.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.Abstractions.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Logging.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Logging.Abstractions.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.FileSystemGlobbing.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.FileProviders.Abstractions.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.FileProviders.Physical.dll" />
+    <VSIXSourceItem Include="$(OutputPath)System.Reactive.dll" />
+  </ItemGroup>
+
   <!-- Resources are a little bit special in a VSIX -->
   <PropertyGroup>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
@@ -125,29 +146,6 @@
   <PropertyGroup>
     <_GeneratedVSIXBindingRedirectFile>$(IntermediateOutputPath)$(MSBuildProjectName).BindingRedirects.cs</_GeneratedVSIXBindingRedirectFile>
   </PropertyGroup>
-
-  <Target Name="_BuildLanguageServer">
-    <MSBuild Projects="..\rzls\rzls.csproj"
-        Targets="Build" />
-  </Target>
-
-  <Target Name="_IncludeLanguageServer" DependsOnTargets="PrepareForBuild;_BuildLanguageServer"  BeforeTargets="CoreCompile">
-    <MSBuild Projects="..\rzls\rzls.csproj"
-        Targets="_GetOutputPath">
-      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
-    </MSBuild>
-
-    <PropertyGroup>
-      <_ResolvedPackageVersionInfoProperty>@(_ResolvedPackageVersionInfo)</_ResolvedPackageVersionInfoProperty>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <Content Include="$(_ResolvedPackageVersionInfoProperty)\*">
-        <IncludeInVsix>true</IncludeInVsix>
-        <VSIXSubPath>LanguageServer\</VSIXSubPath>
-      </Content>
-    </ItemGroup>
-  </Target>
 
   <Target Name="_BuildRazorGrammar">
     <MSBuild Projects="..\Microsoft.AspNetCore.Razor.VSCode.Extension\Microsoft.AspNetCore.Razor.VSCode.Extension.npmproj"

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -126,6 +126,7 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Language\Microsoft.AspNetCore.Razor.Language.csproj" />
     <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor\Microsoft.CodeAnalysis.Razor.csproj" />
     <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
@@ -148,11 +149,10 @@
   </PropertyGroup>
 
   <Target Name="_BuildRazorGrammar">
-    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.VSCode.Extension\Microsoft.AspNetCore.Razor.VSCode.Extension.npmproj"
-        Targets="Build" />
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.VSCode.Extension\Microsoft.AspNetCore.Razor.VSCode.Extension.npmproj" Targets="Build" />
   </Target>
 
-  <Target Name="_IncludeRazorGrammar" DependsOnTargets="PrepareForBuild;_BuildRazorGrammar"  BeforeTargets="CoreCompile">
+  <Target Name="_IncludeRazorGrammar" DependsOnTargets="PrepareForBuild;_BuildRazorGrammar" BeforeTargets="CoreCompile">
     <ItemGroup>
       <Content Include="..\Microsoft.AspNetCore.Razor.VSCode.Extension\syntaxes\aspnetcorerazor.tmLanguage.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -165,7 +165,7 @@
   <Target Name="_GenerateVSIXBindingRedirects" DependsOnTargets="PrepareForBuild;GetAssemblyVersion" BeforeTargets="CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(_GeneratedVSIXBindingRedirectFile)">
     <ItemGroup>
       <BindingRedirectAssemblies Include="@(ProjectReference)" AssemblyName="%(Filename)" />
-      <BindingRedirectAssemblies Include="$(AssemblyName)" AssemblyName="$(AssemblyName)"/>
+      <BindingRedirectAssemblies Include="$(AssemblyName)" AssemblyName="$(AssemblyName)" />
     </ItemGroup>
     <PropertyGroup>
       <_GeneratedVSIXBindingRedirectContent><![CDATA[

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.RazorExtension
     [ProvideEditorFactory(typeof(RazorEditorFactory), 101, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_SupportsPreview)]
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [AboutDialogInfo(PackageGuidString, "ASP.NET Core Razor Language Services", "#110", "#112", IconResourceID = "#400")]
+    [ProvideBindingPath]
     [Guid(PackageGuidString)]
     public sealed class RazorPackage : AsyncPackage
     {

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -18,7 +18,6 @@ namespace Microsoft.VisualStudio.RazorExtension
     [ProvideEditorFactory(typeof(RazorEditorFactory), 101, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_SupportsPreview)]
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [AboutDialogInfo(PackageGuidString, "ASP.NET Core Razor Language Services", "#110", "#112", IconResourceID = "#400")]
-    [ProvideBindingPath]
     [Guid(PackageGuidString)]
     public sealed class RazorPackage : AsyncPackage
     {

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -27,6 +27,26 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.Language.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="OmniSharp.Extensions.JsonRpc.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="OmniSharp.Extensions.LanguageProtocol.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="OmniSharp.Extensions.LanguageServer.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="MediatR.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="MediatR.Extensions.Microsoft.DependencyInjection.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Options.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.DependencyInjection.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Configuration.Json.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Configuration.FileExtensions.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Configuration.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Configuration.Abstractions.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Logging.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Logging.Abstractions.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.FileSystemGlobbing.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.FileProviders.Abstractions.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.FileProviders.Physical.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Reactive.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.Common.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.AspNetCore.Razor.Language.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.CodeAnalysis.Razor.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.Razor.dll" />

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -20,13 +20,6 @@
     <MSBuild Projects="..\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj" Properties="PublishDir=$(TargetPluginOutputPath);RuntimeIdentifier=" Targets="Publish" />
   </Target>
 
-  <Target Name="_GetOutputPath" Returns="@(_ServerOutputPath)">
-    <ItemGroup>
-      <_ServerOutputPath Include="$(OutputPath)">
-      </_ServerOutputPath>
-    </ItemGroup>
-  </Target>
-
   <!--
     Technique for publishing multiple RIDs from
     https://github.com/dotnet/cli/issues/9221#issuecomment-387512008


### PR DESCRIPTION
- Moved away from booting an OOP Razor Language Server in the new Razor LSP editor scenarios in order to remove the requirement to manage the `rzls` process lifetime and to also ensure that Razor's editor communication doesn't need to cross process boundaries.
- Now that the Razor LanguageServer Client references the language server project directly our VS extension transitively references our language server which means it no longer needs to do MSBuild magic to include the language server binaries.
- Added extension manifest and VSIXSource entries to the VS extension project to ensure that O# bits make it into our VS extension
- Added `[ProvideBindingPath]` to our `RazorPackage` definition to enable VS to load O# assemblies without them being MEF discoverable.
- Spent 10+hrs trying to find out why the in-proc language server wouldn't initialize. Turns out O# libraries don't flush after writes to the JSON duplex streams that we create so had to wrap the server's stream in order to auto-flush on O#'s behalf. I plan to submit changes to O# to fix that behavior.

Fixes dotnet/aspnetcore#19185