### PR TITLE
Use Razor's new editor experience in cloud scenarios.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -11,11 +11,12 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.RazorExtension
 {
-    // We attach to the 51st priority order because the traditional Web + XML editors have priority 50. We need to be loaded prior to them
+    // We attach to the 52nd priority order because the traditional Web + XML editors have priority 51. We need to be loaded prior to them
     // since we want to have the option to own the experience for Razor files
-    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.CSHTMLFileExtension, 51, NameResourceID = 101)]
-    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.RazorFileExtension, 51, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.CSHTMLFileExtension, 52, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.RazorFileExtension, 52, NameResourceID = 101)]
     [ProvideEditorFactory(typeof(RazorEditorFactory), 101, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_SupportsPreview)]
+    [ProvideEditorLogicalView(typeof(RazorEditorFactory), VSConstants.LOGVIEWID.TextView_string)]
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [AboutDialogInfo(PackageGuidString, "ASP.NET Core Razor Language Services", "#110", "#112", IconResourceID = "#400")]
     [Guid(PackageGuidString)]


### PR DESCRIPTION
- Found that cloud scenarios require that editor factories running need to support `VSConstants.LOGVIEWID.TextView_string`. Therefore, we now broadcast that we support that which allows our editor to be potentially selected.
- Upped our editor factory priority from 51 -> 52. Must have misread the XML/Web editor priorities when I initially wrote the code. Turns out 51 is what the XML/Web editors are currently at which means if reflection isn't kind enough to us there's a chance that those editors will sit in front of ours which is unintended.

Fixes dotnet/aspnetcore#19186
