### PR TITLE
Make DocumentVersionCache evicting logic smarter

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultForegroundDispatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultForegroundDispatcher.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
-    internal class VSCodeForegroundDispatcher : ForegroundDispatcher
+    internal class DefaultForegroundDispatcher : ForegroundDispatcher
     {
         public override bool IsForegroundThread => Thread.CurrentThread.ManagedThreadId == ForegroundTaskScheduler.Instance.ForegroundThreadId;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentVersionCache.cs
@@ -16,16 +16,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         // Internal for testing
         internal readonly Dictionary<string, List<DocumentEntry>> _documentLookup;
         private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly FilePathNormalizer _filePathNormalizer;
         private ProjectSnapshotManagerBase _projectSnapshotManager;
 
-        public DefaultDocumentVersionCache(ForegroundDispatcher foregroundDispatcher)
+        public DefaultDocumentVersionCache(ForegroundDispatcher foregroundDispatcher, FilePathNormalizer filePathNormalizer)
         {
             if (foregroundDispatcher == null)
             {
                 throw new ArgumentNullException(nameof(foregroundDispatcher));
             }
 
+            if (filePathNormalizer is null)
+            {
+                throw new ArgumentNullException(nameof(filePathNormalizer));
+            }
+
             _foregroundDispatcher = foregroundDispatcher;
+            _filePathNormalizer = filePathNormalizer;
             _documentLookup = new Dictionary<string, List<DocumentEntry>>(FilePathComparer.Instance);
         }
 
@@ -103,7 +110,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             _projectSnapshotManager = projectManager;
             _projectSnapshotManager.Changed += ProjectSnapshotManager_Changed;
-
         }
 
         public override void RazorFileChanged(string filePath, RazorFileChangeKind kind)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal abstract class DocumentVersionCache : ProjectSnapshotChangeTrigger
