### PR TITLE
DescriptionFactory handle Directive attributes

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
@@ -214,6 +214,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             return finalSummaryContent;
         }
 
+        private static readonly char[] NewLineChars = new char[]{'\n', '\r'};
+
         // Internal for testing
         internal static bool TryExtractSummary(string documentation, out string summary)
         {
@@ -226,13 +228,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return false;
             }
 
-            documentation = documentation.Trim(new char[] { '\n', '\r' });
+            documentation = documentation.Trim(NewLineChars);
 
             var summaryTagStart = documentation.IndexOf(summaryStartTag, StringComparison.OrdinalIgnoreCase);
             var summaryTagEndStart = documentation.IndexOf(summaryEndTag, StringComparison.OrdinalIgnoreCase);
             if (summaryTagStart == -1 || summaryTagEndStart == -1)
             {
-                // A really stupid but cheap way to check if this is XML
+                // A really wrong but cheap way to check if this is XML
                 if ((!documentation.StartsWith("<") && !documentation.EndsWith(">")) && (summaryTagStart == -1 && summaryTagEndStart == -1))
                 {
                     // This doesn't look like a doc comment, we'll return it as-is.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperDescriptionFactory.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
-using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Server;
@@ -235,7 +233,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             if (summaryTagStart == -1 || summaryTagEndStart == -1)
             {
                 // A really wrong but cheap way to check if this is XML
-                if ((!documentation.StartsWith("<") && !documentation.EndsWith(">")) && (summaryTagStart == -1 && summaryTagEndStart == -1))
+                if (!documentation.StartsWith("<") && !documentation.EndsWith(">"))
                 {
                     // This doesn't look like a doc comment, we'll return it as-is.
                     summary = documentation;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
@@ -354,12 +354,17 @@ Suffixed invalid content";
             var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(summary);
+            Assert.True(result);
+            Assert.Equal(@"Prefixed invalid content
+
+
+</summary>
+
+Suffixed invalid content", summary);
         }
 
         [Fact]
-        public void TryExtractSummary_NoEndSummary_ReturnsFalse()
+        public void TryExtractSummary_NoEndSummary_ReturnsTrue()
         {
             // Arrange
             var documentation = @"
@@ -374,8 +379,13 @@ Suffixed invalid content";
             var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
 
             // Assert
-            Assert.False(result);
-            Assert.Null(summary);
+            Assert.True(result);
+            Assert.Equal(@"Prefixed invalid content
+
+
+<summary>
+
+Suffixed invalid content", summary);
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperDescriptionFactoryTest.cs
@@ -307,6 +307,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        public void TryExtractSummary_Null_ReturnsFalse()
+        {
+            // Arrange & Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation: null, out var summary);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(summary);
+        }
+
+        [Fact]
         public void TryExtractSummary_ExtractsSummary_ReturnsTrue()
         {
             // Arrange
@@ -365,6 +376,39 @@ Suffixed invalid content";
             // Assert
             Assert.False(result);
             Assert.Null(summary);
+        }
+
+        [Fact]
+        public void TryExtractSummary_XMLButNoSummary_ReturnsFalse()
+        {
+            // Arrange
+            var documentation = @"
+<param type=""stuff"">param1</param>
+<return>Result</return>
+";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(summary);
+        }
+
+        [Fact]
+        public void TryExtractSummary_NoXml_ReturnsTrue()
+        {
+            // Arrange
+            var documentation = @"
+There is no xml, but I got you this < and the >.
+";
+
+            // Act
+            var result = DefaultTagHelperDescriptionFactory.TryExtractSummary(documentation, out var summary);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("There is no xml, but I got you this < and the >.", summary);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/21192.

TLDR: TryExtractSummary was giving up and returning nothing if it couldn't find a matching pair of summary tags. Since Directive attribute documentation doesn't come form doc-comments it's not in that format, and nothing was being returned. Now if it's the case that no XML is detected we'll return the whole documentation (no XML so that if its missing a summary but has return tags and/or param tags we don't show that whole mess).