### PR TITLE
C# Hover Implementation

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    [Shared]
+    [ExportLspMethod(Methods.TextDocumentHoverName)]
+    internal class HoverHandler : IRequestHandler<TextDocumentPositionParams, Hover>
+    {
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+        private readonly LSPRequestInvoker _requestInvoker;
+        private readonly LSPDocumentManager _documentManager;
+        private readonly LSPProjectionProvider _projectionProvider;
+        private readonly LSPDocumentMappingProvider _documentMappingProvider;
+
+        [ImportingConstructor]
+        public HoverHandler(
+            JoinableTaskContext joinableTaskContext,
+            LSPRequestInvoker requestInvoker,
+            LSPDocumentManager documentManager,
+            LSPProjectionProvider projectionProvider,
+            LSPDocumentMappingProvider documentMappingProvider)
+        {
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            if (requestInvoker is null)
+            {
+                throw new ArgumentNullException(nameof(requestInvoker));
+            }
+
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (projectionProvider is null)
+            {
+                throw new ArgumentNullException(nameof(projectionProvider));
+            }
+
+            if (documentMappingProvider is null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingProvider));
+            }
+
+            _joinableTaskFactory = joinableTaskContext.Factory;
+            _requestInvoker = requestInvoker;
+            _documentManager = documentManager;
+            _projectionProvider = projectionProvider;
+            _documentMappingProvider = documentMappingProvider;
+        }
+
+        public async Task<Hover> HandleRequestAsync(TextDocumentPositionParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+        {
+            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
+            {
+                return null;
+            }
+
+            // Switch to a background thread.
+            await TaskScheduler.Default;
+
+            var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
+            if (projectionResult == null)
+            {
+                return null;
+            }
+
+            var serverKind = projectionResult.LanguageKind == RazorLanguageKind.CSharp ? LanguageServerKind.CSharp : LanguageServerKind.Html;
+
+            if (serverKind != LanguageServerKind.CSharp)
+            {
+                // Hover is only supported in the C# LSP for now.
+                return null;
+            }
+
+            var textDocumentPositionParams = new TextDocumentPositionParams()
+            {
+                Position = projectionResult.Position,
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = projectionResult.Uri
+                }
+            };
+
+            Hover result;
+            try
+            {
+                result = await _requestInvoker.RequestServerAsync<TextDocumentPositionParams, Hover>(
+                    Methods.TextDocumentHoverName,
+                    serverKind,
+                    textDocumentPositionParams,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ensure we fail silently (Temporary till roslyn update is live)
+                return null;
+            }
+
+            if (result?.Range == null || result?.Contents == null)
+            {
+                return null;
+            }
+
+            var mappingResult = await _documentMappingProvider.MapToDocumentRangeAsync(projectionResult.LanguageKind, request.TextDocument.Uri, result.Range, cancellationToken).ConfigureAwait(false);
+
+            if (mappingResult == null)
+            {
+                // Couldn't remap the edits properly. Returning hover at initial request position.
+                return new Hover
+                {
+                    Contents = result.Contents,
+                    Range = new Range()
+                    {
+                        Start = request.Position,
+                        End = request.Position
+                    }
+                };
+            }
+            else if (mappingResult.HostDocumentVersion != documentSnapshot.Version)
+            {
+                // Discard hover if document has changed.
+                return null;
+            }
+
+            return new Hover
+            {
+                Contents = result.Contents,
+                Range = mappingResult.Range
+            };
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     FirstTriggerCharacter = ">",
                     MoreTriggerCharacter = new[] { "=", "-" }
                 },
+                HoverProvider = true
             }
         };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -76,6 +76,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(Methods.TextDocumentCompletionName, completionParams, _clientCapabilities, cancellationToken);
         }
 
+        [JsonRpcMethod(Methods.TextDocumentHoverName, UseSingleObjectParameterDeserialization = true)]
+        public Task<Hover> ProvideHoverAsync(TextDocumentPositionParams positionParams, CancellationToken cancellationToken)
+        {
+            if (positionParams is null)
+            {
+                throw new ArgumentNullException(nameof(positionParams));
+            }
+
+            return ExecuteRequestAsync<TextDocumentPositionParams, Hover>(Methods.TextDocumentHoverName, positionParams, _clientCapabilities, cancellationToken);
+        }
+
         [JsonRpcMethod(Methods.TextDocumentCompletionResolveName, UseSingleObjectParameterDeserialization = true)]
         public Task<CompletionItem> ResolveCompletionAsync(CompletionItem request, CancellationToken cancellationToken)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -558,41 +558,5 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var item = Assert.Single((CompletionItem[])result.Value);
             Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