+    internal abstract class DocumentVersionCache : ProjectSnapshotChangeTrigger, IRazorFileChangeListener
     {
         public abstract bool TryGetDocumentVersion(DocumentSnapshot documentSnapshot, out long version);
 
         public abstract void TrackDocumentVersion(DocumentSnapshot documentSnapshot, long version);
+
+        public abstract void RazorFileChanged(string filePath, RazorFileChangeKind kind);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -72,6 +72,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<RazorSemanticTokenLegendEndpoint>()
                     .WithServices(services =>
                     {
+                        var filePathNormalizer = new FilePathNormalizer();
+                        services.AddSingleton<FilePathNormalizer>(filePathNormalizer);
+
                         var foregroundDispatcher = new DefaultForegroundDispatcher();
                         services.AddSingleton<ForegroundDispatcher>(foregroundDispatcher);
 
@@ -79,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<ProjectSnapshotChangeTrigger>(generatedDocumentPublisher);
                         services.AddSingleton<GeneratedDocumentPublisher>(generatedDocumentPublisher);
 
-                        var documentVersionCache = new DefaultDocumentVersionCache(foregroundDispatcher);
+                        var documentVersionCache = new DefaultDocumentVersionCache(foregroundDispatcher, filePathNormalizer);
                         services.AddSingleton<DocumentVersionCache>(documentVersionCache);
                         services.AddSingleton<ProjectSnapshotChangeTrigger>(documentVersionCache);
                         var containerStore = new DefaultGeneratedDocumentContainerStore(
@@ -89,7 +92,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<GeneratedDocumentContainerStore>(containerStore);
                         services.AddSingleton<ProjectSnapshotChangeTrigger>(containerStore);
 
-                        services.AddSingleton<FilePathNormalizer>();
                         services.AddSingleton<RemoteTextLoaderFactory, DefaultRemoteTextLoaderFactory>();
                         services.AddSingleton<ProjectResolver, DefaultProjectResolver>();
                         services.AddSingleton<DocumentResolver, DefaultDocumentResolver>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/DefaultOmniSharpForegroundDispatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/DefaultOmniSharpForegroundDispatcher.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     {
         public DefaultOmniSharpForegroundDispatcher()
         {
-            InternalDispatcher = new VSCodeForegroundDispatcher();
+            InternalDispatcher = new DefaultForegroundDispatcher();
         }
 
         public override bool IsForegroundThread => InternalDispatcher.IsForegroundThread;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -17,10 +18,13 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
         public LanguageServerTestBase()
         {
             Dispatcher = new SingleThreadedForegroundDispatcher();
+            FilePathNormalizer = new FilePathNormalizer();
             LoggerFactory = Mock.Of<ILoggerFactory>(factory => factory.CreateLogger(It.IsAny<string>()) == Mock.Of<ILogger>());
         }
 
         internal ForegroundDispatcher Dispatcher { get; }
+
+        internal FilePathNormalizer FilePathNormalizer { get; }
 
         protected ILoggerFactory LoggerFactory { get; }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
 using Xunit;
@@ -78,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
-        public void ProjectSnapshotManager_Changed_DocumentRemoved_EvictsDocument()
+        public void ProjectSnapshotManager_Changed_DocumentRemoved_DoesNotEvictDocument()
         {
             // Arrange
             var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
@@ -104,11 +105,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             result = documentVersionCache.TryGetDocumentVersion(document, out version);
 
             // Assert - 2
-            Assert.False(result);
+            Assert.True(result);
         }
 
         [Fact]
-        public void ProjectSnapshotManager_Changed_OpenDocumentRemoved_EvictsDocument()
+        public void ProjectSnapshotManager_Changed_OpenDocumentRemoved_DoesNotEvictDocument()
         {
             // Arrange
             var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
@@ -136,7 +137,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             result = documentVersionCache.TryGetDocumentVersion(document, out version);
 
             // Assert - 2
-            Assert.False(result);
+            Assert.True(result);
         }
 
         [Fact]
@@ -256,6 +257,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Assert
             Assert.True(result);
             Assert.Equal(1337, version);
+        }
+
+        [Fact]
+        public void TryGetDocumentVersion_DeletedDocument_ReturnsFalse()
+        {
+            // Arrange
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var document = TestDocumentSnapshot.Create("C:/file.cshtml");
+            documentVersionCache.TrackDocumentVersion(document, 1337);
+            documentVersionCache.RazorFileChanged(document.FilePath, RazorFileChangeKind.Removed);
+
+            // Act
+            var result = documentVersionCache.TryGetDocumentVersion(document, out var version);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(-1, version);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void MarkAsLatestVersion_UntrackedDocument_Noops()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(document, 123);
             var untrackedDocument = TestDocumentSnapshot.Create("C:/other.cshtml");
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void MarkAsLatestVersion_KnownDocument_TracksNewDocumentAsLatest()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var documentInitial = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(documentInitial, 123);
             var documentLatest = TestDocumentSnapshot.Create(documentInitial.FilePath);
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetLatestVersionFromPath_TrackedDocument_ReturnsTrue()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var filePath = "C:/file.cshtml";
             var document1 = TestDocumentSnapshot.Create(filePath);
             var document2 = TestDocumentSnapshot.Create(filePath);
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetLatestVersionFromPath_UntrackedDocument_ReturnsFalse()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
 
             // Act
             var result = documentVersionCache.TryGetLatestVersionFromPath("C:/file.cshtml", out var version);
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_DocumentRemoved_DoesNotEvictDocument()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var projectSnapshotManager = TestProjectSnapshotManager.Create(Dispatcher);
             projectSnapshotManager.AllowNotifyListeners = true;
             documentVersionCache.Initialize(projectSnapshotManager);
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_OpenDocumentRemoved_DoesNotEvictDocument()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var projectSnapshotManager = TestProjectSnapshotManager.Create(Dispatcher);
             projectSnapshotManager.AllowNotifyListeners = true;
             documentVersionCache.Initialize(projectSnapshotManager);
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_DocumentClosed_EvictsDocument()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var projectSnapshotManager = TestProjectSnapshotManager.Create(Dispatcher);
             projectSnapshotManager.AllowNotifyListeners = true;
             documentVersionCache.Initialize(projectSnapshotManager);
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TrackDocumentVersion_AddsFirstEntry()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
 
             // Act
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TrackDocumentVersion_EvictsOldEntries()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
 
             for (var i = 0; i < DefaultDocumentVersionCache.MaxDocumentTrackingCount; i++)
@@ -215,7 +215,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetDocumentVersion_UntrackedDocumentPath_ReturnsFalse()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
 
             // Act
@@ -230,7 +230,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetDocumentVersion_EvictedDocument_ReturnsFalse()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
             var evictedDocument = TestDocumentSnapshot.Create(document.FilePath);
             documentVersionCache.TrackDocumentVersion(document, 1337);
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetDocumentVersion_KnownDocument_ReturnsTrue()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(document, 1337);
 
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetDocumentVersion_DeletedDocument_ReturnsFalse()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(document, 1337);
             documentVersionCache.RazorFileChanged(document.FilePath, RazorFileChangeKind.Removed);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -16,8 +16,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     public class ProjectConfigurationStateSynchronizerTest : LanguageServerTestBase
     {
-        private FilePathNormalizer FilePathNormalizer { get; } = new FilePathNormalizer();
-
         [Fact]
         public void ProjectConfigurationFileChanged_Removed_UnknownDocumentNoops()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/UnsynchronizableContentDocumentProcessedListenerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/UnsynchronizableContentDocumentProcessedListenerTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -181,6 +182,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             public override void TrackDocumentVersion(DocumentSnapshot documentSnapshot, long version) => throw new NotImplementedException();
 
             public override void Initialize(ProjectSnapshotManagerBase projectManager)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void RazorFileChanged(string filePath, RazorFileChangeKind kind)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Before this change, we were evicting documents from the cache when we untrack them even if it still exists on disk. 
This change makes it so we leave it in the cache until it gets deleted from the disk. Otherwise we can run into null-refs when resetting our project snapshot as part of updating our understanding from `project.razor.json`.