### PR TITLE
Update C# buffer in VS LSP scenarios.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
@@ -9,6 +11,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     internal class CSharpVirtualDocument : VirtualDocument
     {
         private readonly ITextBuffer _textBuffer;
+        private long? _hostDocumentSyncVersion;
 
         public CSharpVirtualDocument(Uri uri, ITextBuffer textBuffer)
         {
@@ -27,5 +30,47 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         public override Uri Uri { get; }
+
+        public override long? HostDocumentSyncVersion => _hostDocumentSyncVersion;
+
+        public void Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        {
+            if (changes is null)
+            {
+                throw new ArgumentNullException(nameof(changes));
+            }
+
+            _hostDocumentSyncVersion = hostDocumentVersion;
+
+            if (changes.Count == 0)
+            {
+                return;
+            }
+
+            var edit = _textBuffer.CreateEdit();
+            for (var i = 0; i < changes.Count; i++)
+            {
+                var change = changes[i];
+
+                if (change.IsDelete())
+                {
+                    edit.Delete(change.Span.Start, change.Span.Length);
+                }
+                else if (change.IsReplace())
+                {
+                    edit.Replace(change.Span.Start, change.Span.Length, change.NewText);
+                }
+                else if (change.IsInsert())
+                {
+                    edit.Insert(change.Span.Start, change.NewText);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unknown edit type when updating LSP C# buffer.");
+                }
+            }
+
+            edit.Apply();
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Export(typeof(RazorLanguageServerCustomMessageTarget))]
+    public class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServerCustomMessageTarget
+    {
+        private readonly LSPDocumentManager _documentManager;
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+
+        [ImportingConstructor]
+        public DefaultRazorLanguageServerCustomMessageTarget(
+            LSPDocumentManager documentManager,
+            JoinableTaskContext joinableTaskContext)
+        {
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            _documentManager = documentManager;
+            _joinableTaskFactory = joinableTaskContext.Factory;
+        }
+
+        // Testing constructor
+        internal DefaultRazorLanguageServerCustomMessageTarget(LSPDocumentManager documentManager)
+        {
+            _documentManager = documentManager;
+        }
+
+        public override async Task UpdateCSharpBufferAsync(JToken token, CancellationToken cancellationToken)
+        {
+            if (token is null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            UpdateCSharpBuffer(token);
+        }
+
+        // Internal for testing
+        internal void UpdateCSharpBuffer(JToken token)
+        {
+            var request = token.ToObject<UpdateBufferRequest>();
+            if (request == null || request.HostDocumentFilePath == null)
+            {
+                return;
+            }
+
+            if (!_documentManager.TryGetDocument(request.HostDocumentFilePath, out var document))
+            {
+                return;
+            }
+
+            if (!document.TryGetVirtualDocument<CSharpVirtualDocument>(out var csharpVirtualDocument))
+            {
+                return;
+            }
+
+            csharpVirtualDocument.Update(request.Changes, request.HostDocumentVersion);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -27,5 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         public override Uri Uri { get; }
+
+        public override long? HostDocumentSyncVersion => throw new NotImplementedException();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManagerExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManagerExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public static class LSPDocumentManagerExtensions
+    {
+        /// <summary>
+        /// Retrieves the <see cref="LSPDocument"/> associated with the <paramref name="filePath"/> by converting it to a <see cref="Uri"/>.
+        /// </summary>
+        /// <param name="documentManager">The <see cref="LSPDocumentManager"/> to use.</param>
+        /// <param name="filePath">The file path of the document to look up.</param>
+        /// <param name="lspDocument">The resolved <see cref="LSPDocument"/>.</param>
+        /// <returns><c>true</c> if the <see cref="LSPDocument"/> could be resolved for the given <paramref name="filePath"/>, <c>false</c> otherwise.</returns>
+        public static bool TryGetDocument(this LSPDocumentManager documentManager, string filePath, out LSPDocument lspDocument)
+        {
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (filePath is null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            if (filePath.StartsWith("/") && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                filePath = filePath.Substring(1);
+            }
+
+            var uri = new Uri(filePath, UriKind.Absolute);
+            return documentManager.TryGetDocument(uri, out lspDocument);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public abstract class RazorLanguageServerCustomMessageTarget
+    {
+        [JsonRpcMethod(LanguageServerConstants.RazorUpdateCSharpBufferEndpoint)]
+        public abstract Task UpdateCSharpBufferAsync(JToken token, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextChangeExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextChangeExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public static class TextChangeExtensions
+    {
+        public static bool IsDelete(this TextChange textChange)
+        {
+            return textChange.Span.Length > 0 && textChange.NewText.Length == 0;
+        }
+
+        public static bool IsInsert(this TextChange textChange)
+        {
+            return textChange.Span.Length == 0 && textChange.NewText.Length > 0;
+        }
+
+        public static bool IsReplace(this TextChange textChange)
+        {
+            return textChange.Span.Length > 0 && textChange.NewText.Length > 0;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
@@ -19,5 +19,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         /// The address to use to refer to the current <see cref="VirtualDocument"/>.
         /// </summary>
         public abstract Uri Uri { get; }
+
+        /// <summary>
+        /// The host document version this virtual document is associated with.
+        ///
+        /// This can be <c>null</c> if the virtual document has not yet been initialized for the assocaited host document.
+        /// </summary>
+        public abstract long? HostDocumentSyncVersion { get; }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -135,6 +135,8 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServices.Razor\Microsoft.VisualStudio.LanguageServices.Razor.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.LiveShare.Razor\Microsoft.VisualStudio.LiveShare.Razor.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer.Common\Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class CSharpVirtualDocumentTest
+    {
+        public CSharpVirtualDocumentTest()
+        {
+            Uri = new Uri("C:/path/to/file.razor__virtual.cs");
+        }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public void Update_AlwaysSetsHostDocumentSyncVersion()
+        {
+            // Arrange
+            var textBuffer = Mock.Of<ITextBuffer>();
+            var document = new CSharpVirtualDocument(Uri, textBuffer);
+
+            // Act
+            document.Update(Array.Empty<TextChange>(), hostDocumentVersion: 1337);
+
+            // Assert
+            Assert.Equal(1337, document.HostDocumentSyncVersion);
+        }
+
+        [Fact]
+        public void Update_Insert()
+        {
+            // Arrange
+            var insert = new TextChange(new TextSpan(123, 0), "inserted text");
+            var edit = new Mock<ITextEdit>();
+            edit.Setup(e => e.Insert(insert.Span.Start, insert.NewText)).Verifiable();
+            edit.Setup(e => e.Apply()).Verifiable();
+            var textBuffer = CreateTextBuffer(edit.Object);
+            var document = new CSharpVirtualDocument(Uri, textBuffer);
+
+            // Act
+            document.Update(new[] { insert }, hostDocumentVersion: 1);
+
+            // Assert
+            edit.VerifyAll();
+        }
+
+        [Fact]
+        public void Update_Replace()
+        {
+            // Arrange
+            var replace = new TextChange(new TextSpan(123, 4), "replaced text");
+            var edit = new Mock<ITextEdit>();
+            edit.Setup(e => e.Replace(replace.Span.Start, replace.Span.Length, replace.NewText)).Verifiable();
+            edit.Setup(e => e.Apply()).Verifiable();
+            var textBuffer = CreateTextBuffer(edit.Object);
+            var document = new CSharpVirtualDocument(Uri, textBuffer);
+
+            // Act
+            document.Update(new[] { replace }, hostDocumentVersion: 1);
+
+            // Assert
+            edit.VerifyAll();
+        }
+
+        [Fact]
+        public void Update_Delete()
+        {
+            // Arrange
+            var delete = new TextChange(new TextSpan(123, 4), string.Empty);
+            var edit = new Mock<ITextEdit>();
+            edit.Setup(e => e.Delete(delete.Span.Start, delete.Span.Length)).Verifiable();
+            edit.Setup(e => e.Apply()).Verifiable();
+            var textBuffer = CreateTextBuffer(edit.Object);
+            var document = new CSharpVirtualDocument(Uri, textBuffer);
+
+            // Act
+            document.Update(new[] { delete }, hostDocumentVersion: 1);
+
+            // Assert
+            edit.VerifyAll();
+        }
+
+        [Fact]
+        public void Update_MultipleEdits()
+        {
+            // Arrange
+            var replace = new TextChange(new TextSpan(123, 4), "replaced text");
+            var delete = new TextChange(new TextSpan(123, 4), string.Empty);
+            var edit = new Mock<ITextEdit>();
+            edit.Setup(e => e.Delete(delete.Span.Start, delete.Span.Length)).Verifiable();
+            edit.Setup(e => e.Replace(replace.Span.Start, replace.Span.Length, replace.NewText)).Verifiable();
+            edit.Setup(e => e.Apply()).Verifiable();
+            var textBuffer = CreateTextBuffer(edit.Object);
+            var document = new CSharpVirtualDocument(Uri, textBuffer);
+
+            // Act
+            document.Update(new[] { replace, delete }, hostDocumentVersion: 1);
+
+            // Assert
+            edit.VerifyAll();
+        }
+
+        public ITextBuffer CreateTextBuffer(ITextEdit edit)
+        {
+            var textBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CreateEdit() == edit);
+            return textBuffer;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultRazorLanguageServerCustomMessageTargetTest
+    {
+        [Fact]
+        public void UpdateCSharpBuffer_CanNotDeserializeRequest_NoopsGracefully()
+        {
+            // Arrange
+            LSPDocument document;
+            var documentManager = new Mock<LSPDocumentManager>();
+            documentManager.Setup(manager => manager.TryGetDocument(It.IsAny<Uri>(), out document))
+                .Throws<XunitException>();
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
+            var token = JToken.FromObject(new { });
+
+            // Act & Assert
+            target.UpdateCSharpBuffer(token);
+        }
+
+        [Fact]
+        public void UpdateCSharpBuffer_CannotLookupDocument_NoopsGracefully()
+        {
+            // Arrange
+            LSPDocument document;
+            var documentManager = new Mock<LSPDocumentManager>();
+            documentManager.Setup(manager => manager.TryGetDocument(It.IsAny<Uri>(), out document))
+                .Returns(false);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
+            var request = new UpdateBufferRequest()
+            {
+                HostDocumentFilePath = "C:/path/to/file.razor",
+            };
+            var token = JToken.FromObject(request);
+
+            // Act & Assert
+            target.UpdateCSharpBuffer(token);
+        }
+
+        [Fact]
+        public void UpdateCSharpBuffer_UpdatesDocument()
+        {
+            // Arrange
+            var virtualDocument = new CSharpVirtualDocument(new Uri("C:/path/to/file.razor__virtual.cs"), textBuffer: Mock.Of<ITextBuffer>());
+            var documentManager = new Mock<LSPDocumentManager>();
+            LSPDocument lspDocument = new DefaultLSPDocument(new Uri("C:/path/to/file.razor"), new[] { virtualDocument });
+            documentManager.Setup(manager => manager.TryGetDocument(It.IsAny<Uri>(), out lspDocument))
+                .Returns(true);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
+            var request = new UpdateBufferRequest()
+            {
+                HostDocumentFilePath = "C:/path/to/file.razor",
+                HostDocumentVersion = 1337,
+                Changes = Array.Empty<TextChange>(),
+            };
+            var token = JToken.FromObject(request);
+
+            // Act
+            target.UpdateCSharpBuffer(token);
+
+            // Assert
+            Assert.Equal(1337, virtualDocument.HostDocumentSyncVersion);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
@@ -49,6 +49,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private class TestVirtualDocument : VirtualDocument
         {
             public override Uri Uri => throw new NotImplementedException();
+
+            public override long? HostDocumentSyncVersion => throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
- Added a custom message target for our Language Server client to handle `razor/updateCSharpBuffer` requests from the server.
- Added plumbing on the client to handle C# buffer updates and then update the text buffer that backs the C# virtual document.
- Added extension methods to make interacting with Roslyn types and our document manager easier.
- Added tests for the new API.

Fixes dotnet/aspnetcore#17835