### PR TITLE
Trim newlines from summaries

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Server;
@@ -191,7 +192,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // have additional doc comment types in the summary but none that require cleaning. For instance
             // if there's a <para> in the summary element when it's shown in the completion description window
             // it'll be serialized as html (wont show).
-
+            summaryContent = summaryContent.Trim();
             var crefMatches = ExtractCrefRegex.Value.Matches(summaryContent);
             var summaryBuilder = new StringBuilder(summaryContent);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
@@ -401,17 +401,16 @@ Suffixed invalid content";
             Hello
 
     World
+
 ";
 
             // Act
             var cleanedSummary = DefaultTagHelperDescriptionFactory.CleanSummaryContent(summary);
 
             // Assert
-            Assert.Equal(@"
-Hello
+            Assert.Equal(@"Hello
 
-World
-", cleanedSummary);
+World", cleanedSummary);
         }
 
         [Fact]
@@ -532,8 +531,8 @@ Uses `List<System.String>`s", markdown.Value);
             var descriptionFactory = new DefaultTagHelperDescriptionFactory(LanguageServer);
             var associatedTagHelperInfos = new[]
             {
-                new TagHelperDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
-                new TagHelperDescriptionInfo("Microsoft.AspNetCore.OtherTagHelper", "<summary>Also uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+                new TagHelperDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>\nUses <see cref=\"T:System.Collections.List{System.String}\" />s\n</summary>"),
+                new TagHelperDescriptionInfo("Microsoft.AspNetCore.OtherTagHelper", "<summary>\nAlso uses <see cref=\"T:System.Collections.List{System.String}\" />s\n\r\n\r\r</summary>"),
             };
             var elementDescription = new ElementDescriptionInfo(associatedTagHelperInfos);
 
@@ -594,7 +593,7 @@ Uses `List<System.String>`s", markdown.Value);
                     displayName: "System.Boolean? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty",
                     propertyName: "AnotherProperty",
                     returnTypeName: "System.Boolean?",
-                    documentation: "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
+                    documentation: "<summary>\nUses <see cref=\"T:System.Collections.List{System.String}\" />s\n</summary>"),
             };
             var attributeDescription = new AttributeDescriptionInfo(associatedAttributeDescriptions);
 


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/21306

Basically the summaries we get probably have leading and trailing newlines, so let's trim them, using the StringBuilder for hopefully performance.