### PR TITLE
Support VS LSP C# completion resolution

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -99,7 +99,48 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 completionParams,
                 cancellationToken);
 
+            if (result.HasValue)
+            {
+                result = SetResolveData(result.Value, serverKind);
+            }
+
             return result;
+        }
+
+        // Internal for testing
+        internal SumType<CompletionItem[], CompletionList>? SetResolveData(SumType<CompletionItem[], CompletionList> completionResult, LanguageServerKind kind)
+        {
+            var result = completionResult.Match<SumType<CompletionItem[], CompletionList>?>(
+                items =>
+                {
+                    var newItems = items.Select(item => SetData(item)).ToArray();
+                    return newItems;
+                },
+                list =>
+                {
+                    var newItems = list.Items.Select(item => SetData(item)).ToArray();
+                    return new CompletionList()
+                    {
+                        Items = newItems,
+                        IsIncomplete = list.IsIncomplete,
+                    };
+                },
+                () => null);
+
+            return result;
+
+            CompletionItem SetData(CompletionItem item)
+            {
+                var data = new CompletionResolveData()
+                {
+                    LanguageServerKind = kind,
+                    OriginalData = item.Data
+                };
+
+                item.Data = data;
+
+                return item;
+            }
         }
 
         private bool TriggerAppliesToProjection(CompletionContext context, RazorLanguageKind languageKind)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -101,6 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             if (result.HasValue)
             {
+                // Set some context on the CompletionItem so the CompletionResolveHandler can handle it accordingly.
                 result = SetResolveData(result.Value, serverKind);
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveData.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveData.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    internal class CompletionResolveData
+    {
+        public LanguageServerKind LanguageServerKind { get; set; }
+
+        public object OriginalData { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    [Shared]
+    [ExportLspMethod(Methods.TextDocumentCompletionResolveName)]
+    internal class CompletionResolveHandler : IRequestHandler<CompletionItem, CompletionItem>
+    {
+        private readonly LSPRequestInvoker _requestInvoker;
+
+        [ImportingConstructor]
+        public CompletionResolveHandler(LSPRequestInvoker requestInvoker)
+        {
+            if (requestInvoker is null)
+            {
+                throw new ArgumentNullException(nameof(requestInvoker));
+            }
+
+            _requestInvoker = requestInvoker;
+        }
+
+        public async Task<CompletionItem> HandleRequestAsync(CompletionItem request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+        {
+            if (request?.Data == null)
+            {
+                return request;
+            }
+
+            CompletionResolveData resolveData;
+            if (request.Data is CompletionResolveData data)
+            {
+                resolveData = data;
+            }
+            else
+            {
+                resolveData = ((JToken)request.Data).ToObject<CompletionResolveData>();
+            }
+
+            if (resolveData.LanguageServerKind != LanguageServerKind.CSharp)
+            {
+                // We currently only want to resolve C# completion items.
+                return request;
+            }
+
+            // Set the original resolve data back so the language server deserializes it correctly.
+            request.Data = resolveData.OriginalData;
+
+            var result = await _requestInvoker.RequestServerAsync<CompletionItem, CompletionItem>(
+                Methods.TextDocumentCompletionResolveName,
+                resolveData.LanguageServerKind,
+                request,
+                cancellationToken);
+
+            return result;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -44,14 +44,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 resolveData = ((JToken)request.Data).ToObject<CompletionResolveData>();
             }
 
+            // Set the original resolve data back so the language server deserializes it correctly.
+            request.Data = resolveData.OriginalData;
+
             if (resolveData.LanguageServerKind != LanguageServerKind.CSharp)
             {
                 // We currently only want to resolve C# completion items.
                 return request;
             }
-
-            // Set the original resolve data back so the language server deserializes it correctly.
-            request.Data = resolveData.OriginalData;
 
             var result = await _requestInvoker.RequestServerAsync<CompletionItem, CompletionItem>(
                 Methods.TextDocumentCompletionResolveName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 CompletionProvider = new CompletionOptions()
                 {
                     AllCommitCharacters = new[] { " ", ".", ";", ">", "=" }, // This is necessary to workaround a bug where the commit character in CompletionItem is not respected.
-                    ResolveProvider = false,
+                    ResolveProvider = true,
                     TriggerCharacters = new[] { ".", "@", "<", "&", "\\", "/", "'", "\"", "=", ":" }
                 },
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -77,6 +77,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(Methods.TextDocumentCompletionName, completionParams, _clientCapabilities, cancellationToken);
         }
 
+        [JsonRpcMethod(Methods.TextDocumentCompletionResolveName)]
+        public Task<CompletionItem> ResolveCompletionAsync(JToken input, CancellationToken cancellationToken)
+        {
+            if (input is null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var request = input.ToObject<CompletionItem>();
+            return ExecuteRequestAsync<CompletionItem, CompletionItem>(Methods.TextDocumentCompletionResolveName, request, _clientCapabilities, cancellationToken);
+        }
+
         // Internal for testing
         internal Task<ResponseType> ExecuteRequestAsync<RequestType, ResponseType>(
             string methodName,

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -25,12 +25,19 @@ namespace Microsoft.VisualStudio.RazorExtension
     public sealed class RazorPackage : AsyncPackage
     {
         public const string PackageGuidString = "13b72f58-279e-49e0-a56d-296be02f0805";
+        public const string CSharpPackageGuidString = "13c3bbb4-f18f-4111-9f54-a0fb010d9194";
 
         private RazorEditorFactory _editorFactory;
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Explicitly trigger the load of the CSharp package. This ensures that UI-bound services are appropriately prefetched. Ideally, we shouldn't need this but until Roslyn fixes it on their side, we have to live with it.
+            var shellService = (IVsShell7)AsyncPackage.GetGlobalService(typeof(SVsShell));
+            await shellService.LoadPackageAsync(new Guid(CSharpPackageGuidString));
 
             _editorFactory = new RazorEditorFactory(this);
             RegisterEditorFactory(_editorFactory);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
-using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Threading;
 using Moq;
@@ -21,17 +20,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
             JoinableTaskContext = joinableTaskContext.Context;
             Uri = new Uri("C:/path/to/file.razor");
-            LSPDocumentSynchronizer = Mock.Of<LSPDocumentSynchronizer>(s => s.TrySynchronizeVirtualDocumentAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<VirtualDocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(true));
-            LanguageClientBroker = Mock.Of<ILanguageClientBroker>();
         }
 
         private JoinableTaskContext JoinableTaskContext { get; }
 
         private Uri Uri { get; }
-
-        private LSPDocumentSynchronizer LSPDocumentSynchronizer { get; }
-
-        private ILanguageClientBroker LanguageClientBroker { get; }
 
         [Fact]
         public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
@@ -83,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedResult = new[] { new CompletionItem() { InsertText = "Sample" } };
+            var expectedItem = new CompletionItem() { InsertText = "Sample"};
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -103,7 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     Assert.Equal(LanguageServerKind.Html, serverKind);
                     called = true;
                 })
-                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(expectedResult));
+                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(new[] { expectedItem }));
 
             var projectionResult = new ProjectionResult()
             {
@@ -119,7 +112,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.True(called);
-            Assert.Equal(expectedResult, result);
+            var item = Assert.Single((CompletionItem[])result.Value);
+            Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
         [Fact]
@@ -127,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedResult = new[] { new CompletionItem() { InsertText = "DateTime" } };
+            var expectedItem = new CompletionItem() { InsertText = "DateTime"};
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -147,7 +141,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     Assert.Equal(LanguageServerKind.CSharp, serverKind);
                     called = true;
                 })
-                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(expectedResult));
+                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(new[] { expectedItem }));
 
             var projectionResult = new ProjectionResult()
             {
@@ -163,7 +157,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.True(called);
-            Assert.Equal(expectedResult, result);
+            var item = Assert.Single((CompletionItem[])result.Value);
+            Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
         [Fact]
@@ -235,7 +230,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedResult = new[] { new CompletionItem() { InsertText = "DateTime" } };
+            var expectedItem = new CompletionItem() { InsertText = "DateTime" };
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -255,7 +250,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     Assert.Equal(LanguageServerKind.CSharp, serverKind);
                     called = true;
                 })
