### PR TITLE
Stop evicting document state on file removal.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentVersionCache.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -16,23 +15,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         // Internal for testing
         internal readonly Dictionary<string, List<DocumentEntry>> _documentLookup;
         private readonly ForegroundDispatcher _foregroundDispatcher;
-        private readonly FilePathNormalizer _filePathNormalizer;
         private ProjectSnapshotManagerBase _projectSnapshotManager;
 
-        public DefaultDocumentVersionCache(ForegroundDispatcher foregroundDispatcher, FilePathNormalizer filePathNormalizer)
+        public DefaultDocumentVersionCache(ForegroundDispatcher foregroundDispatcher)
         {
             if (foregroundDispatcher == null)
             {
                 throw new ArgumentNullException(nameof(foregroundDispatcher));
             }
 
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
-            }
-
             _foregroundDispatcher = foregroundDispatcher;
-            _filePathNormalizer = filePathNormalizer;
             _documentLookup = new Dictionary<string, List<DocumentEntry>>(FilePathComparer.Instance);
         }
 
@@ -110,22 +102,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             _projectSnapshotManager = projectManager;
             _projectSnapshotManager.Changed += ProjectSnapshotManager_Changed;
-        }
-
-        public override void RazorFileChanged(string filePath, RazorFileChangeKind kind)
-        {
-            _foregroundDispatcher.AssertForegroundThread();
-
-            switch (kind)
-            {
-                case RazorFileChangeKind.Removed:
-                    if (_documentLookup.ContainsKey(filePath))
-                    {
-                        // Document deleted, evict entry.
-                        _documentLookup.Remove(filePath);
-                    }
-                    break;
-            }
         }
 
         private void ProjectSnapshotManager_Changed(object sender, ProjectChangeEventArgs args)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -152,19 +152,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         }
                     }
                     break;
