### PR TITLE
Add support for C# diagnostics in LSP powered Razor files.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DynamicDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DynamicDocumentContainer.cs
@@ -14,5 +14,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
         public abstract IRazorSpanMappingService GetMappingService();
 
         public abstract IRazorDocumentExcerptService GetExcerptService();
+
+        public abstract IRazorDocumentPropertiesService GetDocumentPropertiesService();
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDocumentServiceProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDocumentServiceProvider.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
         private IRazorSpanMappingService _spanMappingService;
         private IRazorDocumentExcerptService _excerptService;
+        private IRazorDocumentPropertiesService _documentPropertiesService;
 
         public RazorDocumentServiceProvider()
             : this(null)
@@ -66,6 +67,22 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 }
 
                 return (TService)_excerptService;
+            }
+
+            if (typeof(TService) == typeof(IRazorDocumentPropertiesService))
+            {
+                if (_documentPropertiesService == null)
+                {
+                    lock (_lock)
+                    {
+                        if (_documentPropertiesService == null)
+                        {
+                            _documentPropertiesService = _documentContainer.GetDocumentPropertiesService();
+                        }
+                    }
+                }
+
+                return (TService)_documentPropertiesService;
             }
 
             return this as TService;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
@@ -52,5 +52,14 @@ namespace Microsoft.CodeAnalysis.Razor
 
             return _mappingService;
         }
+
+        public override IRazorDocumentPropertiesService GetDocumentPropertiesService()
+        {
+            // DocumentPropertiesServices are used to tell Roslyn to provide C# diagnostics for LSP provided documents to be shown 
+            // in the editor given a specific Language Server Client. Given this type is a container for DocumentSnapshots, we don't
+            // have a Language Server to associate errors with or an open document to display those errors on. We return `null` to
+            // opt out of those features.
+            return null;
+        }
     }
 }


### PR DESCRIPTION
- These diagnostics act similar to non-Razor diagnostics meaning if you open a file which has Razor diagnostics you will now permanently be prompted with those errors until you've resolved them. This was an odd case that I didn't realize was the "norm" for C# files until trying it out in Razor.
- This changeset utilizes changes from Roslyn where we associate our dynamic C# documents with Roslyn's [RazorLanguageClient](https://github.com/dotnet/roslyn/blob/d8e8df8d8bae3df5785acaa419a9963d7e92e74a/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorLanguageClient.cs) which has a `ClientName` of "RazorCSharp". By associating our documents with that language client Roslyn wont treat those documents as closed and allow diagnostics for them to flow through the system.

Fixes dotnet/aspnetcore#19660
