### PR TITLE
Publish generated HTML in the client

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/RazorCodeDocumentExtensions.cs
@@ -126,9 +126,11 @@ namespace Microsoft.AspNetCore.Razor.Language
             if (razorHtmlObj == null)
             {
                 var razorHtmlDocument = RazorHtmlWriter.GetHtmlDocument(document);
-                document.Items[typeof(RazorHtmlDocument)] = razorHtmlDocument;
-
-                return razorHtmlDocument;
+                if (razorHtmlDocument != null)
+                {
+                    document.Items[typeof(RazorHtmlDocument)] = razorHtmlDocument;
+                    return razorHtmlDocument;
+                }
             }
 
             return (RazorHtmlDocument)razorHtmlObj;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -8,5 +8,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public const string ProjectConfigurationFile = "project.razor.json";
 
         public const string RazorRangeFormattingEndpoint = "razor/rangeFormatting";
+
+        public const string RazorUpdateCSharpBufferEndpoint = "razor/updateCSharpBuffer";
+
+        public const string RazorUpdateHtmlBufferEndpoint = "razor/updateHtmlBuffer";
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -128,21 +128,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             switch (args.Kind)
             {
                 case ProjectChangeKind.DocumentChanged:
-                case ProjectChangeKind.DocumentRemoved:
-                    if (_publishedCSharpSourceText.ContainsKey(args.DocumentFilePath) &&
-                        !_projectSnapshotManager.IsDocumentOpen(args.DocumentFilePath))
+                    if (!_projectSnapshotManager.IsDocumentOpen(args.DocumentFilePath))
                     {
-                        // Document closed or removed, evict published source text.
+                        // Document closed, evict published source text.
+                        if (_publishedCSharpSourceText.ContainsKey(args.DocumentFilePath))
+                        {
+                            var removed = _publishedCSharpSourceText.Remove(args.DocumentFilePath);
+                            Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
+                        }
+                        if (_publishedHtmlSourceText.ContainsKey(args.DocumentFilePath))
+                        {
+                            var removed = _publishedHtmlSourceText.Remove(args.DocumentFilePath);
+                            Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
+                        }
+                    }
+                    break;
+                case ProjectChangeKind.DocumentRemoved:
+                    // Document removed, evict published source text.
+                    if (_publishedCSharpSourceText.ContainsKey(args.DocumentFilePath))
+                    {
                         var removed = _publishedCSharpSourceText.Remove(args.DocumentFilePath);
-
                         Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
                     }
-                    if (_publishedHtmlSourceText.ContainsKey(args.DocumentFilePath) &&
-                        !_projectSnapshotManager.IsDocumentOpen(args.DocumentFilePath))
+                    if (_publishedHtmlSourceText.ContainsKey(args.DocumentFilePath))
                     {
-                        // Document closed or removed, evict published source text.
                         var removed = _publishedHtmlSourceText.Remove(args.DocumentFilePath);
-
                         Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
                     }
                     break;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentContainerStore.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentContainerStore.cs
@@ -5,8 +5,8 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal abstract class GeneratedCodeContainerStore : ProjectSnapshotChangeTrigger
+    internal abstract class GeneratedDocumentContainerStore : ProjectSnapshotChangeTrigger
     {
-        public abstract GeneratedCodeContainer Get(string physicalFilePath);
+        public abstract GeneratedDocumentContainer Get(string physicalFilePath);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentPublisher.cs
@@ -6,8 +6,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal abstract class CSharpPublisher : ProjectSnapshotChangeTrigger
+    internal abstract class GeneratedDocumentPublisher : ProjectSnapshotChangeTrigger
     {
-        public abstract void Publish(string filePath, SourceText sourceText, long hostDocumentVersion);
+        public abstract void PublishCSharp(string filePath, SourceText sourceText, long hostDocumentVersion);
+
+        public abstract void PublishHtml(string filePath, SourceText sourceText, long hostDocumentVersion);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Program.cs
@@ -125,9 +125,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         var foregroundDispatcher = new VSCodeForegroundDispatcher();
                         services.AddSingleton<ForegroundDispatcher>(foregroundDispatcher);
 
-                        var csharpPublisher = new DefaultCSharpPublisher(foregroundDispatcher, new Lazy<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>(() => server));
-                        services.AddSingleton<ProjectSnapshotChangeTrigger>(csharpPublisher);
-                        services.AddSingleton<CSharpPublisher>(csharpPublisher);
+                        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(foregroundDispatcher, new Lazy<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>(() => server));
+                        services.AddSingleton<ProjectSnapshotChangeTrigger>(generatedDocumentPublisher);
+                        services.AddSingleton<GeneratedDocumentPublisher>(generatedDocumentPublisher);
 
                         // Formatting
                         services.AddSingleton<RazorFormattingService, DefaultRazorFormattingService>();
@@ -138,11 +138,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         var documentVersionCache = new DefaultDocumentVersionCache(foregroundDispatcher);
                         services.AddSingleton<DocumentVersionCache>(documentVersionCache);
                         services.AddSingleton<ProjectSnapshotChangeTrigger>(documentVersionCache);
-                        var containerStore = new DefaultGeneratedCodeContainerStore(
+                        var containerStore = new DefaultGeneratedDocumentContainerStore(
                             foregroundDispatcher,
                             documentVersionCache,
-                            csharpPublisher);
-                        services.AddSingleton<GeneratedCodeContainerStore>(containerStore);
+                            generatedDocumentPublisher);
+                        services.AddSingleton<GeneratedDocumentContainerStore>(containerStore);
                         services.AddSingleton<ProjectSnapshotChangeTrigger>(containerStore);
                     }));
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsynchronizableContentDocumentProcessedListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsynchronizableContentDocumentProcessedListener.cs
@@ -12,13 +12,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentVersionCache _documentVersionCache;
-        private readonly CSharpPublisher _csharpPublisher;
+        private readonly GeneratedDocumentPublisher _generatedDocumentPublisher;
         private ProjectSnapshotManager _projectManager;
 
         public UnsynchronizableContentDocumentProcessedListener(
             ForegroundDispatcher foregroundDispatcher,
             DocumentVersionCache documentVersionCache,
-            CSharpPublisher csharpPublisher)
+            GeneratedDocumentPublisher generatedDocumentPublisher)
         {
             if (foregroundDispatcher == null)
             {
@@ -30,14 +30,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(documentVersionCache));
             }
 
