### PR TITLE
Ignore error output from `Get-Process`

### DIFF
--- a/eng/scripts/StartDumpCollectionForHangingBuilds.ps1
+++ b/eng/scripts/StartDumpCollectionForHangingBuilds.ps1
@@ -54,7 +54,7 @@ Write-Output "Watching processes $($CandidateProcessNames -join ', ')";
 # This script registers as a scheduled job. This scheduled job executes after $WakeTime.
 # When the scheduled job executes, it runs procdump on all alive processes whose name matches $CandidateProcessNames.
 # The dumps are placed in $ProcDumpOutputPath
-# If the build completes sucessfully in less than $WakeTime, a final step unregisters the job.
+# If the build completes successfully in less than $WakeTime, a final step unregisters the job.
 
 # Create a unique identifier for the job name
 $JobName = "CaptureDumps" + (New-Guid).ToString("N");
@@ -81,7 +81,7 @@ Out-File -FilePath $sentinelFile -InputObject $JobName | Out-Null;
   [System.Diagnostics.Process []]$AliveProcesses = @();
   foreach ($candidate in $CandidateProcessNames) {
     try {
-      $candidateProcesses = Get-Process $candidate;
+      $candidateProcesses = Get-Process $candidate 2>$null
       $candidateProcesses | ForEach-Object { Write-Output "Found candidate process $candidate with PID '$($_.Id)'." };
       $AliveProcesses += $candidateProcesses;
     }


### PR DESCRIPTION
- allow FinishDumpCollectionForHangingBuilds.ps1 to complete w/o writing to `stderr`

nit: copy a typo fix from aspnetcore