### PR TITLE
Added support for auto closing tags in VS LSP

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -7,6 +7,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
     {
         public const string ProjectConfigurationFile = "project.razor.json";
 
+        public const string ExpectsCursorPlaceholderKey = "expectsCursorPlaceholder";
+
+        public const string CursorPlaceholderString = "__placeholder__";
+
         public const string RazorSemanticTokensEndpoint = "razor/semanticTokens";
 
         public const string RazorSemanticTokenLegendEndpoint = "razor/semanticTokensLegend";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -22,5 +22,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public const string RazorUpdateHtmlBufferEndpoint = "razor/updateHtmlBuffer";
 
         public const string RazorLanguageQueryEndpoint = "razor/languageQuery";
+
+        public const string RazorMapToDocumentRangeEndpoint = "razor/mapToDocumentRange";
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
@@ -23,12 +25,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         private readonly ILanguageServer _server;
         private readonly CSharpFormatter _csharpFormatter;
         private readonly HtmlFormatter _htmlFormatter;
+        private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
         private readonly ILogger _logger;
+
+        private static readonly TextEdit[] EmptyArray = Array.Empty<TextEdit>();
 
         public DefaultRazorFormattingService(
             RazorDocumentMappingService documentMappingService,
             FilePathNormalizer filePathNormalizer,
             ILanguageServer server,
+            IOptionsMonitor<RazorLSPOptions> optionsMonitor,
             ILoggerFactory loggerFactory)
         {
             if (documentMappingService is null)
@@ -46,6 +52,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(server));
             }
 
+            if (optionsMonitor is null)
+            {
+                throw new ArgumentNullException(nameof(optionsMonitor));
+            }
+
             if (loggerFactory is null)
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
@@ -54,7 +65,88 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             _server = server;
             _csharpFormatter = new CSharpFormatter(documentMappingService, server, filePathNormalizer);
             _htmlFormatter = new HtmlFormatter(server, filePathNormalizer);
+            _optionsMonitor = optionsMonitor;
             _logger = loggerFactory.CreateLogger<DefaultRazorFormattingService>();
