### PR TITLE
Remove Hover Handler Silent Failure

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
@@ -89,20 +89,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            Hover result;
-            try
-            {
-                result = await _requestInvoker.RequestServerAsync<TextDocumentPositionParams, Hover>(
-                    Methods.TextDocumentHoverName,
-                    serverKind,
-                    textDocumentPositionParams,
-                    cancellationToken).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Ensure we fail silently (Temporary till roslyn update is live)
-                return null;
-            }
+            var result = await _requestInvoker.RequestServerAsync<TextDocumentPositionParams, Hover>(
+                Methods.TextDocumentHoverName,
+                serverKind,
+                textDocumentPositionParams,
+                cancellationToken).ConfigureAwait(false);
 
             if (result?.Range == null || result?.Contents == null)
             {


### PR DESCRIPTION
The Roslyn C# and WTE HTML hover handler `textDocument/hover` endpoints are now available. VSLanguageServer support for multiple hover handlers has also been enabled. Removing the temporary silent failure.

Fixes https://github.com/dotnet/aspnetcore/issues/20962
