### PR TITLE
Skip rename test

### DIFF
--- a/src/Razor/test/VSCode.FunctionalTest/tests/Rename.test.ts
+++ b/src/Razor/test/VSCode.FunctionalTest/tests/Rename.test.ts
@@ -18,9 +18,15 @@ suite('Rename', () => {
         razorPath = path.join(mvcWithComponentsRoot, 'Views', 'Shared', 'NavMenu.razor');
         cshtmlPath = path.join(mvcWithComponentsRoot, 'Views', 'Home', 'Index.cshtml');
         csPath = path.join(mvcWithComponentsRoot, 'Test.cs');
+        await new Promise(r => setTimeout(r, 5000));
     });
 
-    test('Can rename symbol within .razor', async () => {
+    test('Can rename symbol within .razor', async function() {
+        if (process.env.ci === 'true') {
+            // Skipping on the CI as this is flaky.
+            this.skip();
+        }
+
         const razorDoc = await vscode.workspace.openTextDocument(razorPath);
         const razorEditor = await vscode.window.showTextDocument(razorDoc);
         await new Promise(r => setTimeout(r, 5000));
@@ -47,6 +53,7 @@ suite('Rename', () => {
     test('Can rename symbol within .cshtml', async () => {
         const cshtmlDoc = await vscode.workspace.openTextDocument(cshtmlPath);
         const cshtmlEditor = await vscode.window.showTextDocument(cshtmlDoc);
+        await new Promise(r => setTimeout(r, 5000));
         const expectedNewText = 'World';
         const firstLine = new vscode.Position(0, 0);
         await cshtmlEditor.edit(edit => edit.insert(firstLine, '@hello\n'));


### PR DESCRIPTION
This test failed a couple of times seemingly for no reason. Skipping.
[Example failure](https://dev.azure.com/dnceng/internal/_build/results?buildId=554598&view=ms.vss-test-web.build-test-results-tab&runId=17492994&resultId=100046&paneView=debug)

Updated https://github.com/dotnet/aspnetcore/issues/19296