### PR TITLE
Pre-boot language servers if applicable

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -17,8 +17,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [Export(typeof(VirtualDocumentFactory))]
     internal class CSharpVirtualDocumentFactory : VirtualDocumentFactory
     {
+        public const string CSharpLSPContentTypeName = "C#_LSP";
+
         // Internal for testing
-        internal const string CSharpLSPContentTypeName = "C#_LSP";
         internal const string VirtualCSharpFileNameSuffix = ".g.cs";
         internal const string ContainedLanguageMarker = "ContainedLanguageMarker";
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return false;
         }
 
-        private bool IsLSPEditorFeatureEnabled()
+        public override bool IsLSPEditorFeatureEnabled()
         {
             if (EnvironmentFeatureEnabled())
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -65,6 +65,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<InitializeParams, InitializeResult>(Methods.InitializeName, initializeParams, _clientCapabilities, cancellationToken);
         }
 
+        [JsonRpcMethod(Methods.ShutdownName)]
+        public void ShutdownAsync(CancellationToken cancellationToken)
+        {
+            Dispose();
+        }
+
         [JsonRpcMethod(Methods.TextDocumentCompletionName, UseSingleObjectParameterDeserialization =  true)]
         public Task<SumType<CompletionItem[], CompletionList>?> ProvideCompletionsAsync(CompletionParams completionParams, CancellationToken cancellationToken)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServerClient.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         // ILanguageClient infrastructure on the guest to ensure that two language servers don't provide results.
         public const string ClientName = "RazorLSPClientName";
         private readonly IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> _requestHandlers;
