### PR TITLE
Support GoTo Definition in Razor VS LSP

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 if (_csharpLSPContentType == null)
                 {
-                    var registeredContentType = _contentTypeRegistry.GetContentType(RazorLSPConventions.CSharpLSPContentTypeName);
+                    var registeredContentType = _contentTypeRegistry.GetContentType(RazorLSPConstants.CSharpLSPContentTypeName);
                     _csharpLSPContentType = new RemoteContentDefinitionType(registeredContentType);
                 }
 
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(hostDocumentBuffer));
             }
 
-            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName))
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPConstants.RazorLSPContentTypeName))
             {
                 // Another content type we don't care about.
                 virtualDocument = null;
@@ -86,12 +86,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
 
             // Index.cshtml => Index.cshtml__virtual.cs
-            var virtualCSharpFilePath = hostDocumentUri.GetAbsoluteOrUNCPath() + RazorLSPConventions.VirtualCSharpFileNameSuffix;
+            var virtualCSharpFilePath = hostDocumentUri.GetAbsoluteOrUNCPath() + RazorLSPConstants.VirtualCSharpFileNameSuffix;
             var virtualCSharpUri = new Uri(virtualCSharpFilePath);
 
             var csharpBuffer = _textBufferFactory.CreateTextBuffer();
             _fileUriProvider.AddOrUpdate(csharpBuffer, virtualCSharpUri);
-            csharpBuffer.Properties.AddProperty(RazorLSPConventions.ContainedLanguageMarker, true);
+            csharpBuffer.Properties.AddProperty(RazorLSPConstants.ContainedLanguageMarker, true);
             csharpBuffer.Properties.AddProperty(LanguageClientConstants.ClientNamePropertyKey, "RazorCSharp");
 
             // Create a text document to trigger the C# language server initialization.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
@@ -17,12 +16,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [Export(typeof(VirtualDocumentFactory))]
     internal class CSharpVirtualDocumentFactory : VirtualDocumentFactory
     {
-        public const string CSharpLSPContentTypeName = "C#_LSP";
-
-        // Internal for testing
-        internal const string VirtualCSharpFileNameSuffix = ".g.cs";
-        internal const string ContainedLanguageMarker = "ContainedLanguageMarker";
-
         private readonly IContentTypeRegistryService _contentTypeRegistry;
         private readonly ITextBufferFactoryService _textBufferFactory;
         private readonly ITextDocumentFactoryService _textDocumentFactory;
@@ -68,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 if (_csharpLSPContentType == null)
                 {
-                    var registeredContentType = _contentTypeRegistry.GetContentType(CSharpLSPContentTypeName);
+                    var registeredContentType = _contentTypeRegistry.GetContentType(RazorLSPConventions.CSharpLSPContentTypeName);
                     _csharpLSPContentType = new RemoteContentDefinitionType(registeredContentType);
                 }
 
@@ -83,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(hostDocumentBuffer));
             }
 
-            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName))
             {
                 // Another content type we don't care about.
                 virtualDocument = null;
@@ -93,12 +86,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
 
             // Index.cshtml => Index.cshtml__virtual.cs
-            var virtualCSharpFilePath = hostDocumentUri.GetAbsoluteOrUNCPath() + VirtualCSharpFileNameSuffix;
+            var virtualCSharpFilePath = hostDocumentUri.GetAbsoluteOrUNCPath() + RazorLSPConventions.VirtualCSharpFileNameSuffix;
             var virtualCSharpUri = new Uri(virtualCSharpFilePath);
 
             var csharpBuffer = _textBufferFactory.CreateTextBuffer();
             _fileUriProvider.AddOrUpdate(csharpBuffer, virtualCSharpUri);
-            csharpBuffer.Properties.AddProperty(ContainedLanguageMarker, true);
+            csharpBuffer.Properties.AddProperty(RazorLSPConventions.ContainedLanguageMarker, true);
             csharpBuffer.Properties.AddProperty(LanguageClientConstants.ClientNamePropertyKey, "RazorCSharp");
 
             // Create a text document to trigger the C# language server initialization.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 var token = JToken.FromObject(requestParams);
                 var result = await sendRequest(token).ConfigureAwait(false);
                 var edits = result?.ToObject<TextEdit[]>();
-                if (edits == null)
+                if (edits == null || edits.Length == 0)
                 {
                     return emptyResult;
                 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
@@ -90,14 +90,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentException("message", nameof(method));
             }
 
-            var contentType = RazorLSPContentTypeDefinition.Name;
+            var contentType = RazorLSPConventions.RazorLSPContentTypeName;
             if (serverKind == LanguageServerKind.CSharp)
             {
-                contentType = CSharpVirtualDocumentFactory.CSharpLSPContentTypeName;
+                contentType = RazorLSPConventions.CSharpLSPContentTypeName;
             }
             else if (serverKind == LanguageServerKind.Html)
             {
-                contentType = HtmlVirtualDocumentFactory.HtmlLSPContentTypeName;
+                contentType = RazorLSPConventions.HtmlLSPContentTypeName;
             }
 
             var serializedParams = JToken.FromObject(parameters);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
@@ -90,14 +90,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentException("message", nameof(method));
             }
 
