### PR TITLE
Fix ambiguous errors in C# documents on sln reopen with already open documents.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             _foregroundDispatcher = foregroundDispatcher;
             _errorReporter = errorReporter;
-            _triggers = triggers.ToArray();
+            _triggers = triggers.OrderByDescending(trigger => trigger.InitializePriority).ToArray();
             Workspace = workspace;
 
             _projects = new Dictionary<string, Entry>(FilePathComparer.Instance);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotChangeTrigger.cs
@@ -5,6 +5,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal abstract class ProjectSnapshotChangeTrigger
     {
+        public virtual int InitializePriority { get; }
+
         public abstract void Initialize(ProjectSnapshotManagerBase projectManager);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
         private readonly EventHandler _onChangedInEditor;
         private readonly EventHandler _onOpened;
         private readonly EventHandler _onClosed;
-        
+
         private EditorDocumentManager _documentManager;
         private ProjectSnapshotManagerBase _projectManager;
 
@@ -41,6 +41,11 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             _onOpened = onOpened;
             _onClosed = onClosed;
         }
+
+        // InitializePriority controls when a snapshot change trigger gets initialized. By specifying 100 we're saying we're pretty important and should get initialized before
+        // other triggers with lesser priority so we can attach to Changed sooner. We happen to be so important because we control the open/close state of documents. If other triggers
+        // depend on a document being open/closed (some do) then we need to ensure we can mark open/closed prior to them running.
+        public override int InitializePriority => 100;
 
         public override void Initialize(ProjectSnapshotManagerBase projectManager)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var projectManager = new TestProjectSnapshotManager(Dispatcher, triggers, Workspace);
 
             // Assert
-            Assert.Equal(new[] { "lowPriority", "highPriority" }, initializedOrder);
+            Assert.Equal(new[] { "highPriority", "lowPriority" }, initializedOrder);
         }
 
         [ForegroundFact]


### PR DESCRIPTION
- I found that our `BackgroundDocumentGenerator` was queuing up multiple changes on solution load and found that because of `ProjectSnapshotChangeTrigger` ordering it would queue up a background generated document publish while it was still being detected as "closed". This meant that when the actual already-opened file would spin up in the editor it would itself create its own C# buffer which would conflict with the background generated document resulting in ambiguous errors. This looks to be more prevalent in latest VS because MEF doesn't guaruntee ordering.
- Added a `Priority` property to `ProjectSnapshotChangeTrigger`s to control when triggers run to ensure our closed/open document state trigger could run prior to any other triggers that may or may not depend on closed/open document state.
- Added a test to validate initialize order since that's what controls change order.

Fixes dotnet/aspnetcore#21551
