### PR TITLE
Disable Razor doc generated output publishing on doc open.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -160,7 +160,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             if (_documentResolver.TryResolveDocument(textDocumentPath, out var documentSnapshot))
             {
                 // Start generating the C# for the document so it can immediately be ready for incoming requests.
-                documentSnapshot.GetGeneratedOutputAsync();
+                // Temporarily disabled. Tracking re-enablement here: https://github.com/dotnet/aspnetcore/issues/21126
+                //documentSnapshot.GetGeneratedOutputAsync();
             }
         }
 


### PR DESCRIPTION
- I've disabled LSP document open genreated output publishing to work around: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1109023
- The "undo" of this workaround is tracked here: https://github.com/dotnet/aspnetcore/issues/21126

Fixes dotnet/aspnetcore#21115