-            var contentType = RazorLSPConventions.RazorLSPContentTypeName;
+            var contentType = RazorLSPConstants.RazorLSPContentTypeName;
             if (serverKind == LanguageServerKind.CSharp)
             {
-                contentType = RazorLSPConventions.CSharpLSPContentTypeName;
+                contentType = RazorLSPConstants.CSharpLSPContentTypeName;
             }
             else if (serverKind == LanguageServerKind.Html)
             {
-                contentType = RazorLSPConventions.HtmlLSPContentTypeName;
+                contentType = RazorLSPConstants.HtmlLSPContentTypeName;
             }
 
             var serializedParams = JToken.FromObject(parameters);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefinitionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefinitionHandler.cs
@@ -108,9 +108,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     continue;
                 }
 
+                var razorDocumentUri = RazorLSPConventions.GetRazorDocumentUri(location.Uri);
                 var mappingResult = await _documentMappingProvider.MapToDocumentRangeAsync(
                     projectionResult.LanguageKind,
-                    request.TextDocument.Uri,
+                    razorDocumentUri,
                     location.Range,
                     cancellationToken).ConfigureAwait(false);
 
@@ -122,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 
                 var remappedLocation = new Location()
                 {
-                    Uri = request.TextDocument.Uri,
+                    Uri = razorDocumentUri,
                     Range = mappingResult.Range
                 };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefinitionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefinitionHandler.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using System.Threading;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    [Shared]
+    [ExportLspMethod(Methods.TextDocumentDefinitionName)]
+    internal class DefinitionHandler : IRequestHandler<TextDocumentPositionParams, Location[]>
+    {
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+        private readonly LSPRequestInvoker _requestInvoker;
+        private readonly LSPDocumentManager _documentManager;
+        private readonly LSPProjectionProvider _projectionProvider;
+        private readonly LSPDocumentMappingProvider _documentMappingProvider;
+
+        [ImportingConstructor]
+        public DefinitionHandler(
+            JoinableTaskContext joinableTaskContext,
+            LSPRequestInvoker requestInvoker,
+            LSPDocumentManager documentManager,
+            LSPProjectionProvider projectionProvider,
+            LSPDocumentMappingProvider documentMappingProvider)
+        {
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            if (requestInvoker is null)
+            {
+                throw new ArgumentNullException(nameof(requestInvoker));
+            }
+
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (projectionProvider is null)
+            {
+                throw new ArgumentNullException(nameof(projectionProvider));
+            }
+
+            if (documentMappingProvider is null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingProvider));
+            }
+
+            _joinableTaskFactory = joinableTaskContext.Factory;
+            _requestInvoker = requestInvoker;
+            _documentManager = documentManager;
+            _projectionProvider = projectionProvider;
+            _documentMappingProvider = documentMappingProvider;
+        }
+
+        public async Task<Location[]> HandleRequestAsync(TextDocumentPositionParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+        {
+            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
+            {
+                return null;
+            }
+
+            var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
+            if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.CSharp)
+            {
+                return null;
+            }
+
+            var serverKind = LanguageServerKind.CSharp;
+            var textDocumentPositionParams = new TextDocumentPositionParams()
+            {
+                Position = projectionResult.Position,
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = projectionResult.Uri
+                }
+            };
+
+            var result = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(
+                Methods.TextDocumentDefinitionName,
+                serverKind,
+                textDocumentPositionParams,
+                cancellationToken).ConfigureAwait(false);
+
+            if (result == null || result.Length == 0)
+            {
+                return result;
+            }
+
+            var remappedLocations = new List<Location>();
+
+            foreach (var location in result)
+            {
+                if (!RazorLSPConventions.IsRazorCSharpFile(location.Uri))
+                {
+                    // This location doesn't point to a virtual cs file. No need to remap.
+                    remappedLocations.Add(location);
+                    continue;
+                }
+
+                var mappingResult = await _documentMappingProvider.MapToDocumentRangeAsync(
+                    projectionResult.LanguageKind,
+                    request.TextDocument.Uri,
+                    location.Range,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (mappingResult == null || mappingResult.HostDocumentVersion != documentSnapshot.Version)
+                {
+                    // Couldn't remap the location or the document changed in the meantime. Discard this location.
+                    continue;
+                }
+                
+                var remappedLocation = new Location()
+                {
+                    Uri = request.TextDocument.Uri,
+                    Range = mappingResult.Range
+                };
+
+                remappedLocations.Add(remappedLocation);
+            }
+
+            return remappedLocations.ToArray();
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -27,7 +27,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     FirstTriggerCharacter = ">",
                     MoreTriggerCharacter = new[] { "=", "-" }
                 },
-                HoverProvider = true
+                HoverProvider = true,
+                DefinitionProvider = true,
             }
         };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -115,6 +115,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<DocumentOnTypeFormattingParams, TextEdit[]>(Methods.TextDocumentOnTypeFormattingName, request, _clientCapabilities, cancellationToken);
         }
 