-
-        private class TestDocumentManager : TrackingLSPDocumentManager
-        {
-            private readonly Dictionary<Uri, LSPDocumentSnapshot> _documents = new Dictionary<Uri, LSPDocumentSnapshot>();
-
-            public override event EventHandler<LSPDocumentChangeEventArgs> Changed;
-
-            public int UpdateVirtualDocumentCallCount { get; private set; }
-
-            public override bool TryGetDocument(Uri uri, out LSPDocumentSnapshot lspDocumentSnapshot)
-            {
-                return _documents.TryGetValue(uri, out lspDocumentSnapshot);
-            }
-
-            public void AddDocument(Uri uri, LSPDocumentSnapshot documentSnapshot)
-            {
-                _documents.Add(uri, documentSnapshot);
-
-                Changed?.Invoke(this, null);
-            }
-
-            public override void TrackDocument(ITextBuffer buffer)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void UntrackDocument(ITextBuffer buffer)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void UpdateVirtualDocument<TVirtualDocument>(Uri hostDocumentUri, IReadOnlyList<TextChange> changes, long hostDocumentVersion)
-            {
-                UpdateVirtualDocumentCallCount++;
-            }
-        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
@@ -1,0 +1,413 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class HoverHandlerTest
+    {
+        public HoverHandlerTest()
+        {
+            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
+            JoinableTaskContext = joinableTaskContext.Context;
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var hoverhandler = new HoverHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var hoverRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await hoverhandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_ProjectionNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var hoverhandler = new HoverHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var hoverRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await hoverhandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_InvokesCSharpLanguageServer()
+        {
+            // Arrange
+            var called = false;
+
+            var expectedContents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(
+                new MarkedString()
+                {
+                    Language = "markdown",
+                    Value = "Hover Details"
+                }
+            );
+
+            var lspResponse = new Hover()
+            {
+                Range = new Range()
+                {
+                    Start = new Position(10, 0),
+                    End = new Position(10, 1)
+                },
+                Contents = expectedContents
+            };
+
+            var expectedItem = new Hover()
+            {
+                Range = new Range()
+                {
+                    Start = new Position(0, 0),
+                    End = new Position(0, 1)
+                },
+                Contents = expectedContents
+            };
+
+            var hoverRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<TextDocumentPositionParams, Hover>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, hoverParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentHoverName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(lspResponse));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangeResponse()
+            {
+                Range = new Range()
+                {
+                    Start = new Position(0, 0),
+                    End = new Position(0, 1)
+                }
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range>(), It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+
+            // Act
+            var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Equal(expectedItem.Contents, result.Contents);
+            Assert.Equal(expectedItem.Range, result.Range);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_RazorProjection_InvokesHtmlLanguageServer()
+        {
+            // Arrange
+            var called = false;
+
+            var expectedContents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(
+                new MarkedString()
+                {
+                    Language = "markdown",
+                    Value = "HTML Hover Details"
+                }
+            );
+
+            var expectedItem = new Hover()
+            {
+                Range = new Range()
+                {
+                    Start = new Position(0, 0),
+                    End = new Position(0, 1)
+                },
+                Contents = expectedContents
+            };
+
+            var hoverRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<TextDocumentPositionParams, Hover>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, hoverParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentHoverName, method);
+                    Assert.Equal(LanguageServerKind.Html, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(expectedItem));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.Razor,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangeResponse();
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range>(), It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+
+            // Act
+            var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            // (NOT yet supported)
+            Assert.False(called);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_InvokesCSharpLanguageServerWithNoResult()
+        {
+            // Arrange
+            var called = false;
+            var hoverRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<TextDocumentPositionParams, Hover>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, hoverParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentHoverName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult<Hover>(null));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+
+            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+
+            // Act
+            var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_InvokesCSharpLanguageServer_FailsRemappingResultReturnsHoverWithInitialPosition()
+        {
+            // Arrange
+            var called = false;
+
+            var expectedContents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(
+                new MarkedString()
+                {
+                    Language = "markdown",
+                    Value = "Hover Details"
+                }
+            );
+
+            var lspResponse = new Hover()
+            {
+                Range = new Range()
+                {
+                    Start = new Position(10, 0),
+                    End = new Position(10, 1)
+                },
+                Contents = expectedContents
+            };
+
+            var expectedItem = new Hover()
+            {
+                Range = new Range()
+                {
+                    Start = new Position(0, 1),
+                    End = new Position(0, 1)
+                },
+                Contents = expectedContents
+            };
+
+            var hoverRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<TextDocumentPositionParams, Hover>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, hoverParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentHoverName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(lspResponse));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range>(), It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult<RazorMapToDocumentRangeResponse>(null));
+
+            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+
+            // Act
+            var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Equal(expectedItem.Contents, result.Contents);
+            Assert.Equal(expectedItem.Range, result.Range);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_InvokesCSharpLanguageServer_FailsRemappingResultRangeWithHostVersionChanged()
+        {
+            // Arrange
+            var called = false;
+
+            var expectedContents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(
+                new MarkedString()
+                {
+                    Language = "markdown",
+                    Value = "Hover Details"
+                }
+            );
+
+            var lspResponse = new Hover()
+            {
+                Range = new Range()
+                {
+                    Start = new Position(10, 0),
+                    End = new Position(10, 1)
+                },
+                Contents = expectedContents
+            };
+
+            var hoverRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var requestInvoker = new Mock<LSPRequestInvoker>();
+            requestInvoker
+                .Setup(r => r.RequestServerAsync<TextDocumentPositionParams, Hover>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, hoverParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentHoverName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult<Hover>(lspResponse));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangeResponse()
+            {
+                HostDocumentVersion = 1
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range>(), It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+
+            // Act
+            var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Null(result);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestDocumentManager.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestDocumentManager.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class TestDocumentManager : TrackingLSPDocumentManager
+    {
+        private readonly Dictionary<Uri, LSPDocumentSnapshot> _documents = new Dictionary<Uri, LSPDocumentSnapshot>();
+
+        public override event EventHandler<LSPDocumentChangeEventArgs> Changed;
+
+        public int UpdateVirtualDocumentCallCount { get; private set; }
+
+        public override bool TryGetDocument(Uri uri, out LSPDocumentSnapshot lspDocumentSnapshot)
+        {
+            return _documents.TryGetValue(uri, out lspDocumentSnapshot);
+        }
+
+        public void AddDocument(Uri uri, LSPDocumentSnapshot documentSnapshot)
+        {
+            _documents.Add(uri, documentSnapshot);
+
+            Changed?.Invoke(this, null);
+        }
+
+        public override void TrackDocument(ITextBuffer buffer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void UntrackDocument(ITextBuffer buffer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void UpdateVirtualDocument<TVirtualDocument>(Uri hostDocumentUri, IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        {
+            UpdateVirtualDocumentCallCount++;
+        }
+    }
+}


### PR DESCRIPTION
Adds C# Razor Hover Support to Visual Studio. 
- Requires https://github.com/dotnet/roslyn/pull/43388 to be merged in and available for the `textDocument/hover` request to the C# Roslyn LSP to be accepted. Thanks @dibarbet!
- Visual Studio support for multiple hover handlers added.
- HTML hover support is currently blocked on the HTML LSP. Integration just requires removing the C# guard (https://github.com/dotnet/aspnetcore-tooling/compare/taparik/vs_hover_handler?expand=1#diff-ede37ecb91c141853c9e2b65fdc8c051R87-R91) and adding in the appropriate tests.
- Classifications (colors), bold/italics and links are missing (Roslyn is planning to add in the support later)

<img width="650" alt="Screen Shot 2020-04-16 at 10 31 20 AM" src="https://user-images.githubusercontent.com/14852843/79507788-2dc3ba00-7fed-11ea-9add-45e022704af0.png">
<img width="449" alt="Screen Shot 2020-04-16 at 9 28 11 AM" src="https://user-images.githubusercontent.com/14852843/79507799-31574100-7fed-11ea-90d1-02e88281ded8.png">

(Note: The extra trailing blank line can be ignored, I haven't recompiled roslyn with the latest changes which addresses that issue).

Fixes https://github.com/dotnet/aspnetcore/issues/20158