### PR TITLE
Only have lines if they're needed

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
@@ -75,13 +75,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     descriptionBuilder.AppendLine("---");
                 }
 
-                StartOrEndBold(descriptionBuilder);
                 var tagHelperType = descriptionInfo.TagHelperTypeName;
                 var reducedTypeName = ReduceTypeName(tagHelperType);
+                StartOrEndBold(descriptionBuilder);
                 descriptionBuilder.Append(reducedTypeName);
                 StartOrEndBold(descriptionBuilder);
-                descriptionBuilder.AppendLine();
-                descriptionBuilder.AppendLine();
 
                 var documentation = descriptionInfo.Documentation;
                 if (!TryExtractSummary(documentation, out var summaryContent))
@@ -89,8 +87,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     continue;
                 }
 
+                descriptionBuilder.AppendLine();
+                descriptionBuilder.AppendLine();
                 var finalSummaryContent = CleanSummaryContent(summaryContent);
-                descriptionBuilder.AppendLine(finalSummaryContent);
+                descriptionBuilder.Append(finalSummaryContent);
             }
 
             tagHelperDescription = new MarkupContent
@@ -142,8 +142,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 StartOrEndBold(descriptionBuilder);
                 descriptionBuilder.Append(descriptionInfo.PropertyName);
                 StartOrEndBold(descriptionBuilder);
-                descriptionBuilder.AppendLine();
-                descriptionBuilder.AppendLine();
 
                 var documentation = descriptionInfo.Documentation;
                 if (!TryExtractSummary(documentation, out var summaryContent))
@@ -151,6 +149,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     continue;
                 }
 
+                descriptionBuilder.AppendLine();
+                descriptionBuilder.AppendLine();
                 var finalSummaryContent = CleanSummaryContent(summaryContent);
                 descriptionBuilder.AppendLine(finalSummaryContent);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 descriptionBuilder.AppendLine();
                 descriptionBuilder.AppendLine();
                 var finalSummaryContent = CleanSummaryContent(summaryContent);
-                descriptionBuilder.AppendLine(finalSummaryContent);
+                descriptionBuilder.Append(finalSummaryContent);
             }
 
             tagHelperDescription = new MarkupContent

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
@@ -498,8 +498,7 @@ Uses `List<System.String>`s", markdown.Value);
             Assert.True(result);
             Assert.Equal(@"string SomeTypeName.SomeProperty
 
-Uses `List<System.String>`s
-", markdown.Value);
+Uses `List<System.String>`s", markdown.Value);
             Assert.Equal(MarkupKind.PlainText, markdown.Kind);
         }
         [Fact]
@@ -575,8 +574,7 @@ Also uses `List<System.String>`s", markdown.Value);
             Assert.True(result);
             Assert.Equal(@"**string** SomeTypeName.**SomeProperty**
 
-Uses `List<System.String>`s
-", markdown.Value);
+Uses `List<System.String>`s", markdown.Value);
             Assert.Equal(MarkupKind.Markdown, markdown.Kind);
         }
 
@@ -608,12 +606,10 @@ Uses `List<System.String>`s
             Assert.Equal(@"**string** SomeTypeName.**SomeProperty**
 
 Uses `List<System.String>`s
-
 ---
 **Boolean?** AnotherTypeName.**AnotherProperty**
 
-Uses `List<System.String>`s
-", markdown.Value);
+Uses `List<System.String>`s", markdown.Value);
             Assert.Equal(MarkupKind.Markdown, markdown.Kind);
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
@@ -446,8 +446,7 @@ World
             Assert.True(result);
             Assert.Equal(@"**SomeTagHelper**
 
-Uses `List<System.String>`s
-", markdown.Value);
+Uses `List<System.String>`s", markdown.Value);
             Assert.Equal(MarkupKind.Markdown, markdown.Kind);
         }
 
@@ -471,8 +470,7 @@ Uses `List<System.String>`s
             Assert.True(result, "TryCreateDescription should have succeeded");
             Assert.Equal(@"SomeTagHelper
 
-Uses `List<System.String>`s
-", markdown.Value);
+Uses `List<System.String>`s", markdown.Value);
             Assert.Equal(MarkupKind.PlainText, markdown.Kind);
         }
 
@@ -524,8 +522,7 @@ Uses `List<System.String>`s
             Assert.True(result);
             Assert.Equal(@"**SomeTagHelper**
 
-Uses `List<System.String>`s
-", markdown.Value);
+Uses `List<System.String>`s", markdown.Value);
             Assert.Equal(MarkupKind.Markdown, markdown.Kind);
         }
 
@@ -549,12 +546,10 @@ Uses `List<System.String>`s
             Assert.Equal(@"**SomeTagHelper**
 
 Uses `List<System.String>`s
-
 ---
 **OtherTagHelper**
 
-Also uses `List<System.String>`s
-", markdown.Value);
+Also uses `List<System.String>`s", markdown.Value);
             Assert.Equal(MarkupKind.Markdown, markdown.Kind);
         }
 


### PR DESCRIPTION
Right now we end up with trailing new-lines in some cases, which make the Hover/Completion windows look weird. This PR should improve that look and feel somewhat.

Before:
![HoverAttributeUnTrimed](https://user-images.githubusercontent.com/14987221/79600755-83a36b00-809c-11ea-8153-9b36bb152584.png)

After:
![HoverAttributeTrimed](https://user-images.githubusercontent.com/14987221/79600498-18f22f80-809c-11ea-97a8-b46fdb127736.png)

I think there's an argument to be made that the scenario in `TryCreateDescription_Element_MultipleAssociatedTagHelpers_ReturnsTrue` should have newlines before and after the `---` but I went with what looked right to me and kept things more compact.

Fixes https://github.com/dotnet/aspnetcore/issues/20875.