+        [JsonRpcMethod(Methods.TextDocumentDefinitionName, UseSingleObjectParameterDeserialization = true)]
+        public Task<Location[]> GoToDefinitionAsync(TextDocumentPositionParams positionParams, CancellationToken cancellationToken)
+        {
+            if (positionParams is null)
+            {
+                throw new ArgumentNullException(nameof(positionParams));
+            }
+
+            return ExecuteRequestAsync<TextDocumentPositionParams, Location[]>(Methods.TextDocumentDefinitionName, positionParams, _clientCapabilities, cancellationToken);
+        }
+
         // Internal for testing
         internal Task<ResponseType> ExecuteRequestAsync<RequestType, ResponseType>(
             string methodName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServerClient.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     [ClientName(ClientName)]
     [Export(typeof(ILanguageClient))]
-    [ContentType(RazorLSPConventions.RazorLSPContentTypeName)]
+    [ContentType(RazorLSPConstants.RazorLSPContentTypeName)]
     internal class RazorHtmlCSharpLanguageServerClient : ILanguageClient, IDisposable
     {
         // ClientName enables us to turn on-off the ILanguageClient functionality for specific TextBuffers of content type RazorLSPContentTypeDefinition.Name.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServerClient.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     [ClientName(ClientName)]
     [Export(typeof(ILanguageClient))]
-    [ContentType(RazorLSPContentTypeDefinition.Name)]
+    [ContentType(RazorLSPConventions.RazorLSPContentTypeName)]
     internal class RazorHtmlCSharpLanguageServerClient : ILanguageClient, IDisposable
     {
         // ClientName enables us to turn on-off the ILanguageClient functionality for specific TextBuffers of content type RazorLSPContentTypeDefinition.Name.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -13,12 +13,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [Export(typeof(VirtualDocumentFactory))]
     internal class HtmlVirtualDocumentFactory : VirtualDocumentFactory
     {
-        public const string HtmlLSPContentTypeName = "htmlyLSP";
-
-        // Internal for testing
-        internal const string VirtualHtmlFileNameSuffix = "__virtual.html";
-        internal const string ContainedLanguageMarker = "ContainedLanguageMarker";
-
         private readonly IContentTypeRegistryService _contentTypeRegistry;
         private readonly ITextBufferFactoryService _textBufferFactory;
         private readonly ITextDocumentFactoryService _textDocumentFactory;
@@ -64,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 if (_htmlLSPContentType == null)
                 {
-                    _htmlLSPContentType = _contentTypeRegistry.GetContentType(HtmlLSPContentTypeName);
+                    _htmlLSPContentType = _contentTypeRegistry.GetContentType(RazorLSPConventions.HtmlLSPContentTypeName);
                 }
 
                 return _htmlLSPContentType;
@@ -78,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(hostDocumentBuffer));
             }
 
-            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName))
             {
                 // Another content type we don't care about.
                 virtualDocument = null;
@@ -88,12 +82,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
 
             // Index.cshtml => Index.cshtml__virtual.html
-            var virtualHtmlFilePath = hostDocumentUri.GetAbsoluteOrUNCPath() + VirtualHtmlFileNameSuffix;
+            var virtualHtmlFilePath = hostDocumentUri.GetAbsoluteOrUNCPath() + RazorLSPConventions.VirtualHtmlFileNameSuffix;
             var virtualHtmlUri = new Uri(virtualHtmlFilePath);
 
             var htmlBuffer = _textBufferFactory.CreateTextBuffer();
             _fileUriProvider.AddOrUpdate(htmlBuffer, virtualHtmlUri);
-            htmlBuffer.Properties.AddProperty(ContainedLanguageMarker, true);
+            htmlBuffer.Properties.AddProperty(RazorLSPConventions.ContainedLanguageMarker, true);
 
             // Create a text document to trigger the Html language server initialization.
             _textDocumentFactory.CreateTextDocument(htmlBuffer, virtualHtmlFilePath);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 if (_htmlLSPContentType == null)
                 {
-                    _htmlLSPContentType = _contentTypeRegistry.GetContentType(RazorLSPConventions.HtmlLSPContentTypeName);
+                    _htmlLSPContentType = _contentTypeRegistry.GetContentType(RazorLSPConstants.HtmlLSPContentTypeName);
                 }
 
                 return _htmlLSPContentType;
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(hostDocumentBuffer));
             }
 
