### PR TITLE
Add support for declarative Razor comments.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -1,2 +1,12 @@
 ﻿[$RootKey$\TextMate\Repositories]
 "AspNetCoreRazor"="$PackageFolder$\Grammars"
+
+// Defines where the language configuration file for a given
+// grammar name is (value of the ScopeName tag in the tmlanguage file).
+[$RootKey$\TextMate\LanguageConfiguration\GrammarMapping]
+"text.aspnetcorerazor"="$PackageFolder$\language-configuration.json"
+
+// Defines where the language configuration file for a given
+// language name is (partial value of the content type name).
+[$RootKey$\TextMate\LanguageConfiguration\ContentTypeMapping]
+"RazorLSP"="$PackageFolder$\language-configuration.json"

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -175,6 +175,16 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_IncludeRazorLanguageConfiguration" DependsOnTargets="PrepareForBuild" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Content Include="..\Microsoft.AspNetCore.Razor.VSCode.Extension\language-configuration.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <IncludeInVSIX>true</IncludeInVSIX>
+        <VSIXSubPath>\</VSIXSubPath>
+      </Content>
+    </ItemGroup>
+  </Target>
+
   <Target Name="_GenerateVSIXBindingRedirects" DependsOnTargets="PrepareForBuild;GetAssemblyVersion" BeforeTargets="CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(_GeneratedVSIXBindingRedirectFile)">
     <ItemGroup>
       <BindingRedirectAssemblies Include="@(ProjectReference)" AssemblyName="%(Filename)" />


### PR DESCRIPTION
- This also indirectly adds support for some more auto-closing pairs. Ultimately since VS added support for `language-configuration.json` files like in VSCode we now just lift that file into the extension install directory.
- Not something you can write tests for.

![LxlNR5BDnF](https://user-images.githubusercontent.com/2008729/80658575-527f4f00-8a3b-11ea-935d-a835be8c7cc8.gif)


Fixes dotnet/aspnetcore#21290