### PR TITLE
Added null NamePrefix Checks to MarkupSyntaxNode(s)

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperCompletionService.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     out attributes) &&
                 (selectedAttributeName == null ||
                 selectedAttributeNameLocation.Value.IntersectsWith(location.AbsoluteIndex) ||
-                prefixLocation.Value.IntersectsWith(location.AbsoluteIndex)))
+                (prefixLocation?.IntersectsWith(location.AbsoluteIndex) ?? false)))
             {
                 var stringifiedAttributes = _tagHelperFactsService.StringifyAttributes(attributes);
                 var attributeCompletions = GetAttributeCompletions(parent, containingTagNameToken.Content, selectedAttributeName, stringifiedAttributes, codeDocument);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProviderBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProviderBase.cs
@@ -12,16 +12,16 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     internal abstract class DirectiveAttributeCompletionItemProviderBase : RazorCompletionItemProvider
     {
         // Internal for testing
-        internal static bool IntersectsWithAttributeNameOrPrefix(SourceSpan location, TextSpan prefixLocation, TextSpan attributeNameLocation)
+        internal static bool IntersectsWithAttributeNameOrPrefix(SourceSpan location, TextSpan? prefixLocation, TextSpan attributeNameLocation)
         {
-            if (location.AbsoluteIndex == prefixLocation.Start)
+            if (location.AbsoluteIndex == (prefixLocation?.Start ?? -1))
             {
                 // <input| class="test" />
                 // Starts of prefix locations belong to the previous SyntaxNode. It could be the end of an attribute value, the tag name, C# etc.
                 return false;
             }
 
-            if (prefixLocation.IntersectsWith(location.AbsoluteIndex))
+            if (prefixLocation?.IntersectsWith(location.AbsoluteIndex) ?? false)
             {
                 // <input   |  class="test" />
                 return true;
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         // Internal for testing
         internal static bool TryGetAttributeInfo(
             RazorSyntaxNode attributeLeafOwner,
-            out TextSpan prefixLocation,
+            out TextSpan? prefixLocation,
             out string name,
             out TextSpan nameLocation,
             out string parameterName,
@@ -52,11 +52,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             switch (attribute)
             {
                 case MarkupMinimizedAttributeBlockSyntax minimizedMarkupAttribute:
-                    if (minimizedMarkupAttribute.NamePrefix == null)
-                    {
-                        break;
-                    }
-                    prefixLocation = minimizedMarkupAttribute.NamePrefix.Span;
+                    prefixLocation = minimizedMarkupAttribute.NamePrefix?.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         minimizedMarkupAttribute.Name.GetContent(),
                         minimizedMarkupAttribute.Name.Span,
@@ -67,11 +63,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 
                     return true;
                 case MarkupAttributeBlockSyntax markupAttribute:
-                    if (markupAttribute.NamePrefix == null)
-                    {
-                        break;
-                    }
-                    prefixLocation = markupAttribute.NamePrefix.Span;
+                    prefixLocation = markupAttribute.NamePrefix?.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         markupAttribute.Name.GetContent(),
                         markupAttribute.Name.Span,
@@ -81,11 +73,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         out parameterLocation);
                     return true;
                 case MarkupMinimizedTagHelperAttributeSyntax minimizedTagHelperAttribute:
-                    if (minimizedTagHelperAttribute.NamePrefix == null)
-                    {
-                        break;
-                    }
-                    prefixLocation = minimizedTagHelperAttribute.NamePrefix.Span;
+                    prefixLocation = minimizedTagHelperAttribute.NamePrefix?.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         minimizedTagHelperAttribute.Name.GetContent(),
                         minimizedTagHelperAttribute.Name.Span,
@@ -95,11 +83,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         out parameterLocation);
                     return true;
                 case MarkupTagHelperAttributeSyntax tagHelperAttribute:
-                    if (tagHelperAttribute.NamePrefix == null)
-                    {
-                        break;
-                    }
-                    prefixLocation = tagHelperAttribute.NamePrefix.Span;
+                    prefixLocation = tagHelperAttribute.NamePrefix?.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         tagHelperAttribute.Name.GetContent(),
                         tagHelperAttribute.Name.Span,
@@ -110,15 +94,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     return true;
                 case MarkupTagHelperDirectiveAttributeSyntax directiveAttribute:
                     {
-                        if (directiveAttribute.NamePrefix == null)
-                        {
-                            break;
-                        }
                         var attributeName = directiveAttribute.Name;
                         var directiveAttributeTransition = directiveAttribute.Transition;
                         var nameStart = directiveAttributeTransition?.SpanStart ?? attributeName.SpanStart;
                         var nameEnd = attributeName?.Span.End ?? directiveAttributeTransition.Span.End;
-                        prefixLocation = directiveAttribute.NamePrefix.Span;
+                        prefixLocation = directiveAttribute.NamePrefix?.Span;
                         name = string.Concat(directiveAttributeTransition?.GetContent(), attributeName?.GetContent());
                         nameLocation = new TextSpan(nameStart, nameEnd - nameStart);
                         parameterName = directiveAttribute.ParameterName?.GetContent();
@@ -127,15 +107,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     }
                 case MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedDirectiveAttribute:
                     {
-                        if (minimizedDirectiveAttribute.NamePrefix == null)
-                        {
-                            break;
-                        }
                         var attributeName = minimizedDirectiveAttribute.Name;
                         var directiveAttributeTransition = minimizedDirectiveAttribute.Transition;
                         var nameStart = directiveAttributeTransition?.SpanStart ?? attributeName.SpanStart;
                         var nameEnd = attributeName?.Span.End ?? directiveAttributeTransition.Span.End;
-                        prefixLocation = minimizedDirectiveAttribute.NamePrefix.Span;
+                        prefixLocation = minimizedDirectiveAttribute.NamePrefix?.Span;
                         name = string.Concat(directiveAttributeTransition?.GetContent(), attributeName?.GetContent());
                         nameLocation = new TextSpan(nameStart, nameEnd - nameStart);
                         parameterName = minimizedDirectiveAttribute.ParameterName?.GetContent();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProviderBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProviderBase.cs
@@ -47,9 +47,15 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             var attribute = attributeLeafOwner.Parent;
 
+            // The null check on the `NamePrefix` field is required for cases like:
+            // `<svg xml:base=""x| ></svg>` where there's no `NamePrefix` available.
             switch (attribute)
             {
                 case MarkupMinimizedAttributeBlockSyntax minimizedMarkupAttribute:
+                    if (minimizedMarkupAttribute.NamePrefix == null)
+                    {
+                        break;
+                    }
                     prefixLocation = minimizedMarkupAttribute.NamePrefix.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         minimizedMarkupAttribute.Name.GetContent(),
@@ -61,6 +67,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 
                     return true;
                 case MarkupAttributeBlockSyntax markupAttribute:
+                    if (markupAttribute.NamePrefix == null)
+                    {
+                        break;
+                    }
                     prefixLocation = markupAttribute.NamePrefix.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         markupAttribute.Name.GetContent(),
@@ -71,6 +81,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         out parameterLocation);
                     return true;
                 case MarkupMinimizedTagHelperAttributeSyntax minimizedTagHelperAttribute:
+                    if (minimizedTagHelperAttribute.NamePrefix == null)
+                    {
+                        break;
+                    }
                     prefixLocation = minimizedTagHelperAttribute.NamePrefix.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         minimizedTagHelperAttribute.Name.GetContent(),
@@ -81,6 +95,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         out parameterLocation);
                     return true;
                 case MarkupTagHelperAttributeSyntax tagHelperAttribute:
+                    if (tagHelperAttribute.NamePrefix == null)
+                    {
+                        break;
+                    }
                     prefixLocation = tagHelperAttribute.NamePrefix.Span;
                     TryExtractIncompleteDirectiveAttribute(
                         tagHelperAttribute.Name.GetContent(),
@@ -92,6 +110,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     return true;
                 case MarkupTagHelperDirectiveAttributeSyntax directiveAttribute:
                     {
+                        if (directiveAttribute.NamePrefix == null)
+                        {
+                            break;
+                        }
                         var attributeName = directiveAttribute.Name;
                         var directiveAttributeTransition = directiveAttribute.Transition;
                         var nameStart = directiveAttributeTransition?.SpanStart ?? attributeName.SpanStart;
@@ -105,6 +127,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     }
                 case MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedDirectiveAttribute:
                     {
+                        if (minimizedDirectiveAttribute.NamePrefix == null)
+                        {
+                            break;
+                        }
                         var attributeName = minimizedDirectiveAttribute.Name;
                         var directiveAttributeTransition = minimizedDirectiveAttribute.Transition;
                         var nameStart = directiveAttributeTransition?.SpanStart ?? attributeName.SpanStart;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
@@ -46,56 +46,75 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 return false;
             }
 
-            if (attribute is MarkupMinimizedAttributeBlockSyntax minimizedAttributeBlock)
+            // The null check on the `NamePrefix` field is required for cases like:
+            // `<svg xml:base=""x| ></svg>` where there's no `NamePrefix` available.
+            switch (attribute)
             {
-                prefixLocation = minimizedAttributeBlock.NamePrefix.Span;
-                selectedAttributeName = minimizedAttributeBlock.Name.GetContent();
-                selectedAttributeNameLocation = minimizedAttributeBlock.Name.Span;
-                return true;
-            }
-            else if (attribute is MarkupAttributeBlockSyntax attributeBlock)
-            {
-                prefixLocation = attributeBlock.NamePrefix.Span;
-                selectedAttributeName = attributeBlock.Name.GetContent();
-                selectedAttributeNameLocation = attributeBlock.Name.Span;
-                return true;
-            }
-            else if (attribute is MarkupTagHelperAttributeSyntax tagHelperAttribute)
-            {
-                prefixLocation = tagHelperAttribute.NamePrefix.Span;
-                selectedAttributeName = tagHelperAttribute.Name.GetContent();
-                selectedAttributeNameLocation = tagHelperAttribute.Name.Span;
-                return true;
-            }
-            else if (attribute is MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute)
-            {
-                prefixLocation = minimizedAttribute.NamePrefix.Span;
-                selectedAttributeName = minimizedAttribute.Name.GetContent();
-                selectedAttributeNameLocation = minimizedAttribute.Name.Span;
-                return true;
-            }
-            else if (attribute is MarkupTagHelperDirectiveAttributeSyntax tagHelperDirectiveAttribute)
-            {
-                prefixLocation = tagHelperDirectiveAttribute.NamePrefix.Span;
-                selectedAttributeName = tagHelperDirectiveAttribute.FullName;
-                var fullNameSpan = TextSpan.FromBounds(tagHelperDirectiveAttribute.Transition.Span.Start, tagHelperDirectiveAttribute.Name.Span.End);
-                selectedAttributeNameLocation = fullNameSpan;
-                return true;
-            }
-            else if (attribute is MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedTagHelperDirectiveAttribute)
-            {
-                prefixLocation = minimizedTagHelperDirectiveAttribute.NamePrefix.Span;
-                selectedAttributeName = minimizedTagHelperDirectiveAttribute.FullName;
-                var fullNameSpan = TextSpan.FromBounds(minimizedTagHelperDirectiveAttribute.Transition.Span.Start, minimizedTagHelperDirectiveAttribute.Name.Span.End);
-                selectedAttributeNameLocation = fullNameSpan;
-                return true;
-            }
-            else if (attribute is MarkupMiscAttributeContentSyntax)
-            {
-                prefixLocation = null;
-                selectedAttributeName = null;
-                selectedAttributeNameLocation = null;
-                return true;
+                case MarkupMinimizedAttributeBlockSyntax minimizedAttributeBlock:
+                    if (minimizedAttributeBlock.NamePrefix == null)
+                    {
+                        break;
+                    }
+                    prefixLocation = minimizedAttributeBlock.NamePrefix.Span;
+                    selectedAttributeName = minimizedAttributeBlock.Name.GetContent();
+                    selectedAttributeNameLocation = minimizedAttributeBlock.Name.Span;
+                    return true;
+                case MarkupAttributeBlockSyntax attributeBlock:
+                    if (attributeBlock.NamePrefix == null)
+                    {
+                        break;
+                    }
+                    prefixLocation = attributeBlock.NamePrefix.Span;
+                    selectedAttributeName = attributeBlock.Name.GetContent();
+                    selectedAttributeNameLocation = attributeBlock.Name.Span;
+                    return true;
+                case MarkupTagHelperAttributeSyntax tagHelperAttribute:
+                    if (tagHelperAttribute.NamePrefix == null)
+                    {
+                        break;
+                    }
+                    prefixLocation = tagHelperAttribute.NamePrefix.Span;
+                    selectedAttributeName = tagHelperAttribute.Name.GetContent();
+                    selectedAttributeNameLocation = tagHelperAttribute.Name.Span;
+                    return true;
+                case MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute:
+                    if (minimizedAttribute.NamePrefix == null)
+                    {
+                        break;
+                    }
+                    prefixLocation = minimizedAttribute.NamePrefix.Span;
+                    selectedAttributeName = minimizedAttribute.Name.GetContent();
+                    selectedAttributeNameLocation = minimizedAttribute.Name.Span;
+                    return true;
+                case MarkupTagHelperDirectiveAttributeSyntax tagHelperDirectiveAttribute:
+                    {
+                        if (tagHelperDirectiveAttribute.NamePrefix == null)
+                        {
+                            break;
+                        }
+                        prefixLocation = tagHelperDirectiveAttribute.NamePrefix.Span;
+                        selectedAttributeName = tagHelperDirectiveAttribute.FullName;
+                        var fullNameSpan = TextSpan.FromBounds(tagHelperDirectiveAttribute.Transition.Span.Start, tagHelperDirectiveAttribute.Name.Span.End);
+                        selectedAttributeNameLocation = fullNameSpan;
+                        return true;
+                    }
+                case MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedTagHelperDirectiveAttribute:
+                    {
+                        if (minimizedTagHelperDirectiveAttribute.NamePrefix == null)
+                        {
+                            break;
+                        }
+                        prefixLocation = minimizedTagHelperDirectiveAttribute.NamePrefix.Span;
+                        selectedAttributeName = minimizedTagHelperDirectiveAttribute.FullName;
+                        var fullNameSpan = TextSpan.FromBounds(minimizedTagHelperDirectiveAttribute.Transition.Span.Start, minimizedTagHelperDirectiveAttribute.Name.Span.End);
+                        selectedAttributeNameLocation = fullNameSpan;
+                        return true;
+                    }
+                case MarkupMiscAttributeContentSyntax markupMiscAttributeContent:
+                    prefixLocation = null;
+                    selectedAttributeName = null;
+                    selectedAttributeNameLocation = null;
+                    return true;
             }
 
             // Not an attribute type that we know of

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
@@ -46,53 +46,31 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 return false;
             }
 
-            // The null check on the `NamePrefix` field is required for cases like:
-            // `<svg xml:base=""x| ></svg>` where there's no `NamePrefix` available.
             switch (attribute)
             {
                 case MarkupMinimizedAttributeBlockSyntax minimizedAttributeBlock:
-                    if (minimizedAttributeBlock.NamePrefix == null)
-                    {
-                        break;
-                    }
-                    prefixLocation = minimizedAttributeBlock.NamePrefix.Span;
+                    prefixLocation = minimizedAttributeBlock.NamePrefix?.Span;
                     selectedAttributeName = minimizedAttributeBlock.Name.GetContent();
                     selectedAttributeNameLocation = minimizedAttributeBlock.Name.Span;
                     return true;
                 case MarkupAttributeBlockSyntax attributeBlock:
-                    if (attributeBlock.NamePrefix == null)
-                    {
-                        break;
-                    }
-                    prefixLocation = attributeBlock.NamePrefix.Span;
+                    prefixLocation = attributeBlock.NamePrefix?.Span;
                     selectedAttributeName = attributeBlock.Name.GetContent();
                     selectedAttributeNameLocation = attributeBlock.Name.Span;
                     return true;
                 case MarkupTagHelperAttributeSyntax tagHelperAttribute:
-                    if (tagHelperAttribute.NamePrefix == null)
-                    {
-                        break;
-                    }
-                    prefixLocation = tagHelperAttribute.NamePrefix.Span;
+                    prefixLocation = tagHelperAttribute.NamePrefix?.Span;
                     selectedAttributeName = tagHelperAttribute.Name.GetContent();
                     selectedAttributeNameLocation = tagHelperAttribute.Name.Span;
                     return true;
                 case MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute:
-                    if (minimizedAttribute.NamePrefix == null)
-                    {
-                        break;
-                    }
-                    prefixLocation = minimizedAttribute.NamePrefix.Span;
+                    prefixLocation = minimizedAttribute.NamePrefix?.Span;
                     selectedAttributeName = minimizedAttribute.Name.GetContent();
                     selectedAttributeNameLocation = minimizedAttribute.Name.Span;
                     return true;
                 case MarkupTagHelperDirectiveAttributeSyntax tagHelperDirectiveAttribute:
                     {
-                        if (tagHelperDirectiveAttribute.NamePrefix == null)
-                        {
-                            break;
-                        }
-                        prefixLocation = tagHelperDirectiveAttribute.NamePrefix.Span;
+                        prefixLocation = tagHelperDirectiveAttribute.NamePrefix?.Span;
                         selectedAttributeName = tagHelperDirectiveAttribute.FullName;
                         var fullNameSpan = TextSpan.FromBounds(tagHelperDirectiveAttribute.Transition.Span.Start, tagHelperDirectiveAttribute.Name.Span.End);
                         selectedAttributeNameLocation = fullNameSpan;
@@ -100,17 +78,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     }
                 case MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedTagHelperDirectiveAttribute:
                     {
-                        if (minimizedTagHelperDirectiveAttribute.NamePrefix == null)
-                        {
-                            break;
-                        }
-                        prefixLocation = minimizedTagHelperDirectiveAttribute.NamePrefix.Span;
+                        prefixLocation = minimizedTagHelperDirectiveAttribute.NamePrefix?.Span;
                         selectedAttributeName = minimizedTagHelperDirectiveAttribute.FullName;
                         var fullNameSpan = TextSpan.FromBounds(minimizedTagHelperDirectiveAttribute.Transition.Span.Start, minimizedTagHelperDirectiveAttribute.Name.Span.End);
                         selectedAttributeNameLocation = fullNameSpan;
                         return true;
                     }
-                case MarkupMiscAttributeContentSyntax markupMiscAttributeContent:
+                case MarkupMiscAttributeContentSyntax _:
                     prefixLocation = null;
                     selectedAttributeName = null;
                     selectedAttributeNameLocation = null;

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderBaseTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderBaseTest.cs
@@ -51,6 +51,23 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         }
 
         [Fact]
+        public void IntersectsWithAttributeNameOrPrefix_NullPrefix_ReturnsFalse()
+        {
+            // Arrange
+
+            // <svg xml:base="abc"xm| ></svg>
+            var location = new SourceSpan(21, 0);
+            TextSpan? prefixLocation = null;
+            var attributeNameLocation = new TextSpan(4, 5);
+
+            // Act
+            var result = DirectiveAttributeCompletionItemProviderBase.IntersectsWithAttributeNameOrPrefix(location, prefixLocation, attributeNameLocation);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
         public void IntersectsWithAttributeNameOrPrefix_AtNameLeadingEdge_ReturnsTrue()
         {
             // Arrange


### PR DESCRIPTION
Each of these individual Syntax nodes define the `NamePrefix` property. The property is not shared with `MarkupSyntaxNode` nor a common interface.

I didn't see a way to add an interface to the `Syntax.xml` node definitions, so I elected to take this approach.

We encounter this issue in cases like:
`<svg xml:base=""x| ></svg>`

Fixes: https://github.com/dotnet/aspnetcore/issues/21554
