### PR TITLE
Deserialize VS Client LSP types correctly to not lose information

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -103,18 +103,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     }
                 };
 
-                // We want to deserialize to VSCompletionItem type to make sure we don't lose extra information like icons.
-                var response = await _requestInvoker.RequestServerAsync<CompletionParams, SumType<VSCompletionItem[], CompletionList>?>(
+                result = await _requestInvoker.RequestServerAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(
                     Methods.TextDocumentCompletionName,
                     serverKind,
                     completionParams,
                     cancellationToken).ConfigureAwait(false);
-
-                if (response.HasValue)
-                {
-                    // Cast VSCompletionItem back to CompletionItem
-                    result = response.Value.Match<SumType<CompletionItem[], CompletionList>?>(items => items, list => list, () => null);
-                }
             }
 
             if (result.HasValue)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
@@ -75,7 +77,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var (_, resultToken) = await task.ConfigureAwait(false);
 
-            var result = resultToken != null ? resultToken.ToObject<TOut>() : default;
+            // We need these converters so we don't lose information as part of the deserialization.
+            var serializer = new JsonSerializer();
+            serializer.Converters.Add(new VSExtensionConverter<ClientCapabilities, VSClientCapabilities>());
+            serializer.Converters.Add(new VSExtensionConverter<CompletionItem, VSCompletionItem>());
+            serializer.Converters.Add(new VSExtensionConverter<SignatureInformation, VSSignatureInformation>());
+            serializer.Converters.Add(new VSExtensionConverter<Hover, VSHover>());
+            serializer.Converters.Add(new VSExtensionConverter<ServerCapabilities, VSServerCapabilities>());
+            serializer.Converters.Add(new VSExtensionConverter<SymbolInformation, VSSymbolInformation>());
+            serializer.Converters.Add(new VSExtensionConverter<CompletionList, VSCompletionList>());
+
+            var result = resultToken != null ? resultToken.ToObject<TOut>(serializer) : default;
             return result;
         }
     }


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/20324

Without this we were losing information as part of the deserialization and the client never sees the icons set by the HTML language server.

@ToddGrun