### PR TITLE
Finish Blazor VS4Mac experience - Again

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor;
@@ -21,6 +24,9 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
         private const string RazorConfigurationItemType = "RazorConfiguration";
         private const string RazorConfigurationItemTypeExtensionsProperty = "Extensions";
         private const string RootNamespaceProperty = "RootNamespace";
+        private const string ContentItemType = "Content";
+
+        private IReadOnlyList<string> _currentRazorFilePaths = Array.Empty<string>();
 
         public DefaultRazorProjectHost(
             DotNetProject project,
@@ -44,6 +50,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
                     TryGetRootNamespace(projectProperties, out var rootNamespace);
                     var hostProject = new HostProject(DotNetProject.FileName.FullPath, configuration, rootNamespace);
                     await UpdateHostProjectUnsafeAsync(hostProject).ConfigureAwait(false);
+                    UpdateDocuments(hostProject, projectItems);
                 }
                 else
                 {
@@ -51,6 +58,87 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
                     await UpdateHostProjectUnsafeAsync(null).ConfigureAwait(false);
                 }
             });
+        }
+
+        internal IReadOnlyList<string> GetRazorDocuments(string projectDirectory, IEnumerable<IMSBuildItemEvaluated> projectItems)
+        {
+            var documentFilePaths = projectItems
+                .Where(IsRazorDocumentItem)
+                .Select(item => GetAbsolutePath(projectDirectory, item.Include))
+                .ToList();
+
+            return documentFilePaths;
+        }
+
+        private void UpdateDocuments(HostProject hostProject, IEnumerable<IMSBuildItemEvaluated> projectItems)
+        {
+            var projectDirectory = Path.GetDirectoryName(hostProject.FilePath);
+            var documentFilePaths = GetRazorDocuments(projectDirectory, projectItems);
+
+            var oldFiles = _currentRazorFilePaths;
+            var newFiles = documentFilePaths.ToImmutableHashSet();
+            var addedFiles = newFiles.Except(oldFiles);
+            var removedFiles = oldFiles.Except(newFiles);
+
+            _currentRazorFilePaths = documentFilePaths;
+
+            _ = Task.Factory.StartNew(() =>
+              {
+                  foreach (var document in removedFiles)
+                  {
+                      RemoveDocument(hostProject, document);
+                  }
+
+                  foreach (var document in addedFiles)
+                  {
+                      var relativeFilePath = document.Substring(projectDirectory.Length + 1);
+                      AddDocument(hostProject, document, relativeFilePath);
+                  }
+              },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            ForegroundDispatcher.ForegroundScheduler);
+        }
+
+        // Internal for testing
+        internal static bool IsRazorDocumentItem(IMSBuildItemEvaluated item)
+        {
+            if (item is null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            if (item.Name != ContentItemType)
+            {
+                // We only inspect content items for Razor documents.
+                return false;
+            }
+
+            if (item.Include == null)
+            {
+                return false;
+            }
+
+            if (!item.Include.EndsWith(".razor") && !item.Include.EndsWith(".cshtml"))
+            {
+                // Doesn't have a Razor looking file extension
+                return false;
+            }
+
+            return true;
+        }
+
+        private string GetAbsolutePath(string projectDirectory, string relativePath)
+        {
+            if (!Path.IsPathRooted(relativePath))
+            {
+                relativePath = Path.Combine(projectDirectory, relativePath);
+            }
+
+            // Normalize the path separator characters in case they're mixed
+            relativePath = relativePath.Replace('\\', Path.DirectorySeparatorChar);
+
+            return relativePath;
         }
 
         // Internal for testing
@@ -143,7 +231,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             {
                 return Array.Empty<string>();
             }
-            
+
             return extensionNamesValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/DefaultRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/DefaultRazorProjectHostTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
@@ -11,6 +12,83 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 {
     public class DefaultRazorProjectHostTest
     {
+        [Fact]
+        public void IsRazorDocumentItem_NonContentItem_ReturnsFalse()
+        {
+            // Arrange
+            var item = new TestMSBuildItem("NonContent")
+            {
+                Include = "\\Path\\To\\File.razor",
+            };
+
+            // Act
+            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsRazorDocumentItem_NoInclude_ReturnsFalse()
+        {
+            // Arrange
+            var item = new TestMSBuildItem("Content");
+
+            // Act
+            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsRazorDocumentItem_NonRazorFile_ReturnsFalse()
+        {
+            // Arrange
+            var item = new TestMSBuildItem("Content")
+            {
+                Include = "\\Path\\To\\File.notrazor",
+            };
+
+            // Act
+            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsRazorDocumentItem_RazorFile_ReturnsTrue()
+        {
+            // Arrange
+            var item = new TestMSBuildItem("Content")
+            {
+                Include = "\\Path\\To\\File.razor",
+            };
+
+            // Act
+            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsRazorDocumentItem_CSHTMLFile_ReturnsTrue()
+        {
+            // Arrange
+            var item = new TestMSBuildItem("Content")
+            {
+                Include = "\\Path\\To\\File.cshtml",
+            };
+
+            // Act
+            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+
+            // Assert
+            Assert.True(result);
+        }
+
         [Fact]
         public void TryGetDefaultConfiguration_FailsIfNoConfiguration()
         {
@@ -451,16 +529,16 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 
             public IMSBuildPropertyGroupEvaluated Metadata => _metadata;
 
-            public string Condition => throw new System.NotImplementedException();
+            public string Condition => throw new NotImplementedException();
 
-            public bool IsImported => throw new System.NotImplementedException();
+            public bool IsImported => throw new NotImplementedException();
 
 
-            public string UnevaluatedInclude => throw new System.NotImplementedException();
+            public string UnevaluatedInclude => throw new NotImplementedException();
 
-            public MSBuildItem SourceItem => throw new System.NotImplementedException();
+            public MSBuildItem SourceItem => throw new NotImplementedException();
 
-            public IEnumerable<MSBuildItem> SourceItems => throw new System.NotImplementedException();
+            public IEnumerable<MSBuildItem> SourceItems => throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
- Capture project level document information for VS4Mac Blazor scenarios
- Add a few tests.

- Some how we lost this changeset in our master branch.... It was originally done [here](https://github.com/dotnet/aspnetcore-tooling/pull/1335) but maybe it never made it into master? Not entirely sure about the events that led to this mishap but here's a fix.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1086561


/cc @KirillOsenkov 