### PR TITLE
Add LSP document synchronizer.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentSynchronizer.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(LSPDocumentSynchronizer))]
+    internal class DefaultLSPDocumentSynchronizer : LSPDocumentSynchronizer
+    {
+        // Internal for testing
+        internal TimeSpan _synchronizationTimeout = TimeSpan.FromSeconds(2);
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+        private readonly ConcurrentDictionary<Uri, DocumentSynchronizingContext> _synchronizingContexts;
+
+        [ImportingConstructor]
+        public DefaultLSPDocumentSynchronizer(LSPDocumentManager documentManager, JoinableTaskContext joinableTaskContext)
+        {
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            _joinableTaskFactory = joinableTaskContext.Factory;
+
+            documentManager.Changed += DocumentManager_Changed;
+            _synchronizingContexts = new ConcurrentDictionary<Uri, DocumentSynchronizingContext>();
+        }
+
+        public async override Task<bool> TrySynchronizeVirtualDocumentAsync(LSPDocumentSnapshot document, VirtualDocumentSnapshot virtualDocument, CancellationToken cancellationToken)
+        {
+            if (document is null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (virtualDocument is null)
+            {
+                throw new ArgumentNullException(nameof(virtualDocument));
+            }
+
+            if (!document.VirtualDocuments.Contains(virtualDocument))
+            {
+                throw new InvalidOperationException("Virtual document snapshot must belong to the provided LSP document snapshot.");
+            }
+
+            if (document.Version == virtualDocument.HostDocumentSyncVersion)
+            {
+                // Already synchronized
+                return true;
+            }
+
+            var synchronizingContext = _synchronizingContexts.AddOrUpdate(
+                virtualDocument.Uri,
+                (uri) => new DocumentSynchronizingContext(virtualDocument, document.Version, _synchronizationTimeout, cancellationToken),
+                (uri, existingContext) =>
+                {
+                    if (virtualDocument == existingContext.VirtualDocument &&
+                        document.Version == existingContext.ExpectedHostDocumentVersion)
+                    {
+                        // Already contain a synchronizing context that represents this request and it's in-process of being calculated.
+                        return existingContext;
+                    }
+
+                    // Cancel old request
+                    existingContext.SetSynchronized(false);
+                    return new DocumentSynchronizingContext(virtualDocument, document.Version, _synchronizationTimeout, cancellationToken);
+                });
+
+            var result = await _joinableTaskFactory.RunAsync(() => synchronizingContext.OnSynchronizedAsync);
+
+            _synchronizingContexts.TryRemove(virtualDocument.Uri, out _);
+
+            return result;
+        }
+
+        // Internal for testing
+        internal void DocumentManager_Changed(object sender, LSPDocumentChangeEventArgs args)
+        {
+            if (args is null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
+
+            if (args.Kind != LSPDocumentChangeKind.VirtualDocumentChanged)
+            {
+                return;
+            }
+
+            var lspDocument = args.New;
+            for (var i = 0; i < lspDocument.VirtualDocuments.Count; i++)
+            {
+                if (!_synchronizingContexts.TryGetValue(lspDocument.VirtualDocuments[i].Uri, out var synchronizingContext))
+                {
+                    continue;
+                }
+
+                if (lspDocument.Version == synchronizingContext.ExpectedHostDocumentVersion)
+                {
+                    synchronizingContext.SetSynchronized(true);
+                }
+                else if (lspDocument.Version > synchronizingContext.ExpectedHostDocumentVersion)
+                {
+                    // The LSP document version has surpassed what the projected document was expecting for a version. No longer able to synchronize.
+                    synchronizingContext.SetSynchronized(false);
+                }
+            }
+        }
+
+        private class DocumentSynchronizingContext
+        {
+            private readonly TaskCompletionSource<bool> _onSynchronizedSource;
+            private readonly CancellationTokenSource _cts;
+            private bool _synchronizedSet;
+
+            public DocumentSynchronizingContext(
+                VirtualDocumentSnapshot virtualDocument,
+                int expectedHostDocumentVersion,
+                TimeSpan timeout,
+                CancellationToken requestCancellationToken)
+            {
+                VirtualDocument = virtualDocument;
+                ExpectedHostDocumentVersion = expectedHostDocumentVersion;
+                _onSynchronizedSource = new TaskCompletionSource<bool>();
+                _cts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken);
+
+                // This cancellation token is the one passed in from the call-site that needs to synchronize an LSP document with a virtual document.
+                // Meaning, if the outer token is cancelled we need to fail to synchronize.
+                _cts.Token.Register(() => SetSynchronized(false));
+                _cts.CancelAfter(timeout);
+            }
+
+            public VirtualDocumentSnapshot VirtualDocument { get; }
+
+            public int ExpectedHostDocumentVersion { get; }
+
+            public Task<bool> OnSynchronizedAsync => _onSynchronizedSource.Task;
+
+            public void SetSynchronized(bool result)
+            {
+                lock (_onSynchronizedSource)
+                {
+                    if (_synchronizedSet)
+                    {
+                        return;
+                    }
+
+                    _synchronizedSet = true;
+                    _onSynchronizedSource.SetResult(result);
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentSynchronizer.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal abstract class LSPDocumentSynchronizer
+    {
+        public abstract Task<bool> TrySynchronizeVirtualDocumentAsync(LSPDocumentSnapshot document, VirtualDocumentSnapshot virtualDocument, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentSynchronizerTest.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultLSPDocumentSynchronizerTest
+    {
+        public DefaultLSPDocumentSynchronizerTest()
+        {
+            DocumentManager = Mock.Of<LSPDocumentManager>();
+            JoinableTaskContext = new JoinableTaskContext();
+            LSPDocumentUri = new Uri("C:/path/to/file.razor");
+            VirtualDocumentUri = new Uri("C:/path/to/file.razor__virtual.cs");
+        }
+
+        private LSPDocumentManager DocumentManager { get; }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        private Uri LSPDocumentUri { get; }
+
+        private Uri VirtualDocumentUri { get; }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_SynchronizedDocument_ReturnsTrue()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            var virtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var document = new TestLSPDocumentSnapshot(LSPDocumentUri, 123, virtualDocument);
+
+            // Act
+            var result = await synchronizer.TrySynchronizeVirtualDocumentAsync(document, virtualDocument, CancellationToken.None);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_SynchronizesAfterUpdate_ReturnsTrue()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
+            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+
+            // Start synchronization, this will hang until we invoke a DocumentManager_Changed event because the above virtual document expects host doc version 123 but the host doc is 124
+            var synchronizeTask = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+
+            // Create a virtual and host doc that are synchronized (both at version 124).
+            var newVirtualDocument = originalVirtualDocument.Fork(124);
+            var newDocument = originalDocument.Fork(124, newVirtualDocument);
+            var args = new LSPDocumentChangeEventArgs(originalDocument, newDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
+
+            // Act
+            synchronizer.DocumentManager_Changed(DocumentManager, args);
+            var result = await synchronizeTask;
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_SimultaneousEqualSynchronizationRequests_ReturnsTrue()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
+            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+
+            // Start synchronize
+            var synchronizeTask1 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+            var synchronizeTask2 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+
+            var newVirtualDocument = originalVirtualDocument.Fork(124);
+            var newDocument = originalDocument.Fork(124, newVirtualDocument);
+            var args = new LSPDocumentChangeEventArgs(originalDocument, newDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
+
+            // Act
+            synchronizer.DocumentManager_Changed(DocumentManager, args);
+            var result1 = await synchronizeTask1;
+            var result2 = await synchronizeTask2;
+
+            // Assert
+            Assert.True(result1);
+            Assert.True(result2);
+        }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_SimultaneousDifferentSynchronizationRequests_CancelsFirst_ReturnsFalseThenTrue()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
+            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+
+            // Start synchronization that will hang because 123 != 124
+            var synchronizeTask1 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+
+            var newVirtualDocument = originalVirtualDocument.Fork(124);
+            var newDocument = originalDocument.Fork(125, newVirtualDocument);
+
+            // Start another synchronization that will also hang because 124 != 125. However, this synchronization request is for the same addressable virtual document (same URI)
+            // therefore requesting a second synchronization with a different host doc version expectation will cancel the original synchronization request resulting it returning
+            // false.
+            var synchronizeTask2 = synchronizer.TrySynchronizeVirtualDocumentAsync(newDocument, newVirtualDocument, CancellationToken.None);
+
+            var finalVirtualDocument = newVirtualDocument.Fork(125);
+            var finalDocument = newDocument.Fork(125, finalVirtualDocument);
+
+            var args = new LSPDocumentChangeEventArgs(newDocument, finalDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
+
+
+            // Act
+            synchronizer.DocumentManager_Changed(DocumentManager, args);
+            var result1 = await synchronizeTask1;
+            var result2 = await synchronizeTask2;
+
+            // Assert
+            Assert.False(result1);
+            Assert.True(result2);
+        }
+
+        [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_Timeout_ReturnsFalse()
+        {
+            // Arrange
+            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(10);
+            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
+            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+
+            // Start synchronize
+            var synchronizeTask = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+
+            // Act
+            var result = await synchronizeTask;
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPDocumentSnapshot.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class TestLSPDocumentSnapshot : LSPDocumentSnapshot
+    {
+        public TestLSPDocumentSnapshot(Uri uri, int version, params VirtualDocumentSnapshot[] virtualDocuments)
+        {
+            Uri = uri;
+            Version = version;
+            VirtualDocuments = virtualDocuments;
+        }
+
+        public override int Version { get; }
+
+        public override Uri Uri { get; }
+
+        public override ITextSnapshot Snapshot { get; }
+
+        public override IReadOnlyList<VirtualDocumentSnapshot> VirtualDocuments { get; }
+
+        public TestLSPDocumentSnapshot Fork(int version, params VirtualDocumentSnapshot[] virtualDocuments) => new TestLSPDocumentSnapshot(Uri, version, virtualDocuments);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestVirtualDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestVirtualDocumentSnapshot.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class TestVirtualDocumentSnapshot : VirtualDocumentSnapshot
+    {
+        private long? _hostDocumentSyncVersion;
+
+        public TestVirtualDocumentSnapshot(Uri uri, int hostDocumentVersion)
+        {
+            Uri = uri;
+            _hostDocumentSyncVersion = hostDocumentVersion;
+        }
+
+        public override Uri Uri { get; }
+
+        public override ITextSnapshot Snapshot { get; }
+
+        public override long? HostDocumentSyncVersion => _hostDocumentSyncVersion;
+
+        public TestVirtualDocumentSnapshot Fork(int hostDocumentVersion) => new TestVirtualDocumentSnapshot(Uri, hostDocumentVersion);
+    }
+}


### PR DESCRIPTION
- The purpose of an LSP document synchronizer is to synchronize a virtual document and an LSP documents buffers. Given a `VirtualDocumentSnapshot` and an `LSPDocumentSnapshot` the synchronizer will wait until a new `VirtualDocumentSnapshot` becomes available that matches the original `LSPDocumentSnapshot`'s version number. This ensures that any requests done after synchronization will be for the "correct" document.
- By default the synchronizer has a 2s timeout in waiting for virtual documents and host documents to synchronize.
- Synchronizations are memoized, meaning if multiple synchronizations happen for the same virtual / host document combo then we will return a single task object representing the success or failure of those synchronizations.
- I made an assumption that synchronization requests for virtual documents will always have an ever increasing host document sync version. When we get a new synchronization request for a virtual document who's host document sync version is larger than the previous sync request we will cancel older requests.
- Added tests to validate the synchronizer functionality.
- Added a common test virtual and lsp document.

Fixes dotnet/aspnetcore#17802