### PR TITLE
Clean up file writing

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonFileDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonFileDeserializer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             public override TValue Deserialize<TValue>(string filePath) where TValue : class
             {
-                using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
                 using var reader = new StreamReader(stream);
                 try
                 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -209,12 +209,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         protected virtual void SerializeToFile(ProjectSnapshot projectSnapshot, string publishFilePath)
         {
-            var stringWriter = new StringWriter();
-            _serializer.Serialize(stringWriter, projectSnapshot);
-
             var fileInfo = new FileInfo(publishFilePath);
-            using var fileWriter = fileInfo.CreateText();
-            fileWriter.Write(stringWriter.ToString());
+            using var writer = fileInfo.CreateText();
+            _serializer.Serialize(writer, projectSnapshot);
         }
 
         private async Task PublishAfterDelayAsync(string projectFilePath)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -209,9 +209,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         protected virtual void SerializeToFile(ProjectSnapshot projectSnapshot, string publishFilePath)
         {
+            var stringWriter = new StringWriter();
+            _serializer.Serialize(stringWriter, projectSnapshot);
+
             var fileInfo = new FileInfo(publishFilePath);
-            using var writer = fileInfo.CreateText();
-            _serializer.Serialize(writer, projectSnapshot);
+            using var fileWriter = fileInfo.CreateText();
+            fileWriter.Write(stringWriter.ToString());
         }
 
         private async Task PublishAfterDelayAsync(string projectFilePath)


### PR DESCRIPTION
Previously we could read while the file was open for writing, which lead to incomplete JSON.