-            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName))
+            if (!hostDocumentBuffer.ContentType.IsOfType(RazorLSPConstants.RazorLSPContentTypeName))
             {
                 // Another content type we don't care about.
                 virtualDocument = null;
@@ -82,12 +82,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = _fileUriProvider.GetOrCreate(hostDocumentBuffer);
 
             // Index.cshtml => Index.cshtml__virtual.html
-            var virtualHtmlFilePath = hostDocumentUri.GetAbsoluteOrUNCPath() + RazorLSPConventions.VirtualHtmlFileNameSuffix;
+            var virtualHtmlFilePath = hostDocumentUri.GetAbsoluteOrUNCPath() + RazorLSPConstants.VirtualHtmlFileNameSuffix;
             var virtualHtmlUri = new Uri(virtualHtmlFilePath);
 
             var htmlBuffer = _textBufferFactory.CreateTextBuffer();
             _fileUriProvider.AddOrUpdate(htmlBuffer, virtualHtmlUri);
-            htmlBuffer.Properties.AddProperty(RazorLSPConventions.ContainedLanguageMarker, true);
+            htmlBuffer.Properties.AddProperty(RazorLSPConstants.ContainedLanguageMarker, true);
 
             // Create a text document to trigger the Html language server initialization.
             _textDocumentFactory.CreateTextDocument(htmlBuffer, virtualHtmlFilePath);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
@@ -78,9 +78,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             var applicableContentTypes = new[]
             {
-                RazorLSPContentTypeDefinition.Name,
-                CSharpVirtualDocumentFactory.CSharpLSPContentTypeName,
-                HtmlVirtualDocumentFactory.HtmlLSPContentTypeName,
+                RazorLSPConventions.RazorLSPContentTypeName,
+                RazorLSPConventions.CSharpLSPContentTypeName,
+                RazorLSPConventions.HtmlLSPContentTypeName,
             };
 
             var applicableClients = new List<Lazy<ILanguageClient, ILanguageClientMetadata>>();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
@@ -78,9 +78,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             var applicableContentTypes = new[]
             {
-                RazorLSPConventions.RazorLSPContentTypeName,
-                RazorLSPConventions.CSharpLSPContentTypeName,
-                RazorLSPConventions.HtmlLSPContentTypeName,
+                RazorLSPConstants.RazorLSPContentTypeName,
+                RazorLSPConstants.CSharpLSPContentTypeName,
+                RazorLSPConstants.HtmlLSPContentTypeName,
             };
 
             var applicableClients = new List<Lazy<ILanguageClient, ILanguageClientMetadata>>();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal static class RazorLSPConstants
+    {
+        public const string RazorLSPContentTypeName = "RazorLSP";
+
+        public const string CSHTMLFileExtension = ".cshtml";
+
+        public const string RazorFileExtension = ".razor";
+
+        public const string ContainedLanguageMarker = "ContainedLanguageMarker";
+
+        public const string CSharpLSPContentTypeName = "C#_LSP";
+
+        public const string HtmlLSPContentTypeName = "htmlyLSP";
+
+        public const string VirtualCSharpFileNameSuffix = ".g.cs";
+
+        public const string VirtualHtmlFileNameSuffix = "__virtual.html";
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPContentTypeDefinition.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPContentTypeDefinition.cs
@@ -9,15 +9,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     internal sealed class RazorLSPContentTypeDefinition
     {
-        public const string Name = "RazorLSP";
-        public const string CSHTMLFileExtension = ".cshtml";
-        public const string RazorFileExtension = ".razor";
-
         /// <summary>
         /// Exports the Razor LSP content type
         /// </summary>
         [Export]
-        [Name(Name)]
+        [Name(RazorLSPConventions.RazorLSPContentTypeName)]
         [BaseDefinition(CodeRemoteContentDefinition.CodeRemoteContentTypeName)]
         public ContentTypeDefinition RazorLSPContentType { get; set; }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPContentTypeDefinition.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPContentTypeDefinition.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         /// Exports the Razor LSP content type
         /// </summary>
         [Export]
-        [Name(RazorLSPConventions.RazorLSPContentTypeName)]
+        [Name(RazorLSPConstants.RazorLSPContentTypeName)]
         [BaseDefinition(CodeRemoteContentDefinition.CodeRemoteContentTypeName)]
         public ContentTypeDefinition RazorLSPContentType { get; set; }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
@@ -8,22 +8,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     internal static class RazorLSPConventions
     {
-        public const string RazorLSPContentTypeName = "RazorLSP";
-
-        public const string CSHTMLFileExtension = ".cshtml";
-
-        public const string RazorFileExtension = ".razor";
-
-        public const string ContainedLanguageMarker = "ContainedLanguageMarker";
-
-        public const string CSharpLSPContentTypeName = "C#_LSP";
-
-        public const string HtmlLSPContentTypeName = "htmlyLSP";
-
-        public const string VirtualCSharpFileNameSuffix = ".g.cs";
-
-        public const string VirtualHtmlFileNameSuffix = "__virtual.html";
-
         public static bool IsRazorCSharpFile(Uri uri)
         {
             if (uri is null)
@@ -31,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            return uri.GetAbsoluteOrUNCPath()?.EndsWith(VirtualCSharpFileNameSuffix) ?? false;
+            return uri.GetAbsoluteOrUNCPath()?.EndsWith(RazorLSPConstants.VirtualCSharpFileNameSuffix) ?? false;
         }
 
         public static bool IsRazorHtmlFile(Uri uri)
@@ -41,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            return uri.GetAbsoluteOrUNCPath()?.EndsWith(VirtualHtmlFileNameSuffix) ?? false;
+            return uri.GetAbsoluteOrUNCPath()?.EndsWith(RazorLSPConstants.VirtualHtmlFileNameSuffix) ?? false;
         }
 
         public static Uri GetRazorDocumentUri(Uri virtualDocumentUri)
@@ -52,8 +36,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             var path = virtualDocumentUri.GetAbsoluteOrUNCPath();
-            path = path.Replace(VirtualCSharpFileNameSuffix, string.Empty);
-            path = path.Replace(VirtualHtmlFileNameSuffix, string.Empty);
+            path = path.Replace(RazorLSPConstants.VirtualCSharpFileNameSuffix, string.Empty);
+            path = path.Replace(RazorLSPConstants.VirtualHtmlFileNameSuffix, string.Empty);
 
             var uri = new Uri(path, UriKind.Absolute);
             return uri;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal static class RazorLSPConventions
+    {
+        public const string RazorLSPContentTypeName = "RazorLSP";
+
+        public const string CSHTMLFileExtension = ".cshtml";
+
+        public const string RazorFileExtension = ".razor";
+
+        public const string ContainedLanguageMarker = "ContainedLanguageMarker";
+
+        public const string CSharpLSPContentTypeName = "C#_LSP";
+
+        public const string HtmlLSPContentTypeName = "htmlyLSP";
+
+        public const string VirtualCSharpFileNameSuffix = ".g.cs";
+
+        public const string VirtualHtmlFileNameSuffix = "__virtual.html";
+
+        public static bool IsRazorCSharpFile(Uri uri)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            return uri.AbsolutePath?.EndsWith(VirtualCSharpFileNameSuffix) ?? false;
+        }
+
+        public static bool IsRazorHtmlFile(Uri uri)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            return uri.AbsolutePath?.EndsWith(VirtualHtmlFileNameSuffix) ?? false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
@@ -30,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            return uri.AbsolutePath?.EndsWith(VirtualCSharpFileNameSuffix) ?? false;
+            return uri.GetAbsoluteOrUNCPath()?.EndsWith(VirtualCSharpFileNameSuffix) ?? false;
         }
 
         public static bool IsRazorHtmlFile(Uri uri)
@@ -40,7 +41,22 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            return uri.AbsolutePath?.EndsWith(VirtualHtmlFileNameSuffix) ?? false;
+            return uri.GetAbsoluteOrUNCPath()?.EndsWith(VirtualHtmlFileNameSuffix) ?? false;
+        }
+
+        public static Uri GetRazorDocumentUri(Uri virtualDocumentUri)
+        {
+            if (virtualDocumentUri is null)
+            {
+                throw new ArgumentNullException(nameof(virtualDocumentUri));
+            }
+
+            var path = virtualDocumentUri.GetAbsoluteOrUNCPath();
+            path = path.Replace(VirtualCSharpFileNameSuffix, string.Empty);
+            path = path.Replace(VirtualHtmlFileNameSuffix, string.Empty);
+
+            var uri = new Uri(path, UriKind.Absolute);
+            return uri;
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextDocumentCreatedListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextDocumentCreatedListener.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             _textDocumentFactory.TextDocumentCreated += TextDocumentFactory_TextDocumentCreated;
             _textDocumentFactory.TextDocumentDisposed += TextDocumentFactory_TextDocumentDisposed;
-            _razorLSPContentType = contentTypeRegistry.GetContentType(RazorLSPConventions.RazorLSPContentTypeName);
+            _razorLSPContentType = contentTypeRegistry.GetContentType(RazorLSPConstants.RazorLSPContentTypeName);
         }
 
         // Internal for testing
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             var textBuffer = args.TextDocument.TextBuffer;
-            if (!textBuffer.ContentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName))
+            if (!textBuffer.ContentType.IsOfType(RazorLSPConstants.RazorLSPContentTypeName))
             {
                 // This Razor text buffer has yet to be initialized.
 
@@ -172,8 +172,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return false;
             }
 
