### PR TITLE
WorkspaceStateGenerator - Ensure we never cancel a CTS after it's been disposed.

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectWorkspaceStateGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectWorkspaceStateGeneratorTest.cs
@@ -50,6 +50,23 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
         private ProjectWorkspaceState ProjectWorkspaceStateWithTagHelpers { get; }
 
         [ForegroundFact]
+        public void Dispose_MakesUpdateNoop()
+        {
+            // Arrange  
+            using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher))
+            {
+                stateGenerator.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+
+                // Act
+                stateGenerator.Dispose();
+                stateGenerator.Update(WorkspaceProject, ProjectSnapshot);
+
+                // Assert
+                Assert.Empty(stateGenerator._updates);
+            }
+        }
+
+        [ForegroundFact]
         public void Update_StartsUpdateTask()
         {
             // Arrange  


### PR DESCRIPTION
- Not entirely sure why we were getting `ObjectDisposedException`s in VS4Mac but decided to make our code extra defensive.
- Could only write one test for `Disposed` being queued on the foreground thread prior to `Update` but it doesn't make much sense in practice because we never `Dispose` the generator. The other potential path for this issue assumes that VS4Mac's foreground thread isn't truly single threaded which we can't test because that breaks all of our test concepts. Basically, this PR is just being extra defensive to ensure we don't explode some concepts on the VS4Mac side of the world.

Fixes dotnet/aspnetcore#19813