### PR TITLE
Fix: Synchronization fails when document version changes with no Text…

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 // Even though nothing changed here, we want the synchronizer to be aware of the host document version change.
                 // So, let's make an empty edit to invoke the text buffer Changed events.
-                MakeEmptyEdit();
+                TextBuffer.MakeEmptyEdit();
 
                 _currentSnapshot = UpdateSnapshot();
                 return _currentSnapshot;
@@ -88,17 +88,5 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         private CSharpVirtualDocumentSnapshot UpdateSnapshot() => new CSharpVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
-
-        private void MakeEmptyEdit()
-        {
-            var bufferLength = TextBuffer.CurrentSnapshot.Length;
-            using var edit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
-            edit.Insert(bufferLength, " ");
-            edit.Apply();
-
-            using var revertEdit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
-            revertEdit.Delete(bufferLength, 1);
-            revertEdit.Apply();
-        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -50,6 +50,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (changes.Count == 0)
             {
+                // Even though nothing changed here, we want the synchronizer to be aware of the host document version change.
+                // So, let's make an empty edit to invoke the text buffer Changed events.
+                MakeEmptyEdit();
+
                 _currentSnapshot = UpdateSnapshot();
                 return _currentSnapshot;
             }
@@ -84,5 +88,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         private CSharpVirtualDocumentSnapshot UpdateSnapshot() => new CSharpVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
+
+        private void MakeEmptyEdit()
+        {
+            var bufferLength = TextBuffer.CurrentSnapshot.Length;
+            using var edit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
+            edit.Insert(bufferLength, " ");
+            edit.Apply();
+
+            using var revertEdit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
+            revertEdit.Delete(bufferLength, 1);
+            revertEdit.Apply();
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 // Even though nothing changed here, we want the synchronizer to be aware of the host document version change.
                 // So, let's make an empty edit to invoke the text buffer Changed events.
-                MakeEmptyEdit();
+                TextBuffer.MakeEmptyEdit();
 
                 _currentSnapshot = UpdateSnapshot();
                 return _currentSnapshot;
@@ -88,17 +88,5 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         private HtmlVirtualDocumentSnapshot UpdateSnapshot() => new HtmlVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
-
-        private void MakeEmptyEdit()
-        {
-            var bufferLength = TextBuffer.CurrentSnapshot.Length;
-            using var edit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
-            edit.Insert(bufferLength, " ");
-            edit.Apply();
-
-            using var revertEdit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
-            revertEdit.Delete(bufferLength, 1);
-            revertEdit.Apply();
-        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -50,6 +50,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (changes.Count == 0)
             {
+                // Even though nothing changed here, we want the synchronizer to be aware of the host document version change.
+                // So, let's make an empty edit to invoke the text buffer Changed events.
+                MakeEmptyEdit();
+
                 _currentSnapshot = UpdateSnapshot();
                 return _currentSnapshot;
             }
@@ -84,5 +88,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         private HtmlVirtualDocumentSnapshot UpdateSnapshot() => new HtmlVirtualDocumentSnapshot(Uri, TextBuffer.CurrentSnapshot, HostDocumentSyncVersion);
+
+        private void MakeEmptyEdit()
+        {
+            var bufferLength = TextBuffer.CurrentSnapshot.Length;
+            using var edit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
+            edit.Insert(bufferLength, " ");
+            edit.Apply();
+
+            using var revertEdit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
+            revertEdit.Delete(bufferLength, 1);
+            revertEdit.Apply();
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
@@ -42,5 +42,17 @@ namespace Microsoft.VisualStudio.Text
             var matchesContentType = textBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name);
             return matchesContentType;
         }
+
+        public static void MakeEmptyEdit(this ITextBuffer textBuffer)
+        {
+            var bufferLength = textBuffer.CurrentSnapshot.Length;
+            using var edit = textBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
+            edit.Insert(bufferLength, " ");
+            edit.Apply();
+
+            using var revertEdit = textBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
+            revertEdit.Delete(bufferLength, 1);
+            revertEdit.Apply();
+        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
@@ -107,6 +107,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var called = 0;
             textBuffer.PostChanged += (s, a) =>
             {
+                textBuffer.TryGetHostDocumentSyncVersion(out var version);
+                Assert.Equal(1, version);
+
                 called += 1;
             };
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
@@ -98,5 +98,27 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var text = textBuffer.CurrentSnapshot.GetText();
             Assert.Equal("Replaced", text);
         }
+
+        [Fact]
+        public void Update_NoChanges_InvokesPostChangedEventTwice_NoEffectiveChanges()
+        {
+            // Arrange
+            var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
+            var called = 0;
+            textBuffer.PostChanged += (s, a) =>
+            {
+                called += 1;
+            };
+
+            var document = new CSharpVirtualDocument(Uri, textBuffer);
+
+            // Act
+            document.Update(Array.Empty<TextChange>(), hostDocumentVersion: 1);
+
+            // Assert
+            Assert.Equal(2, called);
+            var text = textBuffer.CurrentSnapshot.GetText();
+            Assert.Equal("Hello World", text);
+        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
@@ -107,6 +107,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var called = 0;
             textBuffer.PostChanged += (s, a) =>
             {
+                textBuffer.TryGetHostDocumentSyncVersion(out var version);
+                Assert.Equal(1, version);
+
                 called += 1;
             };
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
@@ -98,5 +98,27 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var text = textBuffer.CurrentSnapshot.GetText();
             Assert.Equal("Replaced", text);
         }
+
+        [Fact]
+        public void Update_NoChanges_InvokesPostChangedEventTwice_NoEffectiveChanges()
+        {
+            // Arrange
+            var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
+            var called = 0;
+            textBuffer.PostChanged += (s, a) =>
+            {
+                called += 1;
+            };
+
+            var document = new HtmlVirtualDocument(Uri, textBuffer);
+
+            // Act
+            document.Update(Array.Empty<TextChange>(), hostDocumentVersion: 1);
+
+            // Assert
+            Assert.Equal(2, called);
+            var text = textBuffer.CurrentSnapshot.GetText();
+            Assert.Equal("Hello World", text);
+        }
     }
 }


### PR DESCRIPTION
…Buffer changes

Fixes https://github.com/dotnet/aspnetcore/issues/20916

- When the host document version changes without changing one of the virtual text buffers, we fail to notify the synchronizer causing it to not see certain versions. This usually happens during provisional completions and causes it to fail sometimes
- The fix was to make empty edits (in the absence of real changes) to the buffer causing the PostChanged event in the synchronizer to fire. This guarantees that the synchronizer sees all versions of the host document
- Added tests