-            if (csharpPublisher is null)
+            if (generatedDocumentPublisher is null)
             {
-                throw new ArgumentNullException(nameof(csharpPublisher));
+                throw new ArgumentNullException(nameof(generatedDocumentPublisher));
             }
 
             _foregroundDispatcher = foregroundDispatcher;
             _documentVersionCache = documentVersionCache;
-            _csharpPublisher = csharpPublisher;
+            _generatedDocumentPublisher = generatedDocumentPublisher;
         }
 
         public override void DocumentProcessed(DocumentSnapshot document)
@@ -60,7 +60,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return;
             }
 
-            var latestSynchronizedDocument = defaultDocument.State.HostDocument.GeneratedCodeContainer.LatestDocument;
+            var documentContainer = defaultDocument.State.GeneratedDocumentContainer;
+            var latestSynchronizedDocument = documentContainer.LatestDocument;
             if (latestSynchronizedDocument == null ||
                 latestSynchronizedDocument == document)
             {
@@ -71,11 +72,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (IdenticalOutputAfterParse(document, latestSynchronizedDocument, syncVersion))
             {
                 // Documents are identical but we didn't synchronize them because they didn't need to be re-evaluated.
-
-                var result = document.TryGetText(out var latestText);
-                Debug.Assert(result, "We just successfully retrieved the text version, this should always return true.");
-
-                _csharpPublisher.Publish(document.FilePath, latestText, syncVersion);
+                _generatedDocumentPublisher.PublishCSharp(document.FilePath, documentContainer.CSharpSourceTextContainer.CurrentText, syncVersion);
+                _generatedDocumentPublisher.PublishHtml(document.FilePath, documentContainer.HtmlSourceTextContainer.CurrentText, syncVersion);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsynchronizableContentDocumentProcessedListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UnsynchronizableContentDocumentProcessedListener.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return;
             }
 
-            if (IdenticalOutputAfterParse(document, latestSynchronizedDocument, syncVersion))
+            if (UnchangedHostDocument(document, latestSynchronizedDocument, syncVersion))
             {
                 // Documents are identical but we didn't synchronize them because they didn't need to be re-evaluated.
                 _generatedDocumentPublisher.PublishCSharp(document.FilePath, documentContainer.CSharpSourceTextContainer.CurrentText, syncVersion);
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _projectManager = projectManager;
         }
 
-        private bool IdenticalOutputAfterParse(DocumentSnapshot document, DocumentSnapshot latestSynchronizedDocument, long syncVersion)
+        private bool UnchangedHostDocument(DocumentSnapshot document, DocumentSnapshot latestSynchronizedDocument, long syncVersion)
         {
             return latestSynchronizedDocument.TryGetTextVersion(out var latestSourceVersion) &&
                 document.TryGetTextVersion(out var documentSourceVersion) &&

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UpdateBufferRequest.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UpdateBufferRequest.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    public class UpdateCSharpBufferRequest
+    public class UpdateBufferRequest
     {
         public long HostDocumentVersion { get; set; }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpDocumentSnapshot.cs
@@ -64,8 +64,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
         public SourceText GetGeneratedCodeSourceText()
         {
-            var generatedCodeContainer = ((DefaultDocumentSnapshot)_documentSnapshot).State.HostDocument.GeneratedCodeContainer;
-            var sourceText = generatedCodeContainer.SourceTextContainer.CurrentText;
+            var generatedDocumentContainer = ((DefaultDocumentSnapshot)_documentSnapshot).State.HostDocument.GeneratedDocumentContainer;
+            var sourceText = generatedDocumentContainer.CSharpSourceTextContainer.CurrentText;
             return sourceText;
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocument.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocument.ts
@@ -4,6 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { IProjectedDocument } from '../IProjectedDocument';
+import { ServerTextChange } from '../RPC/ServerTextChange';
 import { getUriPath } from '../UriPaths';
 import * as vscode from '../vscodeAdapter';
 
@@ -25,19 +26,42 @@ export class HtmlProjectedDocument implements IProjectedDocument {
         return this.projectedDocumentVersion;
     }
 
-    public getContent() {
-        return this.content;
+    public update(edits: ServerTextChange[], hostDocumentVersion: number) {
+        this.hostDocumentVersion = hostDocumentVersion;
+
+        if (edits.length === 0) {
+            return;
+        }
+
+        let content = this.content;
+        for (const edit of edits) {
+            // TODO: Use a better data structure to represent the content, string concatenation is slow.
+            content = this.getEditedContent(edit.newText, edit.span.start, edit.span.end, content);
+        }
+
+        this.setContent(content);
     }
 
-    public setContent(content: string, hostDocumentVersion: number) {
-        this.projectedDocumentVersion++;
-        this.hostDocumentVersion = hostDocumentVersion;
-        this.content = content;
+    public getContent() {
+        return this.content;
     }
 
     public reset() {
         this.projectedDocumentVersion++;
         this.hostDocumentVersion = null;
-        this.content = '';
+        this.setContent('');
+    }
+
+    private getEditedContent(newText: string, start: number, end: number, content: string) {
+        const before = content.substr(0, start);
+        const after = content.substr(end);
+        content = `${before}${newText}${after}`;
+
+        return content;
+    }
+
+    private setContent(content: string) {
+        this.projectedDocumentVersion++;
+        this.content = content;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateBufferRequest.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/UpdateBufferRequest.ts
@@ -5,7 +5,7 @@
 
 import { ServerTextChange } from './ServerTextChange';
 
-export class UpdateCSharpBufferRequest {
+export class UpdateBufferRequest {
     constructor(
         public readonly hostDocumentVersion: number,
         public readonly hostDocumentFilePath: string,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultDocumentSnapshot.cs
@@ -58,13 +58,19 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public override async Task<RazorCodeDocument> GetGeneratedOutputAsync()
         {
-            var (output, _, _) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
+            var (output, _, _, _) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
             return output;
         }
 
-        public override async Task<VersionStamp> GetGeneratedOutputVersionAsync()
+        public override async Task<VersionStamp> GetGeneratedCSharpOutputVersionAsync()
         {
-            var (_, _, version) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
+            var (_, _, version, _) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
+            return version;
+        }
+
+        public override async Task<VersionStamp> GetGeneratedHtmlOutputVersionAsync()
+        {
+            var (_, _, _, version) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
             return version;
         }
 
@@ -90,15 +96,27 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return false;
         }
 
-        public override bool TryGetGeneratedOutputVersionAsync(out VersionStamp result)
+        public override bool TryGetGeneratedCSharpOutputVersionAsync(out VersionStamp result)
         {
             if (State.IsGeneratedOutputResultAvailable)
             {
-                result = State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).Result.outputVersion;
+                result = State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).Result.outputCSharpVersion;
                 return true;
             }
 
-            result = default(VersionStamp);
+            result = default;
+            return false;
+        }
+
+        public override bool TryGetGeneratedHtmlOutputVersionAsync(out VersionStamp result)
+        {
+            if (State.IsGeneratedOutputResultAvailable)
+            {
+                result = State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).Result.outputHtmlVersion;
+                return true;
+            }
+
+            result = default;
             return false;
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultImportDocumentSnapshot.cs
@@ -39,7 +39,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             throw new NotSupportedException();
         }
 
-        public override Task<VersionStamp> GetGeneratedOutputVersionAsync()
+        public override Task<VersionStamp> GetGeneratedCSharpOutputVersionAsync()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override Task<VersionStamp> GetGeneratedHtmlOutputVersionAsync()
         {
             throw new NotSupportedException();
         }
@@ -89,7 +94,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             throw new NotSupportedException();
         }
 
-        public override bool TryGetGeneratedOutputVersionAsync(out VersionStamp result)
+        public override bool TryGetGeneratedCSharpOutputVersionAsync(out VersionStamp result)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool TryGetGeneratedHtmlOutputVersionAsync(out VersionStamp result)
         {
             throw new NotSupportedException();
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -28,7 +28,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public abstract Task<RazorCodeDocument> GetGeneratedOutputAsync();
 
-        public abstract Task<VersionStamp> GetGeneratedOutputVersionAsync();
+        public abstract Task<VersionStamp> GetGeneratedCSharpOutputVersionAsync();
+
+        public abstract Task<VersionStamp> GetGeneratedHtmlOutputVersionAsync();
 
         public abstract bool TryGetText(out SourceText result);
 
@@ -36,6 +38,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public abstract bool TryGetGeneratedOutput(out RazorCodeDocument result);
 
-        public abstract bool TryGetGeneratedOutputVersionAsync(out VersionStamp result);
+        public abstract bool TryGetGeneratedCSharpOutputVersionAsync(out VersionStamp result);
+
+        public abstract bool TryGetGeneratedHtmlOutputVersionAsync(out VersionStamp result);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/HostDocument.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/HostDocument.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             FilePath = other.FilePath;
             TargetPath = other.TargetPath;
 
-            GeneratedCodeContainer = new GeneratedCodeContainer();
+            GeneratedDocumentContainer = new GeneratedDocumentContainer();
         }
 
         public HostDocument(string filePath, string targetPath)
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             FilePath = filePath;
             TargetPath = targetPath;
             FileKind = fileKind ?? FileKinds.GetFileKindFromFilePath(filePath);
-            GeneratedCodeContainer = new GeneratedCodeContainer();
+            GeneratedDocumentContainer = new GeneratedDocumentContainer();
         }
 
         public string FileKind { get; }
@@ -51,6 +51,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public string TargetPath { get; }
 
-        public GeneratedCodeContainer GeneratedCodeContainer { get; }
+        public GeneratedDocumentContainer GeneratedDocumentContainer { get; }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedCodeContainerStoreTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedCodeContainerStoreTest.cs
@@ -17,13 +17,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public DefaultGeneratedCodeContainerStoreTest()
         {
             var documentVersionCache = Mock.Of<DocumentVersionCache>();
-            var csharpPublisher = Mock.Of<CSharpPublisher>();
-            Store = new DefaultGeneratedCodeContainerStore(Dispatcher, documentVersionCache, csharpPublisher);
+            var csharpPublisher = Mock.Of<GeneratedDocumentPublisher>();
+            Store = new DefaultGeneratedDocumentContainerStore(Dispatcher, documentVersionCache, csharpPublisher);
             ProjectManager = TestProjectSnapshotManager.Create(Dispatcher);
             Store.Initialize(ProjectManager);
         }
 
-        private DefaultGeneratedCodeContainerStore Store { get; }
+        private DefaultGeneratedDocumentContainerStore Store { get; }
 
         private TestProjectSnapshotManager ProjectManager { get; }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultHostDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultHostDocumentFactoryTest.cs
@@ -15,10 +15,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         public DefaultHostDocumentFactoryTest()
         {
-            var store = new DefaultGeneratedCodeContainerStore(
+            var store = new DefaultGeneratedDocumentContainerStore(
                 Dispatcher,
                 Mock.Of<DocumentVersionCache>(),
-                Mock.Of<CSharpPublisher>());
+                Mock.Of<GeneratedDocumentPublisher>());
             Factory = new DefaultHostDocumentFactory(Dispatcher, store);
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/HtmlProjectedDocument.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/HtmlProjectedDocument.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import { HtmlProjectedDocument } from 'microsoft.aspnetcore.razor.vscode/dist/Html/HtmlProjectedDocument';
+import { ServerTextChange } from 'microsoft.aspnetcore.razor.vscode/dist/RPC/ServerTextChange';
 import { createTestVSCodeApi } from './Mocks/TestVSCodeApi';
 
 describe('HtmlProjectedDocument', () => {
@@ -14,7 +15,15 @@ describe('HtmlProjectedDocument', () => {
         const api = createTestVSCodeApi();
         const htmlDocumentUri = api.Uri.parse('C:/path/to/file.cshtml.__virtual.html');
         const htmlDocument = new HtmlProjectedDocument(htmlDocumentUri);
-        htmlDocument.setContent('Hello World', 1337);
+        const edit: ServerTextChange = {
+            newText: 'Hello World',
+            span: {
+                start: 0,
+                end: 0,
+                length: 11,
+            },
+        };
+        htmlDocument.update([edit], 1337);
 
         // Act
         htmlDocument.reset();

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -80,20 +79,20 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert
             Assert.False(LegacyDocument.TryGetGeneratedOutput(out _));
-            Assert.False(LegacyDocument.TryGetGeneratedOutputVersionAsync(out _));
+            Assert.False(LegacyDocument.TryGetGeneratedCSharpOutputVersionAsync(out _));
         }
 
         [Fact]
         public async Task GCCollect_OnRegenerationMaintainsOutputVersion()
         {
             // Arrange
-            var initialOutputVersion = await LegacyDocument.GetGeneratedOutputVersionAsync();
+            var initialOutputVersion = await LegacyDocument.GetGeneratedCSharpOutputVersionAsync();
 
             // Forces collection of the cached document output
             GC.Collect();
 
             // Act
-            var regeneratedOutputVersion = await LegacyDocument.GetGeneratedOutputVersionAsync();
+            var regeneratedOutputVersion = await LegacyDocument.GetGeneratedCSharpOutputVersionAsync();
 
             // Assert
             Assert.Equal(initialOutputVersion, regeneratedOutputVersion);
@@ -110,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Act & Assert
             Assert.True(LegacyDocument.TryGetGeneratedOutput(out _));
-            Assert.True(LegacyDocument.TryGetGeneratedOutputVersionAsync(out _));
+            Assert.True(LegacyDocument.TryGetGeneratedCSharpOutputVersionAsync(out _));
         }
 
         [Fact]
@@ -120,8 +119,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await LegacyDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(LegacyHostDocument.GeneratedCodeContainer.Output);
-            Assert.Same(SourceText, LegacyHostDocument.GeneratedCodeContainer.Source);
+            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
+            Assert.Same(SourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
         }
 
         // This is a sanity test that we invoke component codegen for components. It's a little fragile but
@@ -134,8 +133,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await ComponentCshtmlDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(ComponentCshtmlHostDocument.GeneratedCodeContainer.Output);
-            Assert.Contains("using Microsoft.AspNetCore.Components", ComponentCshtmlHostDocument.GeneratedCodeContainer.Output.GeneratedCode);
+            Assert.NotNull(ComponentCshtmlHostDocument.GeneratedDocumentContainer.OutputCSharp);
+            Assert.Contains("using Microsoft.AspNetCore.Components", ComponentCshtmlHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode);
         }
         [Fact]
         public async Task GetGeneratedOutputAsync_Component()
@@ -144,8 +143,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await ComponentDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(ComponentHostDocument.GeneratedCodeContainer.Output);
-            Assert.Contains("ComponentBase", ComponentHostDocument.GeneratedCodeContainer.Output.GeneratedCode);
+            Assert.NotNull(ComponentHostDocument.GeneratedDocumentContainer.OutputCSharp);
+            Assert.Contains("ComponentBase", ComponentHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode);
         }
 
         [Fact]
@@ -155,10 +154,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await NestedComponentDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(NestedComponentHostDocument.GeneratedCodeContainer.Output);
-            Assert.Contains("ComponentBase", NestedComponentHostDocument.GeneratedCodeContainer.Output.GeneratedCode);
-            Assert.Contains("namespace SomeProject.Nested", NestedComponentHostDocument.GeneratedCodeContainer.Output.GeneratedCode);
-            Assert.Contains("class File3", NestedComponentHostDocument.GeneratedCodeContainer.Output.GeneratedCode);
+            Assert.NotNull(NestedComponentHostDocument.GeneratedDocumentContainer.OutputCSharp);
+            Assert.Contains("ComponentBase", NestedComponentHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode);
+            Assert.Contains("namespace SomeProject.Nested", NestedComponentHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode);
+            Assert.Contains("class File3", NestedComponentHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode);
         }
 
         // This is a sanity test that we invoke legacy codegen for .cshtml files. It's a little fragile but
@@ -170,8 +169,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await LegacyDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(LegacyHostDocument.GeneratedCodeContainer.Output);
-            Assert.Contains("Template", LegacyHostDocument.GeneratedCodeContainer.Output.GeneratedCode);
+            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
+            Assert.Contains("Template", LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode);
         }
 
         [Fact]
@@ -189,8 +188,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await newDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(LegacyHostDocument.GeneratedCodeContainer.Output);
-            Assert.Same(newSourceText, LegacyHostDocument.GeneratedCodeContainer.Source);
+            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
+            Assert.Same(newSourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
         }
 
         [Fact]
@@ -208,8 +207,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await LegacyDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(LegacyHostDocument.GeneratedCodeContainer.Output);
-            Assert.Same(newSourceText, LegacyHostDocument.GeneratedCodeContainer.Source);
+            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
+            Assert.Same(newSourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -80,6 +80,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Assert
             Assert.False(LegacyDocument.TryGetGeneratedOutput(out _));
             Assert.False(LegacyDocument.TryGetGeneratedCSharpOutputVersionAsync(out _));
+            Assert.False(LegacyDocument.TryGetGeneratedHtmlOutputVersionAsync(out _));
         }
 
         [Fact]
@@ -92,10 +93,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             GC.Collect();
 
             // Act
-            var regeneratedOutputVersion = await LegacyDocument.GetGeneratedCSharpOutputVersionAsync();
+            var regeneratedCSharpOutputVersion = await LegacyDocument.GetGeneratedCSharpOutputVersionAsync();
+            var regeneratedHtmlOutputVersion = await LegacyDocument.GetGeneratedHtmlOutputVersionAsync();
 
             // Assert
-            Assert.Equal(initialOutputVersion, regeneratedOutputVersion);
+            Assert.Equal(initialOutputVersion, regeneratedCSharpOutputVersion);
+            Assert.Equal(initialOutputVersion, regeneratedHtmlOutputVersion);
         }
 
         [Fact]
@@ -110,6 +113,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Act & Assert
             Assert.True(LegacyDocument.TryGetGeneratedOutput(out _));
             Assert.True(LegacyDocument.TryGetGeneratedCSharpOutputVersionAsync(out _));
+            Assert.True(LegacyDocument.TryGetGeneratedHtmlOutputVersionAsync(out _));
         }
 
         [Fact]
@@ -120,6 +124,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert
             Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
+            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputHtml);
             Assert.Same(SourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
         }
 
@@ -190,6 +195,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Assert
             Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
             Assert.Same(newSourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
+            Assert.Equal("NEW!", LegacyHostDocument.GeneratedDocumentContainer.OutputHtml.GeneratedHtml);
         }
 
         [Fact]
@@ -209,6 +215,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Assert
             Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
             Assert.Same(newSourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
+            Assert.Equal("NEW!", LegacyHostDocument.GeneratedDocumentContainer.OutputHtml.GeneratedHtml);
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.CSharp;
@@ -61,18 +60,19 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 ProjectState.Create(Workspace.Services, HostProject)
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithAddedHostDocument(TestProjectData.AnotherProjectFile1, DocumentState.EmptyLoader);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.Same(originalOutput, actualOutput);
             Assert.Equal(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalOutputVersion, actualOutputVersion);
-            Assert.NotEqual(state.ProjectWorkspaceStateVersion, actualOutputVersion);
-            Assert.NotEqual(state.ConfigurationVersion, actualOutputVersion);
+            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
+            Assert.NotEqual(state.ProjectWorkspaceStateVersion, actualCSharpOutputVersion);
+            Assert.NotEqual(state.ConfigurationVersion, actualCSharpOutputVersion);
         }
 
         [Fact]
@@ -83,16 +83,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 ProjectState.Create(Workspace.Services, HostProject)
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalOutputVersion, actualOutputVersion);
+            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.DocumentCollectionVersion, actualInputVersion);
         }
 
