### PR TITLE
Fixed multiline FullyQualifiedNamespace Edits

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/CodeActions/RazorFullyQualifiedCodeActionTranslator.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/CodeActions/RazorFullyQualifiedCodeActionTranslator.ts
@@ -13,13 +13,39 @@ export class RazorFullyQualifiedCodeActionTranslator implements IRazorCodeAction
     public applyEdit(
         uri: vscode.Uri,
         edit: vscode.TextEdit): [vscode.Uri | undefined, vscode.TextEdit | undefined] {
-        // The edit for this should just translate without additional help.
-        throw new Error('Method not implemented.');
+        // This is kind of wrong. We're manually trimming whitespace and adjusting
+        // for multi-line edits that're provided by O#. Right now, we do not support multi-line edits
+        // (ex. refactoring code actions) however there are certain supported edits which O# is automatically
+        // formatting for us (ex. FullyQualifiedNamespace) into multiple lines, when it should span a single line.
+        // This is due to how we render our virtual cs files, with fewer levels of indentation to facilitate
+        // appropriate error reporting (if we had additional tabs, then the error squigly would appear offset).
+        //
+        // The ideal solution for this would do something like:
+        // https://github.com/dotnet/aspnetcore-tooling/blob/4c8dbd0beb073e6dcee33d96d174453bf44d938a/
+        // src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs#L264
+        // however we're going to hold off on that for now as it isn't immediately necessary and we don't
+        // (currently) support any other kind of multi-line edits.
+
+        const newText = edit.newText.trim();
+
+        // The starting and ending range may be equal in the case when we have other items on the same line. Ex:
+        // Render|Tree apple
+        // where `|` is the cursor. We want to ensure we dont't overwrite `apple` in this case with our edit.
+        if (newText !== edit.newText && !edit.range.start.isEqual(edit.range.end)) {
+            const end = new vscode.Position(edit.range.start.line, edit.range.start.character + newText.length);
+            edit.range = new vscode.Range(edit.range.start, end);
+        }
+
+        const newEdit = new vscode.TextEdit(edit.range, newText);
+        return [ uri, newEdit ];
     }
 
