### PR TITLE
Fix debugging hosted Blazor WASM apps

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -91,6 +91,11 @@
                     "enum": ["verbose", true],
                     "description": "If true, verbose logs from JS debugger are sent to log file. If 'verbose', send logs to console."
                   },
+                  "hosted": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "True if the app is a hosted Blazor WebAssembly app, false otherwise."
+                  },
                   "webRoot": {
                     "type": "string",
                     "default": "${workspaceFolder}",
@@ -100,6 +105,15 @@
                     "type": "number",
                     "default": 30000,
                     "description": "Retry for this number of milliseconds to connect to browser."
+                  },
+                  "program": {
+                    "type": "string",
+                    "default": "${workspaceFolder}/Server/bin/Debug/<target-framework>/<target-dll>",
+                    "description": "The path of the DLL to execute when launching a hosted server app"
+                  },
+                  "env": {
+                    "type": "object",
+                    "description": "Environment variables passed to dotnet. Only valid for hosted apps."
                   }
                 }
               }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
@@ -13,29 +13,68 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
     constructor(private readonly logger: RazorLogger, private readonly vscodeType: typeof vscode) { }
 
     public async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, configuration: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration | undefined> {
-        const shellPath = process.platform === 'win32' ? 'cmd.exe' : 'dotnet';
-        const shellArgs = process.platform === 'win32' ? ['/c', 'chcp 65001 >NUL & dotnet run'] : ['run'];
-        const spawnOptions = {
-            cwd: configuration.cwd || (folder && folder.uri && folder.uri.fsPath),
-        };
-
-        const output = this.vscodeType.window.createTerminal({
-          name: 'Blazor WebAssembly App',
-          shellPath,
-          shellArgs,
-          ...spawnOptions,
-        });
-
         /**
-         * On non-Windows platforms, we need to terminate the Blazor
-         * dev server and its child processes.
+         * If the user is debugging a hosted Blazor WebAssembly application,
+         * then the application server needs to be launched via VS Code's debug
+         * workflow to allow debugging on the server-side logic. If the app is
+         * not hosted, then it can be spun as a standalone process to avoid additional overhead.
          */
-        const terminate = this.vscodeType.debug.onDidTerminateDebugSession(async event => {
-            await onDidTerminateDebugSession(event, this.logger, await output.processId);
-            terminate.dispose();
-        });
+        if (configuration.hosted) {
+            if (!configuration.program && !configuration.cwd) {
+                const message = `Must provide 'program' and 'cwd' properties in launch configuration for hosted Blazor WebAssembly apps.`;
+                this.vscodeType.window.showErrorMessage(message);
+            }
 
-        output.show(/*preserveFocus*/true);
+            const app = {
+                name: '.NET Core Launch (Blazor Hosted)',
+                type: 'coreclr',
+                request: 'launch',
+                preLaunchTask: 'build',
+                program: configuration.program,
+                args: [],
+                cwd: configuration.cwd,
+                env: {
+                    ...configuration.env,
+                },
+            };
+
+            if (process.platform !== 'win32') {
+                this.vscodeType.debug.startDebugging(folder, app).then((appStartFulfilled: boolean) => {
+                    this.logger.logVerbose('[DEBUGGER] Launching hosted Blazor WebAssembly app...');
+                    const terminate = this.vscodeType.debug.onDidTerminateDebugSession(async event => {
+                        await onDidTerminateDebugSession(event, this.logger, /*targetPid*/undefined, /*hosted*/app.program);
+                        terminate.dispose();
+                    });
+                }, (error: Error) => {
+                    this.logger.logError('[DEBUGGER] Error when launching application: ', error);
+                });
+            }
+
+        } else {
+            const shellPath = process.platform === 'win32' ? 'cmd.exe' : 'dotnet';
+            const shellArgs = process.platform === 'win32' ? ['/c', 'chcp 65001 >NUL & dotnet run'] : ['run'];
+            const spawnOptions = {
+                cwd: configuration.cwd || (folder && folder.uri && folder.uri.fsPath),
+            };
+
+            const output = this.vscodeType.window.createTerminal({
+              name: 'Blazor WebAssembly App',
+              shellPath,
+              shellArgs,
+              ...spawnOptions,
+            });
+
+            /**
+             * We need to terminate the Blazor
+             * dev server and its child processes.
+             */
+            const terminate = this.vscodeType.debug.onDidTerminateDebugSession(async event => {
+                await onDidTerminateDebugSession(event, this.logger, await output.processId);
+                terminate.dispose();
+            });
+
+            output.show(/*preserveFocus*/true);
+        }
 
         const browser = {
             name: '.NET Core Debug Blazor Web Assembly in Browser',

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 
 import { RazorLogger } from '../RazorLogger';
+import { HOSTED_APP_NAME, JS_DEBUG_NAME } from './Constants';
 import { onDidTerminateDebugSession } from './TerminateDebugHandler';
 
 export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
@@ -26,7 +27,7 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
             }
 
             const app = {
-                name: '.NET Core Launch (Blazor Hosted)',
+                name: HOSTED_APP_NAME,
                 type: 'coreclr',
                 request: 'launch',
                 preLaunchTask: 'build',
@@ -38,18 +39,17 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
                 },
             };
 
