### PR TITLE
Add OSS Component Governance comment.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -76,7 +76,7 @@
   <ItemGroup>
     <!--
     ***************************************************************************************************************************************
-      NOTE: Adding OSS components to this list must be reviewed against our component governance standards. For now this is a curated list.
+      NOTE: Adding OSS components to this list must be reviewed against our component governance standards. For now this is a curated list. You can read more about the CG process at https://aka.ms/component-governance
     ***************************************************************************************************************************************
     -->
     <VSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.JsonRpc.dll" />

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -74,6 +74,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+    ***************************************************************************************************************************************
+      NOTE: Adding OSS components to this list must be reviewed against our component governance standards. For now this is a curated list.
+    ***************************************************************************************************************************************
+    -->
     <VSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.JsonRpc.dll" />
     <VSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.LanguageProtocol.dll" />
     <VSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.LanguageServer.dll" />


### PR DESCRIPTION
- We've captured the top-level dependencies in our component governance list; however, any additional dependencies we need to add to Visual Studio (we start using one of the APIs) will require us to re-mark one of our component governance items.