### PR TITLE
Don't publish identical C#/HTML data.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -14,9 +14,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
     {
-        private static readonly SourceText EmptySourceText = SourceText.From(string.Empty);
-        private readonly Dictionary<string, SourceText> _publishedCSharpSourceText;
-        private readonly Dictionary<string, SourceText> _publishedHtmlSourceText;
+        private readonly Dictionary<string, PublishData> _publishedCSharpData;
+        private readonly Dictionary<string, PublishData> _publishedHtmlData;
         private readonly Lazy<ILanguageServer> _server;
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private ProjectSnapshotManagerBase _projectSnapshotManager;
@@ -37,8 +36,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _foregroundDispatcher = foregroundDispatcher;
             _server = server;
-            _publishedCSharpSourceText = new Dictionary<string, SourceText>(FilePathComparer.Instance);
-            _publishedHtmlSourceText = new Dictionary<string, SourceText>(FilePathComparer.Instance);
+            _publishedCSharpData = new Dictionary<string, PublishData>(FilePathComparer.Instance);
+            _publishedHtmlData = new Dictionary<string, PublishData>(FilePathComparer.Instance);
         }
 
         public override void Initialize(ProjectSnapshotManagerBase projectManager)
@@ -61,18 +60,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _foregroundDispatcher.AssertForegroundThread();
 
-            if (!_publishedCSharpSourceText.TryGetValue(filePath, out var previouslyPublishedText))
+            if (!_publishedCSharpData.TryGetValue(filePath, out var previouslyPublishedData))
             {
-                previouslyPublishedText = EmptySourceText;
+                previouslyPublishedData = PublishData.Default;
             }
 
             IReadOnlyList<TextChange> textChanges = Array.Empty<TextChange>();
