### PR TITLE
Restart Razor Language Server When Changing Trace Level

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -71,7 +71,7 @@
           },
           {
             "selector": "razorTagHelperAttribute",
-            "scope": [ "razor.taghelpers.attribute"],
+            "scope": [ "razor.taghelpers.attribute" ],
             "light": {
               "foreground": "#800080",
               "fontStyle": "bold"
@@ -174,21 +174,6 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Specifies whether to wait for debug attach when launching the language server."
-                },
-                "razor.trace": {
-                    "type": "string",
-                    "default": "Messages",
-                    "enum": [
-                        "Off",
-                        "Messages",
-                        "Verbose"
-                    ],
-                    "enumDescriptions": [
-                        "Does not log messages from the Razor extension",
-                        "Logs only some messages from the Razor extension",
-                        "Logs all messages from the Razor extension"
-                    ],
-                    "description": "Specifies whether to output all messages [Verbose], some messages [Messages] or not at all [Off]."
                 },
                 "razor.format.enable": {
                     "type": "boolean",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ConfigurationChangeListener.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ConfigurationChangeListener.ts
@@ -16,7 +16,7 @@ export function listenToConfigurationChanges(
 }
 
 function razorTraceConfigurationChangeHandler(languageServerClient: RazorLanguageServerClient) {
-    const promptText = 'Would you like to restart the Razor Language Server to enable this configuration change?';
+    const promptText = 'Would you like to restart the Razor Language Server to enable the Razor trace configuration change?';
     const restartButtonText = 'Restart';
 
     vscode.window.showInformationMessage(promptText, restartButtonText).then(async result => {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ConfigurationChangeListener.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ConfigurationChangeListener.ts
@@ -24,6 +24,9 @@ function razorTraceConfigurationChangeHandler(languageServerClient: RazorLanguag
             return;
         }
 
-        await languageServerClient.stop().then(async () => languageServerClient.start());
+        await languageServerClient.stop().then(async () => {
+            languageServerClient.updateTraceLevel();
+            await languageServerClient.start();
+        });
     });
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ConfigurationChangeListener.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ConfigurationChangeListener.ts
@@ -1,0 +1,29 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { RazorLanguageServerClient } from './RazorLanguageServerClient';
+
+export function listenToConfigurationChanges(
+    languageServerClient: RazorLanguageServerClient) {
+    vscode.workspace.onDidChangeConfiguration(event => {
+        if (event.affectsConfiguration('razor.trace')) {
+            razorTraceConfigurationChangeHandler(languageServerClient);
+        }
+    });
+}
+
+function razorTraceConfigurationChangeHandler(languageServerClient: RazorLanguageServerClient) {
+    const promptText = 'Would you like to restart the Razor Language Server to enable this configuration change?';
+    const restartButtonText = 'Restart';
+
+    vscode.window.showInformationMessage(promptText, restartButtonText).then(async result => {
+        if (result !== restartButtonText) {
+            return;
+        }
+
+        await languageServerClient.stop().then(async () => languageServerClient.start());
+    });
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ConfigurationChangeListener.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ConfigurationChangeListener.ts
@@ -7,8 +7,8 @@ import * as vscode from 'vscode';
 import { RazorLanguageServerClient } from './RazorLanguageServerClient';
 
 export function listenToConfigurationChanges(
-    languageServerClient: RazorLanguageServerClient) {
-    vscode.workspace.onDidChangeConfiguration(event => {
+    languageServerClient: RazorLanguageServerClient): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration(event => {
         if (event.affectsConfiguration('razor.trace')) {
             razorTraceConfigurationChangeHandler(languageServerClient);
         }
@@ -24,9 +24,8 @@ function razorTraceConfigurationChangeHandler(languageServerClient: RazorLanguag
             return;
         }
 
-        await languageServerClient.stop().then(async () => {
-            languageServerClient.updateTraceLevel();
-            await languageServerClient.start();
-        });
+        await languageServerClient.stop();
+        languageServerClient.updateTraceLevel();
+        await languageServerClient.start();
     });
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
@@ -16,6 +16,7 @@ export class ReportIssuePanel {
     private panel: vscode.WebviewPanel | undefined;
     private dataCollector: ReportIssueDataCollector | undefined;
     private issueContent: string | undefined;
+    private traceLevelChange: vscode.Disposable | undefined;
 
     constructor(
         private readonly dataCollectorFactory: ReportIssueDataCollectorFactory,
@@ -88,7 +89,15 @@ export class ReportIssuePanel {
                     return;
             }
         });
-        this.panel.onDidDispose(() => this.panel = undefined);
+
+        this.traceLevelChange = this.logger.onTraceLevelChange(async () => this.update());
+
+        this.panel.onDidDispose(() => {
+            if (this.traceLevelChange) {
+                this.traceLevelChange.dispose();
+            }
+            this.panel = undefined;
+        });
     }
 
     private async update() {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
@@ -206,4 +206,36 @@ export class RazorLanguageServerClient implements vscode.Disposable {
         this.startHandle = undefined;
         this.eventBus.emit(events.ServerStop);
     }
+
+    public async stop() {
+        this.logger.logMessage('Actually stopping Razor Language Server.');
+
+        let resolve: () => void = Function;
+        let reject: (reason: any) => void = Function;
+        this.startHandle = new Promise<void>((resolver, rejecter) => {
+            resolve = resolver;
+            reject = rejecter;
+        });
+
+        try {
+            if (this.client) {
+                await this.client.stop();
+            }
+
+            this.isStarted = false;
+            this.startHandle = undefined;
+            this.eventBus.emit(events.ServerStop);
+
+            resolve();
+        } catch (error) {
+            vscode.window.showErrorMessage(
+                'Razor Language Server failed to stop correctly, ' +
+                'please check the \'Razor Log\' and report an issue.');
+
+            // this.telemetryReporter.reportErrorOnServerStart(error);
+            reject(error);
+        }
+
+        return this.startHandle;
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
@@ -16,6 +16,7 @@ export class RazorLogger implements vscode.Disposable {
     public readonly outputChannel: vscode.OutputChannel;
 
     private readonly onLogEmitter: vscode.EventEmitter<string>;
+    private readonly onTraceLevelChangeEmitter: vscode.EventEmitter<Trace>;
 
     constructor(
         private readonly vscodeApi: vscode.api,
@@ -23,6 +24,7 @@ export class RazorLogger implements vscode.Disposable {
         public trace: Trace) {
         this.processTraceLevel();
         this.onLogEmitter = eventEmitterFactory.create<string>();
+        this.onTraceLevelChangeEmitter = eventEmitterFactory.create<Trace>();
 
         this.outputChannel = this.vscodeApi.window.createOutputChannel(RazorLogger.logName);
 
@@ -33,9 +35,12 @@ export class RazorLogger implements vscode.Disposable {
         this.trace = trace;
         this.processTraceLevel();
         this.logMessage(`Updated trace level to: ${Trace[this.trace]}`);
+        this.onTraceLevelChangeEmitter.fire(this.trace);
     }
 
     public get onLog() { return this.onLogEmitter.event; }
+
+    public get onTraceLevelChange() { return this.onTraceLevelChangeEmitter.event; }
 
     public logAlways(message: string) {
         this.logWithMarker(message);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLogger.ts
@@ -11,8 +11,8 @@ import * as vscode from './vscodeAdapter';
 
 export class RazorLogger implements vscode.Disposable {
     public static readonly logName = 'Razor Log';
-    public readonly verboseEnabled: boolean;
-    public readonly messageEnabled: boolean;
+    public verboseEnabled!: boolean;
+    public messageEnabled!: boolean;
     public readonly outputChannel: vscode.OutputChannel;
 
     private readonly onLogEmitter: vscode.EventEmitter<string>;
@@ -20,14 +20,19 @@ export class RazorLogger implements vscode.Disposable {
     constructor(
         private readonly vscodeApi: vscode.api,
         eventEmitterFactory: IEventEmitterFactory,
-        public readonly trace: Trace) {
-        this.verboseEnabled = this.trace >= Trace.Verbose;
-        this.messageEnabled = this.trace >= Trace.Messages;
+        public trace: Trace) {
+        this.processTraceLevel();
         this.onLogEmitter = eventEmitterFactory.create<string>();
 
         this.outputChannel = this.vscodeApi.window.createOutputChannel(RazorLogger.logName);
 
         this.logRazorInformation();
+    }
+
+    public setTraceLevel(trace: Trace) {
+        this.trace = trace;
+        this.processTraceLevel();
+        this.logMessage(`Updated trace level to: ${Trace[this.trace]}`);
     }
 
     public get onLog() { return this.onLogEmitter.event; }
@@ -98,6 +103,11 @@ ${error.stack}`;
             '-----------------------------------------------------------------------' +
             '------------------------------------------------------');
         this.log('');
+    }
+
+    private processTraceLevel() {
+        this.verboseEnabled = this.trace >= Trace.Verbose;
+        this.messageEnabled = this.trace >= Trace.Messages;
     }
 }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
@@ -31,6 +31,10 @@ export class TelemetryReporter {
         this.reportError('VSCode.Razor.ErrorOnServerStart', error);
     }
 
+    public reportErrorOnServerStop(error: Error) {
+        this.reportError('VSCode.Razor.ErrorOnServerStop', error);
+    }
+
     public reportErrorOnActivation(error: Error) {
         this.reportError('VSCode.Razor.ErrorOnActivation', error);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
@@ -31,10 +31,6 @@ export class TelemetryReporter {
         this.reportError('VSCode.Razor.ErrorOnServerStart', error);
     }
 
-    public reportErrorOnServerStop(error: Error) {
-        this.reportError('VSCode.Razor.ErrorOnServerStop', error);
-    }
-
     public reportErrorOnActivation(error: Error) {
         this.reportError('VSCode.Razor.ErrorOnActivation', error);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -9,6 +9,7 @@ import { ExtensionContext } from 'vscode';
 import { CompositeCodeActionTranslator } from './CodeActions/CompositeRazorCodeActionTranslator';
 import { RazorCodeActionProvider } from './CodeActions/RazorCodeActionProvider';
 import { RazorFullyQualifiedCodeActionTranslator } from './CodeActions/RazorFullyQualifiedCodeActionTranslator';
+import { listenToConfigurationChanges } from './ConfigurationChangeListener';
 import { RazorCSharpFeature } from './CSharp/RazorCSharpFeature';
 import { ReportIssueCommand } from './Diagnostics/ReportIssueCommand';
 import { reportTelemetryForDocuments } from './DocumentTelemetryListener';
@@ -63,6 +64,7 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
 
         const documentManager = new RazorDocumentManager(languageServerClient, logger);
         reportTelemetryForDocuments(documentManager, telemetryReporter);
+        listenToConfigurationChanges(languageServerClient);
         const languageConfiguration = new RazorLanguageConfiguration();
         const csharpFeature = new RazorCSharpFeature(documentManager, eventEmitterFactory, logger);
         const htmlFeature = new RazorHtmlFeature(documentManager, languageServiceClient, eventEmitterFactory, logger);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -62,7 +62,6 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
 
         const documentManager = new RazorDocumentManager(languageServerClient, logger);
         reportTelemetryForDocuments(documentManager, telemetryReporter);
-        listenToConfigurationChanges(languageServerClient);
         const languageConfiguration = new RazorLanguageConfiguration();
         const csharpFeature = new RazorCSharpFeature(documentManager, eventEmitterFactory, logger);
         const htmlFeature = new RazorHtmlFeature(documentManager, languageServiceClient, eventEmitterFactory, logger);
@@ -162,7 +161,8 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
                 csharpFeature.register(),
                 htmlFeature.register(),
                 documentSynchronizer.register(),
-                reportIssueCommand.register());
+                reportIssueCommand.register(),
+                listenToConfigurationChanges(languageServerClient));
             if (enableProposedApis) {
                 const proposedApisFeature = new ProposedApisFeature(
                     documentSynchronizer,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -30,7 +30,6 @@ import { RazorImplementationProvider } from './RazorImplementationProvider';
 import { RazorLanguage } from './RazorLanguage';
 import { RazorLanguageConfiguration } from './RazorLanguageConfiguration';
 import { RazorLanguageServerClient } from './RazorLanguageServerClient';
-import { resolveRazorLanguageServerOptions } from './RazorLanguageServerOptionsResolver';
 import { resolveRazorLanguageServerTrace } from './RazorLanguageServerTraceResolver';
 import { RazorLanguageServiceClient } from './RazorLanguageServiceClient';
 import { RazorLogger } from './RazorLogger';
@@ -51,8 +50,7 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
     const logger = new RazorLogger(vscodeType, eventEmitterFactory, languageServerTrace);
 
     try {
-        const languageServerOptions = resolveRazorLanguageServerOptions(vscodeType, languageServerDir, languageServerTrace, logger);
-        const languageServerClient = new RazorLanguageServerClient(languageServerOptions, telemetryReporter, logger);
+        const languageServerClient = new RazorLanguageServerClient(vscodeType, languageServerDir, telemetryReporter, logger);
         const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
 
         const codeActionTranslators = [


### PR DESCRIPTION
- General implementation for properly stopping and restarting the Razor Language Server (`ConfigurationChangeListener`)
- Propagation of the new trace level
- Restart message prompt on configuration change
- Telemetry for failed server stop

<img width="493" alt="Screen Shot 2020-03-17 at 11 14 48 AM" src="https://user-images.githubusercontent.com/14852843/76888088-86facb00-6840-11ea-8a56-1ebc2b87a42e.png">


Addresses https://github.com/dotnet/aspnetcore/issues/14280
