### PR TITLE
Updated Markup Transition Tag Contextual Availability Logic

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -98,11 +98,17 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                providing incorrect completion in the above two syntactically invalid
                scenarios.
             */
+            var encapsulatingMarkupElementNodeSeen = false;
+
             var closestSignificantAncestor = owner.Ancestors().FirstOrDefault(node =>
             {
-                if (node is MarkupElementSyntax markupNode && markupNode.ChildNodes().Count != 1)
+                if (node is MarkupElementSyntax markupNode)
                 {
-                    return true;
+                    if (encapsulatingMarkupElementNodeSeen) {
+                        return true;
+                    }
+
+                    encapsulatingMarkupElementNodeSeen = true;
                 }
 
                 if (node is CSharpCodeBlockSyntax)
@@ -112,6 +118,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 
                 return false;
             });
+
             return closestSignificantAncestor is CSharpCodeBlockSyntax;
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -100,26 +100,23 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             */
             var encapsulatingMarkupElementNodeSeen = false;
 
-            var closestSignificantAncestor = owner.Ancestors().FirstOrDefault(node =>
-            {
-                if (node is MarkupElementSyntax markupNode)
+            foreach (var ancestor in owner.Ancestors()) {
+                if (ancestor is MarkupElementSyntax markupNode)
                 {
                     if (encapsulatingMarkupElementNodeSeen) {
-                        return true;
+                        return false;
                     }
 
                     encapsulatingMarkupElementNodeSeen = true;
                 }
 
-                if (node is CSharpCodeBlockSyntax)
+                if (ancestor is CSharpCodeBlockSyntax)
                 {
                     return true;
                 }
+            }
 
-                return false;
-            });
-
-            return closestSignificantAncestor is CSharpCodeBlockSyntax;
+            return false;
         }
     }
 }


### PR DESCRIPTION
Turned out to be a relatively simple fix after the investigation revealed the root cause of all three issues to be the same.


## Issue 1
https://github.com/dotnet/aspnetcore/issues/20590

### Before
![78614146-9909d100-7822-11ea-8d88-6305698b26dd](https://user-images.githubusercontent.com/14852843/79285742-44460600-7e73-11ea-8190-f9f85eaaa35e.gif)

### After
![Apr-14-2020 17-23-07](https://user-images.githubusercontent.com/14852843/79286183-ab17ef00-7e74-11ea-85c1-93cb2ae9c000.gif)|

## Issue 2
https://github.com/dotnet/aspnetcore/issues/20590#issuecomment-610523530

### Before
![NavBefore](https://user-images.githubusercontent.com/14852843/79286481-9a1bad80-7e75-11ea-90f9-70fd263d7d63.gif)


### After
![NavAfter](https://user-images.githubusercontent.com/14852843/79286434-6b9dd280-7e75-11ea-89a6-508ca1d56eab.gif)


## Issue 3
https://github.com/dotnet/aspnetcore/issues/19815

### Before
![image](https://user-images.githubusercontent.com/14852843/79285868-a999f700-7e73-11ea-8081-bad3715150a1.png)

### After
![Screen Shot 2020-04-14 at 5 05 10 PM](https://user-images.githubusercontent.com/14852843/79285883-ba4a6d00-7e73-11ea-8c02-227b4b3aa082.png)


The root cause for all three issues relates to the encapsulating `MarkupElementSyntax.ChildNodes`. When there is an (unrelated) closing `>` somewhere else in the document, the parser will interpret everything between the opening `<` and closing `>` as being part of the start tag. @ajaybhargavb clarified that this is by [design](https://github.com/dotnet/aspnetcore-tooling/blob/master/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs#L975). Due to this, the `MarkupElementSyntax` will be shown to have multiple children (which was previously a disqualifier for tag completion as this usually indicates HTML context).

![image](https://user-images.githubusercontent.com/14852843/79286615-08f90680-7e76-11ea-9088-6d6291a69241.png)

Hence we need to handle our logic around `MarkupElementSyntax` nodes differently (if the node had more than 1 child, we just assumed we were in HTML context). I've made a simple change to this logic to now allow the first `MarkupElementSyntax` node (as we know the `<text>` tag will always be within one), and then continue up the ancestor tree to find a relevant `MarkupElementSyntax` node for HTML classification or `CSharpCodeBlockSyntax` for C# classification.

Fixes https://github.com/dotnet/aspnetcore/issues/20590
Fixes https://github.com/dotnet/aspnetcore/issues/19815