### PR TITLE
Update Add/Remove Razor file batch detection to 1s

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         // Internal for testing
-        internal int EnqueueDelay { get; set; } = 250;
+        internal int EnqueueDelay { get; set; } = 1000;
 
         // Used in tests to ensure we can control when delayed notification work starts.
         internal ManualResetEventSlim BlockNotificationWorkStart { get; set; }


### PR DESCRIPTION
- No reason for us to understand file deletions any quicker than every 1s.
- Saw Ryan's box having the duplicate error issue still and want to rule out that it's too slow 😄