+        }
+
+        public override Task<TextEdit[]> FormatOnTypeAsync(Uri uri, RazorCodeDocument codeDocument, Position position, string character, FormattingOptions options)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (codeDocument is null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            if (position is null)
+            {
+                throw new ArgumentNullException(nameof(position));
+            }
+
+            if (string.IsNullOrEmpty(character))
+            {
+                throw new ArgumentNullException(nameof(character));
+            }
+
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (!_optionsMonitor.CurrentValue.AutoClosingTags || character != ">")
+            {
+                // We currently only support auto-closing tags our onType formatter.
+                return Task.FromResult(EmptyArray);
+            }
+
+            bool addCursorPlaceholder;
+            if (options.TryGetValue(LanguageServerConstants.ExpectsCursorPlaceholderKey, out var value) && value.IsBool)
+            {
+                addCursorPlaceholder = value.Bool;
+            }
+            else
+            {
+                // Temporary:
+                // no-op if cursor placeholder isn't supported. This means the request isn't coming from VS.
+                // Can remove this once VSCode starts using this endpoint for auto closing <text> tags.
+                return Task.FromResult(EmptyArray);
+            }
+
+            var formattingContext = CreateFormattingContext(uri, codeDocument, new Range(position, position), options);
+            if (IsAtTextTag(formattingContext, position))
+            {
+                // This is a text tag.
+                var cursorPlaceholder = addCursorPlaceholder ? LanguageServerConstants.CursorPlaceholderString : string.Empty;
+                var edit = new TextEdit()
+                {
+                    NewText = $"{cursorPlaceholder}</{SyntaxConstants.TextTagName}>",
+                    Range = new Range(position, position)
+                };
+                return Task.FromResult(new[] { edit });
+            }
+
+            return Task.FromResult(EmptyArray);
+        }
+
+        private static bool IsAtTextTag(FormattingContext context, Position position)
+        {
+            var syntaxTree = context.CodeDocument.GetSyntaxTree();
+
+            var absoluteIndex = position.GetAbsoluteIndex(context.SourceText) - 1;
+            var change = new SourceChange(absoluteIndex, 0, string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+            if (owner?.Parent != null &&
+                owner.Parent is MarkupStartTagSyntax startTag &&
+                startTag.IsMarkupTransition)
+            {
+                Debug.Assert(string.Equals(startTag.Name.Content, SyntaxConstants.TextTagName, StringComparison.Ordinal), "MarkupTransition that is not a <text> tag.");
+                return true;
+            }
+
+            return false;
         }
 
         public override async Task<TextEdit[]> FormatAsync(Uri uri, RazorCodeDocument codeDocument, Range range, FormattingOptions options)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -140,9 +140,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var owner = syntaxTree.Root.LocateOwner(change);
             if (owner?.Parent != null &&
                 owner.Parent is MarkupStartTagSyntax startTag &&
-                startTag.IsMarkupTransition)
+                startTag.IsMarkupTransition &&
+                startTag.Parent is MarkupElementSyntax element &&
+                element.EndTag == null) // Make sure the end </text> tag doesn't already exist
             {
                 Debug.Assert(string.Equals(startTag.Name.Content, SyntaxConstants.TextTagName, StringComparison.Ordinal), "MarkupTransition that is not a <text> tag.");
+
                 return true;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -12,5 +12,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
     internal abstract class RazorFormattingService
     {
         public abstract Task<TextEdit[]> FormatAsync(Uri uri, RazorCodeDocument codeDocument, Range range, FormattingOptions options);
+
+        public abstract Task<TextEdit[]> FormatOnTypeAsync(Uri uri, RazorCodeDocument codeDocument, Position position, string character, FormattingOptions options);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorOnTypeFormattingEndpoint.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class RazorOnTypeFormattingEndpoint : IDocumentOnTypeFormatHandler
+    {
+        private DocumentOnTypeFormattingCapability _capability;
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly DocumentResolver _documentResolver;
+        private readonly RazorFormattingService _razorFormattingService;
+        private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
+        private readonly ILogger _logger;
+
+        public RazorOnTypeFormattingEndpoint(
+            ForegroundDispatcher foregroundDispatcher,
+            DocumentResolver documentResolver,
+            RazorFormattingService razorFormattingService,
+            IOptionsMonitor<RazorLSPOptions> optionsMonitor,
+            ILoggerFactory loggerFactory)
+        {
+            if (foregroundDispatcher is null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (documentResolver is null)
+            {
+                throw new ArgumentNullException(nameof(documentResolver));
+            }
+
+            if (razorFormattingService is null)
+            {
+                throw new ArgumentNullException(nameof(razorFormattingService));
+            }
+
+            if (optionsMonitor is null)
+            {
+                throw new ArgumentNullException(nameof(optionsMonitor));
+            }
+
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _documentResolver = documentResolver;
+            _razorFormattingService = razorFormattingService;
+            _optionsMonitor = optionsMonitor;
+            _logger = loggerFactory.CreateLogger<RazorFormattingEndpoint>();
+        }
+
+        public DocumentOnTypeFormattingRegistrationOptions GetRegistrationOptions()
+        {
+            return new DocumentOnTypeFormattingRegistrationOptions()
+            {
+                DocumentSelector = RazorDefaults.Selector,
+                FirstTriggerCharacter = ">",
+            };
+        }
+
+        public async Task<TextEditContainer> Handle(DocumentOnTypeFormattingParams request, CancellationToken cancellationToken)
+        {
+            if (!_optionsMonitor.CurrentValue.AutoClosingTags)
+            {
+                // onTypeFormatting is only used for autoClosingTags support for now.
+                return null;
+            }
+
+            var document = await Task.Factory.StartNew(() =>
+            {
+                _documentResolver.TryResolveDocument(request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
+
+                return documentSnapshot;
+            }, cancellationToken, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler);
+
+            if (document is null || cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+
+            var codeDocument = await document.GetGeneratedOutputAsync();
+            if (codeDocument.IsUnsupported())
+            {
+                return null;
+            }
+
+            var edits = await _razorFormattingService.FormatOnTypeAsync(request.TextDocument.Uri, codeDocument, request.Position, request.Character, request.Options);
+
+            var editContainer = new TextEditContainer(edits);
+            return editContainer;
+        }
+
+        public void SetCapability(DocumentOnTypeFormattingCapability capability)
+        {
+            _capability = capability;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorOnTypeFormattingEndpoint.cs
@@ -17,19 +17,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal class RazorOnTypeFormattingEndpoint : IDocumentOnTypeFormatHandler
     {
-        private DocumentOnTypeFormattingCapability _capability;
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentResolver _documentResolver;
         private readonly RazorFormattingService _razorFormattingService;
         private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
-        private readonly ILogger _logger;
+        private DocumentOnTypeFormattingCapability _capability;
 
         public RazorOnTypeFormattingEndpoint(
             ForegroundDispatcher foregroundDispatcher,
             DocumentResolver documentResolver,
             RazorFormattingService razorFormattingService,
-            IOptionsMonitor<RazorLSPOptions> optionsMonitor,
-            ILoggerFactory loggerFactory)
+            IOptionsMonitor<RazorLSPOptions> optionsMonitor)
         {
             if (foregroundDispatcher is null)
             {
@@ -51,16 +49,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(optionsMonitor));
             }
 
-            if (loggerFactory is null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
-
             _foregroundDispatcher = foregroundDispatcher;
             _documentResolver = documentResolver;
             _razorFormattingService = razorFormattingService;
             _optionsMonitor = optionsMonitor;
-            _logger = loggerFactory.CreateLogger<RazorFormattingEndpoint>();
         }
 
         public DocumentOnTypeFormattingRegistrationOptions GetRegistrationOptions()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorLanguageQueryHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorLanguageQueryHandler.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    [Serial, Method("razor/languageQuery")]
+    [Serial, Method(LanguageServerConstants.RazorLanguageQueryEndpoint)]
     internal interface IRazorLanguageQueryHandler : IJsonRpcRequestHandler<RazorLanguageQueryParams, RazorLanguageQueryResponse>
     {
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentRangeHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentRangeHandler.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    [Serial, Method("razor/mapToDocumentRange")]
+    [Serial, Method(LanguageServerConstants.RazorMapToDocumentRangeEndpoint)]
     internal interface IRazorMapToDocumentRangeHandler : IJsonRpcRequestHandler<RazorMapToDocumentRangeParams, RazorMapToDocumentRangeResponse>
     {
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
@@ -10,19 +9,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class RazorLSPOptions : IEquatable<RazorLSPOptions>
     {
-        public RazorLSPOptions(Trace trace, bool enableFormatting)
+        public RazorLSPOptions(Trace trace, bool enableFormatting, bool autoClosingTags)
         {
             Trace = trace;
             EnableFormatting = enableFormatting;
+            AutoClosingTags = autoClosingTags;
         }
 
-        public static RazorLSPOptions Default => new RazorLSPOptions(trace: default, enableFormatting: true);
+        public static RazorLSPOptions Default =>
+            new RazorLSPOptions(trace: default, enableFormatting: true, autoClosingTags: true);
 
         public Trace Trace { get; }
 
         public LogLevel MinLogLevel => GetLogLevelForTrace(Trace);
 
         public bool EnableFormatting { get; }
+
+        public bool AutoClosingTags { get; }
 
         public static LogLevel GetLogLevelForTrace(Trace trace)
         {
@@ -40,7 +43,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return
                 other != null &&
                 Trace == other.Trace &&
-                EnableFormatting == other.EnableFormatting;
+                EnableFormatting == other.EnableFormatting &&
+                AutoClosingTags == other.AutoClosingTags;
         }
 
         public override bool Equals(object obj)
@@ -53,6 +57,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var hash = new HashCodeCombiner();
             hash.Add(Trace);
             hash.Add(EnableFormatting);
+            hash.Add(AutoClosingTags);
             return hash;
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -67,6 +67,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<RazorLanguageEndpoint>()
                     .WithHandler<RazorConfigurationEndpoint>()
                     .WithHandler<RazorFormattingEndpoint>()
+                    .WithHandler<RazorOnTypeFormattingEndpoint>()
                     .WithHandler<RazorSemanticTokenEndpoint>()
                     .WithHandler<RazorSemanticTokenLegendEndpoint>()
                     .WithServices(services =>

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorSyntaxFactsService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorSyntaxFactsService.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorService.cs
@@ -47,6 +47,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             ITextSnapshot snapshot,
             IEnumerable<TextEdit> textEdits)
         {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (snapshot is null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            if (textEdits is null)
+            {
+                throw new ArgumentNullException(nameof(textEdits));
+            }
+
             await _joinableTaskFactory.SwitchToMainThreadAsync();
 
             ApplyTextEdits(textEdits, snapshot, snapshot.TextBuffer);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json.Linq;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(RazorLanguageClientMiddleLayer))]
+    internal class DefaultRazorLanguageClientMiddleLayer : RazorLanguageClientMiddleLayer
+    {
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+        private readonly LSPDocumentManager _documentManager;
+        private readonly SVsServiceProvider _serviceProvider;
+
+        [ImportingConstructor]
+        public DefaultRazorLanguageClientMiddleLayer(
+            JoinableTaskContext joinableTaskContext,
+            LSPDocumentManager documentManager,
+            SVsServiceProvider serviceProvider)
+        {
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            _joinableTaskFactory = joinableTaskContext.Factory;
+            _documentManager = documentManager;
+            _serviceProvider = serviceProvider;
+        }
+
+        public override bool CanHandle(string methodName)
+        {
+            return methodName == Methods.TextDocumentOnTypeFormattingName;
+        }
+
+        public override Task HandleNotificationAsync(string methodName, JToken methodParam, Func<JToken, Task> sendNotification)
+        {
+            return null;
+        }
+
+        public override async Task<JToken> HandleRequestAsync(string methodName, JToken methodParam, Func<JToken, Task<JToken>> sendRequest)
+        {
+            if (methodName == Methods.TextDocumentOnTypeFormattingName)
+            {
+                var emptyResult = JToken.FromObject(Array.Empty<TextEdit>());
+                var requestParams = methodParam.ToObject<DocumentOnTypeFormattingParams>();
+                if (requestParams.Options.OtherOptions == null)
+                {
+                    requestParams.Options.OtherOptions = new Dictionary<string, object>();
+                }
+
+                requestParams.Options.OtherOptions[LanguageServerConstants.ExpectsCursorPlaceholderKey] = true;
+                var token = JToken.FromObject(requestParams);
+                var result = await sendRequest(token);
+                var edits = result?.ToObject<TextEdit[]>();
+                if (edits == null)
+                {
+                    return emptyResult;
+                }
+
+                await _joinableTaskFactory.SwitchToMainThreadAsync();
+
+                if (!_documentManager.TryGetDocument(requestParams.TextDocument.Uri, out var documentSnapshot))
+                {
+                    return emptyResult;
+                }
+
+                Position cursorPosition = null;
+                var filteredEdits = new List<TextEdit>(edits.Length);
+                foreach (var edit in edits)
+                {
+                    if (edit.NewText.Contains(LanguageServerConstants.CursorPlaceholderString))
+                    {
+                        var newEdit = new TextEdit();
+                        newEdit.Range = edit.Range;
+                        newEdit.NewText = edit.NewText.Replace(LanguageServerConstants.CursorPlaceholderString, string.Empty);
+                        filteredEdits.Add(newEdit);
+
+                        cursorPosition = edit.Range.Start;
+                    }
+                    else
+                    {
+                        filteredEdits.Add(edit);
+                    }
+                }
+
+                ApplyTextEdits(filteredEdits, documentSnapshot.Snapshot, documentSnapshot.Snapshot.TextBuffer);
+
+                if (cursorPosition != null)
+                {
+                    var fullPath = GetLocalFilePath(requestParams.TextDocument.Uri);
+                    VsShellUtilities.OpenDocument(_serviceProvider, fullPath, VSConstants.LOGVIEWID.TextView_guid, out _, out _, out _, out var textView);
+                    MoveCaretToPosition(textView, cursorPosition);
+                }
+
+                return emptyResult;
+            }
+            else
+            {
+                return await sendRequest(methodParam);
+            }
+        }
+
+        internal static void ApplyTextEdits(IEnumerable<TextEdit> textEdits, ITextSnapshot snapshot, ITextBuffer textBuffer)
+        {
+            var vsTextEdit = textBuffer.CreateEdit();
+            foreach (var textEdit in textEdits)
+            {
+                if (textEdit.Range.Start == textEdit.Range.End)
+                {
+                    var position = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
+                    if (position > -1)
+                    {
+                        var span = GetTranslatedSpan(position, 0, snapshot, vsTextEdit.Snapshot);
+                        vsTextEdit.Insert(span.Start, textEdit.NewText);
+                    }
+                }
+                else if (string.IsNullOrEmpty(textEdit.NewText))
+                {
+                    var startPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
+                    var endPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.End);
+                    var difference = endPosition - startPosition;
+                    if (startPosition > -1 && endPosition > -1 && difference > 0)
+                    {
+                        var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
+                        vsTextEdit.Delete(span);
+                    }
+                }
+                else
+                {
+                    var startPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
+                    var endPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.End);
+                    var difference = endPosition - startPosition;
+
+                    if (startPosition > -1 && endPosition > -1 && difference > 0)
+                    {
+                        var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
+                        vsTextEdit.Replace(span, textEdit.NewText);
+                    }
+                }
+            }
+
+            vsTextEdit.Apply();
+        }
+
+        private static Span GetTranslatedSpan(int startPosition, int length, ITextSnapshot oldSnapshot, ITextSnapshot newSnapshot)
+        {
+            var span = new Span(startPosition, length);
+
+            if (oldSnapshot.Version != newSnapshot.Version)
+            {
+                var snapshotSpan = new SnapshotSpan(oldSnapshot, span);
+                var translatedSnapshotSpan = snapshotSpan.TranslateTo(newSnapshot, SpanTrackingMode.EdgeExclusive);
+                span = translatedSnapshotSpan.Span;
+            }
+
+            return span;
+        }
+
+        internal static SnapshotPoint GetSnapshotPositionFromProtocolPosition(ITextSnapshot textSnapshot, Position position)
+        {
+            var line = textSnapshot.GetLineFromLineNumber(position.Line);
+            var snapshotPosition = line.Start + position.Character;
+
+            return new SnapshotPoint(textSnapshot, snapshotPosition);
+        }
+
+        internal static void MoveCaretToPosition(IVsTextView textView, Position position, bool sendFocus = true)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            textView.SetCaretPos(position.Line, position.Character);
+            textView.EnsureSpanVisible(new TextSpan() { iStartIndex = position.Character, iStartLine = position.Line, iEndIndex = position.Character, iEndLine = position.Line });
+            textView.CenterLines(position.Line, 1);
+            if (sendFocus)
+            {
+                textView.SendExplicitFocus();
+            }
+        }
+
+        internal static string GetLocalFilePath(Uri documentUri)
+        {
+            Requires.Argument(documentUri.IsFile, nameof(documentUri), "There were no clients that can open the document.");
+
+            // Note: this would remove the '/' from some Uri returned on some LSP providers
+            var absolutePath = documentUri.LocalPath.TrimStart('/');
+            var fullPath = Path.GetFullPath(absolutePath);
+
+            return fullPath;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
@@ -4,13 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json.Linq;
 using Task = System.Threading.Tasks.Task;
@@ -74,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
                 requestParams.Options.OtherOptions[LanguageServerConstants.ExpectsCursorPlaceholderKey] = true;
                 var token = JToken.FromObject(requestParams);
-                var result = await sendRequest(token);
+                var result = await sendRequest(token).ConfigureAwait(false);
                 var edits = result?.ToObject<TextEdit[]>();
                 if (edits == null)
                 {
@@ -88,128 +85,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     return emptyResult;
                 }
 
-                Position cursorPosition = null;
-                var filteredEdits = new List<TextEdit>(edits.Length);
-                foreach (var edit in edits)
-                {
-                    if (edit.NewText.Contains(LanguageServerConstants.CursorPlaceholderString))
-                    {
-                        var newEdit = new TextEdit();
-                        newEdit.Range = edit.Range;
-                        newEdit.NewText = edit.NewText.Replace(LanguageServerConstants.CursorPlaceholderString, string.Empty);
-                        filteredEdits.Add(newEdit);
+                VsUtilities.ApplyTextEdits(_serviceProvider, requestParams.TextDocument.Uri, documentSnapshot.Snapshot, edits);
 
-                        cursorPosition = edit.Range.Start;
-                    }
-                    else
-                    {
-                        filteredEdits.Add(edit);
-                    }
-                }
-
-                ApplyTextEdits(filteredEdits, documentSnapshot.Snapshot, documentSnapshot.Snapshot.TextBuffer);
-
-                if (cursorPosition != null)
-                {
-                    var fullPath = GetLocalFilePath(requestParams.TextDocument.Uri);
-                    VsShellUtilities.OpenDocument(_serviceProvider, fullPath, VSConstants.LOGVIEWID.TextView_guid, out _, out _, out _, out var textView);
-                    MoveCaretToPosition(textView, cursorPosition);
-                }
-
+                // We would have already applied the edits and moved the cursor. Return empty.
                 return emptyResult;
             }
             else
             {
-                return await sendRequest(methodParam);
+                return await sendRequest(methodParam).ConfigureAwait(false);
             }
-        }
-
-        internal static void ApplyTextEdits(IEnumerable<TextEdit> textEdits, ITextSnapshot snapshot, ITextBuffer textBuffer)
-        {
-            var vsTextEdit = textBuffer.CreateEdit();
-            foreach (var textEdit in textEdits)
-            {
-                if (textEdit.Range.Start == textEdit.Range.End)
-                {
-                    var position = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
-                    if (position > -1)
-                    {
-                        var span = GetTranslatedSpan(position, 0, snapshot, vsTextEdit.Snapshot);
-                        vsTextEdit.Insert(span.Start, textEdit.NewText);
-                    }
-                }
-                else if (string.IsNullOrEmpty(textEdit.NewText))
-                {
-                    var startPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
-                    var endPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.End);
-                    var difference = endPosition - startPosition;
-                    if (startPosition > -1 && endPosition > -1 && difference > 0)
-                    {
-                        var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
-                        vsTextEdit.Delete(span);
-                    }
-                }
-                else
-                {
-                    var startPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
-                    var endPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.End);
-                    var difference = endPosition - startPosition;
-
-                    if (startPosition > -1 && endPosition > -1 && difference > 0)
-                    {
-                        var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
-                        vsTextEdit.Replace(span, textEdit.NewText);
-                    }
-                }
-            }
-
-            vsTextEdit.Apply();
-        }
-
-        private static Span GetTranslatedSpan(int startPosition, int length, ITextSnapshot oldSnapshot, ITextSnapshot newSnapshot)
-        {
-            var span = new Span(startPosition, length);
-
-            if (oldSnapshot.Version != newSnapshot.Version)
-            {
-                var snapshotSpan = new SnapshotSpan(oldSnapshot, span);
-                var translatedSnapshotSpan = snapshotSpan.TranslateTo(newSnapshot, SpanTrackingMode.EdgeExclusive);
-                span = translatedSnapshotSpan.Span;
-            }
-
-            return span;
-        }
-
-        internal static SnapshotPoint GetSnapshotPositionFromProtocolPosition(ITextSnapshot textSnapshot, Position position)
-        {
-            var line = textSnapshot.GetLineFromLineNumber(position.Line);
-            var snapshotPosition = line.Start + position.Character;
-
-            return new SnapshotPoint(textSnapshot, snapshotPosition);
-        }
-
-        internal static void MoveCaretToPosition(IVsTextView textView, Position position, bool sendFocus = true)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            textView.SetCaretPos(position.Line, position.Character);
-            textView.EnsureSpanVisible(new TextSpan() { iStartIndex = position.Character, iStartLine = position.Line, iEndIndex = position.Character, iEndLine = position.Line });
-            textView.CenterLines(position.Line, 1);
-            if (sendFocus)
-            {
-                textView.SendExplicitFocus();
-            }
-        }
-
-        internal static string GetLocalFilePath(Uri documentUri)
-        {
-            Requires.Argument(documentUri.IsFile, nameof(documentUri), "There were no clients that can open the document.");
-
-            // Note: this would remove the '/' from some Uri returned on some LSP providers
-            var absolutePath = documentUri.LocalPath.TrimStart('/');
-            var fullPath = Path.GetFullPath(absolutePath);
-
-            return fullPath;
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             _requestInvoker = requestInvoker;
         }
 
-        public async override Task<MappingResult> RazorMapToDocumentRangeAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range projectedRange, CancellationToken cancellationToken)
+        public async override Task<MappingResult> MapToDocumentRangeAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range projectedRange, CancellationToken cancellationToken)
         {
             if (razorDocumentUri is null)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharpPosition = OmniSharp.Extensions.LanguageServer.Protocol.Models.Position;
+using OmniSharpRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    [Shared]
+    [Export(typeof(LSPDocumentMappingProvider))]
+    internal class DefaultLSPDocumentMappingProvider : LSPDocumentMappingProvider
+    {
+        private readonly LSPRequestInvoker _requestInvoker;
+
+        [ImportingConstructor]
+        public DefaultLSPDocumentMappingProvider(LSPRequestInvoker requestInvoker)
+        {
+            if (requestInvoker is null)
+            {
+                throw new ArgumentNullException(nameof(requestInvoker));
+            }
+
+            _requestInvoker = requestInvoker;
+        }
+
+        public async override Task<MappingResult> RazorMapToDocumentRangeAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range projectedRange, CancellationToken cancellationToken)
+        {
+            if (razorDocumentUri is null)
+            {
+                throw new ArgumentNullException(nameof(razorDocumentUri));
+            }
+
+            if (projectedRange is null)
+            {
+                throw new ArgumentNullException(nameof(projectedRange));
+            }
+
+            var mapToDocumentRangeParams = new RazorMapToDocumentRangeParams()
+            {
+                Kind = languageKind,
+                RazorDocumentUri = razorDocumentUri,
+                ProjectedRange = new OmniSharpRange(
+                    new OmniSharpPosition(projectedRange.Start.Line, projectedRange.Start.Character),
+                    new OmniSharpPosition(projectedRange.End.Line, projectedRange.End.Character))
+            };
+
+            var documentMappingResponse = await _requestInvoker.RequestServerAsync<RazorMapToDocumentRangeParams, RazorMapToDocumentRangeResponse>(
+                LanguageServerConstants.RazorMapToDocumentRangeEndpoint,
+                LanguageServerKind.Razor,
+                mapToDocumentRangeParams,
+                cancellationToken).ConfigureAwait(false);
+
+            var mappingResult = new MappingResult()
+            {
+                Range = new Range()
+                {
+                    Start = new Position((int)documentMappingResponse.Range.Start.Line, (int)documentMappingResponse.Range.Start.Character),
+                    End = new Position((int)documentMappingResponse.Range.End.Line, (int)documentMappingResponse.Range.End.Character),
+                },
+                HostDocumentVersion = documentMappingResponse.HostDocumentVersion
+            };
+
+            return mappingResult;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Composition;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
@@ -17,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     [Export(typeof(LSPProjectionProvider))]
     internal class DefaultLSPProjectionProvider : LSPProjectionProvider
     {
-        private readonly int UndefinedDocumentVersion = -1;
+        private const int UndefinedDocumentVersion = -1;
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly LSPDocumentSynchronizer _documentSynchronizer;
         private readonly RazorLogger _logger;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -24,7 +24,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 },
                 DocumentOnTypeFormattingProvider = new DocumentOnTypeFormattingOptions()
                 {
-                    FirstTriggerCharacter = ">"
+                    FirstTriggerCharacter = ">",
+                    MoreTriggerCharacter = new[] { "=" }
                 },
             }
         };

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -22,6 +22,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     ResolveProvider = true,
                     TriggerCharacters = new[] { ".", "@", "<", "&", "\\", "/", "'", "\"", "=", ":" }
                 },
+                DocumentOnTypeFormattingProvider = new DocumentOnTypeFormattingOptions()
+                {
+                    FirstTriggerCharacter = ">"
+                },
             }
         };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
