### PR TITLE
Several changes targeted to improving perf of RazorSyntaxTree.Parse

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpLanguageCharacteristics.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpLanguageCharacteristics.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return new CSharpTokenizer(source);
         }
 
-        protected override SyntaxToken CreateToken(string content, SyntaxKind kind, RazorDiagnostic [] errors)
+        protected override SyntaxToken CreateToken(string content, SyntaxKind kind, RazorDiagnostic[] errors)
         {
             return SyntaxFactory.Token(kind, content, errors);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpLanguageCharacteristics.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpLanguageCharacteristics.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return new CSharpTokenizer(source);
         }
 
-        protected override SyntaxToken CreateToken(string content, SyntaxKind kind, IReadOnlyList<RazorDiagnostic> errors)
+        protected override SyntaxToken CreateToken(string content, SyntaxKind kind, RazorDiagnostic [] errors)
         {
             return SyntaxFactory.Token(kind, content, errors);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpTokenizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpTokenizer.cs
@@ -344,7 +344,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return base.GetTokenContent(type);
         }
 
-        protected override SyntaxToken CreateToken(string content, SyntaxKind kind, IReadOnlyList<RazorDiagnostic> errors)
+        protected override SyntaxToken CreateToken(string content, SyntaxKind kind, RazorDiagnostic [] errors)
         {
             return SyntaxFactory.Token(kind, content, errors);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlLanguageCharacteristics.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlLanguageCharacteristics.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        protected override SyntaxToken CreateToken(string content, SyntaxKind kind, IReadOnlyList<RazorDiagnostic> errors)
+        protected override SyntaxToken CreateToken(string content, SyntaxKind kind, RazorDiagnostic [] errors)
         {
             return SyntaxFactory.Token(kind, content, errors);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlTokenizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlTokenizer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             get { return SyntaxKind.RazorCommentStar; }
         }
 
-        protected override SyntaxToken CreateToken(string content, SyntaxKind type, IReadOnlyList<RazorDiagnostic> errors)
+        protected override SyntaxToken CreateToken(string content, SyntaxKind type, RazorDiagnostic [] errors)
         {
             return SyntaxFactory.Token(type, content, errors);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlTokenizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlTokenizer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             get { return SyntaxKind.RazorCommentStar; }
         }
 
-        protected override SyntaxToken CreateToken(string content, SyntaxKind type, RazorDiagnostic [] errors)
+        protected override SyntaxToken CreateToken(string content, SyntaxKind type, RazorDiagnostic[] errors)
         {
             return SyntaxFactory.Token(type, content, errors);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LanguageCharacteristics.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LanguageCharacteristics.cs
@@ -103,6 +103,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return type == KnownTokenType.Unknown || !Equals(GetKnownTokenType(type), GetKnownTokenType(KnownTokenType.Unknown));
         }
 
-        protected abstract SyntaxToken CreateToken(string content, SyntaxKind type, IReadOnlyList<RazorDiagnostic> errors);
+        protected abstract SyntaxToken CreateToken(string content, SyntaxKind type, RazorDiagnostic [] errors);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LanguageCharacteristics.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LanguageCharacteristics.cs
@@ -103,6 +103,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return type == KnownTokenType.Unknown || !Equals(GetKnownTokenType(type), GetKnownTokenType(KnownTokenType.Unknown));
         }
 
-        protected abstract SyntaxToken CreateToken(string content, SyntaxKind type, RazorDiagnostic [] errors);
+        protected abstract SyntaxToken CreateToken(string content, SyntaxKind type, RazorDiagnostic[] errors);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LegacySyntaxNodeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/LegacySyntaxNodeExtensions.cs
@@ -95,14 +95,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 return null;
             }
 
+            if (node.EndPosition < change.Span.AbsoluteIndex)
+            {
+                // no need to look into this node as it completely precedes the change
+                return null;
+            }
+
             if (IsSpanKind(node))
             {
                 var editHandler = node.GetSpanContext()?.EditHandler ?? SpanEditHandler.CreateDefault();
                 return editHandler.OwnsChange(node, change) ? node : null;
             }
 