-                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(expectedResult));
+                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(new[] { expectedItem }));
 
             var projectionResult = new ProjectionResult()
             {
@@ -271,7 +266,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.True(called);
-            Assert.Equal(expectedResult, result);
+            var item = Assert.Single((CompletionItem[])result.Value);
+            Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
         [Fact]
@@ -279,7 +275,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedResult = new[] { new CompletionItem() { InsertText = "Sample" } };
+            var expectedItem = new CompletionItem() { InsertText = "Sample" };
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -299,7 +295,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     Assert.Equal(LanguageServerKind.Html, serverKind);
                     called = true;
                 })
-                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(expectedResult));
+                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(new[] { expectedItem }));
 
             var projectionResult = new ProjectionResult()
             {
@@ -315,7 +311,33 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.True(called);
-            Assert.Equal(expectedResult, result);
+            var item = Assert.Single((CompletionItem[])result.Value);
+            Assert.Equal(expectedItem.InsertText, item.InsertText);
+        }
+
+        [Fact]
+        public void SetResolveData_RewritesData()
+        {
+            // Arrange
+            var originalData = new object();
+            var items = new[]
+            {
+                new CompletionItem() { InsertText = "Hello", Data = originalData }
+            };
+            var documentManager = new TestDocumentManager();
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider);
+
+            // Act
+            var result = completionHandler.SetResolveData(items, LanguageServerKind.CSharp);
+
+            // Assert
+            Assert.True(result.HasValue);
+            var item = Assert.Single((CompletionItem[])result.Value);
+            var newData = Assert.IsType<CompletionResolveData>(item.Data);
+            Assert.Equal(LanguageServerKind.CSharp, newData.LanguageServerKind);
+            Assert.Same(originalData, newData.OriginalData);
         }
 
         private class TestDocumentManager : LSPDocumentManager

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
@@ -50,5 +50,28 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.Same(expectedResponse, result);
         }
