### PR TITLE
Update LSPDocumentManager to notify on document Changes.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -50,6 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (changes.Count == 0)
             {
+                UpdateSnapshot();
                 return _currentSnapshot;
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             Uri = uri;
             TextBuffer = textBuffer;
-            UpdateSnapshot();
+            _currentSnapshot = UpdateSnapshot();
         }
 
         public override Uri Uri { get; }
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (changes.Count == 0)
             {
-                UpdateSnapshot();
+                _currentSnapshot = UpdateSnapshot();
                 return _currentSnapshot;
             }
 
@@ -78,14 +78,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             edit.Apply();
-            UpdateSnapshot();
+            _currentSnapshot = UpdateSnapshot();
 
             return _currentSnapshot;
         }
 
-        private void UpdateSnapshot()
-        {
-            _currentSnapshot = new CSharpVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
-        }
+        private CSharpVirtualDocumentSnapshot UpdateSnapshot() => new CSharpVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentSnapshot.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class CSharpVirtualDocumentSnapshot : VirtualDocumentSnapshot
+    {
+        public CSharpVirtualDocumentSnapshot(
+            Uri uri,
+            ITextSnapshot snapshot,
+            long? hostDocumentSyncVersion)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (snapshot is null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            Uri = uri;
+            Snapshot = snapshot;
+            HostDocumentSyncVersion = hostDocumentSyncVersion;
+        }
+
+        public override Uri Uri { get; }
+
+        public override ITextSnapshot Snapshot { get; }
+
+        public override long? HostDocumentSyncVersion { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 if (_currentSnapshot != TextBuffer.CurrentSnapshot)
                 {
-                    UpdateSnapshot();
+                    _currentSnapshot = UpdateSnapshot();
                 }
 
                 return _currentSnapshot;
@@ -67,12 +67,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             virtualDocument.Update(changes, hostDocumentVersion);
 
-            UpdateSnapshot();
+            _currentSnapshot = UpdateSnapshot();
 
             return CurrentSnapshot;
         }
 
-        private void UpdateSnapshot()
+        private DefaultLSPDocumentSnapshot UpdateSnapshot()
         {
             var virtualDocumentSnapshots = new VirtualDocumentSnapshot[VirtualDocuments.Count];
             for (var i = 0; i < VirtualDocuments.Count; i++)
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 virtualDocumentSnapshots[i] = VirtualDocuments[i].CurrentSnapshot;
             }
 
-            _currentSnapshot = new DefaultLSPDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, virtualDocumentSnapshots, Version);
+            return new DefaultLSPDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, virtualDocumentSnapshots, Version);
         }
 
         private class DefaultLSPDocumentSnapshot : LSPDocumentSnapshot

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
@@ -3,16 +3,28 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     internal class DefaultLSPDocument : LSPDocument
     {
-        public DefaultLSPDocument(Uri uri, IReadOnlyList<VirtualDocument> virtualDocuments)
+        private LSPDocumentSnapshot _currentSnapshot;
+
+        public DefaultLSPDocument(
+            Uri uri,
+            ITextBuffer textBuffer,
+            IReadOnlyList<VirtualDocument> virtualDocuments)
         {
             if (uri is null)
             {
                 throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
             }
 
             if (virtualDocuments is null)
@@ -21,11 +33,93 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             Uri = uri;
+            TextBuffer = textBuffer;
             VirtualDocuments = virtualDocuments;
         }
 
+        public override int Version => TextBuffer.CurrentSnapshot.Version.VersionNumber;
+
         public override Uri Uri { get; }
 
+        public override ITextBuffer TextBuffer { get; }
+
         public override IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
+
+        public override LSPDocumentSnapshot CurrentSnapshot
+        {
+            get
+            {
+                if (_currentSnapshot != TextBuffer.CurrentSnapshot)
+                {
+                    UpdateSnapshot();
+                }
+
+                return _currentSnapshot;
+            }
+        }
+
+        public override LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        {
+            if (!TryGetVirtualDocument<TVirtualDocument>(out var virtualDocument))
+            {
+                throw new InvalidOperationException($"Cannot update virtual document of type {typeof(TVirtualDocument)} because LSP document {Uri} does not contain a virtual document of that type.");
+            }
+
+            virtualDocument.Update(changes, hostDocumentVersion);
+
+            UpdateSnapshot();
+
+            return CurrentSnapshot;
+        }
+
+        private void UpdateSnapshot()
+        {
+            var virtualDocumentSnapshots = new VirtualDocumentSnapshot[VirtualDocuments.Count];
+            for (var i = 0; i < VirtualDocuments.Count; i++)
+            {
+                virtualDocumentSnapshots[i] = VirtualDocuments[i].CurrentSnapshot;
+            }
+
+            _currentSnapshot = new DefaultLSPDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, virtualDocumentSnapshots, Version);
+        }
+
+        private class DefaultLSPDocumentSnapshot : LSPDocumentSnapshot
+        {
+            public DefaultLSPDocumentSnapshot(
+                Uri uri,
+                ITextSnapshot snapshot,
+                IReadOnlyList<VirtualDocumentSnapshot> virtualDocuments,
+                int version)
+            {
+                if (uri is null)
+                {
+                    throw new ArgumentNullException(nameof(uri));
+                }
+
+                if (snapshot is null)
+                {
+                    throw new ArgumentNullException(nameof(snapshot));
+                }
+
+                if (virtualDocuments is null)
+                {
+                    throw new ArgumentNullException(nameof(virtualDocuments));
+                }
+
+                Uri = uri;
+                Snapshot = snapshot;
+                VirtualDocuments = virtualDocuments;
+                Version = version;
+            }
+
+            public override Uri Uri { get; }
+
+            public override ITextSnapshot Snapshot { get; }
+
+            public override IReadOnlyList<VirtualDocumentSnapshot> VirtualDocuments { get; }
+
+            public override int Version { get; }
+
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentFactory.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var uri = _fileUriProvider.GetOrCreate(buffer);
             var virtualDocuments = CreateVirtualDocuments(buffer);
-            var lspDocument = new DefaultLSPDocument(uri, virtualDocuments);
+            var lspDocument = new DefaultLSPDocument(uri, buffer, virtualDocuments);
 
             return lspDocument;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 
@@ -17,7 +18,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly JoinableTaskContext _joinableTaskContext;
         private readonly FileUriProvider _fileUriProvider;
         private readonly LSPDocumentFactory _documentFactory;
-        private readonly Dictionary<Uri, DocumentTracker> _documents;
+        private readonly Dictionary<Uri, LSPDocument> _documents;
+
+        public override event EventHandler<LSPDocumentChangeEventArgs> Changed;
 
         [ImportingConstructor]
         public DefaultLSPDocumentManager(
@@ -43,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             _joinableTaskContext = joinableTaskContext;
             _fileUriProvider = fileUriProvider;
             _documentFactory = documentFactory;
-            _documents = new Dictionary<Uri, DocumentTracker>();
+            _documents = new Dictionary<Uri, LSPDocument>();
         }
 
         public override void TrackDocument(ITextBuffer buffer)
@@ -56,14 +59,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             Debug.Assert(_joinableTaskContext.IsOnMainThread);
 
             var uri = _fileUriProvider.GetOrCreate(buffer);
-            if (!_documents.TryGetValue(uri, out var documentTracker))
+            if (_documents.TryGetValue(uri, out _))
             {
-                var lspDocument = _documentFactory.Create(buffer);
-                documentTracker = new DocumentTracker(lspDocument);
-                _documents[uri] = documentTracker;
+                throw new InvalidOperationException($"Can not track document that's already being tracked {uri}");
             }
 
-            documentTracker.Refcount++;
+            var lspDocument = _documentFactory.Create(buffer);
+            _documents[uri] = lspDocument;
+            var args = new LSPDocumentChangeEventArgs(old: null, lspDocument.CurrentSnapshot, LSPDocumentChangeKind.Added);
+            Changed?.Invoke(this, args);
         }
 
         public override void UntrackDocument(ITextBuffer buffer)
