### PR TITLE
[Port] Fix formatting fails in the presence of a non-extensible directive (#…

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorSyntaxTreeExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeBlockDirectives = syntaxTree.Root
                 .DescendantNodes(node => node is RazorDocumentSyntax || node is MarkupBlockSyntax || node is CSharpCodeBlockSyntax)
                 .OfType<RazorDirectiveSyntax>()
-                .Where(directive => directive.DirectiveDescriptor.Kind == DirectiveKind.CodeBlock)
+                .Where(directive => directive.DirectiveDescriptor?.Kind == DirectiveKind.CodeBlock)
                 .ToArray();
 
             return codeBlockDirectives;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
@@ -333,6 +333,7 @@ expected: @"
         {
             await RunFormattingTestAsync(
 input: @"
+@using System.Buffers
 |@functions{
      public class Foo
             {
@@ -355,6 +356,7 @@ void Method(){
 }|
 ",
 expected: @"
+@using System.Buffers
 @functions{
     public class Foo
     {


### PR DESCRIPTION
…1663)

Original PR: 
https://github.com/dotnet/aspnetcore-tooling/pull/1663