-            SyntaxNode owner = null;
-            IEnumerable<SyntaxNode> children;
+            IReadOnlyList<SyntaxNode> children;
             if (node is MarkupStartTagSyntax startTag)
             {
                 children = startTag.Children;
@@ -124,8 +129,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 children = node.ChildNodes();
             }
 
-            foreach (var child in children)
+            SyntaxNode owner = null;
+            for (int i = 0; i < children.Count; i++)
             {
+                var child = children[i];
                 owner = LocateOwner(child, change);
                 if (owner != null)
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserHelpers.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserHelpers.cs
@@ -19,7 +19,20 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             '\u2029' // Paragraph separator
         };
 
-        public static bool IsNewLine(char value) => Array.IndexOf<char>(NewLineCharacters, value) != -1;
+        public static bool IsNewLine(char value)
+        {
+            switch(value)
+            {
+                case '\r': // Carriage return
+                case '\n': // Linefeed
+                case '\u0085': // Next Line
+                case '\u2028': // Line separator
+                case '\u2029': // Paragraph separator
+                    return true;
+            }
+
+            return false;
+        }
 
         public static bool IsNewLine(string value)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserHelpers.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserHelpers.cs
@@ -10,18 +10,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     internal static class ParserHelpers
     {
-        public static char[] NewLineCharacters = new[]
-        {
-            '\r', // Carriage return
-            '\n', // Linefeed
-            '\u0085', // Next Line
-            '\u2028', // Line separator
-            '\u2029' // Paragraph separator
-        };
-
         public static bool IsNewLine(char value)
         {
-            switch(value)
+            switch (value)
             {
                 case '\r': // Carriage return
                 case '\n': // Linefeed

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/Tokenizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/Tokenizer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public SourceLocation CurrentStart { get; private set; }
 
-        protected abstract SyntaxToken CreateToken(string content, SyntaxKind type, IReadOnlyList<RazorDiagnostic> errors);
+        protected abstract SyntaxToken CreateToken(string content, SyntaxKind type, RazorDiagnostic [] errors);
 
         protected abstract StateResult Dispatch();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TokenizerBackedParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/TokenizerBackedParser.cs
@@ -185,6 +185,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
+        protected internal void PutBack(IReadOnlyList<SyntaxToken> tokens)
+        {
+            for (int i = tokens.Count - 1; i >= 0; i--)
+            {
+                PutBack(tokens[i]);
+            }
+        }
+
         protected internal void PutCurrentBack()
         {
             if (!EndOfFile && CurrentToken != null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -1,20 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
+using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
 {
     internal static partial class SyntaxFactory
     {
-        internal static SyntaxToken Token(SyntaxKind kind, string content, IEnumerable<RazorDiagnostic> diagnostics)
-        {
-            return Token(kind, content, diagnostics.ToArray());
-        }
-
         internal static SyntaxToken Token(SyntaxKind kind, string content, params RazorDiagnostic[] diagnostics)
         {
+            if (kind == SyntaxKind.Whitespace && diagnostics.Length == 0)
+            {
+                return WhitespaceTokenCache.GetToken(content);
+            }
+
             return new SyntaxToken(kind, content, diagnostics);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/WhitespaceTokenCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/WhitespaceTokenCache.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/WhitespaceTokenCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Syntax/InternalSyntax/WhitespaceTokenCache.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
+{
+    // Simplified version of Roslyn's SyntaxNodeCache
+    internal static class WhitespaceTokenCache
+    {
+        private const int CacheSizeBits = 8;
+        private const int CacheSize = 1 << CacheSizeBits;
+        private const int CacheMask = CacheSize - 1;
+        private static readonly Entry[] s_cache = new Entry[CacheSize];
+
+        private struct Entry
+        {
+            public int Hash { get; }
+            public SyntaxToken Token { get; }
+
+            internal Entry(int hash, SyntaxToken token)
+            {
+                Hash = hash;
+                Token = token;
+            }
+        }
+
+        public static SyntaxToken GetToken(string content)
+        {
+            var hash = content.GetHashCode();
+
+            var idx = hash & CacheMask;
+            var e = s_cache[idx];
+
+            if (e.Hash == hash && e.Token?.Content == content)
+            {
+                return e.Token;
+            }
+
+            var token = new SyntaxToken(SyntaxKind.Whitespace, content, Array.Empty<RazorDiagnostic>());
+            s_cache[idx] = new Entry(hash, token);
+
+            return token;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Text
                 if (delimiterIndex == -1)
                 {
                     delimiterLength = 1;
-                    for (int i = 0; i < Content.Length; i++)
+                    for (int i = start; i < Content.Length; i++)
                     {
                         if (ParserHelpers.IsNewLine(content[i]))
                         {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
@@ -36,7 +36,14 @@ namespace Microsoft.VisualStudio.Text
                 if (delimiterIndex == -1)
                 {
                     delimiterLength = 1;
-                    delimiterIndex = Content.IndexOfAny(ParserHelpers.NewLineCharacters, start);
+                    for(int i = 0; i < Content.Length; i++)
+                    {
+                        if (ParserHelpers.IsNewLine(content[i]))
+                        {
+                            delimiterIndex = i;
+                            break;
+                        }
+                    }
                 }
 
                 var nextLineStartIndex = delimiterIndex != -1 ? delimiterIndex + delimiterLength : Content.Length;

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Text
                 if (delimiterIndex == -1)
                 {
                     delimiterLength = 1;
-                    for(int i = 0; i < Content.Length; i++)
+                    for (int i = 0; i < Content.Length; i++)
                     {
                         if (ParserHelpers.IsNewLine(content[i]))
                         {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.Text
                 {
                     _content = _content.Substring(0, _content.Length - 2);
                 }
-                else if(_content.Length > 0 && ParserHelpers.NewLineCharacters.Contains(_content[_content.Length - 1]))
+                else if(_content.Length > 0 && ParserHelpers.IsNewLine(_content[_content.Length - 1]))
                 {
                     _content = _content.Substring(0, _content.Length - 1);
                 }

--- a/src/Razor/test/RazorLanguage.Test/Legacy/TokenizerLookaheadTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/Legacy/TokenizerLookaheadTest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             protected override SyntaxToken CreateToken(
                 string content,
                 SyntaxKind type,
-                RazorDiagnostic [] errors)
+                RazorDiagnostic[] errors)
             {
                 throw new NotImplementedException();
             }

--- a/src/Razor/test/RazorLanguage.Test/Legacy/TokenizerLookaheadTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/Legacy/TokenizerLookaheadTest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             protected override SyntaxToken CreateToken(
                 string content,
                 SyntaxKind type,
-                IReadOnlyList<RazorDiagnostic> errors)
+                RazorDiagnostic [] errors)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
1) Modify ParserHelpers.IsNewLine to use a switch instead of Array.IndexOf
2) Modify Tokenizer.CreateToken to take in an array of RazorDiagnostics rather than an IReadOnlyList as that was causing a ToArray call on an empty diagnostics very often (during a SyntaxFactory.Token call)
3) Modify TokenizerBackedParser.Putback to allow an IReadOnlyList as a parameter to not require creation of a reverse enumerator.
4) Cut down allocations in HtmlMarkupParser.GetParserState by:
    a) Using an IReadOnlyList instead of IEnumerable to get rid of the allocations from the .any calls
    b) Don't allocate while reading initial spacing
    c) Inline the IsSpacingToken code so cut down on code executed and need to allocate a separate Func
5) Modify CSharpCodeParser.IsSpacingToken to now be a set of methods instead of a single method that allocates a Func. This is a very high traffic method.
6) Implement a fairly rudimentary Whitespace token cache, as they can be reused. This was based off Roslyn's SyntaxNodeCache, but simplified significantly. It's probably worth investigating whether you should more fully embrance token caching outside of whitespace.
7) Modified LocateOwner DFS code to prune searches in nodes that are before the change.