### PR TITLE
Add smart indenting support for HTML + TagHelper scenarios.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -287,7 +287,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 }
 
                 var leadingWhitespace = line.GetLeadingWhitespace();
-                var minCSharpIndentLength = GetIndentationString(context, minCSharpIndentLevel).Length;
+                var minCSharpIndentLength = context.GetIndentationLevelString(minCSharpIndentLevel).Length;
                 if (leadingWhitespace.Length < minCSharpIndentLength)
                 {
                     // For whatever reason, the C# formatter decided to not indent this. Leave it as is.
@@ -299,7 +299,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     // All we want to do at this point is to indent/unindent this line based on the absolute indentation of the block
                     // and the minimum C# indent level. We don't need to worry about the actual existing indentation here because it doesn't matter.
                     var effectiveDesiredIndentationLevel = desiredIndentationLevel - minCSharpIndentLevel;
-                    var effectiveDesiredIndentation = GetIndentationString(context, Math.Abs(effectiveDesiredIndentationLevel));
+                    var effectiveDesiredIndentation = context.GetIndentationLevelString(Math.Abs(effectiveDesiredIndentationLevel));
                     if (effectiveDesiredIndentationLevel < 0)
                     {
                         // This means that we need to unindent.
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // First, make sure the first line is indented correctly.
             var firstLine = changedText.Lines[(int)changedBodyRange.Start.Line];
             var desiredIndentationLevel = context.Indentations[firstLine.LineNumber].IndentationLevel;
-            var desiredIndentation = GetIndentationString(context, desiredIndentationLevel);
+            var desiredIndentation = context.GetIndentationLevelString(desiredIndentationLevel);
             var firstNonWhitespaceOffset = firstLine.GetFirstNonWhitespaceOffset();
             if (firstNonWhitespaceOffset.HasValue)
             {
@@ -360,7 +360,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var textAfterBlockStart = innerCodeBlockLine.ToString().Substring(innerCodeBlock.Position - innerCodeBlockLine.Start);
             var isBlockStartOnSeparateLine = string.IsNullOrWhiteSpace(textAfterBlockStart);
             var innerCodeBlockIndentationLevel = desiredIndentationLevel + 1;
-            var desiredInnerCodeBlockIndentation = GetIndentationString(context, innerCodeBlockIndentationLevel);
+            var desiredInnerCodeBlockIndentation = context.GetIndentationLevelString(innerCodeBlockIndentationLevel);
             var whitespaceAfterBlockStart = textAfterBlockStart.GetLeadingWhitespace();
 
             if (!isBlockStartOnSeparateLine)
@@ -428,7 +428,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             var firstLine = changedText.Lines[(int)changedBodyRange.Start.Line];
             var desiredIndentationLevel = context.Indentations[firstLine.LineNumber].IndentationLevel;
-            var desiredIndentation = GetIndentationString(context, desiredIndentationLevel);
+            var desiredIndentation = context.GetIndentationLevelString(desiredIndentationLevel);
 
             // we want to keep the close '}' on its own line. So bring it to the next line.
             var originalInnerCodeBlockSpan = TextSpan.FromBounds(innerCodeBlock.Position, innerCodeBlock.EndPosition);
@@ -507,18 +507,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var precedingWhitespaceLength = precedingLineText.GetTrailingWhitespace().Length;
 
             return TextSpan.FromBounds(start - precedingWhitespaceLength, end);
-        }
-
-        private static string GetIndentationString(FormattingContext context, int indentationLevel)
-        {
-            var indentChar = context.Options.InsertSpaces ? ' ' : '\t';
-            var indentationLength = indentationLevel;
-            if (context.Options.InsertSpaces)
-            {
-                indentationLength *= (int)context.Options.TabSize;
-            }
-            var indentation = new string(indentChar, indentationLength);
-            return indentation;
         }
 
         // Internal for testing

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -25,17 +25,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public Dictionary<int, IndentationContext> Indentations { get; } = new Dictionary<int, IndentationContext>();
 
+        /// <summary>
+        /// Generates a string of indentation based on a specific indentation level. For instance, inside of a C# method represents 1 indentation level. A method within a class would have indentaiton level of 2 by default etc.
+        /// </summary>
+        /// <param name="indentationLevel">The indentation level to represent</param>
+        /// <returns>A whitespace string representing the indentation level based on the configuration.</returns>
         public string GetIndentationLevelString(int indentationLevel)
         {
-            var indentation = indentationLevel;
-            if (Options.InsertSpaces)
-            {
-                indentation *= (int)Options.TabSize;
-            }
+            var indentation = indentationLevel * (int)Options.TabSize;
             var indentationString = GetIndentationString(indentation);
             return indentationString;
         }
 
+        /// <summary>
+        /// Given a <paramref name="indentation"/> amount of characters, generate a string representing the configured indentation.
+        /// </summary>
+        /// <param name="indentation">An amount of characters to represent the indentation</param>
+        /// <returns>A whitespace string representation indentation.</returns>
         public string GetIndentationString(int indentation)
         {
             if (Options.InsertSpaces)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -24,5 +24,35 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public Range Range { get; set; }
 
         public Dictionary<int, IndentationContext> Indentations { get; } = new Dictionary<int, IndentationContext>();
+
+        public string GetIndentationLevelString(int indentationLevel)
+        {
+            var indentation = indentationLevel;
+            if (Options.InsertSpaces)
+            {
+                indentation *= (int)Options.TabSize;
+            }
+            var indentationString = GetIndentationString(indentation);
+            return indentationString;
+        }
+
+        public string GetIndentationString(int indentation)
+        {
+            if (Options.InsertSpaces)
+            {
+                return new string(' ', indentation);
+            }
+            else
+            {
+                var tabs = indentation / Options.TabSize;
+                var tabPrefix = new string('\t', (int)tabs);
+
+                var spaces = indentation % Options.TabSize;
+                var spaceSuffix = new string(' ', (int)spaces);
+
+                var combined = string.Concat(tabPrefix, spaceSuffix);
+                return combined;
+            }
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlSmartIndentFormatOnTypeProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlSmartIndentFormatOnTypeProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (!context.Options.TryGetValue(LanguageServerConstants.ExpectsCursorPlaceholderKey, out var value) && value.IsBool)
+            if (!context.Options.TryGetValue(LanguageServerConstants.ExpectsCursorPlaceholderKey, out var value) || !value.IsBool || !value.Bool)
             {
                 // Temporary:
                 // no-op if cursor placeholder isn't supported. This means the request isn't coming from VS.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlSmartIndentFormatOnTypeProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlSmartIndentFormatOnTypeProvider.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class HtmlSmartIndentFormatOnTypeProvider : RazorFormatOnTypeProvider
+    {
+        public override string TriggerCharacter => "\n";
+
+        public override bool TryFormatOnType(Position position, FormattingContext context, out TextEdit[] edits)
+        {
+            if (position is null)
+            {
+                throw new ArgumentNullException(nameof(position));
+            }
+
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!context.Options.TryGetValue(LanguageServerConstants.ExpectsCursorPlaceholderKey, out var value) && value.IsBool)
+            {
+                // Temporary:
+                // no-op if cursor placeholder isn't supported. This means the request isn't coming from VS.
+                edits = null;
+                return false;
+            }
+
+            var syntaxTree = context.CodeDocument.GetSyntaxTree();
+
+            var absoluteIndex = position.GetAbsoluteIndex(context.SourceText);
+            var change = new SourceChange(absoluteIndex, 0, string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+
+            if (!IsAtEnterRuleLocation(context, owner))
+            {
+                edits = null;
+                return false;
+            }
+
+            // We're currently at:
+            // <someTag>
+            // |</someTag>
+
+            context.SourceText.GetLineAndOffset(owner.SpanStart, out var lineNumber, out _);
+
+            var existingIndentation = context.Indentations[lineNumber].ExistingIndentation;
+            var existingIndentationString = context.GetIndentationString(existingIndentation);
+            var increasedIndentationString = context.GetIndentationLevelString(indentationLevel: 1);
+            var innerIndentationString = string.Concat(increasedIndentationString, existingIndentationString);
+
+            // We mark start position at the beginning of the line in order to remove any pre-existing whitespace.
+            var startPosition = new Position(position.Line, 0);
+            var edit = new TextEdit()
+            {
+                NewText = $"{innerIndentationString}{LanguageServerConstants.CursorPlaceholderString}{Environment.NewLine}{existingIndentationString}",
+                Range = new Range(startPosition, position)
+            };
+
+            edits = new[] { edit };
+            return true;
+        }
+
+        private static bool IsAtEnterRuleLocation(FormattingContext context, SyntaxNode owner)
+        {
+            if (owner == null)
+            {
+                return false;
+            }
+
+            if (!TryGetApplicableBody(owner, out var body))
+            {
+                return false;
+            }
+
+            if (!IsApplicableElementBody(body))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool TryGetApplicableBody(SyntaxNode owner, out SyntaxList<RazorSyntaxNode> body)
+        {
+            if (TryGetApplicableTagBody(owner, out body))
+            {
+                return true;
+            }
+
+            if (TryGetApplicableTagHelperBody(owner, out body))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetApplicableTagBody(SyntaxNode owner, out SyntaxList<RazorSyntaxNode> body)
+        {
+            var parent = owner.Parent;
+            if (parent.Kind != SyntaxKind.MarkupElement)
+            {
+                return false;
+            }
+
+            var markupElement = (MarkupElementSyntax)parent;
+            if (markupElement.StartTag == null)
+            {
+                return false;
+            }
+
+            if (markupElement.EndTag == null)
+            {
+                return false;
+            }
+
+            body = markupElement.Body;
+            return true;
+        }
+
+        private static bool TryGetApplicableTagHelperBody(SyntaxNode owner, out SyntaxList<RazorSyntaxNode> body)
+        {
+            var parent = owner.Parent;
+            if (parent.Kind != SyntaxKind.MarkupTagHelperElement)
+            {
+                return false;
+            }
+
+            var tagHelperElement = (MarkupTagHelperElementSyntax)parent;
+            if (tagHelperElement.StartTag == null)
+            {
+                return false;
+            }
+
+            if (tagHelperElement.EndTag == null)
+            {
+                return false;
+            }
+
+            body = tagHelperElement.Body;
+            return true;
+        }
+
+        private static bool IsApplicableElementBody(SyntaxList<RazorSyntaxNode> body)
+        {
+            for (var i = 0; i < body.Count; i++)
+            {
+                var child = body[i];
+                if (child.Kind != SyntaxKind.MarkupTextLiteral)
+                {
+                    return false;
+                }
+
+                var textLiteral = (MarkupTextLiteralSyntax)child;
+                var literalTokens = textLiteral.LiteralTokens;
+                var newlineCount = 0;
+
+                for (var j = 0; j < literalTokens.Count; j++)
+                {
+                    var tokenKind = literalTokens[j].Kind;
+
+                    if (tokenKind == SyntaxKind.NewLine)
+                    {
+                        if (newlineCount++ > 0)
+                        {
+                            // More than one newline in the body, we're not going to do anything.
+                            return false;
+                        }
+
+                        continue;
+                    }
+
+                    if (tokenKind != SyntaxKind.Whitespace)
+                    {
+                        // Non-whitespace and non-newline character
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -134,6 +134,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RazorCompletionItemProvider, MarkupTransitionCompletionItemProvider>();
 
                         // Formatting
+                        services.AddSingleton<RazorFormatOnTypeProvider, HtmlSmartIndentFormatOnTypeProvider>();
                         services.AddSingleton<RazorFormatOnTypeProvider, CloseRazorCommentFormatOnTypeProvider>();
                         services.AddSingleton<RazorFormatOnTypeProvider, CloseTextTagFormatOnTypeProvider>();
                         services.AddSingleton<RazorFormattingService, DefaultRazorFormattingService>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormatOnTypeProviderTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormatOnTypeProviderTestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
     {
         internal abstract RazorFormatOnTypeProvider CreateProvider();
 
-        protected void RunFormatOnTypeTest(string input, string expected, string character, bool expectCursorPlaceholder = true, int tabSize = 4, bool insertSpaces = true, string fileKind = default)
+        protected void RunFormatOnTypeTest(string input, string expected, string character, bool expectCursorPlaceholder = true, int tabSize = 4, bool insertSpaces = true, string fileKind = default, IReadOnlyList<TagHelperDescriptor> tagHelpers = default)
         {
             // Arrange
             var location = input.IndexOf('|') + character.Length;
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             var path = "file:///path/to/document.razor";
             var uri = new Uri(path);
-            var codeDocument = CreateCodeDocument(source, uri.AbsolutePath, fileKind: fileKind);
+            var codeDocument = CreateCodeDocument(source, uri.AbsolutePath, tagHelpers, fileKind: fileKind);
             var options = new FormattingOptions()
             {
                 TabSize = tabSize,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlSmartIndentFormatOnTypeProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlSmartIndentFormatOnTypeProviderTest.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Formatting
+{
+    public class HtmlSmartIndentFormatOnTypeProviderTest : FormatOnTypeProviderTestBase
+    {
+        public static IReadOnlyList<TagHelperDescriptor> TagHelpers
+        {
+            get
+            {
+                var descriptor = TagHelperDescriptorBuilder.Create("SpanTagHelper", "TestAssembly");
+                descriptor.SetTypeName("TestNamespace.SpanTagHelper");
+                descriptor.TagMatchingRule(builder => builder.RequireTagName("span"));
+                descriptor.BindAttribute(builder =>
+                    builder
+                        .Name("test")
+                        .PropertyName("test")
+                        .TypeName(typeof(string).FullName));
+                return new[]
+                {
+                    descriptor.Build()
+                };
+            }
+        }
+
+        [Fact]
+        public void FormatOnType_VoidHtmlTag_Noops()
+        {
+            RunFormatOnTypeTest(
+input: @"<input>|<strong></strong>
+",
+expected: @"<input>
+<strong></strong>
+",
+character: Environment.NewLine);
+        }
+
+        [Fact]
+        public void FormatOnType_SelfClosingHtmlTag_Noops()
+        {
+            RunFormatOnTypeTest(
+input: @"<input />|<strong></strong>
+",
+expected: @"<input />
+<strong></strong>
+",
+character: Environment.NewLine);
+        }
+
+        [Fact]
+        public void FormatOnType_SelfClosingVoidHtmlTag_Noops()
+        {
+            RunFormatOnTypeTest(
+input: @"<input />|<input>
+",
+expected: @"<input />
+<input>
+",
+character: Environment.NewLine);
+        }
+
+        [Fact]
+        public void FormatOnType_HtmlTag_SmartIndents()
+        {
+            RunFormatOnTypeTest(
+input: @"<strong>|</strong>
+",
+expected: $@"<strong>
+    {LanguageServerConstants.CursorPlaceholderString}
+</strong>
+",
+character: Environment.NewLine);
+        }
+
+        [Fact]
+        public void FormatOnType_NestedHtmlTag_SmartIndents()
+        {
+            RunFormatOnTypeTest(
+input: @"<section>
+    <div>|</div>
+</section>
+",
+expected: $@"<section>
+    <div>
+        {LanguageServerConstants.CursorPlaceholderString}
+    </div>
+</section>
+",
+character: Environment.NewLine);
+        }
+
+        [Fact]
+        public void FormatOnType_ComplexHtmlTag_SmartIndents()
+        {
+            RunFormatOnTypeTest(
+input: @"
+@if (true)
+{
+    <section class='column-1'>@{<hr>
+        <div onclick='invokeMethod(""Some Content</div>"")'>|</div><input />
+    }
+    <hr /></section>
+}
+",
+expected: $@"
+@if (true)
+{{
+    <section class='column-1'>@{{<hr>
+        <div onclick='invokeMethod(""Some Content</div>"")'>
+            {LanguageServerConstants.CursorPlaceholderString}
+        </div><input />
+    }}
+    <hr /></section>
+}}
+",
+character: Environment.NewLine);
+        }
+
+        [Fact]
+        public void FormatOnType_TagHelperTag_SmartIndents()
+        {
+            RunFormatOnTypeTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<span>|</span>
+",
+expected: $@"
+@addTagHelper *, TestAssembly
+
+<span>
+    {LanguageServerConstants.CursorPlaceholderString}
+</span>
+",
+character: Environment.NewLine,
+fileKind: FileKinds.Legacy,
+tagHelpers: TagHelpers);
+        }
+
+        [Fact]
+        public void FormatOnType_NestedTagHelperTag_SmartIndents()
+        {
+            RunFormatOnTypeTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<section>
+    <span>|</span>
+</section>
+",
+expected: $@"
+@addTagHelper *, TestAssembly
+
+<section>
+    <span>
+        {LanguageServerConstants.CursorPlaceholderString}
+    </span>
+</section>
+",
+character: Environment.NewLine,
+fileKind: FileKinds.Legacy,
+tagHelpers: TagHelpers);
+        }
+
+        [Fact]
+        public void FormatOnType_ComplexTagHelperTag_SmartIndents()
+        {
+            RunFormatOnTypeTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+
+@if (true)
+{
+    <section class='column-1'>@{<hr>
+        <span onclick='invokeMethod(""Some Content</span>"")' test='hello world'>|</span><input />
+    }
+    <hr /></section>
+}
+",
+expected: $@"
+@addTagHelper *, TestAssembly
+
+
+@if (true)
+{{
+    <section class='column-1'>@{{<hr>
+        <span onclick='invokeMethod(""Some Content</span>"")' test='hello world'>
+            {LanguageServerConstants.CursorPlaceholderString}
+        </span><input />
+    }}
+    <hr /></section>
+}}
+",
+character: Environment.NewLine,
+fileKind: FileKinds.Legacy,
+tagHelpers: TagHelpers);
+        }
+
+        internal override RazorFormatOnTypeProvider CreateProvider() => new HtmlSmartIndentFormatOnTypeProvider();
+    }
+}


### PR DESCRIPTION
- I utilized an `OnTypeFormattingProvider` specifically for newlines to handle translating tags into better formatted segments after entering a newline.
- Moved some indentation generation methods onto `FormattingContext` so they could be usable from outside of the formatting service.
- Added tests to validate HTML/TagHelper scenarios.

![MYG26HCfvn](https://user-images.githubusercontent.com/2008729/82619487-efd92900-9b8a-11ea-9430-7d543ff5dc1a.gif)

dotnet/aspnetcore#22119

