### PR TITLE
Don't always re-parse dependent Blazor files on change.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDocumentDivergenceChecker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDocumentDivergenceChecker.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using DocumentSnapshot = Microsoft.CodeAnalysis.Razor.ProjectSystem.DocumentSnapshot;
 using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
 using TextLineCollection = Microsoft.CodeAnalysis.Text.TextLineCollection;
@@ -31,7 +32,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         // The goal of this method is to decide if the older and newer snapshots have diverged in a way that could result in
         // impactful changes to other Razor files. Detecting divergence is an optimization which allows us to not always re-parse
-        // dependent files and therefore not not notify anyone else listening (Roslyn).
+        // dependent files and therefore not notify anyone else listening (Roslyn).
         //
         // Here's how we calculate "divergence":
         //
@@ -58,7 +59,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             if (@new is null)
             {
-
                 throw new ArgumentNullException(nameof(@new));
             }
 
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var propertyList = new List<PropertyDeclarationSyntax>();
             for (var i = 0; i < codeBlocks.Count; i++)
             {
-                var bodyRange = codeBlocks[i].Body.Span;
+                var bodyRange = ((RazorDirectiveBodySyntax)codeBlocks[i].Body).CSharpCode.Span;
                 var bodyTextSpan = TextSpan.FromBounds(bodyRange.Start, bodyRange.End);
                 var subText = newText.GetSubText(bodyTextSpan);
                 var parsedText = CSharpSyntaxTree.ParseText(subText);
@@ -189,95 +189,28 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         private bool TryGetSyntaxTreeAndSource(DocumentSnapshot document, out RazorSyntaxTree syntaxTree, out SourceText sourceText)
         {
-            if (document.TryGetGeneratedOutput(out var codeDocument) &&
-                document.TryGetText(out sourceText))
+            if (!document.TryGetText(out sourceText))
+            {
+                // Can't get the source text synchronously
+                syntaxTree = null;
+                return false;
+            }
+
+            if (document.TryGetGeneratedOutput(out var codeDocument))
             {
                 syntaxTree = codeDocument.GetSyntaxTree();
                 return true;
             }
-            else
-            {
-                if (!document.TryGetText(out sourceText))
-                {
-                    // Can't get the source text synchronously
-                    syntaxTree = null;
-                    return false;
-                }
 
-                syntaxTree = ParseSourceText(document.FilePath, sourceText);
-                return true;
-            }
+            syntaxTree = ParseSourceText(document.FilePath, sourceText);
+            return true;
         }
 
         private RazorSyntaxTree ParseSourceText(string filePath, SourceText sourceText)
         {
-            var sourceDocument = new SourceTextSourceDocument(filePath, sourceText);
+            var sourceDocument = sourceText.GetRazorSourceDocument(filePath, filePath);
             var syntaxTree = RazorSyntaxTree.Parse(sourceDocument, ParserOptions);
             return syntaxTree;
-        }
-
-        private class SourceTextSourceDocument : RazorSourceDocument
-        {
-            private readonly string _filePath;
-            private readonly SourceText _sourceText;
-            private readonly RazorSourceTextLineCollection _lines;
-
-            public SourceTextSourceDocument(string filePath, SourceText sourceText)
-            {
-                if (filePath is null)
-                {
-                    throw new ArgumentNullException(nameof(filePath));
-                }
-
-                if (sourceText is null)
-                {
-                    throw new ArgumentNullException(nameof(sourceText));
-                }
-
-                _filePath = filePath;
-                _sourceText = sourceText;
-                _lines = new RazorSourceTextLineCollection(_sourceText.Lines);
-            }
-
-            public override char this[int position] => _sourceText[position];
-
-            public override Encoding Encoding => _sourceText.Encoding;
-
-            public override string FilePath => _filePath;
-
-            public override int Length => _sourceText.Length;
-
-            public override RazorSourceLineCollection Lines => _lines;
-
-            public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) => _sourceText.CopyTo(sourceIndex, destination, destinationIndex, count);
-
-            public override byte[] GetChecksum() => Array.Empty<byte>();
-
-            private class RazorSourceTextLineCollection : RazorSourceLineCollection
-            {
-                private readonly TextLineCollection _textLines;
-
-                public RazorSourceTextLineCollection(TextLineCollection textLines)
-                {
-                    if (textLines is null)
-                    {
-                        throw new ArgumentNullException(nameof(textLines));
-                    }
-
-                    _textLines = textLines;
-                }
-
-                public override int Count => _textLines.Count;
-
-                public override int GetLineLength(int index) => _textLines[index].Span.Length;
-
-                internal override SourceLocation GetLocation(int position)
-                {
-                    var line = _textLines.GetLinePosition(position);
-                    var sourceLocation = new SourceLocation(position, line.Line, line.Character);
-                    return sourceLocation;
-                }
-            }
         }
 
         private class CodeFunctionsExtractor : SyntaxWalker

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDocumentDivergenceChecker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDocumentDivergenceChecker.cs
@@ -1,0 +1,304 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using DocumentSnapshot = Microsoft.CodeAnalysis.Razor.ProjectSystem.DocumentSnapshot;
+using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
+using TextLineCollection = Microsoft.CodeAnalysis.Text.TextLineCollection;
+using TextSpan = Microsoft.CodeAnalysis.Text.TextSpan;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+    [Shared]
+    [Export(typeof(DocumentDivergenceChecker))]
+    internal class DefaultDocumentDivergenceChecker : DocumentDivergenceChecker
+    {
+        private static readonly RazorParserOptions ParserOptions = RazorParserOptions.Create(builder =>
+        {
+            builder.Directives.Add(FunctionsDirective.Directive);
+            builder.Directives.Add(ComponentCodeDirective.Directive);
+        });
+
+        // The goal of this method is to decide if the older and newer snapshots have diverged in a way that could result in
+        // impactful changes to other Razor files. Detecting divergence is an optimization which allows us to not always re-parse
+        // dependent files and therefore not not notify anyone else listening (Roslyn).
+        //
+        // Here's how we calculate "divergence":
+        //
+        // 1. Get the SyntaxTree for each document. If one has not been calculated yet, create a one-off syntax tree that only cares about
+        //    capturing Razor directives.
+        // 2. Extract @code and @functions directive blocks
+        // 3. Map those directive blocks back to the original source document and extract their inner content.
+        //    Aka @code { private int _foo; } => private int _foo;
+        // 4. Do a light-weight C# parse on the content of each captured @code/@functions content in order to build a C# SyntaxTree. The
+        //    SyntaxTree is not meant to be full-fidelity or error free, it's just meant to represent the key pieces of the content like
+        //    methods, fields, properties etc.
+        // 5. Extract all properties for the new and old documents.
+        // 6. Compare the old documents properties to the new documents properties, if they've changed structurally then we've diverged;
+        //    otherwise no divergence!
+        //
+        // At any point in this flow if we're unable to calculate one of the requirements such as the original Razor documents source text,
+        // assume divergence.
+        public override bool PossibleDivergence(DocumentSnapshot old, DocumentSnapshot @new)
+        {
+            if (old is null)
+            {
+                throw new ArgumentNullException(nameof(old));
+            }
+
+            if (@new is null)
+            {
+
+                throw new ArgumentNullException(nameof(@new));
+            }
+
+            if (!string.Equals(@new.FileKind, FileKinds.Component, StringComparison.OrdinalIgnoreCase))
+            {
+                // Component import or ordinary cshtml file.
+                return true;
+            }
+
+            if (!TryGetSyntaxTreeAndSource(old, out var oldSyntaxTree, out var oldText))
+            {
+                return true;
+            }
+
+            if (!TryGetSyntaxTreeAndSource(@new, out var newSyntaxTree, out var newText))
+            {
+                return true;
+            }
+
+            var newWalker = new CodeFunctionsExtractor();
+            newWalker.Visit(newSyntaxTree.Root);
+
+            var oldWalker = new CodeFunctionsExtractor();
+            oldWalker.Visit(oldSyntaxTree.Root);
+
+            if (newWalker.CodeBlocks.Count == 0 && oldWalker.CodeBlocks.Count == 0)
+            {
+                // No directive code blocks, therefore no properties to analyze.
+                return false;
+            }
+
+            var newProperties = ExtractCSharpProperties(newText, newWalker.CodeBlocks);
+            var oldProperties = ExtractCSharpProperties(oldText, oldWalker.CodeBlocks);
+
+            if (newProperties.Count != oldProperties.Count)
+            {
+                return true;
+            }
+
+            for (var i = 0; i < newProperties.Count; i++)
+            {
+                var newProperty = newProperties[i];
+                var oldProperty = oldProperties[i];
+                if (!CSharpPropertiesEqual(newProperty, oldProperty))
+                {
+                    return true;
+                }
+            }
+
+            // Properties before and after document change are equivalent
+            return false;
+        }
+
+        private static bool CSharpPropertiesEqual(PropertyDeclarationSyntax newProperty, PropertyDeclarationSyntax oldProperty)
+        {
+            if (!newProperty.Identifier.IsEquivalentTo(oldProperty.Identifier))
+            {
+                return false;
+            }
+
+            if (!newProperty.Type.IsEquivalentTo(oldProperty.Type))
+            {
+                return false;
+            }
+
+            if (newProperty.Modifiers.Count != oldProperty.Modifiers.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < newProperty.Modifiers.Count; i++)
+            {
+                var newModifier = newProperty.Modifiers[i];
+                var oldModifier = oldProperty.Modifiers[i];
+                if (newModifier.Text != oldModifier.Text)
+                {
+                    return false;
+                }
+            }
+
+            if (newProperty.AttributeLists.Count != oldProperty.AttributeLists.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < newProperty.AttributeLists.Count; i++)
+            {
+                var newAttributes = newProperty.AttributeLists[i].Attributes;
+                var oldAttributes = oldProperty.AttributeLists[i].Attributes;
+
+                if (newAttributes.Count != oldAttributes.Count)
+                {
+                    return false;
+                }
+
+                for (var j = 0; j < newAttributes.Count; j++)
+                {
+                    var newAttribute = newAttributes[j];
+                    var oldAttribute = oldAttributes[j];
+
+                    if (!newAttribute.IsEquivalentTo(oldAttribute))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static List<PropertyDeclarationSyntax> ExtractCSharpProperties(SourceText newText, IReadOnlyList<RazorDirectiveSyntax> codeBlocks)
+        {
+            var propertyList = new List<PropertyDeclarationSyntax>();
+            for (var i = 0; i < codeBlocks.Count; i++)
+            {
+                var bodyRange = codeBlocks[i].Body.Span;
+                var bodyTextSpan = TextSpan.FromBounds(bodyRange.Start, bodyRange.End);
+                var subText = newText.GetSubText(bodyTextSpan);
+                var parsedText = CSharpSyntaxTree.ParseText(subText);
+                var root = parsedText.GetRoot();
+                var childNodes = root.ChildNodes();
+                var properties = childNodes.Where(node => node.Kind() == CodeAnalysis.CSharp.SyntaxKind.PropertyDeclaration).OfType<PropertyDeclarationSyntax>();
+                propertyList.AddRange(properties);
+            }
+
+            return propertyList;
+        }
+
+        private bool TryGetSyntaxTreeAndSource(DocumentSnapshot document, out RazorSyntaxTree syntaxTree, out SourceText sourceText)
+        {
+            if (document.TryGetGeneratedOutput(out var codeDocument) &&
+                document.TryGetText(out sourceText))
+            {
+                syntaxTree = codeDocument.GetSyntaxTree();
+                return true;
+            }
+            else
+            {
+                if (!document.TryGetText(out sourceText))
+                {
+                    // Can't get the source text synchronously
+                    syntaxTree = null;
+                    return false;
+                }
+
+                syntaxTree = ParseSourceText(document.FilePath, sourceText);
+                return true;
+            }
+        }
+
+        private RazorSyntaxTree ParseSourceText(string filePath, SourceText sourceText)
+        {
+            var sourceDocument = new SourceTextSourceDocument(filePath, sourceText);
+            var syntaxTree = RazorSyntaxTree.Parse(sourceDocument, ParserOptions);
+            return syntaxTree;
+        }
+
+        private class SourceTextSourceDocument : RazorSourceDocument
+        {
+            private readonly string _filePath;
+            private readonly SourceText _sourceText;
+            private readonly RazorSourceTextLineCollection _lines;
+
+            public SourceTextSourceDocument(string filePath, SourceText sourceText)
+            {
+                if (filePath is null)
+                {
+                    throw new ArgumentNullException(nameof(filePath));
+                }
+
+                if (sourceText is null)
+                {
+                    throw new ArgumentNullException(nameof(sourceText));
+                }
+
+                _filePath = filePath;
+                _sourceText = sourceText;
+                _lines = new RazorSourceTextLineCollection(_sourceText.Lines);
+            }
+
+            public override char this[int position] => _sourceText[position];
+
+            public override Encoding Encoding => _sourceText.Encoding;
+
+            public override string FilePath => _filePath;
+
+            public override int Length => _sourceText.Length;
+
+            public override RazorSourceLineCollection Lines => _lines;
+
+            public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) => _sourceText.CopyTo(sourceIndex, destination, destinationIndex, count);
+
+            public override byte[] GetChecksum() => Array.Empty<byte>();
+
+            private class RazorSourceTextLineCollection : RazorSourceLineCollection
+            {
+                private readonly TextLineCollection _textLines;
+
+                public RazorSourceTextLineCollection(TextLineCollection textLines)
+                {
+                    if (textLines is null)
+                    {
+                        throw new ArgumentNullException(nameof(textLines));
+                    }
+
+                    _textLines = textLines;
+                }
+
+                public override int Count => _textLines.Count;
+
+                public override int GetLineLength(int index) => _textLines[index].Span.Length;
+
+                internal override SourceLocation GetLocation(int position)
+                {
+                    var line = _textLines.GetLinePosition(position);
+                    var sourceLocation = new SourceLocation(position, line.Line, line.Character);
+                    return sourceLocation;
+                }
+            }
+        }
+
+        private class CodeFunctionsExtractor : SyntaxWalker
+        {
+            private readonly List<RazorDirectiveSyntax> _codeBlocks;
+
+            public CodeFunctionsExtractor()
+            {
+                _codeBlocks = new List<RazorDirectiveSyntax>();
+            }
+
+            public IReadOnlyList<RazorDirectiveSyntax> CodeBlocks => _codeBlocks;
+
+            public override void VisitRazorDirective(RazorDirectiveSyntax node)
+            {
+                if (node.DirectiveDescriptor == FunctionsDirective.Directive ||
+                    node.DirectiveDescriptor == ComponentCodeDirective.Directive)
+                {
+                    _codeBlocks.Add(node);
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DocumentDivergenceChecker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DocumentDivergenceChecker.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+    internal abstract class DocumentDivergenceChecker
+    {
+        public abstract bool PossibleDivergence(DocumentSnapshot old, DocumentSnapshot @new);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultDocumentDivergenceCheckerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultDocumentDivergenceCheckerTest.cs
@@ -1,0 +1,399 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+    public class DefaultDocumentDivergenceCheckerTest : WorkspaceTestBase
+    {
+        public DefaultDocumentDivergenceCheckerTest()
+        {
+            ProjectSnapshotManager = new TestProjectSnapshotManager(Workspace);
+            HostProject = new HostProject("C:/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
+            ProjectSnapshotManager.ProjectAdded(HostProject);
+            var cshtmlDocument = new HostDocument("C:/path/to/file1.cshtml", "file1.cshtml", FileKinds.Legacy);
+            ProjectSnapshotManager.DocumentAdded(HostProject, cshtmlDocument, new EmptyTextLoader(cshtmlDocument.FilePath));
+            var componentDocument = new HostDocument("C:/path/to/file2.razor", "file2.razor", FileKinds.Component);
+            ProjectSnapshotManager.DocumentAdded(HostProject, componentDocument, new EmptyTextLoader(componentDocument.FilePath));
+            var importDocument = new HostDocument("C:/path/to/_Imports.razor", "_Imports.razor", FileKinds.ComponentImport);
+            ProjectSnapshotManager.DocumentAdded(HostProject, importDocument, new EmptyTextLoader(importDocument.FilePath));
+
+            var project = ProjectSnapshotManager.GetLoadedProject(HostProject.FilePath);
+            CSHTMLDocument = project.GetDocument(cshtmlDocument.FilePath);
+            ComponentDocument = project.GetDocument(componentDocument.FilePath);
+            ImportDocument = project.GetDocument(importDocument.FilePath);
+        }
+
+        private TestProjectSnapshotManager ProjectSnapshotManager { get; }
+
+        private HostProject HostProject { get; }
+
+        private DocumentSnapshot CSHTMLDocument { get; }
+
+        private DocumentSnapshot ComponentDocument { get; }
+
+        private DocumentSnapshot ImportDocument { get; }
+
+        [Fact]
+        public void PossibleDivergence_NonComponent_ReturnsTrue()
+        {
+            // Arrange
+            var old = CSHTMLDocument;
+            var @new = UpdateDocument(CSHTMLDocument.FilePath, SourceText.From(string.Empty));
+            var impactChecker = new DefaultDocumentDivergenceChecker();
+
+            // Act
+            var result = impactChecker.PossibleDivergence(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void PossibleDivergence_Import_ReturnsTrue()
+        {
+            // Arrange
+            var old = ImportDocument;
+            var @new = UpdateDocument(ImportDocument.FilePath, SourceText.From(string.Empty));
+            var impactChecker = new DefaultDocumentDivergenceChecker();
+
+            // Act
+            var result = impactChecker.PossibleDivergence(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_Component_UnretrievableNewSourceText_ReturnsTrue()
+        {
+            // Arrange
+            var old = ComponentDocument;
+            var @new = UpdateDocument(ComponentDocument.FilePath, SourceText.From(string.Empty));
+
+            // Prime the documents source text
+            await old.GetTextAsync();
+
+            var impactChecker = new DefaultDocumentDivergenceChecker();
+
+            // Act
+            var result = impactChecker.PossibleDivergence(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_Component_NoDirectives_ReturnsFalse()
+        {
+            // Arrange
+            var old = ComponentDocument;
+            var @new = UpdateDocument(ComponentDocument.FilePath, SourceText.From(string.Empty));
+
+            // Prime the documents source texts
+            await old.GetTextAsync();
+            await @new.GetTextAsync();
+
+            var impactChecker = new DefaultDocumentDivergenceChecker();
+
+            // Act
+            var result = impactChecker.PossibleDivergence(old, @new);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_Component_IdenticalProperties_ReturnsFalse()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+            var @new =
+@"@code {
+    private int _field;
+
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_SomeSameProperties_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+
+    public string SomeProperty2 { get; set; }
+}";
+            var @new =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+
+    [Parameter]
+    public int SomeProperty2 { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_Count_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+            var @new =
+@"@code {
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_Identifier_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+            var @new =
+@"@code {
+    [Parameter]
+    public int AnotherProperty { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_Type_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+            var @new =
+@"@code {
+    [Parameter]
+    public in SomeProperty { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_ModifierCount_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    private int SomeProperty { get; set; }
+}";
+            var @new = 
+@"@code {
+    [Parameter]
+    private protected int SomeProperty { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_ModifierType_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+            var @new =
+@"@code {
+    [Parameter]
+    private int SomeProperty { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_AttributeListCount_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+            var @new =
+@"@code {
+    [Bind]
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_AttributeCount_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+            var @new =
+@"@code {
+    [Parameter, Bind]
+    public int SomeProperty { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_PropertyDifference_DifferentAttributes_ReturnsTrue()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+}";
+            var @new =
+@"@code {
+    [Bind]
+    public int SomeProperty { get; set; }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task PossibleDivergence_Complex_ReturnsFalse()
+        {
+            // Arrange
+            var old =
+@"@code {
+    [Parameter]
+    public int SomeProperty { get; set; }
+    public string Something { get; }
+}";
+            var @new =
+@"@code {
+    private int _field;
+
+    [Parameter]
+    public int SomeProperty { get; set; }
+
+    public void SetField(int value)
+    {
+        _field = value;
+    }
+
+    public string Something { get; }
+
+    private class NestedClass
+    {
+        public bool Checked { get; set; }
+    }
+}";
+
+            // Act
+            var result = await GetDivergenceAsync(old, @new);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        private async Task<bool> GetDivergenceAsync(string before, string after)
+        {
+            var old = UpdateDocument(ComponentDocument.FilePath, SourceText.From(before));
+            var @new = UpdateDocument(ComponentDocument.FilePath, SourceText.From(after));
+
+            // Prime the documents source texts
+            await @new.GetTextAsync();
+
+            var impactChecker = new DefaultDocumentDivergenceChecker();
+            var result = impactChecker.PossibleDivergence(old, @new);
+
+            return result;
+        }
+
+        private DocumentSnapshot UpdateDocument(string filePath, SourceText sourceText)
+        {
+            ProjectSnapshotManager.DocumentChanged(HostProject.FilePath, filePath, sourceText);
+            var project = ProjectSnapshotManager.GetLoadedProject(HostProject.FilePath);
+            var document = project.GetDocument(filePath);
+            return document;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Editor.Razor;
 using Moq;
 using Xunit;
 
@@ -29,7 +30,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             HostProject2 = new HostProject(TestProjectData.AnotherProject.FilePath, FallbackRazorConfiguration.MVC_1_0, TestProjectData.AnotherProject.RootNamespace);
 
             DynamicFileInfoProvider = new DefaultRazorDynamicFileInfoProvider(new DefaultDocumentServiceProviderFactory());
+
+            DivergenceChecker = Mock.Of<DocumentDivergenceChecker>(checker => checker.PossibleDivergence(It.IsAny<DocumentSnapshot>(), It.IsAny<DocumentSnapshot>()) == true);
         }
+
+        private DocumentDivergenceChecker DivergenceChecker { get; }
 
         private HostDocument[] Documents { get; }
 
@@ -58,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             var project = projectManager.GetLoadedProject(HostProject1.FilePath);
 
-            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider)
+            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider, DivergenceChecker)
             {
                 Delay = TimeSpan.FromMilliseconds(1),
                 NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false),
@@ -89,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             var project = projectManager.GetLoadedProject(HostProject1.FilePath);
 
-            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider)
+            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider, DivergenceChecker)
             {
                 Delay = TimeSpan.FromMilliseconds(1),
                 NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false),
@@ -118,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             var project = projectManager.GetLoadedProject(HostProject1.FilePath);
 
-            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider)
+            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider, DivergenceChecker)
             {
                 Delay = TimeSpan.FromMilliseconds(1),
                 BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
@@ -157,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             var project = projectManager.GetLoadedProject(HostProject1.FilePath);
 
-            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider)
+            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider, DivergenceChecker)
             {
                 Delay = TimeSpan.FromMilliseconds(1),
                 BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
@@ -228,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 projectManager.DocumentAdded(HostProject1, documents[i], null);
             }
 
-            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider)
+            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider, DivergenceChecker)
             {
                 Delay = TimeSpan.FromMilliseconds(1),
                 BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
@@ -284,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             projectManager.DocumentAdded(HostProject1, TestProjectData.SomeProjectComponentFile1, null);
             projectManager.DocumentAdded(HostProject1, TestProjectData.SomeProjectImportFile, null);
 
-            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider)
+            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider, DivergenceChecker)
             {
                 Delay = TimeSpan.FromMilliseconds(1),
                 BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),


### PR DESCRIPTION
- This is a performance optimization where when we see a Razor file has changed we will not re-parse all of the related files unless we determine that the change has impacted a C# property.
- To accomplish this we look at the before and after of a document and see if the documents `@code` / `@functions` has any C# property changes. If they don't we let the `BackgroundDocumentGenerator` know that it doesn't need to re-queue parses for dependent documents. Ultimately this seemed like a heavy check to do on every change; however, a single file reparse for a closed (dependent) document results in us letting Roslyn know about the updated C# which then kicks off re-classification, errors, etc. Basically, a lottt more work then we'd ever want to have happen.
- In our divergence checks I took the approach of trying to allocate as little as possible by building custom data types that utilize the already allocated `SourceText`. This included a `SourceText` specific `RazorSourceDocument`.
- Added tests to verify all the ways we detect divergence of documents.

Fixes dotnet/aspnetcore#19650