### PR TITLE
Stop falling back to RequestAsync when SynchronziedRequestAsync is not available.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
@@ -57,10 +57,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     typeof(CancellationToken)
                 });
 
-            // The LSP platform is adding a SynchronizedRequestAsync method; however, until that change is in we need to conditionally fallback to the old RequestAsync.
-            // Removal tracked by: https://github.com/dotnet/aspnetcore/issues/21468
-            _synchronizedRequestAsyncMethod ??= _requestAsyncMethod;
-
             // We need these converters so we don't lose information as part of the deserialization.
             _serializer = new JsonSerializer();
             _serializer.Converters.Add(new VSExtensionConverter<ClientCapabilities, VSClientCapabilities>());


### PR DESCRIPTION
- With latest VS insertions this should always be available.

Note: This requires a week-old VSMaster build to run the experimental instance otherwise things will explode

Fixes dotnet/aspnetcore#21468