### PR TITLE
Removed duplicate directive documentation

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             {
                 case RazorCompletionItemKind.Directive:
                     {
-                        // There's not a lot of calculation needed for Directives, go ahead and store the documentation/detail
+                        // There's not a lot of calculation needed for Directives, go ahead and store the documentation
                         // on the completion item.
                         var descriptionInfo = razorCompletionItem.GetDirectiveCompletionDescription();
                         var directiveCompletionItem = new CompletionItem()
@@ -238,7 +238,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.DisplayText,
                             SortText = razorCompletionItem.DisplayText,
-                            Detail = descriptionInfo.Description,
                             Documentation = descriptionInfo.Description,
                             Kind = CompletionItemKind.Struct,
                         };
@@ -305,7 +304,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.DisplayText,
                             SortText = razorCompletionItem.DisplayText,
-                            Detail = descriptionInfo.Description,
                             Documentation = descriptionInfo.Description,
                             Kind = CompletionItemKind.TypeParameter,
                             CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -73,8 +73,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.InsertText, converted.InsertText);
             Assert.Equal(completionItem.DisplayText, converted.FilterText);
             Assert.Equal(completionItem.DisplayText, converted.SortText);
-            Assert.Equal(description, converted.Detail);
-            Assert.NotNull(converted.Documentation);
+            Assert.Null(converted.Detail);
+            Assert.Equal(description, converted.Documentation.String);
             Assert.True(converted.TryGetRazorCompletionKind(out var convertedKind));
             Assert.Equal(RazorCompletionItemKind.Directive, convertedKind);
         }
@@ -98,8 +98,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.InsertText, converted.InsertText);
             Assert.Equal(completionItem.DisplayText, converted.FilterText);
             Assert.Equal(completionItem.DisplayText, converted.SortText);
-            Assert.Equal(description, converted.Detail);
-            Assert.NotNull(converted.Documentation);
+            Assert.Null(converted.Detail);
+            Assert.Equal(description, converted.Documentation.String);
             Assert.NotNull(converted.Command);
             Assert.True(converted.TryGetRazorCompletionKind(out var convertedKind));
             Assert.Equal(RazorCompletionItemKind.Directive, convertedKind);
@@ -123,8 +123,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.InsertText, converted.InsertText);
             Assert.Equal(completionItem.DisplayText, converted.FilterText);
             Assert.Equal(completionItem.DisplayText, converted.SortText);
-            Assert.Equal(description, converted.Detail);
-            Assert.NotNull(converted.Documentation);
+            Assert.Null(converted.Detail);
+            Assert.Equal(description, converted.Documentation.String);
             Assert.Equal(converted.CommitCharacters, completionItem.CommitCharacters);
         }
 


### PR DESCRIPTION
Both the `CompletionItem.Detail` and `CompletionItem.Description` were being set.

Per [the definition of `CompletionItem`](https://github.com/OmniSharp/csharp-language-server-protocol/blob/master/src/Protocol/Models/CompletionItem.cs#L34-L45):

Detail is "A human-readable string with additional information about this item, like type or symbol information."

Documentation is "A human-readable string that represents a doc-comment."

Documentation is also a `StringOrMarkupContent` type vs `String` type of `Detail`. As such, `Documentation` seemed to be the better fit. I've updated to only set the `Documentation` when converting a `RazorCompletionItem` to a `Omnisharp.CompletionItem`.

Fixes https://github.com/dotnet/aspnetcore/issues/21189

### Before:
![image](https://user-images.githubusercontent.com/14852843/80424185-0e067e80-8896-11ea-8687-dade9e2efc2d.png)

### After:
<img width="586" alt="Screen Shot 2020-04-27 at 2 48 28 PM" src="https://user-images.githubusercontent.com/14852843/80424242-2b3b4d00-8896-11ea-9e95-8e6406963218.png">