@@ -76,45 +80,74 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             Debug.Assert(_joinableTaskContext.IsOnMainThread);
 
             var uri = _fileUriProvider.GetOrCreate(buffer);
-            if (!_documents.TryGetValue(uri, out var documentTracker))
+            if (!_documents.TryGetValue(uri, out var lspDocument))
             {
                 // We don't know about this document, noop.
                 return;
             }
 
-            documentTracker.Refcount--;
+            _documents.Remove(uri);
 
-            if (documentTracker.Refcount == 0)
-            {
-                _documents.Remove(uri);
-            }
+            var args = new LSPDocumentChangeEventArgs(lspDocument.CurrentSnapshot, @new: null, LSPDocumentChangeKind.Removed);
+            Changed?.Invoke(this, args);
         }
 
-        public override bool TryGetDocument(Uri uri, out LSPDocument lspDocument)
+        public override void UpdateVirtualDocument<TVirtualDocument>(
+            Uri hostDocumentUri,
+            IReadOnlyList<TextChange> changes,
+            long hostDocumentVersion)
+        {
+            if (hostDocumentUri is null)
+            {
+                throw new ArgumentNullException(nameof(hostDocumentUri));
+            }
+
+            if (changes is null)
+            {
+                throw new ArgumentNullException(nameof(changes));
+            }
+
+            Debug.Assert(_joinableTaskContext.IsOnMainThread);
+
+            if (!_documents.TryGetValue(hostDocumentUri, out var lspDocument))
+            {
+                // Don't know about document, noop.
+                return;
+            }
+
+            if (changes.Count == 0 &&
+                lspDocument.TryGetVirtualDocument<TVirtualDocument>(out var virtualDocument) &&
+                virtualDocument.HostDocumentSyncVersion == hostDocumentVersion)
+            {
+                // The current virtual document already knows about this update. Ignore it so we don't prematurely invoke a change event.
+                return;
+            }
+
+            var old = lspDocument.CurrentSnapshot;
+            var @new = lspDocument.UpdateVirtualDocument<TVirtualDocument>(changes, hostDocumentVersion);
+
+            if (old == @new)
+            {
+                return;
+            }
+
+            var args = new LSPDocumentChangeEventArgs(old, @new, LSPDocumentChangeKind.VirtualDocumentChanged);
+            Changed?.Invoke(this, args);
+        }
+
+        public override bool TryGetDocument(Uri uri, out LSPDocumentSnapshot lspDocumentSnapshot)
         {
             Debug.Assert(_joinableTaskContext.IsOnMainThread);
 
-            if (!_documents.TryGetValue(uri, out var documentTracker))
+            if (!_documents.TryGetValue(uri, out var lspDocument))
             {
                 // This should never happen in practice but return `null` so our tests can validate
-                lspDocument = null;
+                lspDocumentSnapshot = null;
                 return false;
             }
 
-            lspDocument = documentTracker.Document;
+            lspDocumentSnapshot = lspDocument.CurrentSnapshot;
             return true;
-        }
-
-        private class DocumentTracker
-        {
-            public DocumentTracker(LSPDocument document)
-            {
-                Document = document;
-            }
-
-            public LSPDocument Document { get; }
-
-            public int Refcount { get; set; }
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentSynchronizer.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(LSPDocumentSynchronizer))]
+    internal class DefaultLSPDocumentSynchronizer : LSPDocumentSynchronizer
+    {
+        // Internal for testing
+        internal TimeSpan _synchronizationTimeout = TimeSpan.FromSeconds(2);
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+        private readonly ConcurrentDictionary<Uri, DocumentSynchronizingContext> _synchronizingContexts;
+
+        [ImportingConstructor]
+        public DefaultLSPDocumentSynchronizer(LSPDocumentManager documentManager, JoinableTaskContext joinableTaskContext)
+        {
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            _joinableTaskFactory = joinableTaskContext.Factory;
+
+            documentManager.Changed += DocumentManager_Changed;
+            _synchronizingContexts = new ConcurrentDictionary<Uri, DocumentSynchronizingContext>();
+        }
+
+        public async override Task<bool> TrySynchronizeVirtualDocumentAsync(LSPDocumentSnapshot document, VirtualDocumentSnapshot virtualDocument, CancellationToken cancellationToken)
+        {
+            if (document is null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (virtualDocument is null)
+            {
+                throw new ArgumentNullException(nameof(virtualDocument));
+            }
+
+            if (!document.VirtualDocuments.Contains(virtualDocument))
+            {
+                throw new InvalidOperationException("Virtual document snapshot must belong to the provided LSP document snapshot.");
+            }
+
+            if (document.Version == virtualDocument.HostDocumentSyncVersion)
+            {
+                // Already synchronized
+                return true;
+            }
+
+            var synchronizingContext = _synchronizingContexts.AddOrUpdate(
+                virtualDocument.Uri,
+                (uri) => new DocumentSynchronizingContext(virtualDocument, document.Version, _synchronizationTimeout, cancellationToken),
+                (uri, existingContext) =>
+                {
+                    if (virtualDocument == existingContext.VirtualDocument &&
+                        document.Version == existingContext.ExpectedHostDocumentVersion)
+                    {
+                        // Already contain a synchronizing context that represents this request and it's in-process of being calculated.
+                        return existingContext;
+                    }
+
+                    // Cancel old request
+                    existingContext.SetSynchronized(false);
+                    return new DocumentSynchronizingContext(virtualDocument, document.Version, _synchronizationTimeout, cancellationToken);
+                });
+
+            var result = await _joinableTaskFactory.RunAsync(() => synchronizingContext.OnSynchronizedAsync);
+
+            _synchronizingContexts.TryRemove(virtualDocument.Uri, out _);
+
+            return result;
+        }
+
+        // Internal for testing
+        internal void DocumentManager_Changed(object sender, LSPDocumentChangeEventArgs args)
+        {
+            if (args is null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
+
+            if (args.Kind != LSPDocumentChangeKind.VirtualDocumentChanged)
+            {
+                return;
+            }
+
+            var lspDocument = args.New;
+            for (var i = 0; i < lspDocument.VirtualDocuments.Count; i++)
+            {
+                if (!_synchronizingContexts.TryGetValue(lspDocument.VirtualDocuments[i].Uri, out var synchronizingContext))
+                {
+                    continue;
+                }
+
+                if (lspDocument.Version == synchronizingContext.ExpectedHostDocumentVersion)
+                {
+                    synchronizingContext.SetSynchronized(true);
+                }
+                else if (lspDocument.Version > synchronizingContext.ExpectedHostDocumentVersion)
+                {
+                    // The LSP document version has surpassed what the projected document was expecting for a version. No longer able to synchronize.
+                    synchronizingContext.SetSynchronized(false);
+                }
+            }
+        }
+
+        private class DocumentSynchronizingContext
+        {
+            private readonly TaskCompletionSource<bool> _onSynchronizedSource;
+            private readonly CancellationTokenSource _cts;
+            private bool _synchronizedSet;
+
+            public DocumentSynchronizingContext(
+                VirtualDocumentSnapshot virtualDocument,
+                int expectedHostDocumentVersion,
+                TimeSpan timeout,
+                CancellationToken requestCancellationToken)
+            {
+                VirtualDocument = virtualDocument;
+                ExpectedHostDocumentVersion = expectedHostDocumentVersion;
+                _onSynchronizedSource = new TaskCompletionSource<bool>();
+                _cts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken);
+
+                // This cancellation token is the one passed in from the call-site that needs to synchronize an LSP document with a virtual document.
+                // Meaning, if the outer token is cancelled we need to fail to synchronize.
+                _cts.Token.Register(() => SetSynchronized(false));
+                _cts.CancelAfter(timeout);
+            }
+
+            public VirtualDocumentSnapshot VirtualDocument { get; }
+
+            public int ExpectedHostDocumentVersion { get; }
+
+            public Task<bool> OnSynchronizedAsync => _onSynchronizedSource.Task;
+
+            public void SetSynchronized(bool result)
+            {
+                lock (_onSynchronizedSource)
+                {
+                    if (_synchronizedSet)
+                    {
+                        return;
+                    }
+
+                    _synchronizedSet = true;
+                    _onSynchronizedSource.SetResult(result);
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -2,13 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     internal class HtmlVirtualDocument : VirtualDocument
     {
-        private readonly ITextBuffer _textBuffer;
+        private HtmlVirtualDocumentSnapshot _currentSnapshot;
 
         public HtmlVirtualDocument(Uri uri, ITextBuffer textBuffer)
         {
@@ -23,11 +25,26 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             Uri = uri;
-            _textBuffer = textBuffer;
+            TextBuffer = textBuffer;
+            UpdateSnapshot();
         }
 
         public override Uri Uri { get; }
 
-        public override long? HostDocumentSyncVersion => throw new NotImplementedException();
+        public override ITextBuffer TextBuffer { get; }
+
+        public override long? HostDocumentSyncVersion => null;
+
+        public override VirtualDocumentSnapshot CurrentSnapshot => _currentSnapshot;
+
+        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void UpdateSnapshot()
+        {
+            _currentSnapshot = new HtmlVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             Uri = uri;
             TextBuffer = textBuffer;
-            UpdateSnapshot();
+            _currentSnapshot = UpdateSnapshot();
         }
 
         public override Uri Uri { get; }
@@ -42,9 +42,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             throw new NotImplementedException();
         }
 
-        private void UpdateSnapshot()
-        {
-            _currentSnapshot = new HtmlVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
-        }
+        private HtmlVirtualDocumentSnapshot UpdateSnapshot() => new HtmlVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentSnapshot.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class HtmlVirtualDocumentSnapshot : VirtualDocumentSnapshot
+    {
+        public HtmlVirtualDocumentSnapshot(
+            Uri uri,
+            ITextSnapshot snapshot,
+            long? hostDocumentSyncVersion)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (snapshot is null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            Uri = uri;
+            Snapshot = snapshot;
+            HostDocumentSyncVersion = hostDocumentSyncVersion;
+        }
+
+        public override Uri Uri { get; }
+
+        public override ITextSnapshot Snapshot { get; }
+
+        public override long? HostDocumentSyncVersion { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentChangeEventArgs.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentChangeEventArgs.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public sealed class LSPDocumentChangeEventArgs : EventArgs
+    {
+        public LSPDocumentChangeEventArgs(LSPDocumentSnapshot old, LSPDocumentSnapshot @new, LSPDocumentChangeKind kind)
+        {
+            Old = old;
+            New = @new;
+            Kind = kind;
+        }
+
+        public LSPDocumentSnapshot Old { get; }
+
+        public LSPDocumentSnapshot New { get; }
+
+        public LSPDocumentChangeKind Kind { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentChangeKind.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentChangeKind.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    public abstract class LSPDocumentManager
+    public enum LSPDocumentChangeKind
     {
-        public abstract event EventHandler<LSPDocumentChangeEventArgs> Changed;
-
-        public abstract bool TryGetDocument(Uri uri, out LSPDocumentSnapshot lspDocumentSnapshot);
+        Added,
+        Removed,
+        VirtualDocumentChanged,
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManagerExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentManagerExtensions.cs
@@ -8,14 +8,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     public static class LSPDocumentManagerExtensions
     {
-        /// <summary>
-        /// Retrieves the <see cref="LSPDocument"/> associated with the <paramref name="filePath"/> by converting it to a <see cref="Uri"/>.
-        /// </summary>
-        /// <param name="documentManager">The <see cref="LSPDocumentManager"/> to use.</param>
-        /// <param name="filePath">The file path of the document to look up.</param>
-        /// <param name="lspDocument">The resolved <see cref="LSPDocument"/>.</param>
-        /// <returns><c>true</c> if the <see cref="LSPDocument"/> could be resolved for the given <paramref name="filePath"/>, <c>false</c> otherwise.</returns>
-        public static bool TryGetDocument(this LSPDocumentManager documentManager, string filePath, out LSPDocument lspDocument)
+        public static bool TryGetDocument(this LSPDocumentManager documentManager, string filePath, out LSPDocumentSnapshot lspDocumentSnapshot)
         {
             if (documentManager is null)
             {
@@ -33,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             var uri = new Uri(filePath, UriKind.Absolute);
-            return documentManager.TryGetDocument(uri, out lspDocument);
+            return documentManager.TryGetDocument(uri, out lspDocumentSnapshot);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentSnapshot.cs
@@ -3,26 +3,21 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    public abstract class LSPDocument
+    public abstract class LSPDocumentSnapshot
     {
         public abstract int Version { get; }
 
         public abstract Uri Uri { get; }
 
-        public abstract ITextBuffer TextBuffer { get; }
+        public abstract ITextSnapshot Snapshot { get; }
 
-        public abstract LSPDocumentSnapshot CurrentSnapshot { get; }
+        public abstract IReadOnlyList<VirtualDocumentSnapshot> VirtualDocuments { get; }
 
-        public abstract IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
-
-        public abstract LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
-
-        public bool TryGetVirtualDocument<TVirtualDocument>(out TVirtualDocument virtualDocument) where TVirtualDocument : VirtualDocument
+        public bool TryGetVirtualDocument<TVirtualDocument>(out TVirtualDocument virtualDocument) where TVirtualDocument : VirtualDocumentSnapshot
         {
             for (var i = 0; i < VirtualDocuments.Count; i++)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentSynchronizer.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal abstract class LSPDocumentSynchronizer
+    {
+        public abstract Task<bool> TrySynchronizeVirtualDocumentAsync(LSPDocumentSnapshot document, VirtualDocumentSnapshot virtualDocument, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TrackingLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TrackingLSPDocumentManager.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
@@ -11,5 +13,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public abstract void TrackDocument(ITextBuffer buffer);
 
         public abstract void UntrackDocument(ITextBuffer buffer);
+
+        public abstract void UpdateVirtualDocument<TVirtualDocument>(
+            Uri hostDocumentUri,
+            IReadOnlyList<TextChange> changes,
+            long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
@@ -2,29 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    /// <summary>
-    /// The core purpose of a virtual document is to represent an embedded language LSP document that is addressable to make re-invoking
-    /// LSP requests possible.
-    ///
-    /// For instance, when we want to invoke an LSP request on a virtual document we'll go through the <see cref="LSPDocumentManager"/>
-    /// to locate the top level <see cref="LSPDocument"/>, find the <see cref="VirtualDocument"/> we care about, invoke the LSP request
-    /// with the new <see cref="Uri"/>.
-    /// </summary>
     public abstract class VirtualDocument
     {
-        /// <summary>
-        /// The address to use to refer to the current <see cref="VirtualDocument"/>.
-        /// </summary>
         public abstract Uri Uri { get; }
 
-        /// <summary>
-        /// The host document version this virtual document is associated with.
-        ///
-        /// This can be <c>null</c> if the virtual document has not yet been initialized for the assocaited host document.
-        /// </summary>
+        public abstract ITextBuffer TextBuffer { get; }
+
+        public abstract VirtualDocumentSnapshot CurrentSnapshot { get; }
+
         public abstract long? HostDocumentSyncVersion { get; }
+
+        public abstract VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocumentSnapshot.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public abstract class VirtualDocumentSnapshot
+    {
+        public abstract Uri Uri { get; }
+
+        public abstract ITextSnapshot Snapshot { get; }
+
+        public abstract long? HostDocumentSyncVersion { get; }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var csharpContentType = Mock.Of<IContentType>();
             ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
                 registry => registry.GetContentType(CSharpVirtualDocumentFactory.CSharpLSPContentTypeName) == csharpContentType);
-            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(csharpContentType) == Mock.Of<ITextBuffer>());
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(csharpContentType) == Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>()));
 
             var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
             RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
@@ -19,16 +19,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private Uri Uri { get; }
 
         [Fact]
-        public void Update_AlwaysSetsHostDocumentSyncVersion()
+        public void Update_AlwaysSetsHostDocumentSyncVersion_AndUpdatesSnapshot()
         {
             // Arrange
             var textBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>());
             var document = new CSharpVirtualDocument(Uri, textBuffer);
+            var originalSnapshot = document.CurrentSnapshot;
 
             // Act
             document.Update(Array.Empty<TextChange>(), hostDocumentVersion: 1337);
 
             // Assert
+            Assert.NotSame(originalSnapshot, document.CurrentSnapshot);
             Assert.Equal(1337, document.HostDocumentSyncVersion);
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentSynchronizerTest.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultLSPDocumentSynchronizerTest
+    {
+        public DefaultLSPDocumentSynchronizerTest()
+        {
+            DocumentManager = Mock.Of<LSPDocumentManager>();
+            JoinableTaskContext = new JoinableTaskContext();
+            LSPDocumentUri = new Uri("C:/path/to/file.razor");
+            VirtualDocumentUri = new Uri("C:/path/to/file.razor__virtual.cs");
+        }
+
+        private LSPDocumentManager DocumentManager { get; }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        private Uri LSPDocumentUri { get; }
+
+        private Uri VirtualDocumentUri { get; }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_SynchronizedDocument_ReturnsTrue()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            var virtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var document = new TestLSPDocumentSnapshot(LSPDocumentUri, 123, virtualDocument);
+
+            // Act
+            var result = await synchronizer.TrySynchronizeVirtualDocumentAsync(document, virtualDocument, CancellationToken.None);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_SynchronizesAfterUpdate_ReturnsTrue()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
+            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+
+            // Start synchronization, this will hang until we invoke a DocumentManager_Changed event because the above virtual document expects host doc version 123 but the host doc is 124
+            var synchronizeTask = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+
+            // Create a virtual and host doc that are synchronized (both at version 124).
+            var newVirtualDocument = originalVirtualDocument.Fork(124);
+            var newDocument = originalDocument.Fork(124, newVirtualDocument);
+            var args = new LSPDocumentChangeEventArgs(originalDocument, newDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
+
+            // Act
+            synchronizer.DocumentManager_Changed(DocumentManager, args);
+            var result = await synchronizeTask;
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_SimultaneousEqualSynchronizationRequests_ReturnsTrue()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
+            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+
+            // Start synchronize
+            var synchronizeTask1 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+            var synchronizeTask2 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+
+            var newVirtualDocument = originalVirtualDocument.Fork(124);
+            var newDocument = originalDocument.Fork(124, newVirtualDocument);
+            var args = new LSPDocumentChangeEventArgs(originalDocument, newDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
+
+            // Act
+            synchronizer.DocumentManager_Changed(DocumentManager, args);
+            var result1 = await synchronizeTask1;
+            var result2 = await synchronizeTask2;
+
+            // Assert
+            Assert.True(result1);
+            Assert.True(result2);
+        }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_SimultaneousDifferentSynchronizationRequests_CancelsFirst_ReturnsFalseThenTrue()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
+            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+
+            // Start synchronization that will hang because 123 != 124
+            var synchronizeTask1 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+
+            var newVirtualDocument = originalVirtualDocument.Fork(124);
+            var newDocument = originalDocument.Fork(125, newVirtualDocument);
+
+            // Start another synchronization that will also hang because 124 != 125. However, this synchronization request is for the same addressable virtual document (same URI)
+            // therefore requesting a second synchronization with a different host doc version expectation will cancel the original synchronization request resulting it returning
+            // false.
+            var synchronizeTask2 = synchronizer.TrySynchronizeVirtualDocumentAsync(newDocument, newVirtualDocument, CancellationToken.None);
+
+            var finalVirtualDocument = newVirtualDocument.Fork(125);
+            var finalDocument = newDocument.Fork(125, finalVirtualDocument);
+
+            var args = new LSPDocumentChangeEventArgs(newDocument, finalDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
+
+
+            // Act
+            synchronizer.DocumentManager_Changed(DocumentManager, args);
+            var result1 = await synchronizeTask1;
+            var result2 = await synchronizeTask2;
+
+            // Assert
+            Assert.False(result1);
+            Assert.True(result2);
+        }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_Timeout_ReturnsFalse()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(10);
+            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+
+            // Start synchronize
+            var synchronizeTask = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+
+            // Act
+            var result = await synchronizeTask;
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentTest.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultLSPDocumentTest
+    {
+        public DefaultLSPDocumentTest()
+        {
+            Uri = new Uri("C:/path/to/file.razor__virtual.cs");
+        }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public void UpdateVirtualDocument_UpdatesProvidedVirtualDocumentWithProvidedArgs_AndRecalcsSnapshot()
+        {
+            // Arrange
+            var snapshot = Mock.Of<ITextSnapshot>(s => s.Version == Mock.Of<ITextVersion>());
+            var textBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == snapshot);
+            var virtualDocument = new TestVirtualDocument();
+            var document = new DefaultLSPDocument(Uri, textBuffer, new[] { virtualDocument });
+            var changes = Array.Empty<TextChange>();
+            var originalSnapshot = document.CurrentSnapshot;
+
+            // Act
+            document.UpdateVirtualDocument<TestVirtualDocument>(changes, hostDocumentVersion: 1337);
+
+            // Assert
+            Assert.Equal(1337, virtualDocument.HostDocumentSyncVersion);
+            Assert.Same(changes, virtualDocument.Changes);
+            Assert.NotEqual(originalSnapshot, document.CurrentSnapshot);
+        }
+
+        private class TestVirtualDocument : VirtualDocument
+        {
+            private long? _hostDocumentVersion;
+
+            public IReadOnlyList<TextChange> Changes { get; private set; }
+
+            public override Uri Uri => throw new NotImplementedException();
+
+            public override ITextBuffer TextBuffer => throw new NotImplementedException();
+
+            public override VirtualDocumentSnapshot CurrentSnapshot => null;
+
+            public override long? HostDocumentSyncVersion => _hostDocumentVersion;
+
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+            {
+                _hostDocumentVersion = hostDocumentVersion;
+                Changes = changes;
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var htmlContentType = Mock.Of<IContentType>();
             ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
                 registry => registry.GetContentType(HtmlVirtualDocumentFactory.HtmlLSPContentTypeName) == htmlContentType);
-            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(htmlContentType) == Mock.Of<ITextBuffer>());
+            TextBufferFactory = Mock.Of<ITextBufferFactoryService>(factory => factory.CreateTextBuffer(htmlContentType) == Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>()));
 
             var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
             RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Xunit;
@@ -21,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void TryGetVirtualDocument_NoCSharpDocument_ReturnsFalse()
         {
             // Arrange
-            var lspDocument = new DefaultLSPDocument(Uri, new[] { Mock.Of<VirtualDocument>() });
+            var lspDocument = new DefaultLSPDocument(Uri, Mock.Of<ITextBuffer>(), new[] { Mock.Of<VirtualDocument>() });
 
             // Act
             var result = lspDocument.TryGetVirtualDocument<TestVirtualDocument>(out var virtualDocument);
@@ -36,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var testVirtualDocument = new TestVirtualDocument();
-            var lspDocument = new DefaultLSPDocument(Uri, new[] { Mock.Of<VirtualDocument>(), testVirtualDocument });
+            var lspDocument = new DefaultLSPDocument(Uri, Mock.Of<ITextBuffer>(), new[] { Mock.Of<VirtualDocument>(), testVirtualDocument });
 
             // Act
             var result = lspDocument.TryGetVirtualDocument<TestVirtualDocument>(out var virtualDocument);
@@ -51,6 +53,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             public override Uri Uri => throw new NotImplementedException();
 
             public override long? HostDocumentSyncVersion => throw new NotImplementedException();
+
+            public override ITextBuffer TextBuffer => throw new NotImplementedException();
+
+            public override VirtualDocumentSnapshot CurrentSnapshot => throw new NotImplementedException();
+
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPDocumentSnapshot.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class TestLSPDocumentSnapshot : LSPDocumentSnapshot
+    {
+        public TestLSPDocumentSnapshot(Uri uri, int version, params VirtualDocumentSnapshot[] virtualDocuments)
+        {
+            Uri = uri;
+            Version = version;
+            VirtualDocuments = virtualDocuments;
+        }
+
+        public override int Version { get; }
+
+        public override Uri Uri { get; }
+
+        public override ITextSnapshot Snapshot { get; }
+
+        public override IReadOnlyList<VirtualDocumentSnapshot> VirtualDocuments { get; }
+
+        public TestLSPDocumentSnapshot Fork(int version, params VirtualDocumentSnapshot[] virtualDocuments) => new TestLSPDocumentSnapshot(Uri, version, virtualDocuments);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestVirtualDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestVirtualDocumentSnapshot.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class TestVirtualDocumentSnapshot : VirtualDocumentSnapshot
+    {
+        private long? _hostDocumentSyncVersion;
+
+        public TestVirtualDocumentSnapshot(Uri uri, int hostDocumentVersion)
+        {
+            Uri = uri;
+            _hostDocumentSyncVersion = hostDocumentVersion;
+        }
+
+        public override Uri Uri { get; }
+
+        public override ITextSnapshot Snapshot { get; }
+
+        public override long? HostDocumentSyncVersion => _hostDocumentSyncVersion;
+
+        public TestVirtualDocumentSnapshot Fork(int hostDocumentVersion) => new TestVirtualDocumentSnapshot(Uri, hostDocumentVersion);
+    }
+}


### PR DESCRIPTION
- To enable `Change` events on the `LSPDocumentManager` I had to transition our VS model to use snapshots for our `LSPDocuments`. Overall this was a positive change anyhow and is one of my regrets of our VSCode infrastructure. Especially given that the LSP document infrastructure will most likely be shared amongst more than our team having the flexibility to understand when events happen in a snapshot based way will ensure we have the least amount of bugs.
- The snapshot model in this changeset pivots the `LSPDocumentManager`'s document retrieval mechanism to retrieve snapshot variants of each `LSPDocument` and their corresponding `VirtualDocument`. We use `LSPDocument`s inside of `LSPDocumentManager` and update those in a stateful way. Each LSP document understands when it or one of its virtual documents change and constructs a new snapshot of itself which can be used for external data access. This is all the same for virtual documents as well.
- Transitioned the main pipeline for updating a document into the `LSPDocumentManager` so there was a single source of truth for updating documents and therefore enables us to publish change events indicating "something" happened. Currently support LSPDocument added, removed and virtual document changed events.
- Bound the non-snapshot types to `ITextBuffer`s and the snapshot types to `ITextSnapshot`s so at any point if we're encountering issues we can easily debug what is/was going wrong with our tooling.
- Nuked the XML docs on most of the `LSPDocument` APIs. Realized it was a bad idea to have so early in the process. When we're ready to make the types available to other consumers we'll add the docs. Until then it's just extra work to maintain and to ensure that tings continue to make sense as new APIs are added or old ones are changed.
- Nuked the XML docs on most of the `LSPDocument` APIs. Realized it was a bad idea to have so early in the process. When we're ready to make the types available to other consumers we'll add the docs. Until then it's just extra work to maintain and to ensure that tings continue to make sense as new APIs are added or old ones are changed.
- Updated existing tests to work with the new snapshot system
- Added new tests across the board to account for the new API.

Part of dotnet/aspnetcore#17802 because of the need to know when to check for document synchronizations

@ajaybhargavb this is the piece I mentioned about "changing the world" 😆 