### PR TITLE
Refactor RazorFileChangeDetector notification dispatch to work with XUnit synchronization context.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -193,6 +193,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             OnStartingDelayedNotificationWork();
 
+            await Task.Factory.StartNew(
+                () => NotifyAfterDelay_Foreground(physicalFilePath),
+                CancellationToken.None, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler);
+        }
+
+        private void NotifyAfterDelay_Foreground(string physicalFilePath)
+        {
             lock (_pendingNotificationsLock)
             {
                 var result = _pendingNotifications.TryGetValue(physicalFilePath, out var notification);
@@ -210,9 +217,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     return;
                 }
 
-                _ = Task.Factory.StartNew(
-                    () => FileSystemWatcher_RazorFileEvent(physicalFilePath, notification.ChangeKind.Value),
-                    CancellationToken.None, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler);
+                FileSystemWatcher_RazorFileEvent(physicalFilePath, notification.ChangeKind.Value);
             }
         }
 


### PR DESCRIPTION
- Tried figuring out why the `FileSystemWatcher_RazorFileEvent_Background_NotificationNoopToAdd_NotifiesAddedOnce` continuously failed only on the public CI's debug build. Only thing  I could come up with was XUnit's synchronization context being a little wacky. I refactored the change detector's notification dispatch piece to do all pending notification calculations on the foreground thread with a lock to ensure ordering and also to enable us to await it on the background thread.
- Take 2 at attempting a build fix. If only I could see this repro in PR builds or even locally 😢 