### PR TITLE
Transition our DynamicFileInfoProvider into using DynamicDocumentContainer.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultDocumentServiceProviderFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultDocumentServiceProviderFactory.cs
@@ -5,20 +5,21 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
     [Export(typeof(DocumentServiceProviderFactory))]
     internal class DefaultDocumentServiceProviderFactory : DocumentServiceProviderFactory
     {
-        public override IDocumentServiceProvider Create(DocumentSnapshot document)
+        public override IDocumentServiceProvider Create(DynamicDocumentContainer documentContainer)
         {
-            if (document == null)
+            if (documentContainer == null)
             {
-                throw new ArgumentNullException(nameof(document));
+                throw new ArgumentNullException(nameof(documentContainer));
             }
 
-            return new RazorDocumentServiceProvider(document);
+            return new RazorDocumentServiceProvider(documentContainer);
         }
 
         public override IDocumentServiceProvider CreateEmpty()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentServiceProviderFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentServiceProviderFactory.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
@@ -10,6 +11,6 @@ namespace Microsoft.CodeAnalysis.Razor
     {
         public abstract IDocumentServiceProvider CreateEmpty();
 
-        public abstract IDocumentServiceProvider Create(DocumentSnapshot document);
+        public abstract IDocumentServiceProvider Create(DynamicDocumentContainer documentContainer);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DynamicDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DynamicDocumentContainer.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
+{
+    internal abstract class DynamicDocumentContainer
+    {
+        public abstract string FilePath { get; }
+
+        public abstract TextLoader GetTextLoader(string filePath);
+
+        public abstract object GetMappingService();
+
+        public abstract object GetExcerptService();
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
@@ -149,7 +149,8 @@ namespace Microsoft.CodeAnalysis.Razor
         protected virtual async Task ProcessDocument(ProjectSnapshot project, DocumentSnapshot document)
         {
             await document.GetGeneratedOutputAsync().ConfigureAwait(false);
-            _infoProvider.UpdateFileInfo(project, document);
+            var container = new DefaultDynamicDocumentContainer(document);
+            _infoProvider.UpdateFileInfo(project.FilePath, container);
         }
 
         public void Enqueue(ProjectSnapshot project, DocumentSnapshot document)
@@ -170,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Razor
             {
                 if (_projectManager.IsDocumentOpen(document.FilePath))
                 {
-                    _infoProvider.SuppressDocument(project, document);
+                    _infoProvider.SuppressDocument(project.FilePath, document.FilePath);
                     return;
                 }
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
@@ -8,6 +8,9 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 namespace Microsoft.CodeAnalysis.Razor
 {
     // This types purpose is to serve as a non-Razor specific document delivery mechanism for Roslyn.
+    // Given a DocumentSnapshot this class allows the retrieval of a TextLoader for the generated C#
+    // and services to help map spans and excerpts to and from the top-level Razor document to behind
+    // the scenes C#.
     internal sealed class DefaultDynamicDocumentContainer : DynamicDocumentContainer
     {
         private readonly DocumentSnapshot _documentSnapshot;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    // This types purpose is to serve as a non-Razor specific document delivery mechanism for Roslyn.
+    internal sealed class DefaultDynamicDocumentContainer : DynamicDocumentContainer
+    {
+        private readonly DocumentSnapshot _documentSnapshot;
+        private RazorDocumentExcerptService _excerptService;
+        private RazorSpanMappingService _mappingService;
+
+        public DefaultDynamicDocumentContainer(DocumentSnapshot documentSnapshot)
+        {
+            if (documentSnapshot is null)
+            {
+                throw new ArgumentNullException(nameof(documentSnapshot));
+            }
+
+            _documentSnapshot = documentSnapshot;
+        }
+
+        public override string FilePath => _documentSnapshot.FilePath;
+
+        public override TextLoader GetTextLoader(string filePath) => new GeneratedDocumentTextLoader(_documentSnapshot, filePath);
+
+        public override object GetExcerptService()
+        {
+            if (_excerptService == null)
+            {
+                var mappingService = (RazorSpanMappingService)GetMappingService();
+                _excerptService = new RazorDocumentExcerptService(_documentSnapshot, mappingService);
+            }
+
+            return _excerptService;
+        }
+
+        public override object GetMappingService()
+        {
+            if (_mappingService == null)
+            {
+                _mappingService = new RazorSpanMappingService(_documentSnapshot);
+            }
+
+            return _mappingService;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorDynamicFileInfoProvider.cs
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
     internal abstract class RazorDynamicFileInfoProvider
     {
-        public abstract void UpdateFileInfo(ProjectSnapshot projectSnapshot, DocumentSnapshot document);
+        public abstract void UpdateFileInfo(string projectFilePath, DynamicDocumentContainer documentContainer);
 
-        public abstract void SuppressDocument(ProjectSnapshot project, DocumentSnapshot document);
+        public abstract void SuppressDocument(string projectFilePath, string documentFilePath);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDocumentInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDocumentInfoProviderTest.cs
@@ -51,9 +51,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Arrange
             var provider = new DefaultRazorDynamicDocumentInfoProvider(Factory);
             provider.Updated += (_) => throw new XunitException("This should not have been called.");
+            var documentContainer = new DefaultDynamicDocumentContainer(DocumentSnapshot);
 
             // Act & Assert
-            provider.UpdateFileInfo(ProjectSnapshot, DocumentSnapshot);
+            provider.UpdateFileInfo(ProjectSnapshot.FilePath, documentContainer);
         }
 
         [Fact]
@@ -69,9 +70,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Populate the providers understanding of our project/document
             provider.GetDynamicDocumentInfo(ProjectId.CreateNewId(), ProjectSnapshot.FilePath, DocumentSnapshot.FilePath);
+            var documentContainer = new DefaultDynamicDocumentContainer(DocumentSnapshot);
 
             // Act
-            provider.UpdateFileInfo(ProjectSnapshot, DocumentSnapshot);
+            provider.UpdateFileInfo(ProjectSnapshot.FilePath, documentContainer);
 
             // Assert
             Assert.NotNull(documentInfo);
@@ -84,9 +86,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Arrange
             var provider = new DefaultRazorDynamicDocumentInfoProvider(Factory);
             provider.Updated += (_) => throw new XunitException("This should not have been called.");
+            var documentContainer = new DefaultDynamicDocumentContainer(DocumentSnapshot);
 
             // Act & Assert
-            provider.SuppressDocument(ProjectSnapshot, DocumentSnapshot);
+            provider.SuppressDocument(ProjectSnapshot.FilePath, DocumentSnapshot.FilePath);
         }
 
         [Fact]
@@ -98,9 +101,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Populate the providers understanding of our project/document
             provider.GetDynamicDocumentInfo(ProjectId.CreateNewId(), ProjectSnapshot.FilePath, DocumentSnapshot.FilePath);
+            var documentContainer = new DefaultDynamicDocumentContainer(DocumentSnapshot);
 
             // Act & Assert
-            provider.SuppressDocument(ProjectSnapshot, DocumentSnapshot);
+            provider.SuppressDocument(ProjectSnapshot.FilePath, DocumentSnapshot.FilePath);
         }
 
         [Fact]
@@ -116,12 +120,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Populate the providers understanding of our project/document
             provider.GetDynamicDocumentInfo(ProjectId.CreateNewId(), ProjectSnapshot.FilePath, DocumentSnapshot.FilePath);
+            var documentContainer = new DefaultDynamicDocumentContainer(DocumentSnapshot);
 
             // Update the document with content
-            provider.UpdateFileInfo(ProjectSnapshot, DocumentSnapshot);
+            provider.UpdateFileInfo(ProjectSnapshot.FilePath, documentContainer);
 
             // Act
-            provider.SuppressDocument(ProjectSnapshot, DocumentSnapshot);
+            provider.SuppressDocument(ProjectSnapshot.FilePath, DocumentSnapshot.FilePath);
 
             // Assert
             Assert.NotNull(documentInfo);
@@ -136,9 +141,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Populate the providers understanding of our project/document
             provider.GetDynamicDocumentInfo(ProjectId.CreateNewId(), ProjectSnapshot.FilePath, DocumentSnapshot.FilePath);
+            var documentContainer = new DefaultDynamicDocumentContainer(DocumentSnapshot);
 
             // Update the document with content
-            provider.UpdateFileInfo(ProjectSnapshot, DocumentSnapshot);
+            provider.UpdateFileInfo(ProjectSnapshot.FilePath, documentContainer);
 
             // Now explode if any further updates happen
             provider.Updated += (_) => throw new XunitException("This should not have been called.");
@@ -147,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             provider.RemoveDynamicDocumentInfo(ProjectId.CreateNewId(), ProjectSnapshot.FilePath, DocumentSnapshot.FilePath);
 
             // Assert this should not update
-            provider.UpdateFileInfo(ProjectSnapshot, DocumentSnapshot);
+            provider.UpdateFileInfo(ProjectSnapshot.FilePath, documentContainer);
         }
     }
 }


### PR DESCRIPTION
- We have a parallel set of work in progress right now where we're moving off of Roslyn's internal types which includes the dynamic file info provider APIs. This changeset accomplishes two things.

  1. Start moving towards Roslyn's internal APIs
  2. Prep the dynamic file info provider APIs to be used to add CSharp virtual document's in LSP editor world to the Roslyn workspace.

- Build a `DynamicDocumentContainer` which is used to query information about our Razor documents (`DocumentSnapshot` or `CSharpVirtualDocumentSnapshot`) and use that information to notify Roslyn on how our documents should be handled in their workspace.

@tmat this is the "prep" work I was referring to.

@KirillOsenkov FYI since this changes a little bit of how our dynamic document file provider in VS4Mac functions.