### PR TITLE
Stop shipping Razor language server bits to NuGet.org.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj
@@ -6,6 +6,7 @@
     <EnableApiCheck>false</EnableApiCheck>
     <!-- Suppress warnings about depending on non-stable version of Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X -->
     <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains common assets that are used in the Razor language server and other assemblies.</Description>
     <EnableApiCheck>false</EnableApiCheck>
-    <!-- Suppress warnings about depending on non-stable version of Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X -->
-    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -7,6 +7,7 @@
     <EnableApiCheck>false</EnableApiCheck>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64;</RuntimeIdentifiers>
     <AssemblyName>rzls</AssemblyName>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package exposes public shims from core Razor that are used in the OmniSharp plugin.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/Microsoft.AspNetCore.Razor.OmniSharpPlugin.csproj
@@ -9,6 +9,7 @@
     <!-- These pieces are required in order to reference OmniSharp.MSBuild -->
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- This was a total oversight on my part. These bits were never intended to be shipped to NuGet.

Fixes dotnet/aspnetcore#19072
