### PR TITLE
Improve HtmlTokenizer.AtToken performance.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlTokenizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlTokenizer.cs
@@ -255,19 +255,25 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         private bool AtToken()
         {
-            return CurrentCharacter == '<' ||
-                   CurrentCharacter == '<' ||
-                   CurrentCharacter == '!' ||
-                   CurrentCharacter == '/' ||
-                   CurrentCharacter == '?' ||
-                   CurrentCharacter == '[' ||
-                   CurrentCharacter == '>' ||
-                   CurrentCharacter == ']' ||
-                   CurrentCharacter == '=' ||
-                   CurrentCharacter == '"' ||
-                   CurrentCharacter == '\'' ||
-                   CurrentCharacter == '@' ||
-                   (CurrentCharacter == '-' && Peek() == '-');
+            switch (CurrentCharacter)
+            {
+                case '<':
+                case '!':
+                case '/':
+                case '?':
+                case '[':
+                case '>':
+                case ']':
+                case '=':
+                case '"':
+                case '\'':
+                case '@':
+                    return true;
+                case '-':
+                    return Peek() == '-';
+            }
+
+            return false;
         }
 
         private StateResult Transition(HtmlTokenizerState state)


### PR DESCRIPTION
Our razor typing test measured 153 CPU ms in this method. Optimized by fewer calls to CurrentCharacter, not checking '<' twice, and using a switch stmt.