### PR TITLE
Fix error when removing project configuration after failed deserialization.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -95,8 +95,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 case RazorFileChangeKind.Removed:
                     {
                         var configurationFilePath = _filePathNormalizer.Normalize(args.ConfigurationFilePath);
-                        var containsKey = _configurationToProjectMap.TryGetValue(configurationFilePath, out var projectFilePath);
-                        Debug.Assert(containsKey);
+                        if (!_configurationToProjectMap.TryGetValue(configurationFilePath, out var projectFilePath))
+                        {
+                            // Failed to deserialize the initial handle on add so we can't remove the configuration file because it doesn't exist in the list.
+                            return;
+                        }
 
                         _configurationToProjectMap.Remove(configurationFilePath);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -19,6 +19,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private FilePathNormalizer FilePathNormalizer { get; } = new FilePathNormalizer();
 
         [Fact]
+        public void ProjectConfigurationFileChanged_Removed_UnknownDocumentNoops()
+        {
+            // Arrange
+            var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
+            var synchronizer = new ProjectConfigurationStateSynchronizer(Dispatcher, projectService.Object, FilePathNormalizer);
+            var jsonFileDeserializer = Mock.Of<JsonFileDeserializer>();
+            var args = new ProjectConfigurationFileChangeEventArgs("/path/to/project.razor.json", RazorFileChangeKind.Removed, jsonFileDeserializer);
+
+            // Act
+            synchronizer.ProjectConfigurationFileChanged(args);
+
+            // Assert
+            projectService.VerifyAll();
+        }
+
+        [Fact]
         public void ProjectConfigurationFileChanged_Removed_NonNormalizedPaths()
         {
             // Arrange


### PR DESCRIPTION
- Found that when our project state synchronization would fail to deserialize a project configuration and then later attempt to remove it we'd hit this `Debug.Assert`. Failing to deserialize a project configuration is allowed due to us lacking control over how the file system writes those files to disk.
- Added a test to cover the scenario.