-            if (!filePath.EndsWith(RazorLSPConventions.CSHTMLFileExtension, FilePathComparison.Instance) &&
-                !filePath.EndsWith(RazorLSPConventions.RazorFileExtension, FilePathComparison.Instance))
+            if (!filePath.EndsWith(RazorLSPConstants.CSHTMLFileExtension, FilePathComparison.Instance) &&
+                !filePath.EndsWith(RazorLSPConstants.RazorFileExtension, FilePathComparison.Instance))
             {
                 // Not a Razor file
                 return false;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextDocumentCreatedListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextDocumentCreatedListener.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             _textDocumentFactory.TextDocumentCreated += TextDocumentFactory_TextDocumentCreated;
             _textDocumentFactory.TextDocumentDisposed += TextDocumentFactory_TextDocumentDisposed;
-            _razorLSPContentType = contentTypeRegistry.GetContentType(RazorLSPContentTypeDefinition.Name);
+            _razorLSPContentType = contentTypeRegistry.GetContentType(RazorLSPConventions.RazorLSPContentTypeName);
         }
 
         // Internal for testing
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             var textBuffer = args.TextDocument.TextBuffer;
-            if (!textBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name))
+            if (!textBuffer.ContentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName))
             {
                 // This Razor text buffer has yet to be initialized.
 
@@ -172,8 +172,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return false;
             }
 
