### PR TITLE
Redesign LSP virtual document synchronization.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             _hostDocumentSyncVersion = hostDocumentVersion;
-            TextBuffer.MarkHostDocumentSyncVersion(_hostDocumentSyncVersion.Value);
+            TextBuffer.SetHostDocumentSyncVersion(_hostDocumentSyncVersion.Value);
 
             if (changes.Count == 0)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             _hostDocumentSyncVersion = hostDocumentVersion;
+            TextBuffer.MarkHostDocumentSyncVersion(_hostDocumentSyncVersion.Value);
 
             if (changes.Count == 0)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -96,6 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var virtualCSharpUri = new Uri(virtualCSharpFilePath);
 
             var csharpBuffer = _textBufferFactory.CreateTextBuffer();
+            _fileUriProvider.AddOrUpdate(csharpBuffer, virtualCSharpUri);
             csharpBuffer.Properties.AddProperty(ContainedLanguageMarker, true);
             csharpBuffer.Properties.AddProperty(LanguageClientConstants.ClientNamePropertyKey, "RazorCSharp");
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultFileUriProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultFileUriProvider.cs
@@ -25,6 +25,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             _textDocumentFactory = textDocumentFactory;
         }
 
+        public override void AddOrUpdate(ITextBuffer textBuffer, Uri uri)
+        {
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            textBuffer.Properties[TextBufferUri] = uri;
+        }
+
         public override Uri GetOrCreate(ITextBuffer textBuffer)
         {
             if (textBuffer is null)
@@ -32,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(textBuffer));
             }
 
-            if (textBuffer.Properties.TryGetProperty<Uri>(TextBufferUri, out var uri))
+            if (TryGet(textBuffer, out var uri))
             {
                 return uri;
             }
@@ -49,8 +64,23 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             uri = new Uri(filePath, UriKind.Absolute);
-            textBuffer.Properties.AddProperty(TextBufferUri, uri);
+            AddOrUpdate(textBuffer, uri);
             return uri;
+        }
+
+        public override bool TryGet(ITextBuffer textBuffer, out Uri uri)
+        {
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            if (textBuffer.Properties.TryGetProperty(TextBufferUri, out uri))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentSynchronizer.cs
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
         }
 
