### PR TITLE
Update .NET Core Sdk version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.2.20120.3",
+    "dotnet": "5.0.100-preview.3.20167.11",
     "runtimes": {
       "dotnet": [
         "2.1.11",
@@ -15,7 +15,7 @@
     }
   },
   "sdk": {
-    "version": "5.0.100-preview.2.20120.3"
+    "version": "5.0.100-preview.3.20167.11"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20228.4",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.5.20251.2",
+    "dotnet": "5.0.100-preview.5.20258.4",
     "runtimes": {
       "dotnet": [
         "2.1.11",
@@ -15,7 +15,7 @@
     }
   },
   "sdk": {
-    "version": "5.0.100-preview.5.20251.2"
+    "version": "5.0.100-preview.5.20258.4"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20228.4",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.3.20167.11",
+    "dotnet": "5.0.100-preview.5.20251.2",
     "runtimes": {
       "dotnet": [
         "2.1.11",
@@ -15,7 +15,7 @@
     }
   },
   "sdk": {
-    "version": "5.0.100-preview.3.20167.11"
+    "version": "5.0.100-preview.5.20251.2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20228.4",


### PR DESCRIPTION
Without this update we get errors during build locally like,
```
 error NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the l ist of actions below: [C:\GitHub\aspnet\AspNetCore-Tooling\src\Razor\src\RazorPageGenerator\RazorPageGenerator.csproj]
 error NU5128: - Add a dependency group for .NETCoreApp5.0 to the nuspec [C:\GitHub\aspnet\AspNetCore-Tooling\src\Razor\src\RazorPageGenerator\RazorPageGenerator.csproj]
 error NU5128: - Add lib or ref assemblies for the net50 target framework [C:\GitHub\aspnet\AspNetCore-Tooling\src\Razor\src\RazorPageGenerator\RazorPageGenerator.csproj]
 error NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the l ist of actions below: [C:\GitHub\aspnet\AspNetCore-Tooling\src\Razor\src\rzls\rzls.csproj]
 error NU5128: - Add a dependency group for .NETCoreApp5.0 to the nuspec [C:\GitHub\aspnet\AspNetCore-Tooling\src\Razor\src\rzls\rzls.csproj]
 error NU5128: - Add lib or ref assemblies for the net50 target framework [C:\GitHub\aspnet\AspNetCore-Tooling\src\Razor\src\rzls\rzls.csproj]
```
