### PR TITLE
Fix perf issue in LineTrackingStringbuffer.ScanLines.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LineTrackingStringBuffer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LineTrackingStringBuffer.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             // binary search for the line containing absoluteIndex
             var lowIndex = startLineIndex;
-            var highIndex = _lines.Count;
+            var highIndex = endLineIndex;
 
             while (lowIndex != highIndex)
             {


### PR DESCRIPTION
I noticed several hundred ms spent in this method from a customer profile. Primarilly, the method was doing a linear scan of all lines trying to find one that contained the requested position. I changed this to a binary search, but kept/improved the optimization around checking next/previous lines before instigating the search.

Note, there was also a bug where the old code did:

else if (absoluteIndex > _currentLine.Index && _currentLine.Index + 1 < _lines.Count)

but it should have been coparing absoluteIndex with _currentLine.Start
