### PR TITLE
Update code owners to include Razor tooling team.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 /eng/common/                                   @dotnet-maestro-bot @dougbu
 /eng/Versions.props                            @dotnet-maestro-bot @dougbu
 /eng/Version.Details.xml                       @dotnet-maestro-bot @dougbu
-/src/Razor/                                    @ajaybhargavb @NTaylorMullen @rynowak
-/src/Razor/src/Microsoft.NET.Sdk.Razor/        @ajaybhargavb @NTaylorMullen @rynowak @pranavkm
-/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/  @ajaybhargavb @NTaylorMullen @rynowak @pranavkm
+/src/Razor/                                    @ajaybhargavb @NTaylorMullen @ryanbrandenburg @TanayParikh
+/src/Razor/src/Microsoft.NET.Sdk.Razor/        @ajaybhargavb @NTaylorMullen @pranavkm @javiercn
+/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/  @ajaybhargavb @NTaylorMullen @pranavkm @javiercn


### PR DESCRIPTION
- This code will auto-require the correct people for the specific paths.