### PR TITLE
[release/3.1] Move SDL validation to ringed release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,6 @@ variables:
   - name: _InternalRuntimeDownloadArgs
     value: ''
 
-# used for post-build phases, internal builds only
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - group: DotNet-AspNet-SDLValidation-Params
-
 trigger:
   batch: true
   branches:
@@ -356,17 +352,3 @@ stages:
       # See https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false
       publishInstallersAndChecksums: true
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: true
-        continueOnError: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "AspNetCore-Tooling"
-        -TsaCodebaseName "AspNetCore-Tooling"
-        -TsaPublish $True'

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -5,5 +5,7 @@
 -TsaCodebaseAdmin REDMOND\kevinpi
 -TsaBugAreaPath DevDiv\ASP.NET Core
 -TsaIterationPath DevDiv
+-TsaRepositoryName AspNetCore-Tooling
+-TsaCodebaseName AspNetCore-Tooling
 -TsaOnboard $True
 -TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,0 +1,11 @@
+-SourceToolsList @("policheck","credscan")
+-TsaInstanceURL https://devdiv.visualstudio.com/
+-TsaProjectName DEVDIV
+-TsaNotificationEmail aspnetcore-build@microsoft.com
+-TsaCodebaseAdmin REDMOND\kevinpi
+-TsaBugAreaPath DevDiv\ASP.NET Core
+-TsaIterationPath DevDiv
+-TsaRepositoryName aspnetcore-tooling
+-TsaCodebaseName dotnet
+-TsaOnboard $True
+-TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -3,7 +3,7 @@
 -TsaProjectName DEVDIV
 -TsaNotificationEmail aspnetcore-build@microsoft.com
 -TsaCodebaseAdmin REDMOND\kevinpi
--TsaBugAreaPath DevDiv\ASP.NET Core
+-TsaBugAreaPath "DevDiv\ASP.NET Core"
 -TsaIterationPath DevDiv
 -TsaRepositoryName AspNetCore-Tooling
 -TsaCodebaseName AspNetCore-Tooling

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -5,7 +5,5 @@
 -TsaCodebaseAdmin REDMOND\kevinpi
 -TsaBugAreaPath DevDiv\ASP.NET Core
 -TsaIterationPath DevDiv
--TsaRepositoryName aspnetcore-tooling
--TsaCodebaseName dotnet
 -TsaOnboard $True
 -TsaPublish $True


### PR DESCRIPTION
Moves SDL out of the repo build and into the ringed release pipeline, as per the goal of reducing build time. CC @Pilchie