-            if (!filePath.EndsWith(RazorLSPContentTypeDefinition.CSHTMLFileExtension, FilePathComparison.Instance) &&
-                !filePath.EndsWith(RazorLSPContentTypeDefinition.RazorFileExtension, FilePathComparison.Instance))
+            if (!filePath.EndsWith(RazorLSPConventions.CSHTMLFileExtension, FilePathComparison.Instance) &&
+                !filePath.EndsWith(RazorLSPConventions.RazorFileExtension, FilePathComparison.Instance))
             {
                 // Not a Razor file
                 return false;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     [ClientName(ClientName)]
     [Export(typeof(ILanguageClient))]
-    [ContentType(RazorLSPContentTypeDefinition.Name)]
+    [ContentType(RazorLSPConventions.RazorLSPContentTypeName)]
     internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCustomMessage2
     {
         // ClientName enables us to turn on-off the ILanguageClient functionality for specific TextBuffers of content type RazorLSPContentTypeDefinition.Name.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     [ClientName(ClientName)]
     [Export(typeof(ILanguageClient))]
-    [ContentType(RazorLSPConventions.RazorLSPContentTypeName)]
+    [ContentType(RazorLSPConstants.RazorLSPContentTypeName)]
     internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCustomMessage2
     {
         // ClientName enables us to turn on-off the ILanguageClient functionality for specific TextBuffers of content type RazorLSPContentTypeDefinition.Name.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Text
                 throw new ArgumentNullException(nameof(textBuffer));
             }
 
-            var matchesContentType = textBuffer.ContentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName);
+            var matchesContentType = textBuffer.ContentType.IsOfType(RazorLSPConstants.RazorLSPContentTypeName);
             return matchesContentType;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextBufferExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Text
                 throw new ArgumentNullException(nameof(textBuffer));
             }
 
-            var matchesContentType = textBuffer.ContentType.IsOfType(RazorLSPContentTypeDefinition.Name);
+            var matchesContentType = textBuffer.ContentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName);
             return matchesContentType;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.RazorExtension
 {
     // We attach to the 52nd priority order because the traditional Web + XML editors have priority 51. We need to be loaded prior to them
     // since we want to have the option to own the experience for Razor files
-    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.CSHTMLFileExtension, 52, NameResourceID = 101)]
-    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPContentTypeDefinition.RazorFileExtension, 52, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPConventions.CSHTMLFileExtension, 52, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPConventions.RazorFileExtension, 52, NameResourceID = 101)]
     [ProvideEditorFactory(typeof(RazorEditorFactory), 101, deferUntilIntellisenseIsReady: false, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_SupportsPreview)]
     [ProvideEditorLogicalView(typeof(RazorEditorFactory), VSConstants.LOGVIEWID.TextView_string)]
     [PackageRegistration(UseManagedResourcesOnly = true)]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.RazorExtension
 {
     // We attach to the 52nd priority order because the traditional Web + XML editors have priority 51. We need to be loaded prior to them
     // since we want to have the option to own the experience for Razor files
-    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPConventions.CSHTMLFileExtension, 52, NameResourceID = 101)]
-    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPConventions.RazorFileExtension, 52, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPConstants.CSHTMLFileExtension, 52, NameResourceID = 101)]
+    [ProvideEditorExtension(typeof(RazorEditorFactory), RazorLSPConstants.RazorFileExtension, 52, NameResourceID = 101)]
     [ProvideEditorFactory(typeof(RazorEditorFactory), 101, deferUntilIntellisenseIsReady: false, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_SupportsPreview)]
     [ProvideEditorLogicalView(typeof(RazorEditorFactory), VSConstants.LOGVIEWID.TextView_string)]
     [PackageRegistration(UseManagedResourcesOnly = true)]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
@@ -15,14 +15,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             var csharpContentType = Mock.Of<IContentType>();
             ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
-                registry => registry.GetContentType(CSharpVirtualDocumentFactory.CSharpLSPContentTypeName) == csharpContentType);
+                registry => registry.GetContentType(RazorLSPConventions.CSharpLSPContentTypeName) == csharpContentType);
             var textBufferFactory = new Mock<ITextBufferFactoryService>();
             textBufferFactory
                 .Setup(factory => factory.CreateTextBuffer())
                 .Returns(Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>() && buffer.Properties == new PropertyCollection()));
             TextBufferFactory = textBufferFactory.Object;
 
-            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName) == true);
             RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
 
             var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             // Assert
             Assert.True(result);
             Assert.NotNull(virtualDocument);
-            Assert.EndsWith(CSharpVirtualDocumentFactory.VirtualCSharpFileNameSuffix, virtualDocument.Uri.OriginalString, StringComparison.Ordinal);
+            Assert.EndsWith(RazorLSPConventions.VirtualCSharpFileNameSuffix, virtualDocument.Uri.OriginalString, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
@@ -15,14 +15,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             var csharpContentType = Mock.Of<IContentType>();
             ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
-                registry => registry.GetContentType(RazorLSPConventions.CSharpLSPContentTypeName) == csharpContentType);
+                registry => registry.GetContentType(RazorLSPConstants.CSharpLSPContentTypeName) == csharpContentType);
             var textBufferFactory = new Mock<ITextBufferFactoryService>();
             textBufferFactory
                 .Setup(factory => factory.CreateTextBuffer())
                 .Returns(Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>() && buffer.Properties == new PropertyCollection()));
             TextBufferFactory = textBufferFactory.Object;
 
-            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName) == true);
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConstants.RazorLSPContentTypeName) == true);
             RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
 
             var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             // Assert
             Assert.True(result);
             Assert.NotNull(virtualDocument);
