### PR TITLE
Revert "Update Roslyn to 3.7 (#1878)"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -119,7 +119,7 @@
     <MicrosoftVisualStudioShellInteropPackageVersion>7.10.6072</MicrosoftVisualStudioShellInteropPackageVersion>
     <MicrosoftVisualStudioTextDataPackageVersion>16.4.280</MicrosoftVisualStudioTextDataPackageVersion>
     <MicrosoftVisualStudioTextUIPackageVersion>16.4.280</MicrosoftVisualStudioTextUIPackageVersion>
-    <MicrosoftVisualStudioThreadingPackageVersion>16.6.5-alpha</MicrosoftVisualStudioThreadingPackageVersion>
+    <MicrosoftVisualStudioThreadingPackageVersion>16.4.45</MicrosoftVisualStudioThreadingPackageVersion>
     <MonoAddinsPackageVersion>1.3.8</MonoAddinsPackageVersion>
     <MonoDevelopSdkPackageVersion>1.0.15</MonoDevelopSdkPackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
@@ -133,22 +133,22 @@
     <Runtime_MicrosoftCodeAnalysisCommonPackageVersion>3.4.0</Runtime_MicrosoftCodeAnalysisCommonPackageVersion>
     <Runtime_MicrosoftCodeAnalysisCSharpPackageVersion>3.4.0</Runtime_MicrosoftCodeAnalysisCSharpPackageVersion>
     <StreamJsonRpcPackageVersion>2.3.103</StreamJsonRpcPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <Tooling_MicrosoftVisualStudioTelemetryPackageVersion>16.0.4-master</Tooling_MicrosoftVisualStudioTelemetryPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.0.0</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCommonPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisCommonPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisRemoteRazorServiceHubPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisRemoteRazorServiceHubPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>
-    <Tooling_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.0.0-beta2.final</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCommonPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisCommonPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisRemoteRazorServiceHubPackageVersion>3.4.0-beta4-19606-05</Tooling_MicrosoftCodeAnalysisRemoteRazorServiceHubPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>3.6.0-3.20202.7</Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <Tooling_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>3.4.0-beta4-19606-05</Tooling_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitVersion>2.4.1</XunitVersion>
   </PropertyGroup>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorLanguageService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorLanguageService.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor
 {
@@ -19,10 +18,10 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
         {
         }
 
-        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(JObject solutionInfo, ProjectSnapshotHandle projectHandle, string factoryTypeName, CancellationToken cancellationToken = default)
+        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(ProjectSnapshotHandle projectHandle, string factoryTypeName, CancellationToken cancellationToken = default)
         {
             var projectSnapshot = await GetProjectSnapshotAsync(projectHandle, cancellationToken).ConfigureAwait(false);
-            var solution = await GetSolutionAsync(solutionInfo, cancellationToken);
+            var solution = await GetSolutionAsync(cancellationToken);
             var workspaceProject = solution
                 .Projects
                 .FirstOrDefault(project => FilePathComparer.Instance.Equals(project.FilePath, projectSnapshot.FilePath));


### PR DESCRIPTION
This reverts commit 924ca9acf9c5a84e8fc08143c345ffe7968e9882.

Reverting this because we need to get an insertion out.

Context: https://github.com/dotnet/aspnetcore-tooling/pull/1878#discussion_r425476043