@@ -11,6 +11,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     internal abstract class LSPDocumentMappingProvider
     {
-        public abstract Task<MappingResult> RazorMapToDocumentRangeAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range projectedRange, CancellationToken cancellationToken);
+        public abstract Task<MappingResult> MapToDocumentRangeAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range projectedRange, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    internal abstract class LSPDocumentMappingProvider
+    {
+        public abstract Task<MappingResult> RazorMapToDocumentRangeAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range projectedRange, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/MappingResult.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/MappingResult.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    internal class MappingResult
+    {
+        public Range Range { get; set; }
+
+        public long HostDocumentVersion { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    [Shared]
+    [ExportLspMethod(Methods.TextDocumentOnTypeFormattingName)]
+    internal class OnTypeFormattingHandler : IRequestHandler<DocumentOnTypeFormattingParams, TextEdit[]>
+    {
+        private static readonly TextEdit[] EmptyEdits = Array.Empty<TextEdit>();
+
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+        private readonly LSPDocumentManager _documentManager;
+        private readonly SVsServiceProvider _serviceProvider;
+        private readonly LSPRequestInvoker _requestInvoker;
+        private readonly LSPProjectionProvider _projectionProvider;
+        private readonly LSPDocumentMappingProvider _documentMappingProvider;
+
+        [ImportingConstructor]
+        public OnTypeFormattingHandler(
+            JoinableTaskContext joinableTaskContext,
+            LSPDocumentManager documentManager,
+            SVsServiceProvider serviceProvider,
+            LSPRequestInvoker requestInvoker,
+            LSPProjectionProvider projectionProvider,
+            LSPDocumentMappingProvider documentMappingProvider)
+        {
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            if (requestInvoker is null)
+            {
+                throw new ArgumentNullException(nameof(requestInvoker));
+            }
+
+            if (projectionProvider is null)
+            {
+                throw new ArgumentNullException(nameof(projectionProvider));
+            }
+
+            if (documentMappingProvider is null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingProvider));
+            }
+
+            _joinableTaskFactory = joinableTaskContext.Factory;
+            _documentManager = documentManager;
+            _serviceProvider = serviceProvider;
+            _requestInvoker = requestInvoker;
+            _projectionProvider = projectionProvider;
+            _documentMappingProvider = documentMappingProvider;
+        }
+
+        public async Task<TextEdit[]> HandleRequestAsync(DocumentOnTypeFormattingParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+        {
+            if (request.Character != ">")
+            {
+                // We currently only support auto-closing tags feature.
+                return EmptyEdits;
+            }
+
+            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
+            {
+                return EmptyEdits;
+            }
+
+            // Switch to a background thread.
+            await TaskScheduler.Default;
+
+            var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
+            if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.Html)
+            {
+                return EmptyEdits;
+            }
+
+            if (request.Options.OtherOptions == null)
+            {
+                request.Options.OtherOptions = new Dictionary<string, object>();
+            }
+            request.Options.OtherOptions[LanguageServerConstants.ExpectsCursorPlaceholderKey] = true;
+
+            var formattingParams = new DocumentOnTypeFormattingParams()
+            {
+                Character = request.Character,
+                Options = request.Options,
+                Position = projectionResult.Position,
+                TextDocument = new TextDocumentIdentifier() { Uri = projectionResult.Uri }
+            };
+
+            var serverKind = projectionResult.LanguageKind == RazorLanguageKind.CSharp ? LanguageServerKind.CSharp : LanguageServerKind.Html;
+            var edits = await _requestInvoker.RequestServerAsync<DocumentOnTypeFormattingParams, TextEdit[]>(
+                Methods.TextDocumentCompletionName,
+                serverKind,
+                formattingParams,
+                cancellationToken).ConfigureAwait(false);
+
+            if (edits == null)
+            {
+                return EmptyEdits;
+            }
+
+            var mappedEdits = new List<TextEdit>();
+            foreach (var edit in edits)
+            {
+                if (edit.Range == null || edit.NewText == null)
+                {
+                    // Sometimes the HTML language server returns invalid edits like these. We should just ignore those.
+                    continue;
+                }
+
+                var mappingResult = await _documentMappingProvider.RazorMapToDocumentRangeAsync(projectionResult.LanguageKind, request.TextDocument.Uri, edit.Range, cancellationToken).ConfigureAwait(false);
+
+                if (mappingResult == null || mappingResult.HostDocumentVersion != documentSnapshot.Version)
+                {
+                    // Couldn't remap the edits properly. Discard this request.
+                    return EmptyEdits;
+                }
+
+                var mappedEdit = new TextEdit()
+                {
+                    NewText = edit.NewText,
+                    Range = mappingResult.Range
+                };
+                mappedEdits.Add(mappedEdit);
+            }
+
+            if (mappedEdits.Count == 0)
+            {
+                return EmptyEdits;
+            }
+
+            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var newDocumentSnapshot) ||
+                newDocumentSnapshot.Version != documentSnapshot.Version)
+            {
+                // The document changed while were working on the background. Discard this request.
+                return EmptyEdits;
+            }
+
+            VsUtilities.ApplyTextEdits(_serviceProvider, documentSnapshot.Uri, documentSnapshot.Snapshot, mappedEdits);
+
+            // We would have already applied the edits and moved the cursor. Return empty.
+            return EmptyEdits;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
@@ -91,8 +92,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return EmptyEdits;
             }
 
