### PR TITLE
Fix undo on <text> tag auto-closing

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorService.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var undoManager = _undoManagerProvider.GetTextBufferUndoManager(snapshot.TextBuffer);
             var undoHistory = undoManager.TextBufferUndoHistory;
-            using var transaction = undoHistory.CreateTransaction("Apply TextEdits");
+            using var transaction = undoHistory.CreateTransaction("Apply Razor LSP text edits");
 
             try
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorService.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
@@ -24,9 +25,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         private readonly JoinableTaskFactory _joinableTaskFactory;
         private readonly SVsServiceProvider _serviceProvider;
+        private readonly ITextBufferUndoManagerProvider _undoManagerProvider;
 
         [ImportingConstructor]
-        public DefaultLSPEditorService(JoinableTaskContext joinableTaskContext, SVsServiceProvider serviceProvider)
+        public DefaultLSPEditorService(JoinableTaskContext joinableTaskContext, SVsServiceProvider serviceProvider, ITextBufferUndoManagerProvider undoManagerProvider)
         {
             if (joinableTaskContext is null)
             {
@@ -38,8 +40,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(serviceProvider));
             }
 
+            if (undoManagerProvider is null)
+            {
+                throw new ArgumentNullException(nameof(undoManagerProvider));
+            }
+
             _joinableTaskFactory = joinableTaskContext.Factory;
             _serviceProvider = serviceProvider;
+            _undoManagerProvider = undoManagerProvider;
         }
 
         public async override Task ApplyTextEditsAsync(
@@ -64,20 +72,31 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             await _joinableTaskFactory.SwitchToMainThreadAsync();
 
-            ApplyTextEdits(textEdits, snapshot, snapshot.TextBuffer);
+            var undoManager = _undoManagerProvider.GetTextBufferUndoManager(snapshot.TextBuffer);
+            var undoHistory = undoManager.TextBufferUndoHistory;
+            using var transaction = undoHistory.CreateTransaction("Apply TextEdits");
 
-            var cursorPosition = ExtractCursorPlaceholder(snapshot.TextBuffer.CurrentSnapshot, textEdits);
-            if (cursorPosition != null)
+            try
             {
-                var fullPath = GetLocalFilePath(uri);
+                ApplyTextEdits(textEdits, snapshot, snapshot.TextBuffer);
 
-                VsShellUtilities.OpenDocument(_serviceProvider, fullPath, VSConstants.LOGVIEWID.TextView_guid, out _, out _, out var windowFrame);
-
-                if (windowFrame != null)
+                var cursorPosition = ExtractCursorPlaceholder(snapshot.TextBuffer.CurrentSnapshot, textEdits);
+                if (cursorPosition != null)
                 {
-                    var textView = GetActiveVsTextView(windowFrame);
-                    MoveCaretToPosition(textView, cursorPosition);
+                    var fullPath = GetLocalFilePath(uri);
+
+                    VsShellUtilities.OpenDocument(_serviceProvider, fullPath, VSConstants.LOGVIEWID.TextView_guid, out _, out _, out var windowFrame);
+
+                    if (windowFrame != null)
+                    {
+                        var textView = GetActiveVsTextView(windowFrame);
+                        MoveCaretToPosition(textView, cursorPosition);
+                    }
                 }
+            }
+            finally
+            {
+                transaction.Complete();
             }
         }
 


### PR DESCRIPTION
After auto-completing a text tag when we press Ctrl + Z,
```razor
@{ <text></text> }
```
Without this change,
```razor
@{ <text>__placeholder__</text> }
```

With this change,
```razor
@{ <text> }
```

Suggest reviewing with [?w=1](https://github.com/dotnet/aspnetcore-tooling/pull/1739/files?w=1)