-            if (process.platform !== 'win32') {
-                this.vscodeType.debug.startDebugging(folder, app).then((appStartFulfilled: boolean) => {
-                    this.logger.logVerbose('[DEBUGGER] Launching hosted Blazor WebAssembly app...');
+            this.vscodeType.debug.startDebugging(folder, app).then((appStartFulfilled: boolean) => {
+                this.logger.logVerbose('[DEBUGGER] Launching hosted Blazor WebAssembly app...');
+                if (process.platform !== 'win32') {
                     const terminate = this.vscodeType.debug.onDidTerminateDebugSession(async event => {
                         await onDidTerminateDebugSession(event, this.logger, /*targetPid*/undefined, /*hosted*/app.program);
                         terminate.dispose();
                     });
-                }, (error: Error) => {
-                    this.logger.logError('[DEBUGGER] Error when launching application: ', error);
-                });
-            }
-
+                }
+            }, (error: Error) => {
+                this.logger.logError('[DEBUGGER] Error when launching application: ', error);
+            });
         } else {
             const shellPath = process.platform === 'win32' ? 'cmd.exe' : 'dotnet';
             const shellArgs = process.platform === 'win32' ? ['/c', 'chcp 65001 >NUL & dotnet run'] : ['run'];
@@ -77,7 +77,7 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
         }
 
         const browser = {
-            name: '.NET Core Debug Blazor Web Assembly in Browser',
+            name: JS_DEBUG_NAME,
             type: configuration.browser === 'edge' ? 'pwa-msedge' : 'pwa-chrome',
             request: 'launch',
             timeout: configuration.timeout || 30000,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/Constants.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/Constants.ts
@@ -1,0 +1,7 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export const HOSTED_APP_NAME = '.NET Core Launch (Blazor Hosted)';
+export const JS_DEBUG_NAME = 'Debug Blazor Web Assembly in Browser';

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
@@ -8,6 +8,8 @@ import { DebugSession } from 'vscode';
 
 import { RazorLogger } from '../RazorLogger';
 
+import { HOSTED_APP_NAME, JS_DEBUG_NAME } from './Constants';
+
 export async function onDidTerminateDebugSession(
   event: DebugSession,
   logger: RazorLogger,
@@ -15,8 +17,8 @@ export async function onDidTerminateDebugSession(
   targetProcess: string | boolean = false,
 ) {
   // Ignore debug sessions that are not applicable to us
-  const VALID_EVENT_TYPES = ['pwa-chrome', 'pwa-msedge', 'coreclr'];
-  if (!VALID_EVENT_TYPES.includes(event.type)) {
+  const VALID_EVENT_NAMES = [HOSTED_APP_NAME, JS_DEBUG_NAME];
+  if (!VALID_EVENT_NAMES.includes(event.name)) {
     return;
   }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
@@ -12,27 +12,47 @@ export async function onDidTerminateDebugSession(
   event: DebugSession,
   logger: RazorLogger,
   targetPid: number | undefined,
+  targetProcess: string | boolean = false,
 ) {
-  if (event.type !== 'pwa-chrome' && event.type !== 'pwa-msedge') {
+  // Ignore debug sessions that are not applicable to us
+  const VALID_EVENT_TYPES = ['pwa-chrome', 'pwa-msedge', 'coreclr'];
+  if (!VALID_EVENT_TYPES.includes(event.type)) {
     return;
   }
+
+  // If there is no targetPid passed and the user has not requested
+  // one be resolved, then exit early
+  if (!targetPid && !targetProcess) {
+    return;
+  }
+
+  let processes: psList.ProcessDescriptor[] = [];
+  try {
+    processes = await psList();
+  } catch (error) {
+    logger.logError(`Error retrieving processes to clean-up: `, error);
+  }
+
+  // If the user has requested resolving the PID for the devserver process,
+  // we do that here
+  if (typeof targetProcess === 'string') {
+    const devserver = processes.find(
+      (process: psList.ProcessDescriptor) => !!(process && process.cmd && process.cmd.includes(targetProcess)));
+    targetPid = devserver ? devserver.pid : undefined;
+  }
+
+  // If no PID was resolved for the dev server, then exit early.
   if (!targetPid) {
     return;
   }
 
   logger.logVerbose(`[DEBUGGER] Terminating debugging session with PID ${targetPid}...`);
 
-  let processes: psList.ProcessDescriptor[] = [];
-  try {
-    processes = await psList();
-  } catch (error) {
-    logger.logError(`Error retrieving processes under PID ${targetPid} to clean-up: `, error);
-  }
-
   try {
     process.kill(targetPid);
     processes.map((proc) => {
       if (proc.ppid === targetPid) {
+        logger.logVerbose(`[DEBUGGER] Terminating child process with PID ${proc.pid}...`);
         process.kill(proc.pid);
       }
     });


### PR DESCRIPTION
This PR fixes an issue in the Blazor debug adapter where hosted applications could not be debugged.

Now, the user can set the `hosted` property to `true` in their launch configuration. This will run the server DLL instead of running `dotnet run` as a subprocess.

Currently, this assumes that they have the solution directory open in their VS Code workspace. Having the Server or Client directories open will not work.