-                case ProjectChangeKind.DocumentRemoved:
-                    // Document removed, evict published source text.
-                    if (_publishedCSharpData.ContainsKey(args.DocumentFilePath))
-                    {
-                        var removed = _publishedCSharpData.Remove(args.DocumentFilePath);
-                        Debug.Assert(removed, "Published data should be protected by the foreground thread and should never fail to remove.");
-                    }
-                    if (_publishedHtmlData.ContainsKey(args.DocumentFilePath))
-                    {
-                        var removed = _publishedHtmlData.Remove(args.DocumentFilePath);
-                        Debug.Assert(removed, "Published data should be protected by the foreground thread and should never fail to remove.");
-                    }
-                    break;
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
@@ -6,12 +6,10 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal abstract class DocumentVersionCache : ProjectSnapshotChangeTrigger, IRazorFileChangeListener
+    internal abstract class DocumentVersionCache : ProjectSnapshotChangeTrigger
     {
         public abstract bool TryGetDocumentVersion(DocumentSnapshot documentSnapshot, out long version);
 
         public abstract void TrackDocumentVersion(DocumentSnapshot documentSnapshot, long version);
-
-        public abstract void RazorFileChanged(string filePath, RazorFileChangeKind kind);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<ProjectSnapshotChangeTrigger>(generatedDocumentPublisher);
                         services.AddSingleton<GeneratedDocumentPublisher>(generatedDocumentPublisher);
 
-                        var documentVersionCache = new DefaultDocumentVersionCache(foregroundDispatcher, filePathNormalizer);
+                        var documentVersionCache = new DefaultDocumentVersionCache(foregroundDispatcher);
                         services.AddSingleton<DocumentVersionCache>(documentVersionCache);
                         services.AddSingleton<ProjectSnapshotChangeTrigger>(documentVersionCache);
                         var containerStore = new DefaultGeneratedDocumentContainerStore(
@@ -109,7 +109,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<IProjectConfigurationFileChangeListener, ProjectConfigurationStateSynchronizer>();
                         services.AddSingleton<IProjectFileChangeListener, ProjectFileSynchronizer>();
                         services.AddSingleton<IRazorFileChangeListener, RazorFileSynchronizer>();
-                        services.AddSingleton<IRazorFileChangeListener>(documentVersionCache);
 
                         // File Change detectors
                         services.AddSingleton<IFileChangeDetector, ProjectConfigurationFileChangeDetector>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentVersionCacheTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void MarkAsLatestVersion_UntrackedDocument_Noops()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(document, 123);
             var untrackedDocument = TestDocumentSnapshot.Create("C:/other.cshtml");
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void MarkAsLatestVersion_KnownDocument_TracksNewDocumentAsLatest()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var documentInitial = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(documentInitial, 123);
             var documentLatest = TestDocumentSnapshot.Create(documentInitial.FilePath);
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetLatestVersionFromPath_TrackedDocument_ReturnsTrue()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var filePath = "C:/file.cshtml";
             var document1 = TestDocumentSnapshot.Create(filePath);
             var document2 = TestDocumentSnapshot.Create(filePath);
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetLatestVersionFromPath_UntrackedDocument_ReturnsFalse()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
 
             // Act
             var result = documentVersionCache.TryGetLatestVersionFromPath("C:/file.cshtml", out var version);
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_DocumentRemoved_DoesNotEvictDocument()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var projectSnapshotManager = TestProjectSnapshotManager.Create(Dispatcher);
             projectSnapshotManager.AllowNotifyListeners = true;
             documentVersionCache.Initialize(projectSnapshotManager);
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_OpenDocumentRemoved_DoesNotEvictDocument()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var projectSnapshotManager = TestProjectSnapshotManager.Create(Dispatcher);
             projectSnapshotManager.AllowNotifyListeners = true;
             documentVersionCache.Initialize(projectSnapshotManager);
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void ProjectSnapshotManager_Changed_DocumentClosed_EvictsDocument()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var projectSnapshotManager = TestProjectSnapshotManager.Create(Dispatcher);
             projectSnapshotManager.AllowNotifyListeners = true;
             documentVersionCache.Initialize(projectSnapshotManager);
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TrackDocumentVersion_AddsFirstEntry()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
 
             // Act
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TrackDocumentVersion_EvictsOldEntries()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
 
             for (var i = 0; i < DefaultDocumentVersionCache.MaxDocumentTrackingCount; i++)
@@ -215,7 +215,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetDocumentVersion_UntrackedDocumentPath_ReturnsFalse()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
 
             // Act
@@ -230,7 +230,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetDocumentVersion_EvictedDocument_ReturnsFalse()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
             var evictedDocument = TestDocumentSnapshot.Create(document.FilePath);
             documentVersionCache.TrackDocumentVersion(document, 1337);
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void TryGetDocumentVersion_KnownDocument_ReturnsTrue()
         {
             // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
+            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher);
             var document = TestDocumentSnapshot.Create("C:/file.cshtml");
             documentVersionCache.TrackDocumentVersion(document, 1337);
 
@@ -257,23 +257,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Assert
             Assert.True(result);
             Assert.Equal(1337, version);
-        }
-
-        [Fact]
-        public void TryGetDocumentVersion_DeletedDocument_ReturnsFalse()
-        {
-            // Arrange
-            var documentVersionCache = new DefaultDocumentVersionCache(Dispatcher, FilePathNormalizer);
-            var document = TestDocumentSnapshot.Create("C:/file.cshtml");
-            documentVersionCache.TrackDocumentVersion(document, 1337);
-            documentVersionCache.RazorFileChanged(document.FilePath, RazorFileChangeKind.Removed);
-
-            // Act
-            var result = documentVersionCache.TryGetDocumentVersion(document, out var version);
-
-            // Assert
-            Assert.False(result);
-            Assert.Equal(-1, version);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
@@ -318,29 +318,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Equal(123, updateRequest.HostDocumentVersion);
         }
 
-        [Fact]
-        public void ProjectSnapshotManager_DocumentRemoved_RepublishesTextChanges()
-        {
-            // Arrange
-            var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
-            generatedDocumentPublisher.Initialize(ProjectManager);
-            var sourceTextContent = "// The content";
-            var initialSourceText = SourceText.From(sourceTextContent);
-            generatedDocumentPublisher.PublishCSharp(HostDocument.FilePath, initialSourceText, 123);
-
-            // Act
-            ProjectManager.DocumentRemoved(HostProject, HostDocument);
-            generatedDocumentPublisher.PublishCSharp(HostDocument.FilePath, initialSourceText, 123);
-
-            // Assert
-            Assert.Equal(2, Server.UpdateRequests.Count);
-            var updateRequest = Server.UpdateRequests.Last();
-            Assert.Equal(HostDocument.FilePath, updateRequest.HostDocumentFilePath);
-            var textChange = Assert.Single(updateRequest.Changes);
-            Assert.Equal(sourceTextContent, textChange.NewText);
-            Assert.Equal(123, updateRequest.HostDocumentVersion);
-        }
-
         private class TestServer : ILanguageServer
         {
             public TestServer()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/UnsynchronizableContentDocumentProcessedListenerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/UnsynchronizableContentDocumentProcessedListenerTest.cs
@@ -185,11 +185,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 throw new NotImplementedException();
             }
-
-            public override void RazorFileChanged(string filePath, RazorFileChangeKind kind)
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }


### PR DESCRIPTION
- Technically LSP clients don't have a concept to notify the server of "deleted" documents. They only have a concept of "closed" documents. Thankfully our project snapshot manager operates in a similar fashion where a document can be removed but still be opened. Therefore, in order to bind our tracked document state (doc version + generated doc publishings) to LSP's capabilities we're only evicting old document state when they get closed. If they get removed it may be a transient state which will later be corrected and shouldn't impact the version cache because its purpose is to retrieve document versions for open/closed documents based on what the LSP client tells our server.
- Removed tests that expected deleted documents to remove corresponding state.

Fixes dotnet/aspnetcore#21302