-        public class DocumentSynchronizingContext
+        private class DocumentSynchronizingContext
         {
             private readonly TaskCompletionSource<bool> _onSynchronizedSource;
             private readonly CancellationTokenSource _cts;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/FileUriProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/FileUriProvider.cs
@@ -20,5 +20,20 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         /// <param name="textBuffer">A text buffer</param>
         /// <returns>A <see cref="Uri"/> that can be used to locate the provided <paramref name="textBuffer"/>.</returns>
         public abstract Uri GetOrCreate(ITextBuffer textBuffer);
+
+        /// <summary>
+        /// Attempts to retrieve the Razor addressable <see cref="Uri"/> for the provided <paramref name="textBuffer"/>.
+        /// </summary>
+        /// <param name="textBuffer">A text buffer</param>
+        /// <param name="uri">A <see cref="Uri"/> that can be used to locate the provided <paramref name="textBuffer"/>.</param>
+        /// <returns><c>true</c> if a Razor based <see cref="Uri"/> existed on the buffer, other wise <c>false</c>.</returns>
+        public abstract bool TryGet(ITextBuffer textBuffer, out Uri uri);
+
+        /// <summary>
+        /// Adds or updates the provided <paramref name="uri"/> for the given <paramref name="textBuffer"/> under a Razor property name.
+        /// </summary>
+        /// <param name="textBuffer">A text buffer</param>
+        /// <param name="uri">A <see cref="Uri"/> that can be used to locate the provided <paramref name="textBuffer"/>.</param>
+        public abstract void AddOrUpdate(ITextBuffer textBuffer, Uri uri);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
             else
             {
-                var synchronized = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync(documentSnapshot, virtualDocument, cancellationToken).ConfigureAwait(false);
+                var synchronized = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocument, cancellationToken).ConfigureAwait(false);
                 if (!synchronized)
                 {
                     // Could not synchronize

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             _hostDocumentSyncVersion = hostDocumentVersion;
-            TextBuffer.MarkHostDocumentSyncVersion(_hostDocumentSyncVersion.Value);
+            TextBuffer.SetHostDocumentSyncVersion(_hostDocumentSyncVersion.Value);
 
             if (changes.Count == 0)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             _hostDocumentSyncVersion = hostDocumentVersion;
+            TextBuffer.MarkHostDocumentSyncVersion(_hostDocumentSyncVersion.Value);
 
             if (changes.Count == 0)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -91,6 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var virtualHtmlUri = new Uri(virtualHtmlFilePath);
 
             var htmlBuffer = _textBufferFactory.CreateTextBuffer();
+            _fileUriProvider.AddOrUpdate(htmlBuffer, virtualHtmlUri);
             htmlBuffer.Properties.AddProperty(ContainedLanguageMarker, true);
 
             // Create a text document to trigger the Html language server initialization.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPDocumentSynchronizer.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    internal abstract class LSPDocumentSynchronizer
+    internal abstract class LSPDocumentSynchronizer : LSPDocumentManagerChangeTrigger
     {
-        public abstract Task<bool> TrySynchronizeVirtualDocumentAsync(LSPDocumentSnapshot document, VirtualDocumentSnapshot virtualDocument, CancellationToken cancellationToken);
+        public abstract Task<bool> TrySynchronizeVirtualDocumentAsync(int requiredHostDocumentVersion, VirtualDocumentSnapshot virtualDocument, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
@@ -8,6 +8,30 @@ namespace Microsoft.VisualStudio.Text
 {
     internal static class TextBufferExtensions
     {
+        private static string HostDocumentVersionMarked = "__Razor_HostDocumentVersionMarker__";
+
+        public static void MarkHostDocumentSyncVersion(this ITextBuffer textBuffer, long hostDocumentVersion)
+        {
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            textBuffer.Properties[HostDocumentVersionMarked] = hostDocumentVersion;
+        }
+
+        public static bool TryGetHostDocumentSyncVersion(this ITextBuffer textBuffer, out long hostDocumentVersion)
+        {
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            var result = textBuffer.Properties.TryGetProperty(HostDocumentVersionMarked, out hostDocumentVersion);
+
+            return result;
+        }
+
         public static bool IsRazorLSPBuffer(this ITextBuffer textBuffer)
         {
             if (textBuffer == null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.Text
     {
         private static string HostDocumentVersionMarked = "__Razor_HostDocumentVersionMarker__";
 
-        public static void MarkHostDocumentSyncVersion(this ITextBuffer textBuffer, long hostDocumentVersion)
+        public static void SetHostDocumentSyncVersion(this ITextBuffer textBuffer, long hostDocumentVersion)
         {
             if (textBuffer is null)
             {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Infrastructure/TestTextBuffer.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Infrastructure/TestTextBuffer.cs
@@ -56,13 +56,13 @@ namespace Microsoft.VisualStudio.Test
                 changedEvent.Invoke(this, args);
             }
 
-            PostChanged?.Invoke(null, null);
+            PostChanged?.Invoke(this, null);
 
-            ReadOnlyRegionsChanged?.Invoke(null, null);
-            ChangedLowPriority?.Invoke(null, null);
-            ChangedHighPriority?.Invoke(null, null);
-            Changing?.Invoke(null, null);
-            ContentTypeChanged?.Invoke(null, null);
+            ReadOnlyRegionsChanged?.Invoke(this, null);
+            ChangedLowPriority?.Invoke(this, null);
+            ChangedHighPriority?.Invoke(this, null);
+            Changing?.Invoke(this, null);
+            ContentTypeChanged?.Invoke(this, null);
         }
 
         public IReadOnlyList<EventHandler<TextContentChangedEventArgs>> AttachedChangedEvents => _attachedChangedEvents;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
-using Moq;
 using Xunit;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
@@ -23,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void Update_AlwaysSetsHostDocumentSyncVersion_AndUpdatesSnapshot()
         {
             // Arrange
-            var textBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>());
+            var textBuffer = new TestTextBuffer(StringTextSnapshot.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
             var originalSnapshot = document.CurrentSnapshot;
 
@@ -39,114 +38,65 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void Update_Insert()
         {
             // Arrange
-            var insert = new TextChange(new TextSpan(123, 0), "inserted text");
-            var edit = new Mock<ITextEdit>();
-            edit.Setup(e => e.Insert(insert.Span.Start, insert.NewText)).Verifiable();
-            edit.Setup(e => e.Apply()).Verifiable();
-            var textBuffer = CreateTextBuffer(edit.Object);
+            var insert = new TextChange(new TextSpan(0, 0), "inserted text");
+            var textBuffer = new TestTextBuffer(StringTextSnapshot.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
             document.Update(new[] { insert }, hostDocumentVersion: 1);
 
             // Assert
-            edit.VerifyAll();
+            var text = textBuffer.CurrentSnapshot.GetText();
+            Assert.Equal(insert.NewText, text);
         }
 
         [Fact]
         public void Update_Replace()
         {
             // Arrange
-            var replace = new TextChange(new TextSpan(123, 4), "replaced text");
-            var edit = new Mock<ITextEdit>();
-            edit.Setup(e => e.Replace(replace.Span.Start, replace.Span.Length, replace.NewText)).Verifiable();
-            edit.Setup(e => e.Apply()).Verifiable();
-            var textBuffer = CreateTextBuffer(edit.Object);
+            var textBuffer = new TestTextBuffer(new StringTextSnapshot("original"));
+            var replace = new TextChange(new TextSpan(0, textBuffer.CurrentSnapshot.Length), "replaced text");
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
             document.Update(new[] { replace }, hostDocumentVersion: 1);
 
             // Assert
-            edit.VerifyAll();
+            var text = textBuffer.CurrentSnapshot.GetText();
+            Assert.Equal(replace.NewText, text);
         }
 
         [Fact]
         public void Update_Delete()
         {
             // Arrange
-            var delete = new TextChange(new TextSpan(123, 4), string.Empty);
-            var edit = new Mock<ITextEdit>();
-            edit.Setup(e => e.Delete(delete.Span.Start, delete.Span.Length)).Verifiable();
-            edit.Setup(e => e.Apply()).Verifiable();
-            var textBuffer = CreateTextBuffer(edit.Object);
+            var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
+            var delete = new TextChange(new TextSpan(6, 5), string.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
             document.Update(new[] { delete }, hostDocumentVersion: 1);
 
             // Assert
-            edit.VerifyAll();
+            var text = textBuffer.CurrentSnapshot.GetText();
+            Assert.Equal("Hello ", text);
         }
 
         [Fact]
         public void Update_MultipleEdits()
         {
             // Arrange
-            var replace = new TextChange(new TextSpan(123, 4), "replaced text");
-            var delete = new TextChange(new TextSpan(123, 4), string.Empty);
-            var edit = new Mock<ITextEdit>();
-            edit.Setup(e => e.Delete(delete.Span.Start, delete.Span.Length)).Verifiable();
-            edit.Setup(e => e.Replace(replace.Span.Start, replace.Span.Length, replace.NewText)).Verifiable();
-            var textBuffer = CreateTextBuffer(edit.Object);
-            edit.Setup(e => e.Apply())
-                .Returns(textBuffer.CurrentSnapshot).Verifiable();
+            var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
+            var replace = new TextChange(new TextSpan(6, 5), "Replaced");
+            var delete = new TextChange(new TextSpan(0, 6), string.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
             document.Update(new[] { replace, delete }, hostDocumentVersion: 1);
 
             // Assert
-            edit.VerifyAll();
-        }
-
-        [Fact]
-        public void Update_RecalculatesSnapshot()
-        {
-            // Arrange
-            var replace = new TextChange(new TextSpan(123, 4), "replaced text");
-            var edit = new Mock<ITextEdit>();
-            edit.Setup(e => e.Replace(replace.Span.Start, replace.Span.Length, replace.NewText));
-            var textBuffer = new Mock<ITextBuffer>();
-            var textBufferSnapshot = Mock.Of<ITextSnapshot>();
-            textBuffer.Setup(buffer => buffer.CreateEdit(EditOptions.None, null, It.IsAny<IInviolableEditTag>()))
-                .Returns(edit.Object);
-            textBuffer.Setup(buffer => buffer.CurrentSnapshot)
-                .Returns(() => textBufferSnapshot);
-            var editedSnapshot = Mock.Of<ITextSnapshot>();
-            edit.Setup(e => e.Apply())
-                .Callback(() =>
-                {
-                    textBufferSnapshot = editedSnapshot;
-                });
-            var document = new CSharpVirtualDocument(Uri, textBuffer.Object);
-
-            // Act
-            document.Update(new[] { replace }, hostDocumentVersion: 1);
-
-            // Assert
-            Assert.Same(editedSnapshot, document.CurrentSnapshot.Snapshot);
-        }
-
-        public static ITextBuffer CreateTextBuffer(ITextEdit edit)
-        {
-            var textBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CreateEdit(EditOptions.None, null, It.IsAny<IInviolableEditTag>()) == edit && buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>());
-            return textBuffer;
-        }
-
-        protected class TestTextChangeCollection : List<ITextChange>, INormalizedTextChangeCollection
-        {
-            public bool IncludesLineChanges => true;
+            var text = textBuffer.CurrentSnapshot.GetText();
+            Assert.Equal("Replaced", text);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentSynchronizerTest.cs
@@ -4,7 +4,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Test;
+using Microsoft.VisualStudio.Text;
 using Moq;
 using Xunit;
 
@@ -14,30 +15,29 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         public DefaultLSPDocumentSynchronizerTest()
         {
-            DocumentManager = Mock.Of<LSPDocumentManager>();
-            JoinableTaskContext = new JoinableTaskContext();
-            LSPDocumentUri = new Uri("C:/path/to/file.razor");
-            VirtualDocumentUri = new Uri("C:/path/to/file.razor__virtual.cs");
+            var snapshot = new StringTextSnapshot("Hello World");
+            var buffer = new TestTextBuffer(snapshot);
+            VirtualDocumentTextBuffer = buffer;
+            snapshot.TextBuffer = buffer;
+            VirtualDocumentSnapshot = snapshot;
         }
 
-        private LSPDocumentManager DocumentManager { get; }
+        private ITextSnapshot VirtualDocumentSnapshot { get; }
 
-        private JoinableTaskContext JoinableTaskContext { get; }
-
-        private Uri LSPDocumentUri { get; }
-
-        private Uri VirtualDocumentUri { get; }
+        private ITextBuffer VirtualDocumentTextBuffer { get; }
 
         [Fact]
         public async Task TrySynchronizeVirtualDocumentAsync_SynchronizedDocument_ReturnsTrue()
         {
             // Arrange
-            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
-            var virtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
-            var document = new TestLSPDocumentSnapshot(LSPDocumentUri, 123, virtualDocument);
+            var (lspDocument, virtualDocument) = CreateDocuments(lspDocumentVersion: 123, virtualDocumentSyncVersion: 123);
+            var fileUriProvider = CreateUriProviderFor(VirtualDocumentTextBuffer, virtualDocument.Uri);
+            var synchronizer = new DefaultLSPDocumentSynchronizer(fileUriProvider);
+            NotifyLSPDocumentAdded(lspDocument, synchronizer);
+            NotifyBufferVersionUpdated(VirtualDocumentTextBuffer, virtualDocument.HostDocumentSyncVersion.Value);
 
             // Act
-            var result = await synchronizer.TrySynchronizeVirtualDocumentAsync(document, virtualDocument, CancellationToken.None).ConfigureAwait(false);
+            var result = await synchronizer.TrySynchronizeVirtualDocumentAsync(lspDocument.Version, virtualDocument, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.True(result);
@@ -47,21 +47,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public async Task TrySynchronizeVirtualDocumentAsync_SynchronizesAfterUpdate_ReturnsTrue()
         {
             // Arrange
-            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            var (lspDocument, virtualDocument) = CreateDocuments(lspDocumentVersion: 124, virtualDocumentSyncVersion: 123);
+            var fileUriProvider = CreateUriProviderFor(VirtualDocumentTextBuffer, virtualDocument.Uri);
+            var synchronizer = new DefaultLSPDocumentSynchronizer(fileUriProvider);
             synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
-            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
-            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
-
-            // Start synchronization, this will hang until we invoke a DocumentManager_Changed event because the above virtual document expects host doc version 123 but the host doc is 124
-            var synchronizeTask = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
-
-            // Create a virtual and host doc that are synchronized (both at version 124).
-            var newVirtualDocument = originalVirtualDocument.Fork(124);
-            var newDocument = originalDocument.Fork(124, newVirtualDocument);
-            var args = new LSPDocumentChangeEventArgs(originalDocument, newDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
+            NotifyLSPDocumentAdded(lspDocument, synchronizer);
 
             // Act
-            synchronizer.DocumentManager_Changed(DocumentManager, args);
+
+            // Start synchronization, this will hang until we notify the buffer versions been updated because the above virtual document expects host doc version 123 but the host doc is 124
+            var synchronizeTask = synchronizer.TrySynchronizeVirtualDocumentAsync(lspDocument.Version, virtualDocument, CancellationToken.None);
+
+            NotifyBufferVersionUpdated(VirtualDocumentTextBuffer, lspDocument.Version);
             var result = await synchronizeTask.ConfigureAwait(false);
 
             // Assert
@@ -72,21 +69,19 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public async Task TrySynchronizeVirtualDocumentAsync_SimultaneousEqualSynchronizationRequests_ReturnsTrue()
         {
             // Arrange
-            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            var (lspDocument, virtualDocument) = CreateDocuments(lspDocumentVersion: 124, virtualDocumentSyncVersion: 123);
+            var fileUriProvider = CreateUriProviderFor(VirtualDocumentTextBuffer, virtualDocument.Uri);
+            var synchronizer = new DefaultLSPDocumentSynchronizer(fileUriProvider);
             synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
-            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
-            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
-
-            // Start synchronize
-            var synchronizeTask1 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
-            var synchronizeTask2 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
-
-            var newVirtualDocument = originalVirtualDocument.Fork(124);
-            var newDocument = originalDocument.Fork(124, newVirtualDocument);
-            var args = new LSPDocumentChangeEventArgs(originalDocument, newDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
+            NotifyLSPDocumentAdded(lspDocument, synchronizer);
 
             // Act
-            synchronizer.DocumentManager_Changed(DocumentManager, args);
+
+            // Start synchronization, this will hang until we notify the buffer versions been updated because the above virtual document expects host doc version 123 but the host doc is 124
+            var synchronizeTask1 = synchronizer.TrySynchronizeVirtualDocumentAsync(lspDocument.Version, virtualDocument, CancellationToken.None);
+            var synchronizeTask2 = synchronizer.TrySynchronizeVirtualDocumentAsync(lspDocument.Version, virtualDocument, CancellationToken.None);
+
+            NotifyBufferVersionUpdated(VirtualDocumentTextBuffer, lspDocument.Version);
             var result1 = await synchronizeTask1.ConfigureAwait(false);
             var result2 = await synchronizeTask2.ConfigureAwait(false);
 
@@ -99,30 +94,24 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public async Task TrySynchronizeVirtualDocumentAsync_SimultaneousDifferentSynchronizationRequests_CancelsFirst_ReturnsFalseThenTrue()
         {
             // Arrange
-            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            var (originalLSPDocument, originalVirtualDocument) = CreateDocuments(lspDocumentVersion: 124, virtualDocumentSyncVersion: 123);
+            var fileUriProvider = CreateUriProviderFor(VirtualDocumentTextBuffer, originalVirtualDocument.Uri);
+            var synchronizer = new DefaultLSPDocumentSynchronizer(fileUriProvider);
             synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(500);
-            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
-            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+            NotifyLSPDocumentAdded(originalLSPDocument, synchronizer);
 
-            // Start synchronization that will hang because 123 != 124
-            var synchronizeTask1 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+            // Act
 
-            var newVirtualDocument = originalVirtualDocument.Fork(124);
-            var newDocument = originalDocument.Fork(125, newVirtualDocument);
+            // Start synchronization, this will hang until we notify the buffer versions been updated because the above virtual document expects host doc version 123 but the host doc is 124
+            var synchronizeTask1 = synchronizer.TrySynchronizeVirtualDocumentAsync(originalLSPDocument.Version, originalVirtualDocument, CancellationToken.None);
 
             // Start another synchronization that will also hang because 124 != 125. However, this synchronization request is for the same addressable virtual document (same URI)
             // therefore requesting a second synchronization with a different host doc version expectation will cancel the original synchronization request resulting it returning
             // false.
-            var synchronizeTask2 = synchronizer.TrySynchronizeVirtualDocumentAsync(newDocument, newVirtualDocument, CancellationToken.None);
+            var (newLSPDocument, newVirtualDocument) = CreateDocuments(lspDocumentVersion: 125, virtualDocumentSyncVersion: 124);
+            var synchronizeTask2 = synchronizer.TrySynchronizeVirtualDocumentAsync(newLSPDocument.Version, newVirtualDocument, CancellationToken.None);
 
-            var finalVirtualDocument = newVirtualDocument.Fork(125);
-            var finalDocument = newDocument.Fork(125, finalVirtualDocument);
-
-            var args = new LSPDocumentChangeEventArgs(newDocument, finalDocument, LSPDocumentChangeKind.VirtualDocumentChanged);
-
-
-            // Act
-            synchronizer.DocumentManager_Changed(DocumentManager, args);
+            NotifyBufferVersionUpdated(VirtualDocumentTextBuffer, newLSPDocument.Version);
             var result1 = await synchronizeTask1.ConfigureAwait(false);
             var result2 = await synchronizeTask2.ConfigureAwait(false);
 
@@ -135,19 +124,51 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public async Task TrySynchronizeVirtualDocumentAsync_Timeout_ReturnsFalse()
         {
             // Arrange
-            var synchronizer = new DefaultLSPDocumentSynchronizer(DocumentManager, JoinableTaskContext);
+            var (lspDocument, virtualDocument) = CreateDocuments(lspDocumentVersion: 123, virtualDocumentSyncVersion: 123);
+            var fileUriProvider = CreateUriProviderFor(VirtualDocumentTextBuffer, virtualDocument.Uri);
+            var synchronizer = new DefaultLSPDocumentSynchronizer(fileUriProvider);
             synchronizer._synchronizationTimeout = TimeSpan.FromMilliseconds(10);
-            var originalVirtualDocument = new TestVirtualDocumentSnapshot(VirtualDocumentUri, 123);
-            var originalDocument = new TestLSPDocumentSnapshot(LSPDocumentUri, 124, originalVirtualDocument);
+            NotifyLSPDocumentAdded(lspDocument, synchronizer);
 
-            // Start synchronize
-            var synchronizeTask = synchronizer.TrySynchronizeVirtualDocumentAsync(originalDocument, originalVirtualDocument, CancellationToken.None);
+            // We're not going to notify that the buffer version was updated so the synchronization will wait until a timeout occurs.
 
             // Act
-            var result = await synchronizeTask.ConfigureAwait(false);
+            var result = await synchronizer.TrySynchronizeVirtualDocumentAsync(lspDocument.Version, virtualDocument, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.False(result);
+        }
+
+        private static void NotifyLSPDocumentAdded(LSPDocumentSnapshot lspDocument, DefaultLSPDocumentSynchronizer synchronizer)
+        {
+            var args = new LSPDocumentChangeEventArgs(old: null, @new: lspDocument, LSPDocumentChangeKind.Added);
+            synchronizer.DocumentManager_Changed(sender: null, args);
+        }
+
+        private (TestLSPDocumentSnapshot, TestVirtualDocumentSnapshot) CreateDocuments(int lspDocumentVersion, long virtualDocumentSyncVersion)
+        {
+            var virtualDocumentUri = new Uri("C:/path/to/file.razor__virtual.cs");
+            var virtualDocument = new TestVirtualDocumentSnapshot(virtualDocumentUri, virtualDocumentSyncVersion, VirtualDocumentSnapshot);
+            var documentUri = new Uri("C:/path/to/file.razor");
+            var document = new TestLSPDocumentSnapshot(documentUri, lspDocumentVersion, virtualDocument);
+
+            return (document, virtualDocument);
+        }
+
+        private FileUriProvider CreateUriProviderFor(ITextBuffer textBuffer, Uri bufferUri)
+        {
+            var fileUriProvider = Mock.Of<FileUriProvider>(provider => provider.TryGet(textBuffer, out bufferUri) == true);
+            return fileUriProvider;
+        }
+
+        private static void NotifyBufferVersionUpdated(ITextBuffer textBuffer, long hostDocumentSyncVersion)
+        {
+            textBuffer.MarkHostDocumentSyncVersion(hostDocumentSyncVersion);
+            var edit = textBuffer.CreateEdit();
+
+            // Content doesn't matter, we're just trying to create an edit that notifies listeners of a changed event.
+            edit.Insert(0, "Test");
+            edit.Apply();
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPDocumentSynchronizerTest.cs
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         private static void NotifyBufferVersionUpdated(ITextBuffer textBuffer, long hostDocumentSyncVersion)
         {
-            textBuffer.MarkHostDocumentSyncVersion(hostDocumentSyncVersion);
+            textBuffer.SetHostDocumentSyncVersion(hostDocumentSyncVersion);
             var edit = textBuffer.CreateEdit();
 
             // Content doesn't matter, we're just trying to create an edit that notifies listeners of a changed event.

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProjectionProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProjectionProviderTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
             documentSynchronizer
-                .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
+                .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
             var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>());
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
             documentSynchronizer
-                .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
+                .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
             var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>());
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
             documentSynchronizer
-                .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
+                .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
             var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>());
@@ -198,7 +198,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
             documentSynchronizer
-                .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
+                .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(false));
 
             var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>());

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestVirtualDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestVirtualDocumentSnapshot.cs
@@ -10,10 +10,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         private long? _hostDocumentSyncVersion;
 
-        public TestVirtualDocumentSnapshot(Uri uri, int hostDocumentVersion)
+        public TestVirtualDocumentSnapshot(Uri uri, long hostDocumentVersion) : this(uri, hostDocumentVersion, snapshot: null)
+        {
+        }
+
+        public TestVirtualDocumentSnapshot(Uri uri, long hostDocumentVersion, ITextSnapshot snapshot)
         {
             Uri = uri;
             _hostDocumentSyncVersion = hostDocumentVersion;
+            Snapshot = snapshot;
         }
 
         public override Uri Uri { get; }


### PR DESCRIPTION
- Prior to this we would listen to the `LSPDocumentManager`'s update events and on a virtual document changed event we would resolve active synchronization requests. Turns out that doesn't work because the act of updating our virtual document representation doesn't mean that the corresponding sub-language language server for the virtual document has seen the change. This "non-guaruntee" gets tested regularly in remote scenarios where our language server is powering a remote client. Therefore to work around this limitation I've rebuilt the synchronizer to act on `PostChanged` events of VirtualDocument's TextBuffers. The reason why this is important is that the LSP platform in Visual Studio will notify language servers of TextBuffer changes; therefore, by waiting for for "post changed" we ensure that the LSP platform has had enough time to see the event and react prior to us performing any extra operations such as "re-invoke completions" or any other re-invocation.
- Changed the C# and HTML document update flow to start marking their corresponding `TextBuffer`s with the appropriate host document version. This couples our virtual document updates to how we synchronize these documents with a parent LSP document but given the complexity of the problem that's alright as long as we contain the complexity in these two classes.
- Expanded our C# and HTML document creation flow to track their Uri's on the TextBuffer so that we can later retrieve it. This turns out to be important in the LSP document synchronization flow because we only have a TextBuffer when trying to reverse look up a corresponding virtual document uri. To do this I added an `AddOrUpdate` and a `TryGet` method to the `FileUriProvider` API.
- Updated the LSP synchronizer tests to use the new synchronization flow. Added several helper APIs to keep them readable.
- Added new `FileUriProvider` tests for the added APIs.

Fixes dotnet/aspnetcore#20641

@ajaybhargavb @ryanbrandenburg @TanayParikh To help review I would treat all changes to the LSP synchronizer and its tests as brand new files (aka view the raw file). I re-architected all parts of it and looking at the diffs will probably be more misleading than anything else.