### PR TITLE
Fix LSP editor feature switch toggle bug.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorDynamicFileInfoProvider.cs
@@ -101,6 +101,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             {
                 lock (entry.Lock)
                 {
+                    entry.SupportsSuppression = true;
                     entry.Current = CreateInfo(key, documentContainer);
                 }
 
@@ -127,9 +128,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var key = new Key(projectFilePath, documentFilePath);
             if (_entries.TryGetValue(key, out var entry))
             {
-                if (!entry.SupportsSuppression)
+                lock (entry.Lock)
                 {
-                    return;
+                    if (!entry.SupportsSuppression)
+                    {
+                        return;
+                    }
                 }
 
                 var updated = false;


### PR DESCRIPTION
- When toggling between Razor LSP editor on/off we need to support turning our dynamic file info provider pieces on/off correctly for LSP documents.
- Could not add tests because of Roslyn IVT restrictions.