### PR TITLE
Simplified provisional completion implementation

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocument.cs
@@ -58,14 +58,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
         }
 
-        public override LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false)
+        public override LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
         {
             if (!TryGetVirtualDocument<TVirtualDocument>(out var virtualDocument))
             {
                 throw new InvalidOperationException($"Cannot update virtual document of type {typeof(TVirtualDocument)} because LSP document {Uri} does not contain a virtual document of that type.");
             }
 
-            virtualDocument.Update(changes, hostDocumentVersion, provisional);
+            virtualDocument.Update(changes, hostDocumentVersion);
 
             _currentSnapshot = UpdateSnapshot();
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
@@ -101,8 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public override void UpdateVirtualDocument<TVirtualDocument>(
             Uri hostDocumentUri,
             IReadOnlyList<TextChange> changes,
-            long hostDocumentVersion,
-            bool provisional = false)
+            long hostDocumentVersion)
         {
             if (hostDocumentUri is null)
             {
@@ -133,7 +132,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var old = lspDocument.CurrentSnapshot;
             var oldVirtual = virtualDocument.CurrentSnapshot;
-            var @new = lspDocument.UpdateVirtualDocument<TVirtualDocument>(changes, hostDocumentVersion, provisional);
+            var @new = lspDocument.UpdateVirtualDocument<TVirtualDocument>(changes, hostDocumentVersion);
 
             if (old == @new)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public override VirtualDocumentSnapshot CurrentSnapshot => _currentSnapshot;
 
-        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false)
+        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
         {
             if (changes is null)
             {
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return _currentSnapshot;
             }
 
-            using var edit = TextBuffer.CreateEdit();
+            using var edit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
             for (var i = 0; i < changes.Count; i++)
             {
                 var change = changes[i];

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/InviolableEditTag.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/InviolableEditTag.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    // Used to indicate that no other entity should respond to the edit event associated with this tag.
+    internal class InviolableEditTag : IInviolableEditTag
+    {
+        private InviolableEditTag() { }
+
+        public readonly static IInviolableEditTag Instance = new InviolableEditTag();
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocument.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public abstract IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
 
-        public abstract LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false) where TVirtualDocument : VirtualDocument;
+        public abstract LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
 
         public bool TryGetVirtualDocument<TVirtualDocument>(out TVirtualDocument virtualDocument) where TVirtualDocument : VirtualDocument
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TrackingLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TrackingLSPDocumentManager.cs
@@ -17,7 +17,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public abstract void UpdateVirtualDocument<TVirtualDocument>(
             Uri hostDocumentUri,
             IReadOnlyList<TextChange> changes,
-            long hostDocumentVersion,
-            bool provisional = false) where TVirtualDocument : VirtualDocument;
+            long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VirtualDocument.cs
@@ -18,6 +18,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public abstract long? HostDocumentSyncVersion { get; }
 
-        public abstract VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional = false);
+        public abstract VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentManagerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 document.Uri == Uri &&
                 document.CurrentSnapshot == LSPDocumentSnapshot &&
                 document.VirtualDocuments == new[] { new TestVirtualDocument() } &&
-                document.UpdateVirtualDocument<TestVirtualDocument>(It.IsAny<IReadOnlyList<TextChange>>(), It.IsAny<long>(), It.IsAny<bool>()) == Mock.Of<LSPDocumentSnapshot>());
+                document.UpdateVirtualDocument<TestVirtualDocument>(It.IsAny<IReadOnlyList<TextChange>>(), It.IsAny<long>()) == Mock.Of<LSPDocumentSnapshot>());
             LSPDocumentFactory = Mock.Of<LSPDocumentFactory>(factory => factory.Create(TextBuffer) == LSPDocument);
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var changes = new[] { new TextChange(new TextSpan(1, 1), string.Empty) };
 
             // Act
-            manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123, provisional: true);
+            manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123);
 
             // Assert
             Assert.True(changedCalled);
@@ -207,7 +207,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public override long? HostDocumentSyncVersion => 123;
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
             {
                 throw new NotImplementedException();
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentTest.cs
@@ -31,12 +31,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var originalSnapshot = document.CurrentSnapshot;
 
             // Act
-            document.UpdateVirtualDocument<TestVirtualDocument>(changes, hostDocumentVersion: 1337, provisional: true);
+            document.UpdateVirtualDocument<TestVirtualDocument>(changes, hostDocumentVersion: 1337);
 
             // Assert
             Assert.Equal(1337, virtualDocument.HostDocumentSyncVersion);
             Assert.Same(changes, virtualDocument.Changes);
-            Assert.True(virtualDocument.Provisional);
             Assert.NotEqual(originalSnapshot, document.CurrentSnapshot);
         }
 
@@ -46,8 +45,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public IReadOnlyList<TextChange> Changes { get; private set; }
 
-            public bool Provisional { get; private set; }
-
             public override Uri Uri => throw new NotImplementedException();
 
             public override ITextBuffer TextBuffer => throw new NotImplementedException();
@@ -56,11 +53,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public override long? HostDocumentSyncVersion => _hostDocumentVersion;
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
             {
                 _hostDocumentVersion = hostDocumentVersion;
                 Changes = changes;
-                Provisional = provisional;
 
                 return null;
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var documentManager = new Mock<TrackingLSPDocumentManager>();
-            documentManager.Setup(manager => manager.UpdateVirtualDocument<CSharpVirtualDocument>(It.IsAny<Uri>(), It.IsAny<IReadOnlyList<TextChange>>(), 1337, false /* UpdateCSharpBuffer request should never be provisional */))
+            documentManager.Setup(manager => manager.UpdateVirtualDocument<CSharpVirtualDocument>(It.IsAny<Uri>(), It.IsAny<IReadOnlyList<TextChange>>(), 1337))
                 .Verifiable();
             var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
             var request = new UpdateBufferRequest()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             edit.Setup(e => e.Replace(replace.Span.Start, replace.Span.Length, replace.NewText));
             var textBuffer = new Mock<ITextBuffer>();
             var textBufferSnapshot = Mock.Of<ITextSnapshot>();
-            textBuffer.Setup(buffer => buffer.CreateEdit())
+            textBuffer.Setup(buffer => buffer.CreateEdit(EditOptions.None, null, It.IsAny<IInviolableEditTag>()))
                 .Returns(edit.Object);
             textBuffer.Setup(buffer => buffer.CurrentSnapshot)
                 .Returns(() => textBufferSnapshot);
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public static ITextBuffer CreateTextBuffer(ITextEdit edit)
         {
-            var textBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CreateEdit() == edit && buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>());
+            var textBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CreateEdit(EditOptions.None, null, It.IsAny<IInviolableEditTag>()) == edit && buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>());
             return textBuffer;
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPDocumentTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public override VirtualDocumentSnapshot CurrentSnapshot => throw new NotImplementedException();
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion, bool provisional)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/17803

- Turns out we don't even need to persist the provisional change till the next update. We just need the change there long enough for us to invoke a completion request and get the result.
- This simplifies things a lot and removes the need for any kind of hackery in the Document manager or the Virtual Document layer
- All logic for provisional completions is contained within a single method in CompletionHandler
- Reverted a bunch of code from my previous PR and updated tests
- Verified manually that this works as expected and doesn't visibly impact performance