-            if (!sourceText.ContentEquals(previouslyPublishedText))
+            if (!sourceText.ContentEquals(previouslyPublishedData.SourceText))
             {
-                textChanges = sourceText.GetTextChanges(previouslyPublishedText);
+                textChanges = sourceText.GetTextChanges(previouslyPublishedData.SourceText);
+            }
+            else if (hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
+            {
+                // Source texts match along with host documetn versions. We've already published something that looks like this. No-op.
+                return;
             }
 
-            _publishedCSharpSourceText[filePath] = sourceText;
+            _publishedCSharpData[filePath] = new PublishData(sourceText, hostDocumentVersion);
 
             var request = new UpdateBufferRequest()
             {
@@ -98,18 +102,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _foregroundDispatcher.AssertForegroundThread();
 
-            if (!_publishedHtmlSourceText.TryGetValue(filePath, out var previouslyPublishedText))
+            if (!_publishedHtmlData.TryGetValue(filePath, out var previouslyPublishedData))
             {
-                previouslyPublishedText = EmptySourceText;
+                previouslyPublishedData = PublishData.Default;
             }
 
             IReadOnlyList<TextChange> textChanges = Array.Empty<TextChange>();
-            if (!sourceText.ContentEquals(previouslyPublishedText))
+            if (!sourceText.ContentEquals(previouslyPublishedData.SourceText))
             {
-                textChanges = sourceText.GetTextChanges(previouslyPublishedText);
+                textChanges = sourceText.GetTextChanges(previouslyPublishedData.SourceText);
+            }
+            else if (hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
+            {
+                // Source texts match along with host documetn versions. We've already published something that looks like this. No-op.
+                return;
             }
 
-            _publishedHtmlSourceText[filePath] = sourceText;
+            _publishedHtmlData[filePath] = new PublishData(sourceText, hostDocumentVersion);
 
             var request = new UpdateBufferRequest()
             {
@@ -131,32 +140,47 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     if (!_projectSnapshotManager.IsDocumentOpen(args.DocumentFilePath))
                     {
                         // Document closed, evict published source text.
-                        if (_publishedCSharpSourceText.ContainsKey(args.DocumentFilePath))
+                        if (_publishedCSharpData.ContainsKey(args.DocumentFilePath))
                         {
-                            var removed = _publishedCSharpSourceText.Remove(args.DocumentFilePath);
-                            Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
+                            var removed = _publishedCSharpData.Remove(args.DocumentFilePath);
+                            Debug.Assert(removed, "Published data should be protected by the foreground thread and should never fail to remove.");
                         }
-                        if (_publishedHtmlSourceText.ContainsKey(args.DocumentFilePath))
+                        if (_publishedHtmlData.ContainsKey(args.DocumentFilePath))
                         {
-                            var removed = _publishedHtmlSourceText.Remove(args.DocumentFilePath);
-                            Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
+                            var removed = _publishedHtmlData.Remove(args.DocumentFilePath);
+                            Debug.Assert(removed, "Published data should be protected by the foreground thread and should never fail to remove.");
                         }
                     }
                     break;
                 case ProjectChangeKind.DocumentRemoved:
                     // Document removed, evict published source text.
-                    if (_publishedCSharpSourceText.ContainsKey(args.DocumentFilePath))
+                    if (_publishedCSharpData.ContainsKey(args.DocumentFilePath))
                     {
-                        var removed = _publishedCSharpSourceText.Remove(args.DocumentFilePath);
-                        Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
+                        var removed = _publishedCSharpData.Remove(args.DocumentFilePath);
+                        Debug.Assert(removed, "Published data should be protected by the foreground thread and should never fail to remove.");
                     }
-                    if (_publishedHtmlSourceText.ContainsKey(args.DocumentFilePath))
+                    if (_publishedHtmlData.ContainsKey(args.DocumentFilePath))
                     {
-                        var removed = _publishedHtmlSourceText.Remove(args.DocumentFilePath);
-                        Debug.Assert(removed, "Published source text should be protected by the foreground thread and should never fail to remove.");
+                        var removed = _publishedHtmlData.Remove(args.DocumentFilePath);
+                        Debug.Assert(removed, "Published data should be protected by the foreground thread and should never fail to remove.");
                     }
                     break;
             }
+        }
+
+        private sealed class PublishData
+        {
+            public static readonly PublishData Default = new PublishData(SourceText.From(string.Empty), -1);
+
+            public PublishData(SourceText sourceText, long hostDocumentVersion)
+            {
+                SourceText = sourceText;
+                HostDocumentVersion = hostDocumentVersion;
+            }
+
+            public SourceText SourceText { get; }
+
+            public long HostDocumentVersion { get; }
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else if (hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
             {
-                // Source texts match along with host documetn versions. We've already published something that looks like this. No-op.
+                // Source texts match along with host document versions. We've already published something that looks like this. No-op.
                 return;
             }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
@@ -211,7 +211,29 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
-        public void ProjectSnapshotManager_DocumentChanged_OpenDocument_PublishesEmptyTextChanges()
+        public void ProjectSnapshotManager_DocumentChanged_OpenDocument_PublishesEmptyTextChanges_CSharp()
+        {
+            // Arrange
+            var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            generatedDocumentPublisher.Initialize(ProjectManager);
+            var sourceTextContent = "// The content";
+            var initialSourceText = SourceText.From(sourceTextContent);
+            generatedDocumentPublisher.PublishCSharp(HostDocument.FilePath, initialSourceText, 123);
+
+            // Act
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, initialSourceText);
+            generatedDocumentPublisher.PublishCSharp(HostDocument.FilePath, initialSourceText, 124);
+
+            // Assert
+            Assert.Equal(2, Server.UpdateRequests.Count);
+            var updateRequest = Server.UpdateRequests.Last();
+            Assert.Equal(HostDocument.FilePath, updateRequest.HostDocumentFilePath);
+            Assert.Empty(updateRequest.Changes);
+            Assert.Equal(124, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void ProjectSnapshotManager_DocumentChanged_OpenDocument_VersionEquivalent_Noops_CSharp()
         {
             // Arrange
             var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
@@ -225,10 +247,50 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             generatedDocumentPublisher.PublishCSharp(HostDocument.FilePath, initialSourceText, 123);
 
             // Assert
+            var updateRequest = Assert.Single(Server.UpdateRequests);
+            Assert.Equal(HostDocument.FilePath, updateRequest.HostDocumentFilePath);
+            Assert.Equal(123, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void ProjectSnapshotManager_DocumentChanged_OpenDocument_PublishesEmptyTextChanges_Html()
+        {
+            // Arrange
+            var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            generatedDocumentPublisher.Initialize(ProjectManager);
+            var sourceTextContent = "<!-- The content -->";
+            var initialSourceText = SourceText.From(sourceTextContent);
+            generatedDocumentPublisher.PublishHtml(HostDocument.FilePath, initialSourceText, 123);
+
+            // Act
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, initialSourceText);
+            generatedDocumentPublisher.PublishHtml(HostDocument.FilePath, initialSourceText, 124);
+
+            // Assert
             Assert.Equal(2, Server.UpdateRequests.Count);
             var updateRequest = Server.UpdateRequests.Last();
             Assert.Equal(HostDocument.FilePath, updateRequest.HostDocumentFilePath);
             Assert.Empty(updateRequest.Changes);
+            Assert.Equal(124, updateRequest.HostDocumentVersion);
+        }
+
+        [Fact]
+        public void ProjectSnapshotManager_DocumentChanged_OpenDocument_VersionEquivalent_Noops_Html()
+        {
+            // Arrange
+            var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
+            generatedDocumentPublisher.Initialize(ProjectManager);
+            var sourceTextContent = "<!-- The content -->";
+            var initialSourceText = SourceText.From(sourceTextContent);
+            generatedDocumentPublisher.PublishHtml(HostDocument.FilePath, initialSourceText, 123);
+
+            // Act
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, initialSourceText);
+            generatedDocumentPublisher.PublishHtml(HostDocument.FilePath, initialSourceText, 123);
+
+            // Assert
+            var updateRequest = Assert.Single(Server.UpdateRequests);
+            Assert.Equal(HostDocument.FilePath, updateRequest.HostDocumentFilePath);
             Assert.Equal(123, updateRequest.HostDocumentVersion);
         }
 


### PR DESCRIPTION
- I found that when interacting with the editor our document snapshot system would not always hold onto generated ouptut once all references to it were relinquished. Internally our document snapshots have a weak reference to their output meaning that data can be GCd inbetween requests.
- To handle situations where our generated documents output data was GCd I changed how our document publisher would decide to publish virtual document output. It now stores its last publish data (source text + doc version) and compares the previous publish data to what's about to be published. In the case that everything matches then there's no reason to re-publish.
- Ultimately this should result in huge performance gains in both VSCode and VS because we'll no longer be re-publishing our C#/HTML on every editor interaction.
- Added tests to validate the new scenario.

Fixes dotnet/aspnetcore#19522
