### PR TITLE
Removed debug assert in projection provider.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -81,8 +81,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
             else
             {
-                Debug.Assert(languageResponse.HostDocumentVersion == documentSnapshot.Version);
-
                 var synchronized = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync(documentSnapshot, virtualDocument, cancellationToken);
                 if (!synchronized)
                 {


### PR DESCRIPTION
- With how the synchronization APIs work we can't re-inspect the document snapshot's host document version without re-querying for the document (it's a snapshot). Therefore, removed the debug assert and are relying on the correctness of the synchronizer.