### PR TITLE
Add colorization support for "return" & other C# loop constructs.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -157,7 +157,7 @@
 
       <dict>
         <key>scope</key>
-        <string>keyword.control.conditional, keyword.control.loop.in.cs, keyword.control.loop.foreach.cs</string>
+        <string>keyword.control.conditional, keyword.control.loop, keyword.control.flow</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>


### PR DESCRIPTION
- C# control flow statements like `return`  weren't getting colored. Added a listing to the `keyword.control.flow` listing.
- Other C# loop constructs such as `while` and `do` weren't getting their proper colorization so expanded the `keyword.control.loop` entries to not be specific on a per-keyword basis.

Fixes dotnet/aspnetcore#20880