### PR TITLE
Fixed HTML Tag Auto-closing

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlPreviewPanel.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlPreviewPanel.ts
@@ -86,7 +86,7 @@ export class HtmlPreviewPanel {
         let virtualDocumentFilePath = '';
 
         if (document) {
-            // The document is guarunteed to be a Razor document
+            // The document is guaranteed to be a Razor document
             this.htmlContent = document.htmlDocument.getContent();
             hostDocumentFilePath = getUriPath(document.uri);
             virtualDocumentFilePath = getUriPath(document.htmlDocument.uri);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
@@ -142,7 +142,6 @@ export class HtmlTagCompletionProvider {
                 return;
             }
 
-
             const razorDoc = await this.documentManager.getActiveDocument();
             if (razorDoc) {
                 // The document is guaranteed to be a Razor document

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
@@ -97,7 +97,7 @@ export class HtmlTagCompletionProvider {
         }
 
         const changeOffset = document.offsetAt(lastChange.range.start);
-        var documentContent = document.getText();
+        let documentContent = document.getText();
         const potentialSelfClosingCharacter = documentContent.charAt(changeOffset - 1);
         if (potentialSelfClosingCharacter === '/' || potentialSelfClosingCharacter === '>') {
             // Tag was already closed or is incomplete no need to auto-complete.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
@@ -145,7 +145,7 @@ export class HtmlTagCompletionProvider {
 
             const razorDoc = await this.documentManager.getActiveDocument();
             if (razorDoc) {
-                // The document is guarunteed to be a Razor document
+                // The document is guaranteed to be a Razor document
                 documentContent = razorDoc.htmlDocument.getContent();
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
@@ -9,6 +9,7 @@ import {
     LanguageService as HtmlLanguageService,
 } from 'vscode-html-languageservice';
 import { TextDocument as ServiceTextDocument } from 'vscode-languageserver-types';
+import { IRazorDocumentManager } from '../IRazorDocumentManager';
 import { RazorLanguage } from '../RazorLanguage';
 import { RazorLanguageServiceClient } from '../RazorLanguageServiceClient';
 import { LanguageKind } from '../RPC/LanguageKind';
@@ -18,7 +19,8 @@ export class HtmlTagCompletionProvider {
     private enabled = false;
     private htmlLanguageService: HtmlLanguageService | undefined;
 
-    constructor(private readonly serviceClient: RazorLanguageServiceClient) {
+    constructor(private readonly documentManager: IRazorDocumentManager,
+                private readonly serviceClient: RazorLanguageServiceClient) {
     }
 
     public register() {
@@ -95,7 +97,7 @@ export class HtmlTagCompletionProvider {
         }
 
         const changeOffset = document.offsetAt(lastChange.range.start);
-        const documentContent = document.getText();
+        var documentContent = document.getText();
         const potentialSelfClosingCharacter = documentContent.charAt(changeOffset - 1);
         if (potentialSelfClosingCharacter === '/' || potentialSelfClosingCharacter === '>') {
             // Tag was already closed or is incomplete no need to auto-complete.
@@ -120,7 +122,7 @@ export class HtmlTagCompletionProvider {
         // instantly swapping to another) to flow through the system. Basically, if content that would trigger
         // an auto-close occurs we allow a small amount of time for other edits to invalidate the current
         // auto-close task.
-        this.timeout = setTimeout(() => {
+        this.timeout = setTimeout(async () => {
             if (!this.enabled) {
                 return;
             }
@@ -138,6 +140,13 @@ export class HtmlTagCompletionProvider {
             const position = new vscode.Position(rangeStart.line, rangeStart.character + lastChange.text.length);
             if (!this.htmlLanguageService) {
                 return;
+            }
+
+
+            const razorDoc = await this.documentManager.getActiveDocument();
+            if (razorDoc) {
+                // The document is guarunteed to be a Razor document
+                documentContent = razorDoc.htmlDocument.getContent();
             }
 
             const serviceTextDocument = ServiceTextDocument.create(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/RazorHtmlFeature.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/RazorHtmlFeature.ts
@@ -23,7 +23,7 @@ export class RazorHtmlFeature {
         eventEmitterFactory: IEventEmitterFactory,
         logger: RazorLogger) {
         this.projectionProvider = new HtmlProjectedDocumentContentProvider(documentManager, eventEmitterFactory, logger);
-        this.htmlTagCompletionProvider = new HtmlTagCompletionProvider(serviceClient);
+        this.htmlTagCompletionProvider = new HtmlTagCompletionProvider(documentManager, serviceClient);
         this.htmlPreviewPanel = new HtmlPreviewPanel(documentManager);
     }
 


### PR DESCRIPTION
Now passing the HTML text content, instead of the raw razor content to the HTML parser.

Before:
![TextTagCompletion](https://user-images.githubusercontent.com/14852843/80046410-6537d800-84bf-11ea-829c-ba86c37dc4d7.gif)

After:
![TagAutoclosingFix](https://user-images.githubusercontent.com/14852843/80129093-73cbd100-854b-11ea-9563-29c5d6a8efed.gif)

Fixes https://github.com/dotnet/aspnetcore/issues/21127