### PR TITLE
Fix completion commit with explicit expressions

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     [ExportLspMethod(Methods.TextDocumentCompletionName)]
     internal class CompletionHandler : IRequestHandler<CompletionParams, SumType<CompletionItem[], CompletionList>?>
     {
-        private static readonly IReadOnlyList<string> CSharpTriggerCharacters = new[] { ".", "@" };
+        private static readonly IReadOnlyList<string> CSharpTriggerCharacters = new[] { ".", "@", "(" };
         private static readonly IReadOnlyList<string> HtmlTriggerCharacters = new[] { "<", "&", "\\", "/", "'", "\"", "=", ":", " " };
         private static readonly IReadOnlyList<string> AllTriggerCharacters = CSharpTriggerCharacters.Concat(HtmlTriggerCharacters).ToArray();
 
@@ -192,6 +192,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 list =>
                 {
                     var newItems = list.Items.Select(item => SetData(item)).ToArray();
+                    if (list is VSCompletionList vsList)
+                    {
+                        return new VSCompletionList()
+                        {
+                            Items = newItems,
+                            IsIncomplete = vsList.IsIncomplete,
+                            SuggesstionMode = vsList.SuggesstionMode,
+                            ContinueCharacters = vsList.ContinueCharacters
+                        };
+                    }
+
                     return new CompletionList()
                     {
                         Items = newItems,
@@ -236,6 +247,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 // This is an auto-invoked completion from the VS LSP platform. Completions are automatically invoked upon typing identifiers
                 // and are represented as CompletionTriggerKind.TriggerCharacter and have a trigger character that we have not registered for.
                 return true;
+            }
+
+            if (context.TriggerCharacter == "(")
+            {
+                // This is a special case.
+                // We added `(` as a trigger character to workaround problems with Razor explicit expressions.
+                // Example - https://github.com/dotnet/aspnetcore/issues/21154
+                // But we don't really want to show a completion box every time a `(` is typed.
+                return false;
             }
 
             if (IsApplicableTriggerCharacter(context.TriggerCharacter, languageKind))

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 {
                     AllCommitCharacters = new[] { " ", ".", ";", ">", "=" }, // This is necessary to workaround a bug where the commit character in CompletionItem is not respected.
                     ResolveProvider = true,
-                    TriggerCharacters = new[] { ".", "@", "<", "&", "\\", "/", "'", "\"", "=", ":", " " }
+                    TriggerCharacters = new[] { ".", "@", "<", "&", "\\", "/", "'", "\"", "=", ":", " ", "(" }
                 },
                 DocumentOnTypeFormattingProvider = new DocumentOnTypeFormattingOptions()
                 {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -585,6 +585,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         [InlineData("@", CompletionTriggerKind.Invoked, true)]
         [InlineData("a", CompletionTriggerKind.TriggerCharacter, true)] // Auto-invoked from VS platform
         [InlineData("a", CompletionTriggerKind.Invoked, true)]
+        [InlineData("(", CompletionTriggerKind.TriggerCharacter, false)]
         public void TriggerAppliedToProjection_Html_ReturnsExpectedResult(string character, CompletionTriggerKind kind, bool expected)
         {
             // Arrange
@@ -609,6 +610,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         [InlineData("<", CompletionTriggerKind.TriggerCharacter, false)]
         [InlineData("a", CompletionTriggerKind.TriggerCharacter, true)] // Auto-invoked from VS platform
         [InlineData("a", CompletionTriggerKind.Invoked, true)]
+        [InlineData("(", CompletionTriggerKind.TriggerCharacter, false)]
         public void TriggerAppliedToProjection_CSharp_ReturnsExpectedResult(string character, CompletionTriggerKind kind, bool expected)
         {
             // Arrange


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/21154

Before:
![image](https://i.imgur.com/WgXRATe.gif)

After:
![be85e338-c6e5-45bc-b502-cba2e297715c](https://user-images.githubusercontent.com/1579269/80549176-5d6dad00-8971-11ea-81e4-62939da0db04.gif)

