### PR TITLE
Take 3 at fixing the public CI build.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Assert
 
-            // We acquire the notification prior to unblockign notification work because once we allow that work to proceed the notification will be removed.
+            // We acquire the notification prior to unblocking notification work because once we allow that work to proceed the notification will be removed.
             var notification = Assert.Single(fileChangeDetector._pendingNotifications);
 
             fileChangeDetector.BlockNotificationWorkStart.Set();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Assert
 
-            // We acquire the notification prior to unblockign notification work because once we allow that work to proceed the notification will be removed.
+            // We acquire the notification prior to unblocking notification work because once we allow that work to proceed the notification will be removed.
             var notification = Assert.Single(fileChangeDetector._pendingNotifications);
 
             fileChangeDetector.BlockNotificationWorkStart.Set();


### PR DESCRIPTION
- Now that the `RazorFileChangeDetector` awaits its dispatched foreground thread I can change the way the test "waits for completion" by exposing the pending notifications and awaiting their notifications.