-            Assert.EndsWith(RazorLSPConventions.VirtualCSharpFileNameSuffix, virtualDocument.Uri.OriginalString, StringComparison.Ordinal);
+            Assert.EndsWith(RazorLSPConstants.VirtualCSharpFileNameSuffix, virtualDocument.Uri.OriginalString, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPRequestInvokerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPRequestInvokerTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPContentTypeDefinition.Name, contentType);
+                Assert.Equal(RazorLSPConventions.RazorLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(HtmlVirtualDocumentFactory.HtmlLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConventions.HtmlLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(CSharpVirtualDocumentFactory.CSharpLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConventions.CSharpLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPContentTypeDefinition.Name, contentType);
+                Assert.Equal(RazorLSPConventions.RazorLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(HtmlVirtualDocumentFactory.HtmlLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConventions.HtmlLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(CSharpVirtualDocumentFactory.CSharpLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConventions.CSharpLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPRequestInvokerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPRequestInvokerTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPConventions.RazorLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConstants.RazorLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPConventions.HtmlLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConstants.HtmlLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPConventions.CSharpLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConstants.CSharpLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPConventions.RazorLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConstants.RazorLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPConventions.HtmlLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConstants.HtmlLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageClientBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPConventions.CSharpLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConstants.CSharpLSPContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefinitionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefinitionHandlerTest.cs
@@ -1,0 +1,317 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class DefinitionHandlerTest
+    {
+        public DefinitionHandlerTest()
+        {
+            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
+            JoinableTaskContext = joinableTaskContext.Context;
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var definitionRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await definitionHandler.HandleRequestAsync(definitionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_ProjectionNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var definitionRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await definitionHandler.HandleRequestAsync(definitionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_HtmlProjection_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.Html,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
+            var definitionRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await definitionHandler.HandleRequestAsync(definitionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_InvokesCSharpLanguageServer()
+        {
+            // Arrange
+            var called = false;
+            var expectedLocation = GetLocation(5, 5, 5, 5, Uri);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var virtualCSharpUri = new Uri("C:/path/to/file.razor.g.cs");
+            var csharpLocation = GetLocation(100, 100, 100, 100, virtualCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentDefinitionName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { csharpLocation }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangeResponse()
+            {
+                Range = expectedLocation.Range
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await definitionHandler.HandleRequestAsync(definitionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            var actualLocation = Assert.Single(result);
+            Assert.Equal(expectedLocation, actualLocation);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_DoesNotRemapNonRazorFiles()
+        {
+            // Arrange
+            var called = false;
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var externalCSharpUri = new Uri("C:/path/to/someotherfile.cs");
+            var externalCsharpLocation = GetLocation(100, 100, 100, 100, externalCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentDefinitionName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { externalCsharpLocation }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+
+            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await definitionHandler.HandleRequestAsync(definitionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            var actualLocation = Assert.Single(result);
+            Assert.Equal(externalCsharpLocation, actualLocation);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_VersionMismatch_DiscardsLocation()
+        {
+            // Arrange
+            var called = false;
+            var expectedLocation = GetLocation(5, 5, 5, 5, Uri);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 123));
+
+            var virtualCSharpUri = new Uri("C:/path/to/file.razor.g.cs");
+            var csharpLocation = GetLocation(100, 100, 100, 100, virtualCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentDefinitionName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { csharpLocation }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangeResponse()
+            {
+                Range = expectedLocation.Range,
+                HostDocumentVersion = 122 // Different from document version (123)
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await definitionHandler.HandleRequestAsync(definitionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_RemapFailure_DiscardsLocation()
+        {
+            // Arrange
+            var called = false;
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var virtualCSharpUri = new Uri("C:/path/to/file.razor.g.cs");
+            var csharpLocation = GetLocation(100, 100, 100, 100, virtualCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentDefinitionName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { csharpLocation }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult<RazorMapToDocumentRangeResponse>(null));
+
+            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await definitionHandler.HandleRequestAsync(definitionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Empty(result);
+        }
+
+        private Location GetLocation(int startLine, int startCharacter, int endLine, int endCharacter, Uri uri)
+        {
+            var location = new Location()
+            {
+                Uri = uri,
+                Range = new Range()
+                {
+                    Start = new Position(startLine, startCharacter),
+                    End = new Position(endLine, endCharacter)
+                }
+            };
+
+            return location;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToDefinitionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToDefinitionHandlerTest.cs
@@ -12,9 +12,9 @@ using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
-    public class DefinitionHandlerTest
+    public class GoToDefinitionHandlerTest
     {
-        public DefinitionHandlerTest()
+        public GoToDefinitionHandlerTest()
         {
             var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
             JoinableTaskContext = joinableTaskContext.Context;
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestInvoker = Mock.Of<LSPRequestInvoker>();
             var projectionProvider = Mock.Of<LSPProjectionProvider>();
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestInvoker = Mock.Of<LSPRequestInvoker>();
             var projectionProvider = Mock.Of<LSPProjectionProvider>();
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
+            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, externalUri, csharpLocation.Range, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -238,7 +238,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
 
-            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -292,7 +292,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -339,7 +339,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult<RazorMapToDocumentRangeResponse>(null));
 
-            var definitionHandler = new DefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
@@ -5,10 +5,10 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -15,14 +15,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             var htmlContentType = Mock.Of<IContentType>();
             ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
-                registry => registry.GetContentType(HtmlVirtualDocumentFactory.HtmlLSPContentTypeName) == htmlContentType);
+                registry => registry.GetContentType(RazorLSPConventions.HtmlLSPContentTypeName) == htmlContentType);
             var textBufferFactory = new Mock<ITextBufferFactoryService>();
             textBufferFactory
                 .Setup(factory => factory.CreateTextBuffer())
                 .Returns(Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>() && buffer.Properties == new PropertyCollection()));
             TextBufferFactory = textBufferFactory.Object;
 
-            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName) == true);
             RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
 
             var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             // Assert
             Assert.True(result);
             Assert.NotNull(virtualDocument);
-            Assert.EndsWith(HtmlVirtualDocumentFactory.VirtualHtmlFileNameSuffix, virtualDocument.Uri.OriginalString, StringComparison.Ordinal);
+            Assert.EndsWith(RazorLSPConventions.VirtualHtmlFileNameSuffix, virtualDocument.Uri.OriginalString, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -15,14 +15,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             var htmlContentType = Mock.Of<IContentType>();
             ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
-                registry => registry.GetContentType(RazorLSPConventions.HtmlLSPContentTypeName) == htmlContentType);
+                registry => registry.GetContentType(RazorLSPConstants.HtmlLSPContentTypeName) == htmlContentType);
             var textBufferFactory = new Mock<ITextBufferFactoryService>();
             textBufferFactory
                 .Setup(factory => factory.CreateTextBuffer())
                 .Returns(Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>() && buffer.Properties == new PropertyCollection()));
             TextBufferFactory = textBufferFactory.Object;
 
-            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName) == true);
+            var razorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConstants.RazorLSPContentTypeName) == true);
             RazorLSPBuffer = Mock.Of<ITextBuffer>(textBuffer => textBuffer.ContentType == razorLSPContentType);
 
             var nonRazorLSPContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(It.IsAny<string>()) == false);
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             // Assert
             Assert.True(result);
             Assert.NotNull(virtualDocument);
-            Assert.EndsWith(RazorLSPConventions.VirtualHtmlFileNameSuffix, virtualDocument.Uri.OriginalString, StringComparison.Ordinal);
+            Assert.EndsWith(RazorLSPConstants.VirtualHtmlFileNameSuffix, virtualDocument.Uri.OriginalString, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextDocumentCreatedListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextDocumentCreatedListenerTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         public RazorLSPTextDocumentCreatedListenerTest()
         {
-            RazorContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName) == true);
+            RazorContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConstants.RazorLSPContentTypeName) == true);
             UnavailableFeatureDetector = Mock.Of<LSPEditorFeatureDetector>(detector => detector.IsLSPEditorAvailable(It.IsAny<string>(), null) == false);
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             LSPEditorFeatureDetector lspEditorFeatureDetector = null)
         {
             var textDocumentFactory = Mock.Of<ITextDocumentFactoryService>();
-            var contentTypeRegistry = Mock.Of<IContentTypeRegistryService>(registry => registry.GetContentType(RazorLSPConventions.RazorLSPContentTypeName) == RazorContentType);
+            var contentTypeRegistry = Mock.Of<IContentTypeRegistryService>(registry => registry.GetContentType(RazorLSPConstants.RazorLSPContentTypeName) == RazorContentType);
 
             lspDocumentManager ??= Mock.Of<TrackingLSPDocumentManager>();
             lspEditorFeatureDetector ??= Mock.Of<LSPEditorFeatureDetector>(detector => detector.IsLSPEditorAvailable(It.IsAny<string>(), null) == true);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextDocumentCreatedListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPTextDocumentCreatedListenerTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         public RazorLSPTextDocumentCreatedListenerTest()
         {
-            RazorContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPContentTypeDefinition.Name) == true);
+            RazorContentType = Mock.Of<IContentType>(contentType => contentType.IsOfType(RazorLSPConventions.RazorLSPContentTypeName) == true);
             UnavailableFeatureDetector = Mock.Of<LSPEditorFeatureDetector>(detector => detector.IsLSPEditorAvailable(It.IsAny<string>(), null) == false);
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             LSPEditorFeatureDetector lspEditorFeatureDetector = null)
         {
             var textDocumentFactory = Mock.Of<ITextDocumentFactoryService>();
-            var contentTypeRegistry = Mock.Of<IContentTypeRegistryService>(registry => registry.GetContentType(RazorLSPContentTypeDefinition.Name) == RazorContentType);
+            var contentTypeRegistry = Mock.Of<IContentTypeRegistryService>(registry => registry.GetContentType(RazorLSPConventions.RazorLSPContentTypeName) == RazorContentType);
 
             lspDocumentManager ??= Mock.Of<TrackingLSPDocumentManager>();
             lspEditorFeatureDetector ??= Mock.Of<LSPEditorFeatureDetector>(detector => detector.IsLSPEditorAvailable(It.IsAny<string>(), null) == true);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22015

![87167778-bba8-47ad-bf67-f8be5a900401](https://user-images.githubusercontent.com/1579269/82397831-2e91a680-9a06-11ea-820a-e89c978b876e.gif)

- Moved some constants and added some utility functions in `RazorLSPConventions` (Most of the file changes here are due to that)
- Added `DefinitionHandler` to do the thing. This now supports go to def on C# parts of Razor. It can,
  -  go to definitions within the razor file
  - between open razor files
  - to external .cs files (open or closed)
- The other way around is not supported yet as that requires changes from Roslyn and is out of scope for this release
- Added tests