### PR TITLE
Move cursor on the guest

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPEditorService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPEditorService.cs
@@ -12,5 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     internal abstract class LSPEditorService
     {
         public abstract Task ApplyTextEditsAsync(Uri uri, ITextSnapshot snapshot, IEnumerable<TextEdit> textEdits);
+
+        public abstract void MoveCaretToPosition(string fullPath, int absoluteIndex);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextDocumentCreatedListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextDocumentCreatedListener.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Composition;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.Shell;
@@ -19,9 +21,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         private static readonly Guid HtmlLanguageServiceGuid = new Guid("9BBFD173-9770-47DC-B191-651B7FF493CD");
 
+        private const string FilePathPropertyKey = "RazorTextBufferFilePath";
+
         private readonly TrackingLSPDocumentManager _lspDocumentManager;
         private readonly ITextDocumentFactoryService _textDocumentFactory;
         private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
+        private readonly LSPEditorService _editorService;
         private readonly SVsServiceProvider _serviceProvider;
         private readonly IEditorOptionsFactoryService _editorOptionsFactory;
         private readonly IContentType _razorLSPContentType;
@@ -32,6 +37,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             IContentTypeRegistryService contentTypeRegistry,
             LSPDocumentManager lspDocumentManager,
             LSPEditorFeatureDetector lspEditorFeatureDetector,
+            LSPEditorService editorService,
             SVsServiceProvider serviceProvider,
             IEditorOptionsFactoryService editorOptionsFactory)
         {
@@ -55,6 +61,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(lspEditorFeatureDetector));
             }
 
+            if (editorService is null)
+            {
+                throw new ArgumentNullException(nameof(editorService));
+            }
+
             if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider));
@@ -76,6 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             _textDocumentFactory = textDocumentFactory;
             _lspEditorFeatureDetector = lspEditorFeatureDetector;
+            _editorService = editorService;
             _serviceProvider = serviceProvider;
             _editorOptionsFactory = editorOptionsFactory;
 
@@ -102,7 +114,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 // This Razor text buffer has yet to be initialized.
 
-                InitializeRazorLSPTextBuffer(textBuffer);
+                InitializeRazorLSPTextBuffer(args.TextDocument.FilePath, textBuffer);
             }
         }
 
@@ -162,7 +174,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return true;
         }
 
-        private void InitializeRazorLSPTextBuffer(ITextBuffer textBuffer)
+        private void InitializeRazorLSPTextBuffer(string filePath, ITextBuffer textBuffer)
         {
             if (_lspEditorFeatureDetector.IsRemoteClient())
             {
@@ -171,6 +183,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
                 // We still change the content type for remote scenarios in order to enable our TextMate grammar to light up the Razor editor properly.
                 textBuffer.ChangeContentType(_razorLSPContentType, editTag: null);
+
+                // Temporary: The guest needs to react to the host manually applying edits and moving the cursor.
+                // This can be removed once the client starts supporting snippets.
+                textBuffer.Properties.AddProperty(FilePathPropertyKey, filePath);
+                textBuffer.ChangedHighPriority += RazorGuestBuffer_Changed;
             }
             else
             {
@@ -205,6 +222,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 var razorOptions = _editorOptionsFactory.GetOptions(textBuffer);
                 razorOptions.SetOptionValue(DefaultOptions.ConvertTabsToSpacesOptionId, insertSpaces);
                 razorOptions.SetOptionValue(DefaultOptions.TabSizeOptionId, (int)tabSize);
+            }
+        }
+
+        private void RazorGuestBuffer_Changed(object sender, TextContentChangedEventArgs args)
+        {
+            var replacePlaceholderChange = args.Changes.FirstOrDefault(c => c.OldText == LanguageServerConstants.CursorPlaceholderString && c.NewText == string.Empty);
+            if (replacePlaceholderChange != null)
+            {
+                if (!(sender is ITextBuffer buffer) ||
+                    !buffer.Properties.TryGetProperty<string>(FilePathPropertyKey, out var filePath))
+                {
+                    return;
+                }
+
+                _editorService.MoveCaretToPosition(filePath, replacePlaceholderChange.NewPosition);
             }
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextDocumentCreatedListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextDocumentCreatedListenerTest.cs
@@ -239,6 +239,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 contentTypeRegistry,
                 lspDocumentManager,
                 lspEditorFeatureDetector,
+                Mock.Of<LSPEditorService>(),
                 Mock.Of<SVsServiceProvider>(s => s.GetService(It.IsAny<Type>()) == Mock.Of<IVsTextManager2>()),
                 Mock.Of<IEditorOptionsFactoryService>(s => s.GetOptions(It.IsAny<ITextBuffer>()) == Mock.Of<IEditorOptions>()));
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/20651

_Left: Host &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Right: Guest_
![guest-cursor](https://user-images.githubusercontent.com/1579269/79411872-dffd7200-7f58-11ea-882c-7fe0de4cf982.gif)

- Added a temporary method to listen for guest buffer changes. Whenever we see a change that replaces `__placeholder__` with cursor position, we now manually move the cursor position on the guest as well
- This doesn't fix the undo stack on the guest. Fixing that with the current design would take a lot more time/effort and not worth it IMO
- Testing this would be a pain as this is all VS API. Plus this is all super temporary code so... yolo.