### PR TITLE
Small perf improvement in TokenizerBackedParser.Accept and ReadWhile.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -893,7 +893,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        protected bool TryParseDirective(in SyntaxListBuilder<RazorSyntaxNode> builder, IEnumerable<SyntaxToken> whitespace, CSharpTransitionSyntax transition, string directive)
+        protected bool TryParseDirective(in SyntaxListBuilder<RazorSyntaxNode> builder, IReadOnlyList<SyntaxToken> whitespace, CSharpTransitionSyntax transition, string directive)
         {
             if (_directiveParserMap.TryGetValue(directive, out var handler))
             {
@@ -1679,7 +1679,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        private bool TryParseKeyword(in SyntaxListBuilder<RazorSyntaxNode> builder, IEnumerable<SyntaxToken> whitespace, CSharpTransitionSyntax transition)
+        private bool TryParseKeyword(in SyntaxListBuilder<RazorSyntaxNode> builder, IReadOnlyList<SyntaxToken> whitespace, CSharpTransitionSyntax transition)
         {
             var result = CSharpTokenizer.GetTokenKeyword(CurrentToken);
             Debug.Assert(CurrentToken.Kind == SyntaxKind.Keyword && result.HasValue);
@@ -2387,7 +2387,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        private IEnumerable<SyntaxToken> SkipToNextImportantToken(in SyntaxListBuilder<RazorSyntaxNode> builder)
+        private IReadOnlyList<SyntaxToken> SkipToNextImportantToken(in SyntaxListBuilder<RazorSyntaxNode> builder)
         {
             while (!EndOfFile)
             {
@@ -2406,7 +2406,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     return whitespace;
                 }
             }
-            return Enumerable.Empty<SyntaxToken>();
+            return Array.Empty<SyntaxToken>();
         }
 
         private void DefaultSpanContextConfig(SpanContextBuilder spanContext)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
@@ -1085,9 +1085,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        private bool TryParseAttributeName(out IEnumerable<SyntaxToken> nameTokens)
+        private bool TryParseAttributeName(out IReadOnlyList<SyntaxToken> nameTokens)
         {
-            nameTokens = Enumerable.Empty<SyntaxToken>();
+            nameTokens = Array.Empty<SyntaxToken>();
             //
             // We are currently here <input |name="..." />
             // If we encounter a transition (@) here, it can be parsed as CSharp or Markup depending on the feature flag.


### PR DESCRIPTION
In the razor perf typing test, Accept was showing 27 ms allocating enumerators. Additionally, modified ReadWhile to only allocate if it would return a non-empty collection (and to not use the complexity introduced by using yield enumerators)