### PR TITLE
Support auto-closing Razor comments

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorOnTypeFormattingEndpoint.cs
@@ -61,17 +61,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 DocumentSelector = RazorDefaults.Selector,
                 FirstTriggerCharacter = ">",
+                MoreTriggerCharacter = new[] { "*" }
             };
         }
 
         public async Task<TextEditContainer> Handle(DocumentOnTypeFormattingParams request, CancellationToken cancellationToken)
         {
-            if (!_optionsMonitor.CurrentValue.AutoClosingTags)
-            {
-                // onTypeFormatting is only used for autoClosingTags support for now.
-                return null;
-            }
-
             var document = await Task.Factory.StartNew(() =>
             {
                 _documentResolver.TryResolveDocument(request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorService.cs
@@ -8,6 +8,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -26,9 +28,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly JoinableTaskFactory _joinableTaskFactory;
         private readonly SVsServiceProvider _serviceProvider;
         private readonly ITextBufferUndoManagerProvider _undoManagerProvider;
+        private readonly ICompletionBroker _completionBroker;
+        private readonly IVsEditorAdaptersFactoryService _adaptersFactoryService;
 
         [ImportingConstructor]
-        public DefaultLSPEditorService(JoinableTaskContext joinableTaskContext, SVsServiceProvider serviceProvider, ITextBufferUndoManagerProvider undoManagerProvider)
+        public DefaultLSPEditorService(
+            JoinableTaskContext joinableTaskContext,
+            SVsServiceProvider serviceProvider,
+            ITextBufferUndoManagerProvider undoManagerProvider,
+            ICompletionBroker completionBroker,
+            IVsEditorAdaptersFactoryService adaptersFactoryService)
         {
             if (joinableTaskContext is null)
             {
@@ -45,9 +54,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(undoManagerProvider));
             }
 
+            if (completionBroker is null)
+            {
+                throw new ArgumentNullException(nameof(completionBroker));
+            }
+
+            if (adaptersFactoryService is null)
+            {
+                throw new ArgumentNullException(nameof(adaptersFactoryService));
+            }
+
             _joinableTaskFactory = joinableTaskContext.Factory;
             _serviceProvider = serviceProvider;
             _undoManagerProvider = undoManagerProvider;
+            _completionBroker = completionBroker;
+            _adaptersFactoryService = adaptersFactoryService;
         }
 
         public async override Task ApplyTextEditsAsync(
@@ -89,8 +110,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
                     if (windowFrame != null)
                     {
-                        var textView = GetActiveVsTextView(windowFrame);
-                        MoveCaretToPosition(textView, cursorPosition);
+                        var vsTextView = GetActiveVsTextView(windowFrame);
+
+                        // Since we are moving the cursor we should dismiss any existing completion sessions as that is no longer valid.
+                        var textView = _adaptersFactoryService.GetWpfTextView(vsTextView);
+                        _completionBroker.DismissAllSessions(textView);
+
+                        MoveCaretToPosition(vsTextView, cursorPosition);
                     }
                 }
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -77,8 +77,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            
-
             var serverKind = projectionResult.LanguageKind == RazorLanguageKind.CSharp ? LanguageServerKind.CSharp : LanguageServerKind.Html;
 
             var (succeeded, result) = await TryGetProvisionalCompletionsAsync(request, documentSnapshot, projectionResult, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
@@ -582,5 +582,18 @@ expected: $@"
 ",
 character: "*");
         }
+
+        [Fact]
+        public async Task OnTypeStar_BeforeText_ClosesRazorComment()
+        {
+            await RunFormatOnTypeTestAsync(
+input: @"
+@| Hello
+",
+expected: $@"
+@* {LanguageServerConstants.CursorPlaceholderString} *@ Hello
+",
+character: "*");
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
@@ -543,5 +543,44 @@ expected: $@"
 ",
 character: ">");
         }
+
+        [Fact]
+        public async Task OnTypeStar_ClosesRazorComment()
+        {
+            await RunFormatOnTypeTestAsync(
+input: @"
+@|
+",
+expected: $@"
+@* {LanguageServerConstants.CursorPlaceholderString} *@
+",
+character: "*");
+        }
+
+        [Fact]
+        public async Task OnTypeStar_InsideRazorComment_Noops()
+        {
+            await RunFormatOnTypeTestAsync(
+input: @"
+@* @| *@
+",
+expected: $@"
+@* @* *@
+",
+character: "*");
+        }
+
+        [Fact]
+        public async Task OnTypeStar_EndRazorComment_Noops()
+        {
+            await RunFormatOnTypeTestAsync(
+input: @"
+@* Hello |@
+",
+expected: $@"
+@* Hello *@
+",
+character: "*");
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -97,12 +97,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task Handle_FormattingDisabled_ReturnsNull()
         {
             // Arrange
-            var codeDocument = TestRazorCodeDocument.CreateEmpty();
-            var uri = new Uri("file://path/test.razor");
-            var documentResolver = CreateDocumentResolver(uri.AbsolutePath, codeDocument);
             var formattingService = new TestRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
-            var endpoint = new RazorFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var endpoint = new RazorFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor, LoggerFactory);
             var @params = new DocumentRangeFormattingParams();
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -97,9 +97,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task Handle_FormattingDisabled_ReturnsNull()
         {
             // Arrange
+            var codeDocument = TestRazorCodeDocument.CreateEmpty();
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.AbsolutePath, codeDocument);
             var formattingService = new TestRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
-            var endpoint = new RazorFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor, LoggerFactory);
+            var endpoint = new RazorFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor, LoggerFactory);
             var @params = new DocumentRangeFormattingParams();
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorOnTypeFormattingEndpointTest.cs
@@ -100,10 +100,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task Handle_FormattingDisabled_ReturnsNull()
         {
             // Arrange
+            var codeDocument = TestRazorCodeDocument.CreateEmpty();
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.AbsolutePath, codeDocument);
             var formattingService = new TestRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(autoClosingTags: false);
-            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, EmptyDocumentResolver, formattingService, optionsMonitor);
-            var @params = new DocumentOnTypeFormattingParams();
+            var endpoint = new RazorOnTypeFormattingEndpoint(Dispatcher, documentResolver, formattingService, optionsMonitor);
+            var @params = new DocumentOnTypeFormattingParams()
+            {
+                TextDocument = new TextDocumentIdentifier(uri)
+            };
 
             // Act
             var result = await endpoint.Handle(@params, CancellationToken.None);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/20619

![close-comment](https://user-images.githubusercontent.com/1579269/79173297-f31f0f00-7dab-11ea-86fe-997fa5a0405c.gif)

- Handled onTypeFormatting for `*` to enable Razor comment auto-closing
- Updated cursor movement logic to also dismiss any existing completion dialogs. Without that, the completion dialog from typing the `@` remains even after we applied the edits
- Added tests