### PR TITLE
Do not build deps when building vsix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,6 +242,7 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             /p:BuildVsix=true
+            /p:BuildProjectReferences=false
             $(_BuildArgs)
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)


### PR DESCRIPTION
Hopefully resolves the duplicate publishing issue. Not sure if it'll help resolve the missing symbols issue though.