### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
 	"recommendations": [
 		"ms-vscode.vscode-typescript-tslint-plugin",
-		"ms-vscode.csharp",
+		"ms-dotnettools.csharp",
 		"EditorConfig.EditorConfig"
 	]
 }


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)