-            // Switch to a background thread.
-            await TaskScheduler.Default;
+            await SwitchToBackgroundThread().ConfigureAwait(false);
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
             if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.Html)
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     continue;
                 }
 
-                var mappingResult = await _documentMappingProvider.RazorMapToDocumentRangeAsync(projectionResult.LanguageKind, request.TextDocument.Uri, edit.Range, cancellationToken).ConfigureAwait(false);
+                var mappingResult = await _documentMappingProvider.MapToDocumentRangeAsync(projectionResult.LanguageKind, request.TextDocument.Uri, edit.Range, cancellationToken).ConfigureAwait(false);
 
                 if (mappingResult == null || mappingResult.HostDocumentVersion != documentSnapshot.Version)
                 {
@@ -169,6 +169,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // We would have already applied the edits and moved the cursor. Return empty.
             return EmptyEdits;
+        }
+
+        protected async virtual Task SwitchToBackgroundThread()
+        {
+            await TaskScheduler.Default;
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
@@ -22,19 +22,19 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         private readonly JoinableTaskFactory _joinableTaskFactory;
         private readonly LSPDocumentManager _documentManager;
-        private readonly SVsServiceProvider _serviceProvider;
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly LSPProjectionProvider _projectionProvider;
         private readonly LSPDocumentMappingProvider _documentMappingProvider;
+        private readonly LSPEditorService _editorService;
 
         [ImportingConstructor]
         public OnTypeFormattingHandler(
             JoinableTaskContext joinableTaskContext,
             LSPDocumentManager documentManager,
-            SVsServiceProvider serviceProvider,
             LSPRequestInvoker requestInvoker,
             LSPProjectionProvider projectionProvider,
-            LSPDocumentMappingProvider documentMappingProvider)
+            LSPDocumentMappingProvider documentMappingProvider,
+            LSPEditorService editorService)
         {
             if (joinableTaskContext is null)
             {
@@ -44,11 +44,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             if (documentManager is null)
             {
                 throw new ArgumentNullException(nameof(documentManager));
-            }
-
-            if (serviceProvider is null)
-            {
-                throw new ArgumentNullException(nameof(serviceProvider));
             }
 
             if (requestInvoker is null)
@@ -66,12 +61,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(documentMappingProvider));
             }
 
+            if (editorService is null)
+            {
+                throw new ArgumentNullException(nameof(editorService));
+            }
+
             _joinableTaskFactory = joinableTaskContext.Factory;
             _documentManager = documentManager;
-            _serviceProvider = serviceProvider;
             _requestInvoker = requestInvoker;
             _projectionProvider = projectionProvider;
             _documentMappingProvider = documentMappingProvider;
+            _editorService = editorService;
         }
 
         public async Task<TextEdit[]> HandleRequestAsync(DocumentOnTypeFormattingParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return EmptyEdits;
             }
 
-            VsUtilities.ApplyTextEdits(_serviceProvider, documentSnapshot.Uri, documentSnapshot.Snapshot, mappedEdits);
+            _editorService.ApplyTextEditsAsync(documentSnapshot.Uri, documentSnapshot.Snapshot, mappedEdits);
 
             // We would have already applied the edits and moved the cursor. Return empty.
             return EmptyEdits;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -76,16 +76,26 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(Methods.TextDocumentCompletionName, completionParams, _clientCapabilities, cancellationToken);
         }
 
