### PR TITLE
Remove Debug.Fail when tmp file still exists.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (tempFileInfo.Exists)
             {
-                Debug.Fail($"'{tempFileInfo.FullName}' should not exist but it does. This could be caused by failures during serialization or early process termination.");
+                // This could be caused by failures during serialization or early process termination.
                 tempFileInfo.Delete();
             }
 


### PR DESCRIPTION
- Since we can't control when a might have a tmp file lying around we shouldn't be debug asserting its failure.