-        private RazorHtmlCSharpLanguageServer _langaugeServer;
+        private RazorHtmlCSharpLanguageServer _languageServer;
 
         [ImportingConstructor]
         public RazorHtmlCSharpLanguageServerClient([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
 
-            _langaugeServer = new RazorHtmlCSharpLanguageServer(serverStream, serverStream, _requestHandlers);
+            _languageServer = new RazorHtmlCSharpLanguageServer(serverStream, serverStream, _requestHandlers);
 
             var connection = new Connection(clientStream, clientStream);
             return Task.FromResult(connection);
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public void Dispose()
         {
-            _langaugeServer?.Dispose();
+            _languageServer?.Dispose();
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -13,8 +13,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [Export(typeof(VirtualDocumentFactory))]
     internal class HtmlVirtualDocumentFactory : VirtualDocumentFactory
     {
+        public const string HtmlLSPContentTypeName = "htmlyLSP";
+
         // Internal for testing
-        internal const string HtmlLSPContentTypeName = "htmlyLSP";
         internal const string VirtualHtmlFileNameSuffix = "__virtual.html";
         internal const string ContainedLanguageMarker = "ContainedLanguageMarker";
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPEditorFeatureDetector.cs
@@ -10,5 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public abstract bool IsLSPEditorAvailable(string documentMoniker, IVsHierarchy hierarchy);
 
         public abstract bool IsRemoteClient();
+
+        public abstract bool IsLSPEditorFeatureEnabled();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [AppliesTo("(DotNetCoreRazor & DotNetCoreRazorConfiguration) | ((DotNetCoreRazor | DotNetCoreWeb) & !DotNetCoreRazorConfiguration)")]
+    [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
+    internal class LSPRazorProjectHost : IProjectDynamicLoadComponent
+    {
+        private readonly LSPEditorFeatureDetector _featureDetector;
+        private readonly List<Lazy<ILanguageClient, ILanguageClientMetadata>> _applicableLanguageClients;
+        private readonly Lazy<ILanguageClientBroker> _languageClientBroker;
+
+        [ImportingConstructor]
+        public LSPRazorProjectHost(
+            LSPEditorFeatureDetector featureDetector,
+            Lazy<ILanguageClientBroker> languageClientBroker,
+            [ImportMany] IEnumerable<Lazy<ILanguageClient, IDictionary<string, object>>> languageClients)
+        {
+            if (featureDetector is null)
+            {
+                throw new ArgumentNullException(nameof(featureDetector));
+            }
+
+            if (languageClientBroker is null)
+            {
+                throw new ArgumentNullException(nameof(languageClientBroker));
+            }
+
+            if (languageClients is null)
+            {
+                throw new ArgumentNullException(nameof(languageClients));
+            }
+
+            _featureDetector = featureDetector;
+            _languageClientBroker = languageClientBroker;
+            _applicableLanguageClients = GetApplicableClients(languageClients);
+        }
+
+        public Task LoadAsync()
+        {
+            if (!_featureDetector.IsLSPEditorFeatureEnabled())
+            {
+                return Task.CompletedTask;
+            }
+
+            foreach (var client in _applicableLanguageClients)
+            {
+                _languageClientBroker.Value.LoadAsync(client.Metadata, client.Value).Forget();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task UnloadAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        private static List<Lazy<ILanguageClient, ILanguageClientMetadata>> GetApplicableClients(IEnumerable<Lazy<ILanguageClient, IDictionary<string, object>>> languageClients)
+        {
+            var applicableContentTypes = new[]
+            {
+                RazorLSPContentTypeDefinition.Name,
+                CSharpVirtualDocumentFactory.CSharpLSPContentTypeName,
+                HtmlVirtualDocumentFactory.HtmlLSPContentTypeName,
+            };
+
+            var applicableClients = new List<Lazy<ILanguageClient, ILanguageClientMetadata>>();
+            foreach (var client in languageClients)
+            {
+                if (!client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ContentTypes), out object contentTypeValue) ||
+                    !(contentTypeValue is IEnumerable<string> contentTypes) ||
+                    !contentTypes.Intersect(applicableContentTypes).Any())
+                {
+                    continue;
+                }
+
+                string clientName = null;
+                if (client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ClientName), out object clientNameValue))
+                {
+                    clientName = clientNameValue.ToString();
+                }
+
+                applicableClients.Add(new Lazy<ILanguageClient, ILanguageClientMetadata>(
+                    () => { return client.Value; },
+                    new LanguageClientMetadata(clientName, contentTypes)));
+            }
+
+            return applicableClients;
+        }
+
+        private class LanguageClientMetadata : ILanguageClientMetadata
+        {
+            public LanguageClientMetadata(string clientName, IEnumerable<string> contentTypes)
+            {
+                ClientName = clientName;
+                ContentTypes = contentTypes;
+            }
+
+            public string ClientName { get; }
+
+            public IEnumerable<string> ContentTypes { get; }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var applicableClients = new List<Lazy<ILanguageClient, ILanguageClientMetadata>>();
             foreach (var client in languageClients)
             {
-                if (!client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ContentTypes), out object contentTypeValue) ||
+                if (!client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ContentTypes), out var contentTypeValue) ||
                     !(contentTypeValue is IEnumerable<string> contentTypes) ||
                     !contentTypes.Intersect(applicableContentTypes).Any())
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 }
 
                 string clientName = null;
-                if (client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ClientName), out object clientNameValue))
+                if (client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ClientName), out var clientNameValue))
                 {
                     clientName = clientNameValue.ToString();
                 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -29,6 +29,11 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="$(MicrosoftVisualStudioLanguageServerClientPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" Version="$(MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime" Version="$(MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
+    <!--<PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="$(MicrosoftVisualStudioProjectSystemManagedVSPackageVersion)" ExcludeAssets="analyzers" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(Tooling_MicrosoftCodeAnalysisCommonPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />-->
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -30,10 +30,6 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" Version="$(MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime" Version="$(MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
-    <!--<PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="$(MicrosoftVisualStudioProjectSystemManagedVSPackageVersion)" ExcludeAssets="analyzers" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(Tooling_MicrosoftCodeAnalysisCommonPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />-->
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
@@ -57,10 +57,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // to the UI thread to push our updates.
             //
             // Just subscribe and handle the notification later.
-            // Don't try to evaluate any properties here since the project is still loading and we require access
-            // to the UI thread to push our updates.
-            //
-            // Just subscribe and handle the notification later.
             var receiver = new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(OnProjectChanged);
             _subscription = CommonServices.ActiveConfiguredProjectSubscription.JointRuleSource.SourceBlock.LinkTo(
                 receiver,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPRazorProjectHostTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class LSPRazorProjectHostTest
+    {
+        [Fact]
+        public async Task LoadAsync_NoopsWhenLSPEditorFeatureNotAvailable()
+        {
+            // Arrange
+            var featureDetector = Mock.Of<LSPEditorFeatureDetector>(f => f.IsLSPEditorFeatureEnabled() == false);
+            var broker = new Lazy<ILanguageClientBroker>();
+            var client = new Lazy<ILanguageClient, IDictionary<string, object>>(
+                () => throw new NotImplementedException(), new Dictionary<string, object>());
+            var languageClients = new[] { client };
+
+            var host = new LSPRazorProjectHost(featureDetector, broker, languageClients);
+
+            // Act & Assert (does not throw)
+            await host.LoadAsync().ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task LoadAsync_LSPEditorFeatureAvailable_LoadsClients()
+        {
+            // Arrange
+            var featureDetector = Mock.Of<LSPEditorFeatureDetector>(f => f.IsLSPEditorFeatureEnabled() == true);
+
+            var metadata = new Dictionary<string, object>()
+            {
+                { "ClientName", "RazorClient" },
+                { "ContentTypes", new[] { "RazorLSP" } }
+            };
+            var client = new Lazy<ILanguageClient, IDictionary<string, object>>(() => Mock.Of<ILanguageClient>(), metadata);
+            var languageClients = new[] { client };
+
+            var loaded = false;
+            var brokerMock = new Mock<ILanguageClientBroker>();
+            brokerMock
+                .Setup(b => b.LoadAsync(It.IsAny<ILanguageClientMetadata>(), It.IsAny<ILanguageClient>()))
+                .Returns(Task.CompletedTask)
+                .Callback<ILanguageClientMetadata, ILanguageClient>((metadata, c) =>
+                {
+                    loaded = true;
+                    Assert.Same(client.Value, c);
+                    Assert.Equal("RazorClient", metadata.ClientName);
+                    var contentType = Assert.Single(metadata.ContentTypes);
+                    Assert.Equal("RazorLSP", contentType);
+                });
+            var broker = new Lazy<ILanguageClientBroker>(() => brokerMock.Object);
+
+            var host = new LSPRazorProjectHost(featureDetector, broker, languageClients);
+
+            // Act
+            await host.LoadAsync().ConfigureAwait(false);
+
+            // Assert
+            Assert.True(loaded);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/21035

- We'll now boot Razor, C# and HTML servers if we open a Razor project and have the LSP preview feature checked.
- Also handled Shutdown request that we missed in one of our servers
- Separately, there is an issue with Shutdown not being called on solution close on non-liveshare scenarios that I am following up with partner teams on
