### PR TITLE
Support provisional C# completion

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
@@ -11,7 +12,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     internal class CSharpVirtualDocument : VirtualDocument
     {
         private long? _hostDocumentSyncVersion;
+        private CSharpVirtualDocumentSnapshot _previousSnapshot;
         private CSharpVirtualDocumentSnapshot _currentSnapshot;
+
+        private bool _hasProvisionalChanges = false;
 
         public CSharpVirtualDocument(Uri uri, ITextBuffer textBuffer)
         {
@@ -27,6 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             Uri = uri;
             TextBuffer = textBuffer;
+            _previousSnapshot = null;
             _currentSnapshot = UpdateSnapshot();
         }
 
@@ -38,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public override VirtualDocumentSnapshot CurrentSnapshot => _currentSnapshot;
 
-        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false)
         {
             if (changes is null)
             {
@@ -47,13 +52,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             _hostDocumentSyncVersion = hostDocumentVersion;
 
+            TryRevertProvisionalChanges();
+            _hasProvisionalChanges = provisional;
+
             if (changes.Count == 0)
             {
                 _currentSnapshot = UpdateSnapshot();
                 return _currentSnapshot;
             }
 
-            var edit = TextBuffer.CreateEdit();
+            using var edit = TextBuffer.CreateEdit();
             for (var i = 0; i < changes.Count; i++)
             {
                 var change = changes[i];
@@ -82,6 +90,42 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return _currentSnapshot;
         }
 
-        private CSharpVirtualDocumentSnapshot UpdateSnapshot() => new CSharpVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
+        private bool TryRevertProvisionalChanges()
+        {
+            if (!_hasProvisionalChanges)
+            {
+                return false;
+            }
+
+            Debug.Assert(_previousSnapshot != null);
+
+            using var revertEdit = TextBuffer.CreateEdit(EditOptions.None, _previousSnapshot.Snapshot.Version.VersionNumber, InviolableEditTag.Instance);
+            var previousChanges = _previousSnapshot.Snapshot.Version.Changes;
+            for (var i = 0; i < previousChanges.Count; i++)
+            {
+                var change = previousChanges[i];
+                revertEdit.Replace(change.NewSpan, change.OldText);
+            }
+
+            revertEdit.Apply();
+
+            _hasProvisionalChanges = false;
+
+            return true;
+        }
+
+        private CSharpVirtualDocumentSnapshot UpdateSnapshot()
+        {
+            _previousSnapshot = _currentSnapshot;
+            return new CSharpVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
+        }
+
+        // This indicates that no other entity should respond to the edit event associated with this tag.
+        private class InviolableEditTag : IInviolableEditTag
+        {
+            private InviolableEditTag() { }
+
+            public readonly static IInviolableEditTag Instance = new InviolableEditTag();
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
@@ -58,14 +58,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
         }
 
-        public override LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        public override LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false)
         {
             if (!TryGetVirtualDocument<TVirtualDocument>(out var virtualDocument))
             {
                 throw new InvalidOperationException($"Cannot update virtual document of type {typeof(TVirtualDocument)} because LSP document {Uri} does not contain a virtual document of that type.");
             }
 
-            virtualDocument.Update(changes, hostDocumentVersion);
+            virtualDocument.Update(changes, hostDocumentVersion, provisional);
 
             _currentSnapshot = UpdateSnapshot();
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
@@ -101,7 +101,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public override void UpdateVirtualDocument<TVirtualDocument>(
             Uri hostDocumentUri,
             IReadOnlyList<TextChange> changes,
-            long hostDocumentVersion)
+            long hostDocumentVersion,
+            bool provisional = false)
         {
             if (hostDocumentUri is null)
             {
@@ -132,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var old = lspDocument.CurrentSnapshot;
             var oldVirtual = virtualDocument.CurrentSnapshot;
-            var @new = lspDocument.UpdateVirtualDocument<TVirtualDocument>(changes, hostDocumentVersion);
+            var @new = lspDocument.UpdateVirtualDocument<TVirtualDocument>(changes, hostDocumentVersion, provisional);
 
             if (old == @new)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Threading;
 
@@ -77,11 +78,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            if (!TriggerAppliesToProjection(request.Context, projectionResult.LanguageKind))
-            {
-                return null;
-            }
-
             var completionParams = new CompletionParams()
             {
                 Context = request.Context,
@@ -93,6 +89,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             };
 
             var serverKind = projectionResult.LanguageKind == RazorLanguageKind.CSharp ? LanguageServerKind.CSharp : LanguageServerKind.Html;
+
+            var provisionalCompletionParams = await GetProvisionalCompletionParamsAsync(request, documentSnapshot, projectionResult, cancellationToken).ConfigureAwait(false);
+            if (provisionalCompletionParams != null)
+            {
+                // This means the user has just typed a dot after some identifier such as (cursor is pipe): "DateTime.| "
+                // In this case Razor interprets after the dot as Html and before it as C#.
+                // We use this criteria to provide a better completion experience for what we call provisional changes.
+                completionParams = provisionalCompletionParams;
+                serverKind = LanguageServerKind.CSharp;
+            }
+            else if (!TriggerAppliesToProjection(request.Context, projectionResult.LanguageKind))
+            {
+                return null;
+            }
+
             var result = await _requestInvoker.RequestServerAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(
                 Methods.TextDocumentCompletionName,
                 serverKind,
@@ -106,6 +117,54 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             return result;
+        }
+
+        internal async Task<CompletionParams> GetProvisionalCompletionParamsAsync(CompletionParams request, LSPDocumentSnapshot documentSnapshot, ProjectionResult projection, CancellationToken cancellationToken)
+        {
+            if (projection.LanguageKind != RazorLanguageKind.Html ||
+                request.Context.TriggerKind != CompletionTriggerKind.TriggerCharacter ||
+                request.Context.TriggerCharacter != ".")
+            {
+                return null;
+            }
+
+            if (projection.Position.Character == 0)
+            {
+                // We're at the start of line. Can't have provisional completions here.
+                return null;
+            }
+
+            var previousCharacterPosition = new Position(projection.Position.Line, projection.Position.Character - 1);
+            var previousCharacterProjection = await _projectionProvider.GetProjectionAsync(documentSnapshot, previousCharacterPosition, cancellationToken).ConfigureAwait(false);
+            if (previousCharacterProjection == null || previousCharacterProjection.LanguageKind != RazorLanguageKind.CSharp)
+            {
+                return null;
+            }
+
+            // Edit the CSharp projected document to contain a '.'. This allows C# completion to provide valid
+            // completion items for moments when a user has typed a '.' that's typically interpreted as Html.
+            if (!(_documentManager is TrackingLSPDocumentManager trackingDocumentManager))
+            {
+                return null;
+            }
+
+            var changes = new[]
+            {
+                new TextChange(TextSpan.FromBounds(previousCharacterProjection.PositionIndex, previousCharacterProjection.PositionIndex), "."),
+            };
+
+            await _joinableTaskFactory.SwitchToMainThreadAsync();
+
+            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, changes, previousCharacterProjection.HostDocumentVersion, provisional: true);
+
+            var provisionalCompletionParams = new CompletionParams()
+            {
+                Context = request.Context,
+                Position = new Position(previousCharacterProjection.Position.Line, previousCharacterProjection.Position.Character + 1),
+                TextDocument = new TextDocumentIdentifier() { Uri = previousCharacterProjection.Uri }
+            };
+
+            return provisionalCompletionParams;
         }
 
         // Internal for testing

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -141,13 +141,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            // Edit the CSharp projected document to contain a '.'. This allows C# completion to provide valid
-            // completion items for moments when a user has typed a '.' that's typically interpreted as Html.
             if (!(_documentManager is TrackingLSPDocumentManager trackingDocumentManager))
             {
                 return null;
             }
 
+            // Edit the CSharp projected document to contain a '.'. This allows C# completion to provide valid
+            // completion items for moments when a user has typed a '.' that's typically interpreted as Html.
             var changes = new[]
             {
                 new TextChange(TextSpan.FromBounds(previousCharacterProjection.PositionIndex, previousCharacterProjection.PositionIndex), "."),

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -92,7 +92,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 Uri = virtualDocument.Uri,
                 Position = new Position((int)languageResponse.Position.Line, (int)languageResponse.Position.Character),
+                PositionIndex = languageResponse.PositionIndex,
                 LanguageKind = languageResponse.Kind,
+                HostDocumentVersion = languageResponse.HostDocumentVersion
             };
 
             return result;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/ProjectionResult.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/ProjectionResult.cs
@@ -13,6 +13,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public Position Position { get; set; }
 
+        public int PositionIndex { get; set; }
+
         public RazorLanguageKind LanguageKind { get; set; }
+
+        public long HostDocumentVersion { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public override VirtualDocumentSnapshot CurrentSnapshot => _currentSnapshot;
 
-        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false)
         {
             if (changes is null)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return _currentSnapshot;
             }
 
-            var edit = TextBuffer.CreateEdit();
+            using var edit = TextBuffer.CreateEdit();
             for (var i = 0; i < changes.Count; i++)
             {
                 var change = changes[i];

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public abstract IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
 
-        public abstract LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
+        public abstract LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false) where TVirtualDocument : VirtualDocument;
 
         public bool TryGetVirtualDocument<TVirtualDocument>(out TVirtualDocument virtualDocument) where TVirtualDocument : VirtualDocument
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TrackingLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TrackingLSPDocumentManager.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public abstract void UpdateVirtualDocument<TVirtualDocument>(
             Uri hostDocumentUri,
             IReadOnlyList<TextChange> changes,
-            long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
+            long hostDocumentVersion,
+            bool provisional = false) where TVirtualDocument : VirtualDocument;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
@@ -18,6 +18,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public abstract long? HostDocumentSyncVersion { get; }
 
-        public abstract VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion);
+        public abstract VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentManagerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 document.Uri == Uri &&
                 document.CurrentSnapshot == LSPDocumentSnapshot &&
                 document.VirtualDocuments == new[] { new TestVirtualDocument() } &&
-                document.UpdateVirtualDocument<TestVirtualDocument>(It.IsAny<IReadOnlyList<TextChange>>(), It.IsAny<long>()) == Mock.Of<LSPDocumentSnapshot>());
+                document.UpdateVirtualDocument<TestVirtualDocument>(It.IsAny<IReadOnlyList<TextChange>>(), It.IsAny<long>(), It.IsAny<bool>()) == Mock.Of<LSPDocumentSnapshot>());
             LSPDocumentFactory = Mock.Of<LSPDocumentFactory>(factory => factory.Create(TextBuffer) == LSPDocument);
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var changes = new[] { new TextChange(new TextSpan(1, 1), string.Empty) };
 
             // Act