-    public canHandleEdit(uri: vscode.Uri, edit: vscode.TextEdit): boolean {
-        // The edit for this should just translate without additional help.
-        return false;
+    public canHandleEdit(uri: vscode.Uri, edit: vscode.TextEdit) {
+        const completeFullyQualifiedRegex = new RegExp('^(\\w+\\.)+\\w+$'); // Microsoft.AspNetCore.Mvc
+        const partialFullyQualifiedRegex = new RegExp('^(\\w+\\.)+$');      // Microsoft.AspNetCore.Mvc.
+        const newText = edit.newText.trim();
+        return (!edit.range.isSingleLine && completeFullyQualifiedRegex.test(newText)) ||
+            (edit.range.start.isEqual(edit.range.end) && partialFullyQualifiedRegex.test(newText));
     }
 
     public canHandleCodeAction(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/CodeActions/RazorFullyQualifiedCodeActionTranslator.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/CodeActions/RazorFullyQualifiedCodeActionTranslator.ts
@@ -41,9 +41,14 @@ export class RazorFullyQualifiedCodeActionTranslator implements IRazorCodeAction
     }
 
     public canHandleEdit(uri: vscode.Uri, edit: vscode.TextEdit) {
+        // CodeActions do not have a distinct identifier, so we must determine
+        // if a potential edit is a Fully Qualified Namespace edit. We do so by
+        // examining whether the new text of the edit fits one of two potential forms.
         const completeFullyQualifiedRegex = new RegExp('^(\\w+\\.)+\\w+$'); // Microsoft.AspNetCore.Mvc
         const partialFullyQualifiedRegex = new RegExp('^(\\w+\\.)+$');      // Microsoft.AspNetCore.Mvc.
+
         const newText = edit.newText.trim();
+
         return (!edit.range.isSingleLine && completeFullyQualifiedRegex.test(newText)) ||
             (edit.range.start.isEqual(edit.range.end) && partialFullyQualifiedRegex.test(newText));
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCSharpLanguageMiddleware.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCSharpLanguageMiddleware.ts
@@ -77,7 +77,7 @@ export class RazorCSharpLanguageMiddleware implements LanguageMiddleware {
                     // appropriate error reporting (if we had additional tabs, then the error squigly would appear offset).
                     //
                     // The ideal solution for this would do something like:
-                    // https://github.com/dotnet/aspnetcore-tooling/blob/master/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs#L264
+                    // https://github.com/dotnet/aspnetcore-tooling/blob/4c8dbd0beb073e6dcee33d96d174453bf44d938a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs#L264
                     // however we're going to hold off on that for now as it isn't immediately necessary and we don't
                     // (currently) support any other kind of multi-line edits.
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCSharpLanguageMiddleware.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCSharpLanguageMiddleware.ts
@@ -69,10 +69,33 @@ export class RazorCSharpLanguageMiddleware implements LanguageMiddleware {
                         continue;
                     }
                 } else {
-                    this.logger.logVerbose(
-                        `Re-mapping text ${edit.newText} at ${edit.range} in ${uri.path} to ${remappedResponse.range} in ${documentUri.path}`);
+                    // Similar to above, this is kind of wrong. We're manually trimming whitespace and adjusting
+                    // for multi-line edits that're provided by O#. Right now, we do not support multi-line edits
+                    // (ex. refactoring code actions) however there are certain supported edits which O# is automatically
+                    // formatting for us (ex. FullyQualifiedNamespace) into multiple lines, when it should span a single line.
+                    // This is due to how we render our virtual cs files, with fewer levels of indentation to facilitate
+                    // appropriate error reporting (if we had additional tabs, then the error squigly would appear offset).
+                    //
+                    // The ideal solution for this would do something like:
+                    // https://github.com/dotnet/aspnetcore-tooling/blob/master/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs#L264
+                    // however we're going to hold off on that for now as it isn't immediately necessary and we don't
+                    // (currently) support any other kind of multi-line edits.
 
-                    const newEdit = new vscode.TextEdit(remappedResponse.range, edit.newText);
+                    const newText = edit.newText.trim();
+                    let remappedRange = remappedResponse.range;
+
+                    // The starting and ending range may be equal in the case when we have other items on the same line. Ex:
+                    // Render|Tree apple
+                    // where `|` is the cursor. We want to ensure we dont't overwrite `apple` in this case with our edit.
+                    if (newText !== edit.newText && !remappedResponse.range.start.isEqual(remappedResponse.range.end)) {
+                        const end = new vscode.Position(remappedResponse.range.start.line, remappedResponse.range.start.character + newText.length);
+                        remappedRange = new vscode.Range(remappedResponse.range.start, end);
+                    }
+
+                    this.logger.logVerbose(
+                        `Re-mapping text ${newText} at ${edit.range} in ${uri.path} to ${remappedRange} in ${documentUri.path}`);
+
+                    const newEdit = new vscode.TextEdit(remappedRange, newText);
                     this.addElementToDictionary(map, documentUri, newEdit);
                 }
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCSharpLanguageMiddleware.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCSharpLanguageMiddleware.ts
@@ -69,17 +69,16 @@ export class RazorCSharpLanguageMiddleware implements LanguageMiddleware {
                         continue;
                     }
                 } else {
-                    edit.range = remappedResponse.range;
+                    const remappedEdit = new vscode.TextEdit(remappedResponse.range, edit.newText);
+                    const [codeActionUri, codeActionEdit] = this.tryApplyingCodeActions(uri, remappedEdit);
 
-                    const [codeActionUri, codeActionEdit] = this.tryApplyingCodeActions(uri, edit);
                     if (codeActionUri && codeActionEdit) {
                         this.addElementToDictionary(map, documentUri, codeActionEdit);
-                    } else if (remappedResponse && remappedResponse.range) {
+                    } else {
                         this.logger.logVerbose(
                             `Re-mapping text ${edit.newText} at ${edit.range} in ${uri.path} to ${remappedResponse.range} in ${documentUri.path}`);
 
-                        const newEdit = new vscode.TextEdit(remappedResponse.range, edit.newText);
-                        this.addElementToDictionary(map, documentUri, newEdit);
+                        this.addElementToDictionary(map, documentUri, remappedEdit);
                     }
                 }
 


### PR DESCRIPTION
Resolves the double tab spacing when using the Fully Qualified Namespace code action within @code blocks. Further details in code comments.

Fixes dotnet/aspnetcore#19449