@@ -105,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader)
                 .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var version = VersionStamp.Create();
@@ -115,10 +116,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             });
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.NotEqual(originalOutputVersion, actualOutputVersion);
+            Assert.NotEqual(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.NotEqual(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(version, actualInputVersion);
         }
 
@@ -131,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader)
                 .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var version = VersionStamp.Create();
@@ -141,10 +143,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             });
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.NotEqual(originalOutputVersion, actualOutputVersion);
+            Assert.NotEqual(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(version, actualInputVersion);
         }
 
@@ -157,16 +160,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader)
                 .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithRemovedHostDocument(TestProjectData.SomeProjectImportFile);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalOutputVersion, actualOutputVersion);
+            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.DocumentCollectionVersion, actualInputVersion);
         }
 
@@ -179,17 +183,18 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader)
                 .WithProjectWorkspaceState(ProjectWorkspaceState.Default);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
             var changed = new ProjectWorkspaceState(Array.Empty<TagHelperDescriptor>(), default);
 
             // Act
             var state = original.WithProjectWorkspaceState(changed);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.Same(originalOutput, actualOutput);
             Assert.Equal(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalOutputVersion, actualOutputVersion);
+            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
         }
 
@@ -202,17 +207,18 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 ProjectState.Create(Workspace.Services, HostProject)
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
             var changed = new ProjectWorkspaceState(SomeTagHelpers, default);
 
             // Act
             var state = original.WithProjectWorkspaceState(changed);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalOutputVersion, actualOutputVersion);
