### PR TITLE
Tell NPM to use "C:\python3.7.0\python.exe" if it's present

### DIFF
--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -44,7 +44,7 @@
   <Target Name="Restore">
     <Message Importance="High" Text="Running yarn install on $(MSBuildProjectFullPath)" />
     <!-- Workaround until Python is on the path on build agents -->
-    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="echo npm config set python C:\python3.7.0\python.exe" />
+    <Exec Condition=" '$(OS)' == 'Windows_NT' and Exists('C:\python3.7.0\python.exe') " Command="npm config set python C:\python3.7.0\python.exe" />
     <Yarn Command="install --mutex network $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
   </Target>
 

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -43,7 +43,7 @@
 
   <Target Name="Restore">
     <Message Importance="High" Text="Running yarn install on $(MSBuildProjectFullPath)" />
-    <Yarn Command="install --mutex network $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
+    <Yarn Command="install --mutex network $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" --python="C:\python3.7.0\python.exe" />
   </Target>
 
   <Target Name="PrepareForBuild">

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -11,7 +11,6 @@
     <IntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)'))$(Configuration)\</IntermediateOutputPath>
     <InstallArgs Condition="'$(RestoreLockedMode)' == 'true'">$(InstallArgs) --frozen-lockfile</InstallArgs>
     <InstallArgs>$(InstallArgs) --ignore-engines</InstallArgs>
-    <InstallArgs Condition=" '$(OS)' == 'Windows_NT' ">$(InstallArgs) --python=C:\python3.7.0\python.exe</InstallArgs>
     <_BackupPackageJson>$(IntermediateOutputPath)$(MSBuildProjectName).package.json.bak</_BackupPackageJson>
     <BuildDependsOn>
       PrepareForBuild;
@@ -44,6 +43,8 @@
 
   <Target Name="Restore">
     <Message Importance="High" Text="Running yarn install on $(MSBuildProjectFullPath)" />
+    <!-- Workaround until Python is on the path on build agents -->
+    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="echo npm config set python C:\python3.7.0\python.exe" />
     <Yarn Command="install --mutex network $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
   </Target>
 

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -11,6 +11,7 @@
     <IntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)'))$(Configuration)\</IntermediateOutputPath>
     <InstallArgs Condition="'$(RestoreLockedMode)' == 'true'">$(InstallArgs) --frozen-lockfile</InstallArgs>
     <InstallArgs>$(InstallArgs) --ignore-engines</InstallArgs>
+    <InstallArgs Condition=" '$(OS)' == 'Windows_NT' ">$(InstallArgs) --python=C:\python3.7.0\python.exe</InstallArgs>
     <_BackupPackageJson>$(IntermediateOutputPath)$(MSBuildProjectName).package.json.bak</_BackupPackageJson>
     <BuildDependsOn>
       PrepareForBuild;
@@ -43,7 +44,7 @@
 
   <Target Name="Restore">
     <Message Importance="High" Text="Running yarn install on $(MSBuildProjectFullPath)" />
-    <Yarn Command="install --mutex network $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" --python="C:\python3.7.0\python.exe" />
+    <Yarn Command="install --mutex network $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
   </Target>
 
   <Target Name="PrepareForBuild">


### PR DESCRIPTION
Add Explicit Helix Python path if that path exists for build. 

Summary of the changes (Less than 80 chars)
 - Python 2 is EOL as of 1/1/2020; the most recent rollout removed this from Windows machines
 - Certain Yarn installs require a viable python 2 or 3 on the path; this broke the build.

Works around https://github.com/dotnet/core-eng/issues/9351 until it is addressed.
