### PR TITLE
Stop platform agnosticly normalizing file paths on windows.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 throw new ArgumentNullException(nameof(filePath));
             }
 
-            var normalizedPath = _filePathNormalizer.NormalizeForRead(filePath);
+            var normalizedPath = _filePathNormalizer.Normalize(filePath);
             return new RemoteTextLoader(normalizedPath);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Razor;
@@ -37,6 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 normalized[0] == '/' &&
                 !normalized.StartsWith("//", StringComparison.OrdinalIgnoreCase))
             {
+                // We've been provided a path that probably looks something like /C:/path/to
                 normalized = normalized.Substring(1);
             }
             else

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Dive through existing project configuration files and fabricate "added" events so listeners can accurately listen to state changes for them.
 
-            workspaceDirectory = _filePathNormalizer.NormalizeForRead(workspaceDirectory);
+            workspaceDirectory = _filePathNormalizer.Normalize(workspaceDirectory);
             var existingConfigurationFiles = GetExistingConfigurationFiles(workspaceDirectory);
 
             await Task.Factory.StartNew(() =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     {
                         if (!args.TryDeserialize(out var handle))
                         {
-                            var configurationFilePath = _filePathNormalizer.NormalizeForRead(args.ConfigurationFilePath);
+                            var configurationFilePath = _filePathNormalizer.Normalize(args.ConfigurationFilePath);
                             if (!_configurationToProjectMap.TryGetValue(configurationFilePath, out var projectFilePath))
                             {
                                 // Could not resolve an associated project file, noop.
@@ -85,8 +85,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                             return;
                         }
 
-                        var projectFilePath = _filePathNormalizer.NormalizeForRead(handle.FilePath);
-                        var configurationFilePath = _filePathNormalizer.NormalizeForRead(args.ConfigurationFilePath);
+                        var projectFilePath = _filePathNormalizer.Normalize(handle.FilePath);
+                        var configurationFilePath = _filePathNormalizer.Normalize(args.ConfigurationFilePath);
                         _configurationToProjectMap[configurationFilePath] = projectFilePath;
                         _projectService.AddProject(projectFilePath);
                         UpdateProject(handle);
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     }
                 case RazorFileChangeKind.Removed:
                     {
-                        var configurationFilePath = _filePathNormalizer.NormalizeForRead(args.ConfigurationFilePath);
+                        var configurationFilePath = _filePathNormalizer.Normalize(args.ConfigurationFilePath);
                         var containsKey = _configurationToProjectMap.TryGetValue(configurationFilePath, out var projectFilePath);
                         Debug.Assert(containsKey);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Dive through existing project files and fabricate "added" events so listeners can accurately listen to state changes for them.
 
-            workspaceDirectory = _filePathNormalizer.NormalizeForRead(workspaceDirectory);
+            workspaceDirectory = _filePathNormalizer.Normalize(workspaceDirectory);
             var existingProjectFiles = GetExistingProjectFiles(workspaceDirectory);
 
             await Task.Factory.StartNew(() =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -354,8 +354,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             var normalizedFilePath = _filePathNormalizer.Normalize(filePath);
             if (!normalizedFilePath.StartsWith(projectDirectory))
             {
-                // Remove '/' from document path
-                normalizedFilePath = normalizedFilePath.Substring(1);
                 normalizedFilePath = _filePathNormalizer.Normalize(projectDirectory + normalizedFilePath);
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -354,7 +355,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             var normalizedFilePath = _filePathNormalizer.Normalize(filePath);
             if (!normalizedFilePath.StartsWith(projectDirectory))
             {
-                normalizedFilePath = _filePathNormalizer.Normalize(projectDirectory + normalizedFilePath);
+                var absolutePath = Path.Combine(projectDirectory, normalizedFilePath);
+                normalizedFilePath = _filePathNormalizer.Normalize(absolutePath);
             }
 
             return normalizedFilePath;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Dive through existing Razor files and fabricate "added" events so listeners can accurately listen to state changes for them.
 
-            workspaceDirectory = _filePathNormalizer.NormalizeForRead(workspaceDirectory);
+            workspaceDirectory = _filePathNormalizer.Normalize(workspaceDirectory);
             var existingRazorFiles = GetExistingRazorFiles(workspaceDirectory);
 
             await Task.Factory.StartNew(() =>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -10,28 +10,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
     {
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Test only valid on Windows boxes")]
-        public void NormalizeForRead_StripsPrecedingSlash()
+        public void Normalize_Windows_StripsPrecedingSlash()
         {
             // Arrange
             var filePathNormalizer = new FilePathNormalizer();
             var path = "/c:/path/to/something";
 
             // Act
-            path = filePathNormalizer.NormalizeForRead(path);
+            path = filePathNormalizer.Normalize(path);
 
             // Assert
             Assert.Equal("c:/path/to/something", path);
         }
 
         [Fact]
-        public void NormalizeForRead_IgnoresUNCPaths()
+        public void Normalize_IgnoresUNCPaths()
         {
             // Arrange
             var filePathNormalizer = new FilePathNormalizer();
             var path = "//ComputerName/path/to/something";
 
             // Act
-            path = filePathNormalizer.NormalizeForRead(path);
+            path = filePathNormalizer.Normalize(path);
 
             // Assert
             Assert.Equal("//ComputerName/path/to/something", path);
@@ -42,13 +42,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         {
             // Arrange
             var filePathNormalizer = new FilePathNormalizer();
-            var directory = "\\path\\to\\directory\\";
+            var directory = "C:\\path\\to\\directory\\";
 
             // Act
             var normalized = filePathNormalizer.NormalizeDirectory(directory);
 
             // Assert
-            Assert.Equal("/path/to/directory/", normalized);
+            Assert.Equal("C:/path/to/directory/", normalized);
         }
 
         [Fact]
@@ -56,13 +56,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         {
             // Arrange
             var filePathNormalizer = new FilePathNormalizer();
-            var directory = "\\path\\to\\directory";
+            var directory = "C:\\path\\to\\directory";
 
             // Act
             var normalized = filePathNormalizer.NormalizeDirectory(directory);
 
             // Assert
-            Assert.Equal("/path/to/directory/", normalized);
+            Assert.Equal("C:/path/to/directory/", normalized);
         }
 
         [Fact]
@@ -100,27 +100,27 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         {
             // Arrange
             var filePathNormalizer = new FilePathNormalizer();
-            var filePath = "path/to/document.cshtml";
+            var filePath = "C:/path/to/document.cshtml";
 
             // Act
             var normalized = filePathNormalizer.GetDirectory(filePath);
 
             // Assert
-            Assert.Equal("/path/to/", normalized);
+            Assert.Equal("C:/path/to/", normalized);
         }
 
         [Fact]
-        public void GetDirectory_NoDirectory_ReturnsSlash()
+        public void GetDirectory_NoDirectory_ReturnsRoot()
         {
             // Arrange
             var filePathNormalizer = new FilePathNormalizer();
-            var filePath = "document.cshtml";
+            var filePath = "C:/document.cshtml";
 
             // Act
             var normalized = filePathNormalizer.GetDirectory(filePath);
 
             // Assert
-            Assert.Equal("/", normalized);
+            Assert.Equal("C:/", normalized);
         }
 
         [Fact]
@@ -149,8 +149,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             Assert.Equal("/", normalized);
         }
 
-        [Fact]
-        public void Normalize_AddsLeadingForwardSlash()
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Test only valid on non-Windows boxes")]
+        public void Normalize_NonWindows_AddsLeadingForwardSlash()
         {
             // Arrange
             var filePathNormalizer = new FilePathNormalizer();
@@ -174,7 +175,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             var normalized = filePathNormalizer.Normalize(filePath);
 
             // Assert
-            Assert.Equal("/C:/path to/document.cshtml", normalized);
+            Assert.Equal("C:/path to/document.cshtml", normalized);
         }
 
         [Fact]
@@ -182,13 +183,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         {
             // Arrange
             var filePathNormalizer = new FilePathNormalizer();
-            var filePath = "\\path\\to\\document.cshtml";
+            var filePath = "C:\\path\\to\\document.cshtml";
 
             // Act
             var normalized = filePathNormalizer.Normalize(filePath);
 
             // Assert
-            Assert.Equal("/path/to/document.cshtml", normalized);
+            Assert.Equal("C:/path/to/document.cshtml", normalized);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentResolverTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "C:\\path\\to\\document.cshtml";
-            var normalizedFilePath = "/C:/path/to/document.cshtml";
+            var normalizedFilePath = "C:/path/to/document.cshtml";
             var filePathNormalizer = new FilePathNormalizer();
             var expectedDocument = Mock.Of<DocumentSnapshot>();
             var project = Mock.Of<ProjectSnapshot>(shim =>
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "C:\\path\\to\\document.cshtml";
-            var normalizedFilePath = "/C:/path/to/document.cshtml";
+            var normalizedFilePath = "C:/path/to/document.cshtml";
             var filePathNormalizer = new FilePathNormalizer();
             var project = Mock.Of<ProjectSnapshot>(shim => shim.DocumentFilePaths == new string[0]);
             var projectResolver = Mock.Of<ProjectResolver>(resolver => resolver.TryResolvePotentialProject(normalizedFilePath, out project) == true);
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "C:\\path\\to\\document.cshtml";
-            var normalizedFilePath = "/C:/path/to/document.cshtml";
+            var normalizedFilePath = "C:/path/to/document.cshtml";
             var filePathNormalizer = new FilePathNormalizer();
             var expectedDocument = Mock.Of<DocumentSnapshot>();
             var project = Mock.Of<ProjectSnapshot>(shim => shim.GetDocument(normalizedFilePath) == expectedDocument && shim.DocumentFilePaths == new[] { normalizedFilePath });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
@@ -15,9 +15,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
-            var document = TestDocumentSnapshot.Create("/C:/file.cshtml");
+            var document = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(document, 123);
-            var untrackedDocument = TestDocumentSnapshot.Create("/C:/other.cshtml");
+            var untrackedDocument = TestDocumentSnapshot.Create("C:/other.cshtml");
 
             // Act
             documentVersionCache.MarkAsLatestVersion(untrackedDocument);
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
-            var documentInitial = TestDocumentSnapshot.Create("/C:/file.cshtml");
+            var documentInitial = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(documentInitial, 123);
             var documentLatest = TestDocumentSnapshot.Create(documentInitial.FilePath);
 
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
-            var filePath = "/C:/file.cshtml";
+            var filePath = "C:/file.cshtml";
             var document1 = TestDocumentSnapshot.Create(filePath);
             var document2 = TestDocumentSnapshot.Create(filePath);
             documentVersionCache.TrackDocumentVersion(document1, 123);
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
 
             // Act
-            var result = documentVersionCache.TryGetLatestVersionFromPath("/C:/file.cshtml", out var version);
+            var result = documentVersionCache.TryGetLatestVersionFromPath("C:/file.cshtml", out var version);
 
             // Assert
             Assert.False(result);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedCodeContainerStoreTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedCodeContainerStoreTest.cs
@@ -31,12 +31,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void Get_CachesValueBasedOnPath()
         {
             // Arrange
-            var filePath = "/C:/path/to/file.cshtml";
+            var filePath = "C:/path/to/file.cshtml";
 
             // Act
             var container1 = Store.Get(filePath);
             var container2 = Store.Get(filePath);
-            var otherContainer = Store.Get("/C:/path/to/other/file.cshtml");
+            var otherContainer = Store.Get("C:/path/to/other/file.cshtml");
 
             // Assert
             Assert.Same(container1, container2);
@@ -47,8 +47,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_DocumentRemoved_EvictsCache()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/file.cshtml";
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var documentFilePath = "C:/path/to/file.cshtml";
+            var projectFilePath = "C:/path/to/project.csproj";
             var container = Store.Get(documentFilePath);
             var oldProject = TestProjectSnapshot.Create(projectFilePath, new[] { documentFilePath });
             var newProjet = TestProjectSnapshot.Create(projectFilePath);
@@ -66,8 +66,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_DocumentChanged_ClosedDoc_EvictsCache()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/file.cshtml";
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var documentFilePath = "C:/path/to/file.cshtml";
+            var projectFilePath = "C:/path/to/project.csproj";
             var container = Store.Get(documentFilePath);
             var oldProject = TestProjectSnapshot.Create(projectFilePath, new[] { documentFilePath });
             var newProjet = TestProjectSnapshot.Create(projectFilePath, new[] { documentFilePath });
@@ -85,8 +85,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_DocumentChanged_OpenDoc_DoesNotEvictCache()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/file.cshtml";
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var documentFilePath = "C:/path/to/file.cshtml";
+            var projectFilePath = "C:/path/to/project.csproj";
             var container = Store.Get(documentFilePath);
             var project = new HostProject(projectFilePath, RazorConfiguration.Default, "TestRootNamespace");
             ProjectManager.ProjectAdded(project);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
-            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
+            var hostProject = new HostProject("C:/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             projectManager.ProjectAdded(hostProject);
             var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectManager);
             var projectWorkspaceState = new ProjectWorkspaceState(Array.Empty<TagHelperDescriptor>(), LanguageVersion.LatestMajor);
@@ -46,9 +46,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
-            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
+            var hostProject = new HostProject("C:/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             projectManager.ProjectAdded(hostProject);
-            var hostDocument = new HostDocument("/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
+            var hostDocument = new HostDocument("C:/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
             projectManager.DocumentAdded(hostProject, hostDocument, Mock.Of<TextLoader>());
             var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectManager);
             var newDocument = new DocumentSnapshotHandle("file.cshtml", "file.cshtml", FileKinds.Component);
@@ -115,9 +115,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
-            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
+            var hostProject = new HostProject("C:/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             projectManager.ProjectAdded(hostProject);
-            var legacyDocument = new HostDocument("/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
+            var legacyDocument = new HostDocument("C:/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
             projectManager.DocumentAdded(hostProject, legacyDocument, Mock.Of<TextLoader>());
             var projectService = CreateProjectService(Mock.Of<ProjectResolver>(), projectManager);
             var newDocument = new DocumentSnapshotHandle(legacyDocument.FilePath, legacyDocument.TargetPath, FileKinds.Component);
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateProject_SameConfigurationDifferentRootNamespace_UpdatesRootNamespace()
         {
             // Arrange
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var projectFilePath = "C:/path/to/project.csproj";
             var ownerProject = TestProjectSnapshot.Create(projectFilePath);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             var expectedRootNamespace = "NewRootNamespace";
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateProject_SameConfigurationAndRootNamespaceNoops()
         {
             // Arrange
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var projectFilePath = "C:/path/to/project.csproj";
             var ownerProject = TestProjectSnapshot.Create(projectFilePath);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateProject_NullConfigurationUsesDefault()
         {
             // Arrange
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var projectFilePath = "C:/path/to/project.csproj";
             var ownerProject = TestProjectSnapshot.Create(projectFilePath);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateProject_ChangesProjectToUseProvidedConfiguration()
         {
             // Arrange
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var projectFilePath = "C:/path/to/project.csproj";
             var ownerProject = TestProjectSnapshot.Create(projectFilePath);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateProject_UntrackedProjectNoops()
         {
             // Arrange
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var projectFilePath = "C:/path/to/project.csproj";
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
                 .Returns<ProjectSnapshot>(null);
@@ -245,14 +245,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void CloseDocument_ClosesDocumentInOwnerProject()
         {
             // Arrange
-            var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
+            var expectedDocumentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = TestProjectSnapshot.Create("C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("//__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentClosed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TextLoader>()))
                 .Callback<string, string, TextLoader>((projectFilePath, documentFilePath, text) =>
@@ -274,8 +274,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void CloseDocument_ClosesDocumentInMiscellaneousProject()
         {
             // Arrange
-            var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var expectedDocumentFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -300,14 +300,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void OpenDocument_OpensAlreadyAddedDocumentInOwnerProject()
         {
             // Arrange
-            var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
+            var expectedDocumentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = TestProjectSnapshot.Create("C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Throws(new InvalidOperationException("This shouldn't have been called."));
@@ -334,8 +334,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void OpenDocument_OpensAlreadyAddedDocumentInMiscellaneousProject()
         {
             // Arrange
-            var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var expectedDocumentFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -365,14 +365,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void OpenDocument_OpensAndAddsDocumentToOwnerProject()
         {
             // Arrange
-            var expectedDocumentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
+            var expectedDocumentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = TestProjectSnapshot.Create("C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
                     [expectedDocumentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Callback<HostProject, HostDocument, TextLoader>((hostProject, hostDocument, loader) =>
@@ -422,14 +422,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void AddDocument_AddsDocumentToOwnerProject()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = TestProjectSnapshot.Create("C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
                 .Callback<HostProject, HostDocument, TextLoader>((hostProject, hostDocument, loader) =>
@@ -451,8 +451,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void AddDocument_AddsDocumentToMiscellaneousProject()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
@@ -475,14 +475,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void RemoveDocument_RemovesDocumentFromOwnerProject()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj", new[] { documentFilePath });
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = TestProjectSnapshot.Create("C:/path/to/project.csproj", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProject>(), It.IsAny<HostDocument>()))
                 .Callback<HostProject, HostDocument>((hostProject, hostDocument) =>
@@ -503,8 +503,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void RemoveDocument_RemovesDocumentFromMiscellaneousProject()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath });
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -535,7 +535,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.DocumentRemoved(It.IsAny<HostProject>(), It.IsAny<HostDocument>()))
                 .Throws(new InvalidOperationException("Should not have been called."));
@@ -550,7 +550,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var documentFilePath = "C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new string[0]);
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__", new string[0]);
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
                 miscellaneousProject);
@@ -567,14 +567,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateDocument_ChangesDocumentInOwnerProject()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj", new[] { documentFilePath });
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = TestProjectSnapshot.Create("C:/path/to/project.csproj", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var newText = SourceText.From("Something New");
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentChanged(ownerProject.FilePath, documentFilePath, newText))
@@ -597,11 +597,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateDocument_ChangesDocumentInMiscProject()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath });
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>(),
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var newText = SourceText.From("Something New");
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.DocumentChanged(miscellaneousProject.FilePath, documentFilePath, newText))
@@ -624,14 +624,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateDocument_TracksKnownDocumentVersion()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj", new[] { documentFilePath });
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = TestProjectSnapshot.Create("C:/path/to/project.csproj", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             DocumentSnapshot documentSnapshot = TestDocumentSnapshot.Create(documentFilePath);
             var documentResolver = Mock.Of<DocumentResolver>(resolver => resolver.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true);
             var documentVersionCache = new Mock<DocumentVersionCache>(MockBehavior.Strict);
@@ -659,14 +659,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void UpdateDocument_IgnoresUnknownDocumentVersions()
         {
             // Arrange
-            var documentFilePath = "/C:/path/to/document.cshtml";
-            var ownerProject = TestProjectSnapshot.Create("/C:/path/to/project.csproj", new[] { documentFilePath });
+            var documentFilePath = "C:/path/to/document.cshtml";
+            var ownerProject = TestProjectSnapshot.Create("C:/path/to/project.csproj", new[] { documentFilePath });
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {
                     [documentFilePath] = ownerProject
                 },
-                TestProjectSnapshot.Create("/__MISC_PROJECT__"));
+                TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
             var documentVersionCache = new Mock<DocumentVersionCache>();
             documentVersionCache.Setup(cache => cache.TrackDocumentVersion(It.IsAny<DocumentSnapshot>(), It.IsAny<long>()))
                 .Throws<XunitException>();
@@ -684,8 +684,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void AddProject_AddsProjectWithDefaultConfiguration()
         {
             // Arrange
-            var projectFilePath = "/C:/path/to/project.csproj";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var projectFilePath = "C:/path/to/project.csproj";
+            var miscellaneousProject = TestProjectSnapshot.Create("/./__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.ProjectAdded(It.IsAny<HostProject>()))
@@ -708,8 +708,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void AddProject_AlreadyAdded_Noops()
         {
             // Arrange
-            var projectFilePath = "/C:/path/to/project.csproj";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var projectFilePath = "C:/path/to/project.csproj";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
@@ -727,9 +727,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void RemoveProject_RemovesProject()
         {
             // Arrange
-            var projectFilePath = "/C:/path/to/project.csproj";
+            var projectFilePath = "C:/path/to/project.csproj";
             var ownerProject = TestProjectSnapshot.Create(projectFilePath);
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectSnapshotManager.Setup(manager => manager.GetLoadedProject(projectFilePath))
@@ -753,7 +753,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var projectFilePath = "C:/path/to/project.csproj";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.ProjectRemoved(It.IsAny<HostProject>()))
@@ -770,7 +770,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentFilePath1 = "C:/path/to/some/document1.cshtml";
             var documentFilePath2 = "C:/path/to/some/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
             var removedProject = TestProjectSnapshot.Create("C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
             var projectToBeMigratedTo = TestProjectSnapshot.Create("C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
@@ -805,10 +805,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateDocumentsFromRemovedProject_MigratesDocumentsToMiscProject()
         {
             // Arrange
-            var documentFilePath1 = "/C:/path/to/some/document1.cshtml";
-            var documentFilePath2 = "/C:/path/to/some/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__");
-            var removedProject = TestProjectSnapshot.Create("/C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
+            var documentFilePath1 = "C:/path/to/some/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/some/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
+            var removedProject = TestProjectSnapshot.Create("C:/path/to/some/project.csproj", new[] { documentFilePath1, documentFilePath2 });
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var migratedDocuments = new List<HostDocument>();
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
@@ -835,9 +835,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateMiscellaneousDocumentsToProject_DoesNotMigrateDocumentsIfNoOwnerProject()
         {
             // Arrange
-            var documentFilePath1 = "/C:/path/to/document1.cshtml";
-            var documentFilePath2 = "/C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
+            var documentFilePath1 = "C:/path/to/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
             var projectResolver = new TestProjectResolver(new Dictionary<string, ProjectSnapshot>(), miscellaneousProject);
             var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>();
             projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<HostProject>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
@@ -852,10 +852,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryMigrateMiscellaneousDocumentsToProject_MigratesDocumentsToNewOwnerProject()
         {
             // Arrange
-            var documentFilePath1 = "/C:/path/to/document1.cshtml";
-            var documentFilePath2 = "/C:/path/to/document2.cshtml";
-            var miscellaneousProject = TestProjectSnapshot.Create("/__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
-            var projectToBeMigratedTo = TestProjectSnapshot.Create("/C:/path/to/project.csproj");
+            var documentFilePath1 = "C:/path/to/document1.cshtml";
+            var documentFilePath2 = "C:/path/to/document2.cshtml";
+            var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__", new[] { documentFilePath1, documentFilePath2 });
+            var projectToBeMigratedTo = TestProjectSnapshot.Create("C:/path/to/project.csproj");
             var projectResolver = new TestProjectResolver(
                 new Dictionary<string, ProjectSnapshot>
                 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
@@ -18,8 +18,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var jsonFileDeserializer = new Mock<JsonFileDeserializer>();
             jsonFileDeserializer.Setup(deserializer => deserializer.Deserialize<FullProjectSnapshotHandle>(It.IsAny<string>()))
-                .Returns(new FullProjectSnapshotHandle("/c:/path/to/project.csproj", configuration: null, rootNamespace: null, projectWorkspaceState: null, documents: Array.Empty<DocumentSnapshotHandle>()));
-            var args = new ProjectConfigurationFileChangeEventArgs("/c:/some/path", RazorFileChangeKind.Removed, jsonFileDeserializer.Object);
+                .Returns(new FullProjectSnapshotHandle("c:/path/to/project.csproj", configuration: null, rootNamespace: null, projectWorkspaceState: null, documents: Array.Empty<DocumentSnapshotHandle>()));
+            var args = new ProjectConfigurationFileChangeEventArgs("c:/some/path", RazorFileChangeKind.Removed, jsonFileDeserializer.Object);
 
             // Act
             var result = args.TryDeserialize(out var handle);
@@ -34,10 +34,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var jsonFileDeserializer = new Mock<JsonFileDeserializer>();
-            var projectSnapshotHandle = new FullProjectSnapshotHandle("/c:/path/to/project.csproj", configuration: null, rootNamespace: null, projectWorkspaceState: null, documents: Array.Empty<DocumentSnapshotHandle>());
+            var projectSnapshotHandle = new FullProjectSnapshotHandle("c:/path/to/project.csproj", configuration: null, rootNamespace: null, projectWorkspaceState: null, documents: Array.Empty<DocumentSnapshotHandle>());
             jsonFileDeserializer.Setup(deserializer => deserializer.Deserialize<FullProjectSnapshotHandle>(It.IsAny<string>()))
                 .Returns(projectSnapshotHandle);
-            var args = new ProjectConfigurationFileChangeEventArgs("/c:/some/path", RazorFileChangeKind.Added, jsonFileDeserializer.Object);
+            var args = new ProjectConfigurationFileChangeEventArgs("c:/some/path", RazorFileChangeKind.Added, jsonFileDeserializer.Object);
 
             // Act
             var result1 = args.TryDeserialize(out var handle1);
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             jsonFileDeserializer.Setup(deserializer => deserializer.Deserialize<FullProjectSnapshotHandle>(It.IsAny<string>()))
                 .Callback(() => callCount++)
                 .Returns<FullProjectSnapshotHandle>(null);
-            var args = new ProjectConfigurationFileChangeEventArgs("/c:/some/path", RazorFileChangeKind.Changed, jsonFileDeserializer.Object);
+            var args = new ProjectConfigurationFileChangeEventArgs("c:/some/path", RazorFileChangeKind.Changed, jsonFileDeserializer.Object);
 
             // Act
             var result1 = args.TryDeserialize(out var handle1);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectFileChangeDetectorTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var listener2 = new Mock<IProjectFileChangeListener>(MockBehavior.Strict);
             listener2.Setup(l => l.ProjectFileChanged(It.IsAny<string>(), It.IsAny<RazorFileChangeKind>()))
                 .Callback<string, RazorFileChangeKind>((filePath, kind) => args2.Add((filePath, kind)));
-            var existingProjectFiles = new[] { "/c:/path/to/project.csproj", "/c:/other/path/project.csproj" };
+            var existingProjectFiles = new[] { "c:/path/to/project.csproj", "c:/other/path/project.csproj" };
             var cts = new CancellationTokenSource();
             var detector = new TestProjectFileChangeDetector(
                 cts,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsPublisherTest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public RazorDiagnosticsPublisherTest()
         {
             var testProjectManager = TestProjectSnapshotManager.Create(Dispatcher);
-            var hostProject = new HostProject("/C:/project/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
+            var hostProject = new HostProject("C:/project/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             testProjectManager.ProjectAdded(hostProject);
             var sourceText = SourceText.From(string.Empty);
             var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);
-            var openedHostDocument = new HostDocument("/C:/project/open_document.cshtml", "/C:/project/open_document.cshtml");
+            var openedHostDocument = new HostDocument("C:/project/open_document.cshtml", "C:/project/open_document.cshtml");
             testProjectManager.DocumentAdded(hostProject, openedHostDocument, TextLoader.From(textAndVersion));
             testProjectManager.DocumentOpened(hostProject.FilePath, openedHostDocument.FilePath, sourceText);
-            var closedHostDocument = new HostDocument("/C:/project/closed_document.cshtml", "/C:/project/closed_document.cshtml");
+            var closedHostDocument = new HostDocument("C:/project/closed_document.cshtml", "C:/project/closed_document.cshtml");
             testProjectManager.DocumentAdded(hostProject, closedHostDocument, TextLoader.From(textAndVersion));
 
             OpenedDocument = testProjectManager.Projects[0].GetDocument(openedHostDocument.FilePath);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var listener2 = new Mock<IRazorFileChangeListener>(MockBehavior.Strict);
             listener2.Setup(l => l.RazorFileChanged(It.IsAny<string>(), It.IsAny<RazorFileChangeKind>()))
                 .Callback<string, RazorFileChangeKind>((filePath, kind) => args2.Add((filePath, kind)));
-            var existingRazorFiles = new[] { "/c:/path/to/index.razor", "/c:/other/path/_Host.cshtml" };
+            var existingRazorFiles = new[] { "c:/path/to/index.razor", "c:/other/path/_Host.cshtml" };
             var cts = new CancellationTokenSource();
             var detector = new TestRazorFileChangeDetector(
                 cts,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void GetItem_RootlessFilePath()
         {
             // Arrange
-            var fileSystem = new RemoteRazorProjectFileSystem("/C:/path/to", FilePathNormalizer);
+            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to", FilePathNormalizer);
             var documentFilePath = "file.cshtml";
 
             // Act
@@ -27,15 +27,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Assert
             Assert.Equal(documentFilePath, item.FilePath);
-            Assert.Equal("/C:/path/to/file.cshtml", item.PhysicalPath);
+            Assert.Equal("C:/path/to/file.cshtml", item.PhysicalPath);
         }
 
         [Fact]
         public void GetItem_RootedFilePath_BelongsToProject()
         {
             // Arrange
-            var fileSystem = new RemoteRazorProjectFileSystem("/C:/path/to", FilePathNormalizer);
-            var documentFilePath = "/C:/path/to/file.cshtml";
+            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to", FilePathNormalizer);
+            var documentFilePath = "C:/path/to/file.cshtml";
 
             // Act
             var item = fileSystem.GetItem(documentFilePath, fileKind: null);
@@ -49,8 +49,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void GetItem_RootedFilePath_DoesNotBelongToProject()
         {
             // Arrange
-            var fileSystem = new RemoteRazorProjectFileSystem("/C:/path/to", FilePathNormalizer);
-            var documentFilePath = "/C:/otherpath/to/file.cshtml";
+            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to", FilePathNormalizer);
+            var documentFilePath = "C:/otherpath/to/file.cshtml";
 
             // Act
             var item = fileSystem.GetItem(documentFilePath, fileKind: null);


### PR DESCRIPTION
- I imagine this changeset will cause several unintended side effects. I've tried to verify our scenarios in VS and VSCode but undoubtedly I've missed a few. That's why I'm getting this in early to verify things work as expected.
- Found that we were already normalizing file paths this way for read operations. Because of that I removed the `NormalizeForRead` in favor of our new `Normalize` method to ensure all call paths are flowing through the same normalization path.
- Updated the `NormalizeForRead` tests to test the new `Normalize` path.
- Updated existing tests that passed in a path with a prefixed slash (`/path/to/file`) to use `C:/`. Surprisingly `C:/` paths work as expected cross-plat at runtime as long as we don't test trying to write any files (we don't).
- Found that our filepath normalization logic in our remote project file system layer had incredibly odd behavior when being handed a `/` (the default when finding hierarchical items like `_Imports.razor`). Had to special case the `/` case because we no longer root all of our paths on windows with `/`.

Fixes dotnet/aspnetcore#19948