+            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
         }
 
@@ -231,16 +237,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 });
             var changedWorkspaceState = new ProjectWorkspaceState(SomeTagHelpers, LanguageVersion.CSharp8);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithProjectWorkspaceState(changedWorkspaceState);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.NotEqual(originalOutputVersion, actualOutputVersion);
+            Assert.NotEqual(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
         }
 
@@ -252,26 +259,27 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 ProjectState.Create(Workspace.Services, HostProject)
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithHostProject(HostProjectWithConfigurationChange);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.NotEqual(originalOutputVersion, actualOutputVersion);
+            Assert.NotEqual(originalCSharpOutputVersion, actualCSharpOutputVersion);
+            Assert.NotEqual(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.NotEqual(state.ProjectWorkspaceStateVersion, actualInputVersion);
         }
 
-        private static Task<(RazorCodeDocument, VersionStamp, VersionStamp)> GetOutputAsync(ProjectState project, HostDocument hostDocument)
+        private static Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetOutputAsync(ProjectState project, HostDocument hostDocument)
         {
             var document = project.Documents[hostDocument.FilePath];
             return GetOutputAsync(project, document);
         }
 
-        private static Task<(RazorCodeDocument, VersionStamp, VersionStamp)> GetOutputAsync(ProjectState project, DocumentState document)
+        private static Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetOutputAsync(ProjectState project, DocumentState document)
         {
 
             var projectSnapshot = new DefaultProjectSnapshot(project);

--- a/src/Razor/test/VSCode.FunctionalTest/tests/Completions.test.ts
+++ b/src/Razor/test/VSCode.FunctionalTest/tests/Completions.test.ts
@@ -106,4 +106,15 @@ suite('Completions', () => {
 
         assertHasCompletion(completions, 'strong');
     });
+
+    test('HTML tag completion not affected by C# code in .cshtml', async () => {
+        const lastLine = new vscode.Position(0, 0);
+        await editor.edit(edit => edit.insert(lastLine, '@{ if (1 < 2) {} } <str'));
+        const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            cshtmlDoc.uri,
+            new vscode.Position(0, 23));
+
+        assertHasCompletion(completions, 'strong');
+    });
 });