+
+        [Fact]
+        public async Task HandleRequestAsync_DoesNotInvokeHtmlLanguageServer()
+        {
+            // Arrange
+            var originalData = new object();
+            var request = new CompletionItem()
+            {
+                InsertText = "div",
+                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.Html, OriginalData = originalData }
+            };
+
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+
+            var handler = new CompletionResolveHandler(requestInvoker.Object);
+
+            // Act
+            var result = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None);
+
+            // Assert (Does not throw with MockBehavior.Strict)
+            Assert.Equal("div", result.InsertText);
+            Assert.Same(originalData, result.Data);
+        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class CompletionResolveHandlerTest
+    {
+        [Fact]
+        public async Task HandleRequestAsync_InvokesCSharpLanguageServer()
+        {
+            // Arrange
+            var called = false;
+            var originalData = new object();
+            var request = new CompletionItem()
+            {
+                InsertText = "DateTime",
+                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp, OriginalData = originalData }
+            };
+            var expectedResponse = new CompletionItem()
+            {
+                InsertText = "DateTime",
+                Data = originalData,
+                Detail = "Some documentation"
+            };
+
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<CompletionItem, CompletionItem>(It.IsAny<string>(), LanguageServerKind.CSharp, It.IsAny<CompletionItem>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, CompletionItem, CancellationToken>((method, serverKind, completionItem, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentCompletionResolveName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    Assert.Same(originalData, completionItem.Data);
+                    called = true;
+                })
+                .Returns(Task.FromResult<CompletionItem>(expectedResponse));
+
+            var handler = new CompletionResolveHandler(requestInvoker.Object);
+
+            // Act
+            var result = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None);
+
+            // Assert
+            Assert.True(called);
+            Assert.Same(expectedResponse, result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/19628 and https://github.com/dotnet/aspnetcore/issues/19851

Added a CompletionResolveHandler that manually invokes the correct language server based on the given CompletionItem. We currently only call through to the CSharp language server because the Html one doesn't yet support completion resolution.