### PR TITLE
 Don't build windows debug internally

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,22 +163,29 @@ stages:
             queue: BuildPool.Server.Amd64.VS2019
         strategy:
           matrix:
-            debug:
-              _BuildConfig: Debug
-              _PublishArgs: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-            release:
-              _BuildConfig: Release
-              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                _DotNetPublishToBlobFeed: true
-                _PublishArgs: /p:PublishToSymbolServer=true
-                  /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                  /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                  /p:PublishToAzure=true
-                  /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-                  /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                  /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                  /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
-                  /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              debug:
+                _BuildConfig: Debug
+                _PublishArgs: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+              release:
+                _BuildConfig: Release
+                _PublishArgs: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              release:
+                _BuildConfig: Release
+                ${{ if in(variables['Build.Reason'], 'PullRequest')) }}:
+                  _PublishArgs: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                ${{ if notin(variables['Build.Reason'], 'PullRequest')) }}:
+                  _DotNetPublishToBlobFeed: true
+                  _PublishArgs: /p:PublishToSymbolServer=true
+                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                    /p:PublishToAzure=true
+                    /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                    /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                    /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
+                    /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
         variables:
         - _DotNetPublishToBlobFeed : false
         - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,9 +173,9 @@ stages:
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               release:
                 _BuildConfig: Release
-                ${{ if in(variables['Build.Reason'], 'PullRequest')) }}:
+                ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
                   _PublishArgs: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-                ${{ if notin(variables['Build.Reason'], 'PullRequest')) }}:
+                ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
                   _DotNetPublishToBlobFeed: true
                   _PublishArgs: /p:PublishToSymbolServer=true
                     /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)


### PR DESCRIPTION
Currently the master branch builds both debug and release configurations internally, and both try to publish. This creates a race condition by which we sometimes wind up publishing debug packages/symbols - one symptom is mismatched symbols being published to msdl, among potentially others. This isn't an issue in 3.1 as we don't try to publish from the debug configuration there. The safest way to fix the issue is just to disable windows debug builds on the internal side.

CC @NTaylorMullen @mmitche @MattGal @dougbu @JunTaoLuo 

Internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=582612