### PR TITLE
Decrease allocations from using method groups

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -2623,22 +2623,22 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         // Following four high traffic methods cached as using method groups would cause allocation on every invocation.
-        protected static Func<SyntaxToken, bool> IsSpacingToken = (token) =>
+        protected static readonly Func<SyntaxToken, bool> IsSpacingToken = (token) =>
         {
             return token.Kind == SyntaxKind.Whitespace;
         };
 
-        protected static Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLines = (token) =>
+        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLines = (token) =>
         {
             return IsSpacingToken(token) || token.Kind == SyntaxKind.NewLine;
         };
 
-        protected static Func<SyntaxToken, bool> IsSpacingTokenIncludingComments = (token) =>
+        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingComments = (token) =>
         {
             return IsSpacingToken(token) || token.Kind == SyntaxKind.CSharpComment;
         };
 
-        protected static Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLinesAndComments = (token) =>
+        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLinesAndComments = (token) =>
         {
             return IsSpacingTokenIncludingNewLines(token) || token.Kind == SyntaxKind.CSharpComment;
         };

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -16,6 +16,27 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*'
         });
 
+        // Following four high traffic methods cached as using method groups would cause allocation on every invocation.
+        protected static readonly Func<SyntaxToken, bool> IsSpacingToken = (token) =>
+        {
+            return token.Kind == SyntaxKind.Whitespace;
+        };
+
+        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLines = (token) =>
+        {
+            return IsSpacingToken(token) || token.Kind == SyntaxKind.NewLine;
+        };
+
+        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingComments = (token) =>
+        {
+            return IsSpacingToken(token) || token.Kind == SyntaxKind.CSharpComment;
+        };
+
+        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLinesAndComments = (token) =>
+        {
+            return IsSpacingTokenIncludingNewLines(token) || token.Kind == SyntaxKind.CSharpComment;
+        };
+
         private static readonly Func<SyntaxToken, bool> IsValidStatementSpacingToken =
             IsSpacingTokenIncludingNewLinesAndComments;
 
@@ -2621,27 +2642,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 result.HasValue &&
                 result.Value == keyword;
         }
-
-        // Following four high traffic methods cached as using method groups would cause allocation on every invocation.
-        protected static readonly Func<SyntaxToken, bool> IsSpacingToken = (token) =>
-        {
-            return token.Kind == SyntaxKind.Whitespace;
-        };
-
-        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLines = (token) =>
-        {
-            return IsSpacingToken(token) || token.Kind == SyntaxKind.NewLine;
-        };
-
-        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingComments = (token) =>
-        {
-            return IsSpacingToken(token) || token.Kind == SyntaxKind.CSharpComment;
-        };
-
-        protected static readonly Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLinesAndComments = (token) =>
-        {
-            return IsSpacingTokenIncludingNewLines(token) || token.Kind == SyntaxKind.CSharpComment;
-        };
 
         protected class Block
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -2622,25 +2622,26 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 result.Value == keyword;
         }
 
-        protected static bool IsSpacingToken(SyntaxToken token)
+        // Following four high traffic methods cached as using method groups would cause allocation on every invocation.
+        protected static Func<SyntaxToken, bool> IsSpacingToken = (token) =>
         {
             return token.Kind == SyntaxKind.Whitespace;
-        }
+        };
 
-        protected static bool IsSpacingTokenIncludingNewLines(SyntaxToken token)
+        protected static Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLines = (token) =>
         {
             return IsSpacingToken(token) || token.Kind == SyntaxKind.NewLine;
-        }
+        };
 
-        protected static bool IsSpacingTokenIncludingComments(SyntaxToken token)
+        protected static Func<SyntaxToken, bool> IsSpacingTokenIncludingComments = (token) =>
         {
             return IsSpacingToken(token) || token.Kind == SyntaxKind.CSharpComment;
-        }
+        };
 
-        protected static bool IsSpacingTokenIncludingNewLinesAndComments(SyntaxToken token)
+        protected static Func<SyntaxToken, bool> IsSpacingTokenIncludingNewLinesAndComments = (token) =>
         {
             return IsSpacingTokenIncludingNewLines(token) || token.Kind == SyntaxKind.CSharpComment;
-        }
+        };
 
         protected class Block
         {


### PR DESCRIPTION
Previous optimization didn't help as much as intended.

By specifying a method group as the arguments to method like ReadWhile, an allocation was still occurring. Instead, cache the Func as a member in the class and use it instead of the method group.