-        [JsonRpcMethod(Methods.TextDocumentCompletionResolveName)]
-        public Task<CompletionItem> ResolveCompletionAsync(JToken input, CancellationToken cancellationToken)
+        [JsonRpcMethod(Methods.TextDocumentCompletionResolveName, UseSingleObjectParameterDeserialization = true)]
+        public Task<CompletionItem> ResolveCompletionAsync(CompletionItem request, CancellationToken cancellationToken)
         {
-            if (input is null)
+            if (request is null)
             {
-                throw new ArgumentNullException(nameof(input));
+                throw new ArgumentNullException(nameof(request));
             }
 
-            var request = input.ToObject<CompletionItem>();
             return ExecuteRequestAsync<CompletionItem, CompletionItem>(Methods.TextDocumentCompletionResolveName, request, _clientCapabilities, cancellationToken);
+        }
+
+        [JsonRpcMethod(Methods.TextDocumentOnTypeFormattingName, UseSingleObjectParameterDeserialization = true)]
+        public Task<TextEdit[]> FormatOnTypeAsync(DocumentOnTypeFormattingParams request, CancellationToken cancellationToken)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            return ExecuteRequestAsync<DocumentOnTypeFormattingParams, TextEdit[]>(Methods.TextDocumentOnTypeFormattingName, request, _clientCapabilities, cancellationToken);
         }
 
         // Internal for testing

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPEditorService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPEditorService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal abstract class LSPEditorService
+    {
+        public abstract Task ApplyTextEditsAsync(Uri uri, ITextSnapshot snapshot, IEnumerable<TextEdit> textEdits);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageClientMiddleLayer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageClientMiddleLayer.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public abstract class RazorLanguageClientMiddleLayer : ILanguageClientMiddleLayer
+    {
+        public abstract bool CanHandle(string methodName);
+
+        public abstract Task HandleNotificationAsync(string methodName, JToken methodParam, Func<JToken, Task> sendNotification);
+
+        public abstract Task<JToken> HandleRequestAsync(string methodName, JToken methodParam, Func<JToken, Task<JToken>> sendRequest);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -27,16 +27,23 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         // ILanguageClient infrastructure on the guest to ensure that two language servers don't provide results.
         public const string ClientName = "RazorLSPClientName";
         private readonly RazorLanguageServerCustomMessageTarget _customMessageTarget;
+        private readonly ILanguageClientMiddleLayer _middleLayer;
 
         [ImportingConstructor]
-        public RazorLanguageServerClient(RazorLanguageServerCustomMessageTarget customTarget)
+        public RazorLanguageServerClient(RazorLanguageServerCustomMessageTarget customTarget, RazorLanguageClientMiddleLayer middleLayer)
         {
             if (customTarget is null)
             {
                 throw new ArgumentNullException(nameof(customTarget));
             }
 
+            if (middleLayer is null)
+            {
+                throw new ArgumentNullException(nameof(middleLayer));
+            }
+
             _customMessageTarget = customTarget;
+            _middleLayer = middleLayer;
         }
 
         public string Name => "Razor Language Server Client";
@@ -47,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public IEnumerable<string> FilesToWatch => null;
 
-        public object MiddleLayer => null;
+        public object MiddleLayer => _middleLayer;
 
         public object CustomMessageTarget => _customMessageTarget;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VsUtilities.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VsUtilities.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal static class VsUtilities
+    {
+        public static void ApplyTextEdits(
+            IServiceProvider serviceProvider,
+            Uri uri,
+            ITextSnapshot snapshot,
+            IEnumerable<TextEdit> textEdits)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            ApplyTextEdits(textEdits, snapshot, snapshot.TextBuffer);
+
+            var cursorPosition = ExtractCursorPlaceholder(snapshot.TextBuffer.CurrentSnapshot);
+            if (cursorPosition != null)
+            {
+                var fullPath = GetLocalFilePath(uri);
+
+                VsShellUtilities.OpenDocument(serviceProvider, fullPath, VSConstants.LOGVIEWID.TextView_guid, out _, out _, out var windowFrame);
+
+                if (windowFrame != null)
+                {
+                    var textView = GetActiveVsTextView(windowFrame);
+                    MoveCaretToPosition(textView, cursorPosition);
+                }
+            }
+        }
+
+        // Internal for testing
+        internal static Position ExtractCursorPlaceholder(ITextSnapshot snapshot)
+        {
+            Position cursorPosition = null;
+            var text = snapshot.GetText();
+            if (text.Contains(LanguageServerConstants.CursorPlaceholderString))
+            {
+                var cursorPositionIndex = text.IndexOf(LanguageServerConstants.CursorPlaceholderString, StringComparison.Ordinal);
+                var cursorPositionLine = snapshot.GetLineFromPosition(cursorPositionIndex);
+                var cursorPositionLineText = cursorPositionLine.GetText();
+                var characterPosition = cursorPositionLineText.IndexOf(LanguageServerConstants.CursorPlaceholderString, StringComparison.Ordinal);
+
+                cursorPosition = new Position(cursorPositionLine.LineNumber, characterPosition);
+
+                // Now that we have obtained the cursor position, let's nuke the placeholder.
+                var newEdit = new TextEdit();
+                newEdit.Range = new Range()
+                {
+                    Start = cursorPosition,
+                    End = new Position(cursorPosition.Line, cursorPosition.Character + LanguageServerConstants.CursorPlaceholderString.Length)
+                };
+                newEdit.NewText = string.Empty;
+
+                ApplyTextEdits(new[] { newEdit }, snapshot, snapshot.TextBuffer);
+            }
+
+            return cursorPosition;
+        }
+
+        private static void ApplyTextEdits(IEnumerable<TextEdit> textEdits, ITextSnapshot snapshot, ITextBuffer textBuffer)
+        {
+            var vsTextEdit = textBuffer.CreateEdit();
+            foreach (var textEdit in textEdits)
+            {
+                if (textEdit.Range.Start == textEdit.Range.End)
+                {
+                    var position = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
+                    if (position > -1)
+                    {
+                        var span = GetTranslatedSpan(position, 0, snapshot, vsTextEdit.Snapshot);
+                        vsTextEdit.Insert(span.Start, textEdit.NewText);
+                    }
+                }
+                else if (string.IsNullOrEmpty(textEdit.NewText))
+                {
+                    var startPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
+                    var endPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.End);
+                    var difference = endPosition - startPosition;
+                    if (startPosition > -1 && endPosition > -1 && difference > 0)
+                    {
+                        var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
+                        vsTextEdit.Delete(span);
+                    }
+                }
+                else
+                {
+                    var startPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.Start);
+                    var endPosition = GetSnapshotPositionFromProtocolPosition(snapshot, textEdit.Range.End);
+                    var difference = endPosition - startPosition;
+
+                    if (startPosition > -1 && endPosition > -1 && difference > 0)
+                    {
+                        var span = GetTranslatedSpan(startPosition, difference, snapshot, vsTextEdit.Snapshot);
+                        vsTextEdit.Replace(span, textEdit.NewText);
+                    }
+                }
+            }
+
+            vsTextEdit.Apply();
+        }
+
+        private static void MoveCaretToPosition(IVsTextView textView, Position position, bool sendFocus = true)
+        {
+            textView.SetCaretPos(position.Line, position.Character);
+            textView.EnsureSpanVisible(new TextSpan() { iStartIndex = position.Character, iStartLine = position.Line, iEndIndex = position.Character, iEndLine = position.Line });
+            textView.CenterLines(position.Line, 1);
+            if (sendFocus)
+            {
+                textView.SendExplicitFocus();
+            }
+        }
+
+        private static SnapshotPoint GetSnapshotPositionFromProtocolPosition(ITextSnapshot textSnapshot, Position position)
+        {
+            var line = textSnapshot.GetLineFromLineNumber(position.Line);
+            var snapshotPosition = line.Start + position.Character;
+
+            return new SnapshotPoint(textSnapshot, snapshotPosition);
+        }
+
+        private static Span GetTranslatedSpan(int startPosition, int length, ITextSnapshot oldSnapshot, ITextSnapshot newSnapshot)
+        {
+            var span = new Span(startPosition, length);
+
+            if (oldSnapshot.Version != newSnapshot.Version)
+            {
+                var snapshotSpan = new SnapshotSpan(oldSnapshot, span);
+                var translatedSnapshotSpan = snapshotSpan.TranslateTo(newSnapshot, SpanTrackingMode.EdgeExclusive);
+                span = translatedSnapshotSpan.Span;
+            }
+
+            return span;
+        }
+
+        private static string GetLocalFilePath(Uri documentUri)
+        {
+            Requires.Argument(documentUri.IsFile, nameof(documentUri), "There were no clients that can open the document.");
+
+            // Note: this would remove the '/' from some Uri returned on some LSP providers
+            var absolutePath = documentUri.LocalPath.TrimStart('/');
+            var fullPath = Path.GetFullPath(absolutePath);
+
+            return fullPath;
+        }
+
+        private static IVsTextView GetActiveVsTextView(IVsWindowFrame windowFrame)
+        {
+            Requires.NotNull(windowFrame, nameof(windowFrame));
+
+            // We want to query for IVsCodeWindow here in order to get the correct text view in diff mode.
+            // Using windowFrame.GetProperty() method gets us the difference viewer that's always tied to the right view, which won't work for inline diff.
+            IntPtr ppCodeWindow;
+            ErrorHandler.ThrowOnFailure(windowFrame.QueryViewInterface(typeof(IVsCodeWindow).GUID, out ppCodeWindow));
+
+            var vsCodeWindow = Marshal.GetObjectForIUnknown(ppCodeWindow) as IVsCodeWindow;
+            Marshal.Release(ppCodeWindow);
+
+            if (vsCodeWindow != null)
+            {
+                // We want to call GetLastActiveView() to make sure we get the right text view to support inline diff.
+                // Otherwise we might be stuck with the right view only for side by side diff.
+                ErrorHandler.ThrowOnFailure(vsCodeWindow.GetLastActiveView(out IVsTextView textView));
+                return textView;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -17,8 +17,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public async Task GetLatestOptionsAsync_ReturnsExpectedOptions()
         {
             // Arrange
-            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false);
-            var jsonString = @"
+            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false, autoClosingTags: false);
+            var razorJsonString = @"
 {
   ""trace"": ""Messages"",
   ""format"": {
@@ -26,7 +26,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
   }
 }
 ".Trim();
-            var result = new object[] { jsonString };
+            var htmlJsonString = @"
+{
+  ""autoClosingTags"": ""false""
+}
+".Trim();
+            var result = new object[] { razorJsonString, htmlJsonString };
             var languageServer = GetLanguageServer(result);
             var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
@@ -494,6 +495,53 @@ expected: @"
 }
 ",
 tabSize: 12);
