### PR TITLE
Skipping flaky tests

### DIFF
--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         public ITestOutputHelper Output { get; private set; }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/22049")]
         [InitializeTestProject("AppWithPackageAndP2PReference", language: "C#", additionalProjects: new[] { "ClassLibrary", "ClassLibrary2" })]
         public async Task Build_GeneratesStaticWebAssetsManifest_Success_CreatesManifest()
         {

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(publish, PublishOutputPath, Path.Combine("wwwroot", "_content", "PackageLibraryTransitiveDependency", "js", "pkg-transitive-dep.js"));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/22049")]
         [InitializeTestProject("AppWithPackageAndP2PReference", additionalProjects: new[] { "ClassLibrary", "ClassLibrary2" })]
         public async Task Publish_NoBuild_CopiesStaticWebAssetsToDestinationFolder()
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -214,8 +214,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
         }
 
-        [ForegroundFact]
-        [Flaky("https://github.com/dotnet/aspnetcore/issues/14805", FlakyOn.All)]
+        [ForegroundFact(Skip = "https://github.com/dotnet/aspnetcore/issues/14805")]
         public async Task DocumentChanged_ReparsesRelatedFiles()
         {
             // Arrange


### PR DESCRIPTION
FlakyAttribute does not appear to work so skipping the [flaky test](https://dev.azure.com/dnceng/public/_build/results?buildId=654186&view=ms.vss-test-web.build-test-results-tab&runId=20303614&resultId=100122&paneView=debug) instead.

Another timeout in the SDK test: https://dev.azure.com/dnceng/public/_build/results?buildId=654266&view=ms.vss-test-web.build-test-results-tab&runId=20306860&resultId=100161&paneView=debug, so skipping that too