### PR TITLE
Disable Razor LSP editor in unsupported projects.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultProjectHierarchyInspector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultProjectHierarchyInspector.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using Microsoft.VisualStudio.LiveShare.Razor.Guest;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Export(typeof(ProjectHierarchyInspector))]
+    internal class DefaultProjectHierarchyInspector : ProjectHierarchyInspector
+    {
+        private readonly LiveShareSessionAccessor _sessionAccessor;
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+
+        [ImportingConstructor]
+        public DefaultProjectHierarchyInspector(
+            LiveShareSessionAccessor sessionAccessor,
+            JoinableTaskContext joinableTaskContext)
+        {
+            if (sessionAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(sessionAccessor));
+            }
+
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            _sessionAccessor = sessionAccessor;
+            _joinableTaskFactory = joinableTaskContext.Factory;
+        }
+
+        public override bool HasCapability(string documentMoniker, IVsHierarchy hierarchy, string capability)
+        {
+            if (_sessionAccessor.IsGuestSessionActive)
+            {
+                var remoteHasCapability = RemoteHasCapability(documentMoniker, capability);
+                return remoteHasCapability;
+            }
+
+            var localHasCapability = LocalHasCapability(hierarchy, capability);
+            return localHasCapability;
+        }
+
+        private static bool LocalHasCapability(IVsHierarchy hierarchy, string capability)
+        {
+            if (hierarchy == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var hasCapability = hierarchy.IsCapabilityMatch(capability);
+                return hasCapability;
+            }
+            catch (NotSupportedException)
+            {
+                // IsCapabilityMatch throws a NotSupportedException if it can't create a
+                // BooleanSymbolExpressionEvaluator COM object
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                // IsCapabilityMatch throws an ObjectDisposedException if the underlying hierarchy has been disposed
+                return false;
+            }
+        }
+
+        private bool RemoteHasCapability(string documentMoniker, string capability)
+        {
+            // On a guest box. The project hierarchy is not fully populated. We need to ask the host machine
+            // questions on hierarchy capabilities.
+            return _joinableTaskFactory.Run(async () =>
+            {
+                var remoteHierarchyService = await _sessionAccessor.Session.GetRemoteServiceAsync<IRemoteHierarchyService>(nameof(IRemoteHierarchyService), CancellationToken.None).ConfigureAwait(false);
+                var documentMonikerUri = _sessionAccessor.Session.ConvertLocalPathToSharedUri(documentMoniker);
+                var hasCapability = await remoteHierarchyService.HasCapabilityAsync(documentMonikerUri, capability, CancellationToken.None).ConfigureAwait(false);
+                return hasCapability;
+            });
+        }
+
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/IRemoteHierarchyService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/IRemoteHierarchyService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LiveShare;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    // This type must be a public interface in order to properly advertise itself as part of the LiveShare ICollaborationService infrastructure.
+    public interface IRemoteHierarchyService : ICollaborationService
+    {
+        public Task<bool> HasCapabilityAsync(Uri pathOfFileInProject, string capability, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.LiveShare.Razor\Microsoft.VisualStudio.LiveShare.Razor.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ProjectHierarchyInspector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ProjectHierarchyInspector.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal abstract class ProjectHierarchyInspector
+    {
+        public abstract bool HasCapability(string documentMoniker, IVsHierarchy hierarchy, string capability);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RemoteHierarchyService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RemoteHierarchyService.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LiveShare;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class RemoteHierarchyService : IRemoteHierarchyService
+    {
+        private readonly CollaborationSession _session;
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+
+        internal RemoteHierarchyService(CollaborationSession session, JoinableTaskFactory joinableTaskFactory)
+        {
+            if (session is null)
+            {
+                throw new ArgumentNullException(nameof(session));
+            }
+
+            if (joinableTaskFactory is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskFactory));
+            }
+
+            _session = session;
+            _joinableTaskFactory = joinableTaskFactory;
+        }
+
+        public async Task<bool> HasCapabilityAsync(Uri pathOfFileInProject, string capability, CancellationToken cancellationToken)
+        {
+            if (capability is null)
+            {
+                throw new ArgumentNullException(nameof(capability));
+            }
+
+            if (pathOfFileInProject is null)
+            {
+                throw new ArgumentNullException(nameof(pathOfFileInProject));
+            }
+
+            await _joinableTaskFactory.SwitchToMainThreadAsync();
+
+            var hostPathOfFileInProject = _session.ConvertSharedUriToLocalPath(pathOfFileInProject);
+            var vsUIShellOpenDocument = ServiceProvider.GlobalProvider.GetService(typeof(SVsUIShellOpenDocument)) as IVsUIShellOpenDocument;
+            if (vsUIShellOpenDocument == null)
+            {
+                return false;
+            }
+
+            var hr = vsUIShellOpenDocument.IsDocumentInAProject(hostPathOfFileInProject, out IVsUIHierarchy hierarchy, out _, out _, out _);
+            if (!ErrorHandler.Succeeded(hr) || hierarchy == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var isCapabilityMatch = hierarchy.IsCapabilityMatch(capability);
+                return isCapabilityMatch;
+            }
+            catch (NotSupportedException)
+            {
+                // IsCapabilityMatch throws a NotSupportedException if it can't create a
+                // BooleanSymbolExpressionEvaluator COM object
+            }
+            catch (ObjectDisposedException)
+            {
+                // IsCapabilityMatch throws an ObjectDisposedException if the underlying
+                //    hierarchy has been disposed (Bug 253462)
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RemoteHierarchyServiceFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RemoteHierarchyServiceFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LiveShare;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    /// <summary>
+    /// In cloud scenarios a client will not have a project system which means any code running on the client needs to have the ability to
+    /// query the remote project system. That is what this class is responsible for.
+    /// </summary>
+    [ExportCollaborationService(
+        typeof(IRemoteHierarchyService),
+        Name = nameof(IRemoteHierarchyService),
+        Scope = SessionScope.Host,
+        Role = ServiceRole.RemoteService)]
+    internal sealed class RemoteHierarchyServiceFactory : ICollaborationServiceFactory
+    {
+        public Task<ICollaborationService> CreateServiceAsync(CollaborationSession session, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<ICollaborationService>(new RemoteHierarchyService(session, ThreadHelper.JoinableTaskFactory));
+        }
+    }
+}


### PR DESCRIPTION
- "Unsupported projects" typically represents legacy ASP.NET projects.
- This change was slightly more tricky than anticipated. Reason being, in cloud scenarios (LiveShare) you can't always directly access the project system because it doesn't exist on the guest machine. To account for this I used the LiveShare infrastructure to create proxy services that enable a guest to query the host for project system capability fulfillments.
- Abstracted project project hierarchy inspection into a project hierarchy inspector. For now we only inspect capabilities; however, any project system asks in the future will need to flow through this path as well. In practice this class is responsible for undersetanding if it's running in a "Guest" or "Host" environment and doing the "right thing".
- Created a `RemoteHierarchyService` that has the brains to resolve an `IVsHierarchy` from a document moniker and then inspect that hierarchy for certain project capabilities. We use LiveShare's "only load on the host" infrastructure to ensure this service doesn't get loaded when we don't want it to.
- Could not add tests for these new APIs because they interact directly with `IVsHierarchy` which is a COMObject that does magic behind the scenes resulting in it being unmockable. Also, the other code paths we invoke here are typically excercised in end-to-end scenarios.

Fixes dotnet/aspnetcore#19182

/cc @alexgav @ToddGrun @jimmylewis 