+        }
+
+        [Fact]
+        public async Task OnTypeCloseAngle_ClosesTextTag()
+        {
+            await RunFormatOnTypeTestAsync(
+input: @"
+@{
+    <text|
+}
+",
+expected: $@"
+@{{
+    <text>{LanguageServerConstants.CursorPlaceholderString}</text>
+}}
+",
+character: ">");
+        }
+
+        [Fact]
+        public async Task OnTypeCloseAngle_ClosesTextTag_DoesNotReturnPlaceholder()
+        {
+            await RunFormatOnTypeTestAsync(
+input: @"
+@{
+    <text|
+}
+",
+expected: @"
+@{
+    <text></text>
+}
+",
+character: ">", expectCursorPlaceholder: false);
+        }
+
+        [Fact]
+        public async Task OnTypeCloseAngle_OutsideRazorBlock_DoesNotCloseTextTag()
+        {
+            await RunFormatOnTypeTestAsync(
+input: @"
+    <text|
+",
+expected: $@"
+    <text>
+",
+character: ">");
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         private static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting)
         {
             var monitor = new Mock<IOptionsMonitor<RazorLSPOptions>>();
-            monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, enableFormatting));
+            monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, enableFormatting, true));
             return monitor.Object;
         }
 
@@ -138,6 +138,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 Called = true;
                 return Task.FromResult(Array.Empty<TextEdit>());