--- a/src/Razor/test/VSCode.FunctionalTest/tests/HoverComponents.test.ts
+++ b/src/Razor/test/VSCode.FunctionalTest/tests/HoverComponents.test.ts
@@ -17,7 +17,6 @@ suite('Hover Components', () => {
         const filePath = path.join(componentRoot, 'Components', 'Shared', 'MainLayout.razor');
         cshtmlDoc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(cshtmlDoc);
-        await new Promise(r => setTimeout(r, 5000));
     });
 
     test('Can perform hovers on directive attributes', async () => {
@@ -38,7 +37,7 @@ suite('Hover Components', () => {
             return;
         }
 
-        assert.equal(hoverResult.length, 1, 'Something else may be providing hover results');
+        assert.ok(hoverResult.length > 0, 'Should have atleast one result.');
 
         const onClickResult = hoverResult[0];
         const expectedRange = new vscode.Range(

--- a/src/Razor/test/VSCode.FunctionalTest/tests/HoverComponents.test.ts
+++ b/src/Razor/test/VSCode.FunctionalTest/tests/HoverComponents.test.ts
@@ -17,6 +17,7 @@ suite('Hover Components', () => {
         const filePath = path.join(componentRoot, 'Components', 'Shared', 'MainLayout.razor');
         cshtmlDoc = await vscode.workspace.openTextDocument(filePath);
         editor = await vscode.window.showTextDocument(cshtmlDoc);
+        await new Promise(r => setTimeout(r, 5000));
     });
 
     test('Can perform hovers on directive attributes', async () => {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/14286

- Refactored GeneratedCodeContainer and friends to include two output versions instead of one (CSharp and HTML)
- Added an `updateHtmlBuffer` command to update the buffer on the client
- Updated `RazorDocumentManager` and `HtmlDocument` on the client side to follow the same behavior of CSharp for updating the virtual background document
- Fixed a bug in `UnsyncronizedDocumentProcessedListener` where we were updating the background C# document with all razor content
- Updated tests