-            manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123);
+            manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123, provisional: true);
 
             // Assert
             Assert.True(changedCalled);
@@ -207,7 +207,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public override long? HostDocumentSyncVersion => 123;
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional)
             {
                 throw new NotImplementedException();
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentTest.cs
@@ -31,11 +31,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var originalSnapshot = document.CurrentSnapshot;
 
             // Act
-            document.UpdateVirtualDocument<TestVirtualDocument>(changes, hostDocumentVersion: 1337);
+            document.UpdateVirtualDocument<TestVirtualDocument>(changes, hostDocumentVersion: 1337, provisional: true);
 
             // Assert
             Assert.Equal(1337, virtualDocument.HostDocumentSyncVersion);
             Assert.Same(changes, virtualDocument.Changes);
+            Assert.True(virtualDocument.Provisional);
             Assert.NotEqual(originalSnapshot, document.CurrentSnapshot);
         }
 
@@ -45,6 +46,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public IReadOnlyList<TextChange> Changes { get; private set; }
 
+            public bool Provisional { get; private set; }
+
             public override Uri Uri => throw new NotImplementedException();
 
             public override ITextBuffer TextBuffer => throw new NotImplementedException();
@@ -53,10 +56,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public override long? HostDocumentSyncVersion => _hostDocumentVersion;
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional)
             {
                 _hostDocumentVersion = hostDocumentVersion;
                 Changes = changes;
+                Provisional = provisional;
 
                 return null;
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.Text;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -54,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var documentManager = new Mock<TrackingLSPDocumentManager>();
-            documentManager.Setup(manager => manager.UpdateVirtualDocument<CSharpVirtualDocument>(It.IsAny<Uri>(), It.IsAny<IReadOnlyList<TextChange>>(), 1337))
+            documentManager.Setup(manager => manager.UpdateVirtualDocument<CSharpVirtualDocument>(It.IsAny<Uri>(), It.IsAny<IReadOnlyList<TextChange>>(), 1337, false /* UpdateCSharpBuffer request should never be provisional */))
                 .Verifiable();
             var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
             var request = new UpdateBufferRequest()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public override VirtualDocumentSnapshot CurrentSnapshot => throw new NotImplementedException();
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/17803

- Updated the `TrackingLSPDocumentManager` and `LSPVirtualDocument` APIs to support provisional changes
- Update `CSharpVirtualDocument` to apply provisional changes and revert it whenever another change is about to happen
- TODO: Revert when the completion dialog is dismissed without needing to wait for another change. This is trickier than I thought. I'm planning to do it in a separate PR
- Added/updated tests

![provisionalcompletion](https://user-images.githubusercontent.com/1579269/77985205-a544da00-72c8-11ea-8652-c47295ca472d.gif)