+            }
+
+            public override Task<TextEdit[]> FormatOnTypeAsync(Uri uri, RazorCodeDocument codeDocument, Position position, string character, FormattingOptions options)
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorOnTypeFormattingEndpointTest.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Options;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    public class RazorOnTypeFormattingEndpointTest : LanguageServerTestBase
+    {
+        public RazorOnTypeFormattingEndpointTest()
+        {
+            EmptyDocumentResolver = Mock.Of<DocumentResolver>();
+        }
+
+        private DocumentResolver EmptyDocumentResolver { get; }
+
+        [Fact]
+        public async Task Handle_AutoCloseTagsEnabled_InvokesFormattingService()
+        {
+            // Arrange
+            var codeDocument = TestRazorCodeDocument.CreateEmpty();
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
+            var formattingService = new TestRazorFormattingService();
+            var optionsMonitor = GetOptionsMonitor(autoClosingTags: true);
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var @params = new DocumentOnTypeFormattingParams()
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Character = ">"
+            };
+
+            // Act
+            var result = await endpoint.Handle(@params, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(formattingService.Called);
+        }
+
+        [Fact]
+        public async Task Handle_DocumentNotFound_ReturnsNull()
+        {
+            // Arrange
+            var formattingService = new TestRazorFormattingService();
+            var optionsMonitor = GetOptionsMonitor(autoClosingTags: true);
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var uri = new Uri("file://path/test.razor");
+            var @params = new DocumentOnTypeFormattingParams()
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Character = ">"
+            };
+
+            // Act
+            var result = await endpoint.Handle(@params, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Handle_UnsupportedCodeDocument_ReturnsNull()
+        {
+            // Arrange
+            var codeDocument = TestRazorCodeDocument.CreateEmpty();
+            codeDocument.SetUnsupported();
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.AbsolutePath, codeDocument);
+            var formattingService = new TestRazorFormattingService();
+            var optionsMonitor = GetOptionsMonitor(autoClosingTags: true);
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var @params = new DocumentOnTypeFormattingParams()
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Character = ">"
+            };
+
+            // Act
+            var result = await endpoint.Handle(@params, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Handle_FormattingDisabled_ReturnsNull()
+        {
+            // Arrange
+            var formattingService = new TestRazorFormattingService();
+            var optionsMonitor = GetOptionsMonitor(autoClosingTags: false);
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var @params = new DocumentOnTypeFormattingParams();
+
+            // Act
+            var result = await endpoint.Handle(@params, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        private static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool autoClosingTags)
+        {
+            var monitor = new Mock<IOptionsMonitor<RazorLSPOptions>>();
+            monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, true, autoClosingTags));
+            return monitor.Object;
+        }
+
+        private static DocumentResolver CreateDocumentResolver(string documentPath, RazorCodeDocument codeDocument)
+        {
+            var sourceTextChars = new char[codeDocument.Source.Length];
+            codeDocument.Source.CopyTo(0, sourceTextChars, 0, codeDocument.Source.Length);
+            var sourceText = SourceText.From(new string(sourceTextChars));
+            var documentSnapshot = Mock.Of<DocumentSnapshot>(document =>
+                document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
+                document.GetTextAsync() == Task.FromResult(sourceText));
+            var documentResolver = new Mock<DocumentResolver>();
+            documentResolver.Setup(resolver => resolver.TryResolveDocument(documentPath, out documentSnapshot))
+                .Returns(true);
+            return documentResolver.Object;
+        }
+
+        private class TestRazorFormattingService : RazorFormattingService
+        {
+            public bool Called { get; private set; }
+
+            public override Task<TextEdit[]> FormatAsync(Uri uri, RazorCodeDocument codeDocument, OmniSharp.Extensions.LanguageServer.Protocol.Models.Range range, FormattingOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<TextEdit[]> FormatOnTypeAsync(Uri uri, RazorCodeDocument codeDocument, Position position, string character, FormattingOptions options)
+            {
+                Called = true;
+                return Task.FromResult(Array.Empty<TextEdit>());
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorOnTypeFormattingEndpointTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var formattingService = new TestRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(autoClosingTags: true);
-            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor);
             var @params = new DocumentOnTypeFormattingParams()
             {
                 TextDocument = new TextDocumentIdentifier(uri),
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Arrange
             var formattingService = new TestRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(autoClosingTags: true);
-            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor);
             var uri = new Uri("file://path/test.razor");
             var @params = new DocumentOnTypeFormattingParams()
             {
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var documentResolver = CreateDocumentResolver(uri.AbsolutePath, codeDocument);
             var formattingService = new TestRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(autoClosingTags: true);
-            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor);
             var @params = new DocumentOnTypeFormattingParams()
             {
                 TextDocument = new TextDocumentIdentifier(uri),
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Arrange
             var formattingService = new TestRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(autoClosingTags: false);
-            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor);
             var @params = new DocumentOnTypeFormattingParams();
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public async Task UpdateAsync_Invokes_OnChangeRegistration()
         {
             // Arrange
-            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false);
+            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false, autoClosingTags: true);
             var configService = Mock.Of<RazorConfigurationService>(f => f.GetLatestOptionsAsync() == Task.FromResult(expectedOptions));
             var optionsMonitor = new RazorLSPOptionsMonitor(configService, Cache);
             var called = false;
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public async Task UpdateAsync_DoesNotInvoke_OnChangeRegistration_AfterDispose()
         {
             // Arrange
-            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false);
+            var expectedOptions = new RazorLSPOptions(Trace.Messages, enableFormatting: false, autoClosingTags: true);
             var configService = Mock.Of<RazorConfigurationService>(f => f.GetLatestOptionsAsync() == Task.FromResult(expectedOptions));
             var optionsMonitor = new RazorLSPOptionsMonitor(configService, Cache);
             var called = false;

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
@@ -62,9 +62,9 @@ namespace Microsoft.VisualStudio.Text
 
         public IContentType ContentType => throw new NotImplementedException();
 
-        public int LineCount => throw new NotImplementedException();
+        public int LineCount => _lines.Count;
 
-        public IEnumerable<ITextSnapshotLine> Lines => throw new NotImplementedException();
+        public IEnumerable<ITextSnapshotLine> Lines => _lines;
 
         public ITextImage TextImage => new StringTextImage(Content);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorServiceTest.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultLSPEditorServiceTest
+    {
+        [Fact]
+        public void ExtractsCursorPlaceholder_AppliesEditsCorrectly()
+        {
+            // Arrange
+            var expectedCursorPosition = new Position(2, 10);
+            var snapshot = new TestTextSnapshot($@"
+@{{
+    <text>{LanguageServerConstants.CursorPlaceholderString}</text>
+}}");
+            var edits = new[]
+            {
+                new TextEdit()
+                {
+                    NewText = $"{LanguageServerConstants.CursorPlaceholderString}</text>",
+                    Range = new Range() { Start = expectedCursorPosition, End = expectedCursorPosition },
+                }
+            };
+
+            // Act
+            var cursorPosition = DefaultLSPEditorService.ExtractCursorPlaceholder(snapshot, edits);
+
+            // Assert
+            Assert.Equal(expectedCursorPosition, cursorPosition);
+        }
+
+        [Fact]
+        public void ExtractsCursorPlaceholder_MultipleEdits_AppliesEditsCorrectly()
+        {
+            // Arrange
+            var expectedCursorPosition = new Position(2, 10);
+            var snapshot = new TestTextSnapshot($@"
+@{{
+    <text>{LanguageServerConstants.CursorPlaceholderString}</text>
+}}");
+            var edits = new[]
+            {
+                new TextEdit()
+                {
+                    NewText = $"unrelated Edit",
+                    Range = new Range() { Start = new Position(0, 0), End = new Position(0, 1) },
+                },
+                new TextEdit()
+                {
+                    NewText = $"{LanguageServerConstants.CursorPlaceholderString}</text>",
+                    Range = new Range() { Start = expectedCursorPosition, End = expectedCursorPosition },
+                }
+            };
+
+            // Act
+            var cursorPosition = DefaultLSPEditorService.ExtractCursorPlaceholder(snapshot, edits);
+
+            // Assert
+            Assert.Equal(expectedCursorPosition, cursorPosition);
+        }
+
+        private class TestTextSnapshot : ITextSnapshot
+        {
+            private readonly StringTextSnapshot _inner;
+
+            public TestTextSnapshot(string text)
+            {
+                _inner = new StringTextSnapshot(text);
+                var buffer = new Mock<ITextBuffer>();
+                buffer.Setup(b => b.CreateEdit()).Returns(Mock.Of<ITextEdit>(e => e.Snapshot == _inner));
+                _inner.TextBuffer = buffer.Object;
+            }
+
+            public char this[int position] => _inner[position];
+
+            public ITextBuffer TextBuffer => _inner.TextBuffer;
+
+            public IContentType ContentType => throw new NotImplementedException();
+
+            public ITextVersion Version => _inner.Version;
+
+            public int Length => _inner.Length;
+
+            public int LineCount => _inner.GetLineFromPosition(_inner.Length - 1).LineNumber;
+
+            public IEnumerable<ITextSnapshotLine> Lines => throw new NotImplementedException();
+
+            public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ITrackingPoint CreateTrackingPoint(int position, PointTrackingMode trackingMode)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ITrackingPoint CreateTrackingPoint(int position, PointTrackingMode trackingMode, TrackingFidelityMode trackingFidelity)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ITrackingSpan CreateTrackingSpan(Span span, SpanTrackingMode trackingMode)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ITrackingSpan CreateTrackingSpan(Span span, SpanTrackingMode trackingMode, TrackingFidelityMode trackingFidelity)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ITrackingSpan CreateTrackingSpan(int start, int length, SpanTrackingMode trackingMode)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ITrackingSpan CreateTrackingSpan(int start, int length, SpanTrackingMode trackingMode, TrackingFidelityMode trackingFidelity)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ITextSnapshotLine GetLineFromLineNumber(int lineNumber)
+            {
+                return _inner.GetLineFromLineNumber(lineNumber);
+            }
+
+            public ITextSnapshotLine GetLineFromPosition(int position)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int GetLineNumberFromPosition(int position)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetText(Span span)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetText(int startIndex, int length)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetText()
+            {
+                throw new NotImplementedException();
+            }
+
+            public char[] ToCharArray(int startIndex, int length)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Write(TextWriter writer, Span span)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Write(TextWriter writer)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorServiceTest.cs
@@ -1,13 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Utilities;
 using Moq;
 using Xunit;
 using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
@@ -21,7 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var expectedCursorPosition = new Position(2, 10);
-            var snapshot = new TestTextSnapshot($@"
+            var snapshot = GetTextSnapshot($@"
 @{{
     <text>{LanguageServerConstants.CursorPlaceholderString}</text>
 }}");
@@ -46,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var expectedCursorPosition = new Position(2, 10);
-            var snapshot = new TestTextSnapshot($@"
+            var snapshot = GetTextSnapshot($@"
 @{{
     <text>{LanguageServerConstants.CursorPlaceholderString}</text>
 }}");
@@ -71,111 +67,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             Assert.Equal(expectedCursorPosition, cursorPosition);
         }
 
-        private class TestTextSnapshot : ITextSnapshot
+        private ITextSnapshot GetTextSnapshot(string text)
         {
-            private readonly StringTextSnapshot _inner;
-
-            public TestTextSnapshot(string text)
-            {
-                _inner = new StringTextSnapshot(text);
-                var buffer = new Mock<ITextBuffer>();
-                buffer.Setup(b => b.CreateEdit()).Returns(Mock.Of<ITextEdit>(e => e.Snapshot == _inner));
-                _inner.TextBuffer = buffer.Object;
-            }
-
-            public char this[int position] => _inner[position];
-
-            public ITextBuffer TextBuffer => _inner.TextBuffer;
-
-            public IContentType ContentType => throw new NotImplementedException();
-
-            public ITextVersion Version => _inner.Version;
-
-            public int Length => _inner.Length;
-
-            public int LineCount => _inner.GetLineFromPosition(_inner.Length - 1).LineNumber;
-
-            public IEnumerable<ITextSnapshotLine> Lines => throw new NotImplementedException();
-
-            public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITrackingPoint CreateTrackingPoint(int position, PointTrackingMode trackingMode)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITrackingPoint CreateTrackingPoint(int position, PointTrackingMode trackingMode, TrackingFidelityMode trackingFidelity)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITrackingSpan CreateTrackingSpan(Span span, SpanTrackingMode trackingMode)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITrackingSpan CreateTrackingSpan(Span span, SpanTrackingMode trackingMode, TrackingFidelityMode trackingFidelity)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITrackingSpan CreateTrackingSpan(int start, int length, SpanTrackingMode trackingMode)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITrackingSpan CreateTrackingSpan(int start, int length, SpanTrackingMode trackingMode, TrackingFidelityMode trackingFidelity)
-            {
-                throw new NotImplementedException();
-            }
-
-            public ITextSnapshotLine GetLineFromLineNumber(int lineNumber)
-            {
-                return _inner.GetLineFromLineNumber(lineNumber);
-            }
-
-            public ITextSnapshotLine GetLineFromPosition(int position)
-            {
-                throw new NotImplementedException();
-            }
-
-            public int GetLineNumberFromPosition(int position)
-            {
-                throw new NotImplementedException();
-            }
-
-            public string GetText(Span span)
-            {
-                throw new NotImplementedException();
-            }
-
-            public string GetText(int startIndex, int length)
-            {
-                throw new NotImplementedException();
-            }
-
-            public string GetText()
-            {
-                throw new NotImplementedException();
-            }
-
-            public char[] ToCharArray(int startIndex, int length)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Write(TextWriter writer, Span span)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Write(TextWriter writer)
-            {
-                throw new NotImplementedException();
-            }
+            var snapshot = new StringTextSnapshot(text);
+            var buffer = new Mock<ITextBuffer>();
+            buffer.Setup(b => b.CreateEdit()).Returns(Mock.Of<ITextEdit>(e => e.Snapshot == snapshot));
+            snapshot.TextBuffer = buffer.Object;
+            return snapshot;
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageClientMiddleLayerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageClientMiddleLayerTest.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class DefaultRazorLanguageClientMiddleLayerTest
+    {
+        public DefaultRazorLanguageClientMiddleLayerTest()
+        {
+            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
+            JoinableTaskContext = joinableTaskContext.Context;
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        private Uri Uri { get; }
+
+
+        [Fact]
+        public async Task OnTypeFormattingRequest_InterceptsRequestAndResponseCorrectly()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var appliedTextEdits = false;
+            var editorService = new Mock<LSPEditorService>(MockBehavior.Strict);
+            editorService
+                .Setup(e => e.ApplyTextEditsAsync(Uri, It.IsAny<ITextSnapshot>(), It.IsAny<IEnumerable<TextEdit>>()))
+                .Callback<Uri, ITextSnapshot, IEnumerable<TextEdit>>((uri, snapshot, edits) =>
+                {
+                    var edit = Assert.Single(edits);
+                    Assert.Equal("SampleEdit", edit.NewText);
+                    appliedTextEdits = true;
+                })
+                .Returns(Task.CompletedTask);
+
+            var inputParams = new DocumentOnTypeFormattingParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Options = new FormattingOptions(),
+            };
+            var actualTextEdits = JToken.FromObject(new[] { new TextEdit() { NewText = "SampleEdit" } });
+            Func<JToken, Task<JToken>> actualRequest = token =>
+            {
+                var request = token.ToObject<DocumentOnTypeFormattingParams>();
+                Assert.True(request.Options.OtherOptions.ContainsKey(LanguageServerConstants.ExpectsCursorPlaceholderKey));
+
+                return Task.FromResult(actualTextEdits);
+            };
+
+            var middleLayer = new DefaultRazorLanguageClientMiddleLayer(JoinableTaskContext, documentManager, editorService.Object);
+
+            // Act
+            await middleLayer.HandleRequestAsync(Methods.TextDocumentOnTypeFormattingName, JToken.FromObject(inputParams), actualRequest).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(appliedTextEdits);
+        }
+
+        private class TestDocumentManager : LSPDocumentManager
+        {
+            private readonly Dictionary<Uri, LSPDocumentSnapshot> _documents = new Dictionary<Uri, LSPDocumentSnapshot>();
+
+            public override event EventHandler<LSPDocumentChangeEventArgs> Changed;
+
+            public override bool TryGetDocument(Uri uri, out LSPDocumentSnapshot lspDocumentSnapshot)
+            {
+                return _documents.TryGetValue(uri, out lspDocumentSnapshot);
+            }
+
+            public void AddDocument(Uri uri, LSPDocumentSnapshot documentSnapshot)
+            {
+                _documents.Add(uri, documentSnapshot);
+
+                Changed?.Invoke(this, null);
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             };
 
             // Act
-            var result = await mappingProvider.RazorMapToDocumentRangeAsync(RazorLanguageKind.CSharp, uri, projectedRange, CancellationToken.None).ConfigureAwait(false);
+            var result = await mappingProvider.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, uri, projectedRange, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(result);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Moq;
+using Xunit;
+using OmniSharpPosition = OmniSharp.Extensions.LanguageServer.Protocol.Models.Position;
+using OmniSharpRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class DefaultLSPDocumentMappingProviderTest
+    {
+        [Fact]
+        public async Task RazorMapToDocumentRangeAsync_InvokesLanguageServer()
+        {
+            // Arrange
+            var uri = new Uri("file:///some/folder/to/file.razor");
+
+            var response = new RazorMapToDocumentRangeResponse()
+            {
+                Range = new OmniSharpRange(new OmniSharpPosition(1, 1), new OmniSharpPosition(3, 3)),
+                HostDocumentVersion = 1
+            };
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<RazorMapToDocumentRangeParams, RazorMapToDocumentRangeResponse>(LanguageServerConstants.RazorMapToDocumentRangeEndpoint, LanguageServerKind.Razor, It.IsAny<RazorMapToDocumentRangeParams>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(response));
+
+            var mappingProvider = new DefaultLSPDocumentMappingProvider(requestInvoker.Object);
+            var projectedRange = new Range()
+            {
+                Start = new Position(10, 10),
+                End = new Position(15, 15)
+            };
+
+            // Act
+            var result = await mappingProvider.RazorMapToDocumentRangeAsync(RazorLanguageKind.CSharp, uri, projectedRange, CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(1, result.HostDocumentVersion);
+            Assert.Equal(new Position(1, 1), result.Range.Start);
+            Assert.Equal(new Position(3, 3), result.Range.End);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
@@ -1,0 +1,288 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Differencing;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class OnTypeFormattingHandlerTest
+    {
+        public OnTypeFormattingHandlerTest()
+        {
+            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
+            JoinableTaskContext = joinableTaskContext.Context;
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public async Task HandleRequestAsync_UnknownTriggerCharacter_DoesNotInvokeServer()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(s => s.Uri == Uri));
+
+            var invokedServer = false;
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<DocumentOnTypeFormattingParams, TextEdit[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<DocumentOnTypeFormattingParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, DocumentOnTypeFormattingParams, CancellationToken>((method, serverKind, formattingParams, ct) =>
+                {
+                    invokedServer = true;
+                })
+                .Returns(Task.FromResult<TextEdit[]>(new[] { new TextEdit() }));
+
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var editorService = Mock.Of<LSPEditorService>();
+
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
+            var request = new DocumentOnTypeFormattingParams()
+            {
+                Character = "?",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Options = new FormattingOptions()
+                {
+                    OtherOptions = new Dictionary<string, object>()
+                },
+                Position = new Position(0, 0)
+            };
+
+            // Act
+            var edits = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.False(invokedServer);
+            Assert.Empty(edits);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_DocumentNotFound_DoesNotInvokeServer()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+
+            var invokedServer = false;
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<DocumentOnTypeFormattingParams, TextEdit[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<DocumentOnTypeFormattingParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, DocumentOnTypeFormattingParams, CancellationToken>((method, serverKind, formattingParams, ct) =>
+                {
+                    invokedServer = true;
+                })
+                .Returns(Task.FromResult<TextEdit[]>(new[] { new TextEdit() }));
+
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var editorService = Mock.Of<LSPEditorService>();
+
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
+            var request = new DocumentOnTypeFormattingParams()
+            {
+                Character = ">",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Options = new FormattingOptions()
+                {
+                    OtherOptions = new Dictionary<string, object>()
+                },
+                Position = new Position(0, 0)
+            };
+
+            // Act
+            var edits = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.False(invokedServer);
+            Assert.Empty(edits);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_NonHtmlProjection_DoesNotInvokeServer()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(s => s.Uri == Uri));
+
+            var invokedServer = false;
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<DocumentOnTypeFormattingParams, TextEdit[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<DocumentOnTypeFormattingParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, DocumentOnTypeFormattingParams, CancellationToken>((method, serverKind, formattingParams, ct) =>
+                {
+                    invokedServer = true;
+                })
+                .Returns(Task.FromResult<TextEdit[]>(new[] { new TextEdit() }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var editorService = Mock.Of<LSPEditorService>();
+
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
+            var request = new DocumentOnTypeFormattingParams()
+            {
+                Character = ">",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Options = new FormattingOptions()
+                {
+                    OtherOptions = new Dictionary<string, object>()
+                },
+                Position = new Position(0, 0)
+            };
+
+            // Act
+            var edits = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.False(invokedServer);
+            Assert.Empty(edits);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_InvokesServerWithCorrectKey()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(s => s.Uri == Uri));
+
+            var invokedServer = false;
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<DocumentOnTypeFormattingParams, TextEdit[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<DocumentOnTypeFormattingParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, DocumentOnTypeFormattingParams, CancellationToken>((method, serverKind, formattingParams, ct) =>
+                {
+                    Assert.True(formattingParams.Options.OtherOptions.ContainsKey(LanguageServerConstants.ExpectsCursorPlaceholderKey));
+                    invokedServer = true;
+                })
+                .Returns(Task.FromResult<TextEdit[]>(new[] { new TextEdit() }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.Html,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var editorService = Mock.Of<LSPEditorService>();
+
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
+            var request = new DocumentOnTypeFormattingParams()
+            {
+                Character = ">",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Options = new FormattingOptions()
+                {
+                    OtherOptions = new Dictionary<string, object>()
+                },
+                Position = new Position(0, 0)
+            };
+
+            // Act
+            var edits = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(invokedServer);
+            Assert.Empty(edits);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_InvokesServer_RemapsAndAppliesEdits()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(s => s.Uri == Uri && s.Snapshot == Mock.Of<ITextSnapshot>()));
+
+            var invokedServer = false;
+            var mappedTextEdits = false;
+            var appliedTextEdits = false;
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<DocumentOnTypeFormattingParams, TextEdit[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<DocumentOnTypeFormattingParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, DocumentOnTypeFormattingParams, CancellationToken>((method, serverKind, formattingParams, ct) =>
+                {
+                    Assert.True(formattingParams.Options.OtherOptions.ContainsKey(LanguageServerConstants.ExpectsCursorPlaceholderKey));
+                    invokedServer = true;
+                })
+                .Returns(Task.FromResult<TextEdit[]>(new[] { new TextEdit() { Range = new Range(), NewText = "sometext" } }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.Html,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider
+                .Setup(d => d.RazorMapToDocumentRangeAsync(RazorLanguageKind.Html, Uri, It.IsAny<Range>(), It.IsAny<CancellationToken>()))
+                .Callback(() => { mappedTextEdits = true; })
+                .Returns(Task.FromResult(new MappingResult()));
+
+            var editorService = new Mock<LSPEditorService>(MockBehavior.Strict);
+            editorService.Setup(e => e.ApplyTextEditsAsync(Uri, It.IsAny<ITextSnapshot>(), It.IsAny<IEnumerable<TextEdit>>())).Callback(() => { appliedTextEdits = true; })
+                .Returns(Task.CompletedTask);
+
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider.Object, editorService.Object);
+            var request = new DocumentOnTypeFormattingParams()
+            {
+                Character = "=",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Options = new FormattingOptions()
+                {
+                    OtherOptions = new Dictionary<string, object>()
+                },
+                Position = new Position(1, 4)
+            };
+
+            // Act
+            var edits = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(invokedServer);
+            Assert.True(mappedTextEdits);
+            Assert.True(appliedTextEdits);
+            Assert.Empty(edits);
+        }
+
+        private class TestDocumentManager : LSPDocumentManager
+        {
+            private readonly Dictionary<Uri, LSPDocumentSnapshot> _documents = new Dictionary<Uri, LSPDocumentSnapshot>();
+
+            public override event EventHandler<LSPDocumentChangeEventArgs> Changed;
+
+            public override bool TryGetDocument(Uri uri, out LSPDocumentSnapshot lspDocumentSnapshot)
+            {
+                return _documents.TryGetValue(uri, out lspDocumentSnapshot);
+            }
+
+            public void AddDocument(Uri uri, LSPDocumentSnapshot documentSnapshot)
+            {
+                _documents.Add(uri, documentSnapshot);
+
+                Changed?.Invoke(this, null);
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
@@ -3,14 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Microsoft.CodeAnalysis.Differencing;
-using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
@@ -236,7 +232,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
             documentMappingProvider
-                .Setup(d => d.RazorMapToDocumentRangeAsync(RazorLanguageKind.Html, Uri, It.IsAny<Range>(), It.IsAny<CancellationToken>()))
+                .Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.Html, Uri, It.IsAny<Range>(), It.IsAny<CancellationToken>()))
                 .Callback(() => { mappedTextEdits = true; })
                 .Returns(Task.FromResult(new MappingResult()));
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
+            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = "?",
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
+            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
+            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
+            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -240,7 +240,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             editorService.Setup(e => e.ApplyTextEditsAsync(Uri, It.IsAny<ITextSnapshot>(), It.IsAny<IEnumerable<TextEdit>>())).Callback(() => { appliedTextEdits = true; })
                 .Returns(Task.CompletedTask);
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider.Object, editorService.Object);
+            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider.Object, editorService.Object);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = "=",
@@ -278,6 +278,31 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 _documents.Add(uri, documentSnapshot);
 
                 Changed?.Invoke(this, null);
+            }
+        }
+
+        private class TestOnTypeFormattingHandler : OnTypeFormattingHandler
+        {
+            public TestOnTypeFormattingHandler(
+            JoinableTaskContext joinableTaskContext,
+            LSPDocumentManager documentManager,
+            LSPRequestInvoker requestInvoker,
+            LSPProjectionProvider projectionProvider,
+            LSPDocumentMappingProvider documentMappingProvider,
+            LSPEditorService editorService) : base(
+                joinableTaskContext,
+                documentManager,
+                requestInvoker,
+                projectionProvider,
+                documentMappingProvider,
+                editorService)
+            {
+            }
+
+            protected override Task SwitchToBackgroundThread()
+            {
+                // Let it stay on the foreground thread because our fake JoinableTaskContext cannot handle switching back to the foreground thread.
+                return Task.CompletedTask;
             }
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.Editor.Razor.Test\Microsoft.VisualStudio.Editor.Razor.Test.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/19808

![htmlautoclosetags](https://user-images.githubusercontent.com/1579269/77402806-74b2ec80-6d6c-11ea-83ae-a05cc1aeb1f4.gif)

- Added support for auto-closing <text> tags in the server
- Added a middle layer in the client to intercept ontypeFormatting requests to replace cursor placeholder and manually move the cursor
- Added a handler to call into Html language server on typing `>`
- Cleanup and tests

Note: I needed to make changes to VSLanguageClient bits to make this work. They were not invoking the middle layer for onTypeFormatting requests. 