### PR TITLE
Fix Razor completion source deadlock.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -632,9 +632,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     }
 
                     _done = true;
-                    _cancellationTokenRegistration.Dispose();
-                    _taskCompletionSource.SetResult(codeDocument);
                 }
+
+                _cancellationTokenRegistration.Dispose();
+                _taskCompletionSource.SetResult(codeDocument);
             }
 
             public void Cancel()
@@ -646,10 +647,11 @@ namespace Microsoft.VisualStudio.Editor.Razor
                         return;
                     }
 
-                    _taskCompletionSource.TrySetCanceled();
-                    _cancellationTokenRegistration.Dispose();
                     _done = true;
                 }
+
+                _taskCompletionSource.TrySetCanceled();
+                _cancellationTokenRegistration.Dispose();
             }
         }
     }


### PR DESCRIPTION
- WTE found an issue where if you dismiss completion at the right moment it's possible to deadlock our complete/cancel callbacks in our pre-existing Visual Studio Razor Parser. Basically what would happen is that Dismiss and cancel would be called simultaneously and due to how the task completion source registration/cancellation token would invoke their callbacks we'd get stuck waiting on ourselves. Turns out we don't need to have our cancellation token/task completion source management in our lock at all.

/cc @alexgav @ToddGrun 