### PR TITLE
Removes attribute snippet support

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DefaultTagHelperCompletionService.cs
@@ -28,8 +28,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public DefaultTagHelperCompletionService(
             RazorTagHelperCompletionService razorCompletionService,
             HtmlFactsService htmlFactsService,
-            TagHelperFactsService tagHelperFactsService,
-            ILanguageServer languageServer)
+            TagHelperFactsService tagHelperFactsService)
         {
             if (razorCompletionService is null)
             {
@@ -46,18 +45,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 throw new ArgumentNullException(nameof(tagHelperFactsService));
             }
 
-            if (languageServer is null)
-            {
-                throw new ArgumentNullException(nameof(languageServer));
-            }
-
             _razorTagHelperCompletionService = razorCompletionService;
             _htmlFactsService = htmlFactsService;
             _tagHelperFactsService = tagHelperFactsService;
-            LanguageServer = languageServer;
         }
-
-        public ILanguageServer LanguageServer { get; }
 
         public override IReadOnlyList<CompletionItem> GetCompletionsAt(SourceSpan location, RazorCodeDocument codeDocument)
         {
@@ -67,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             }
 
             var syntaxTree = codeDocument.GetSyntaxTree();
-            var change = new SourceChange(location, "");
+            var change = new SourceChange(location, string.Empty);
             var owner = syntaxTree.Root.LocateOwner(change);
 
             if (owner == null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -275,13 +275,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters),
                         };
 
-                        var indexerCompletion = razorCompletionItem.DisplayText.EndsWith("...");
-                        if (TryResolveDirectiveAttributeInsertionSnippet(razorCompletionItem.InsertText, indexerCompletion, descriptionInfo, out var snippetText))
-                        {
-                            directiveAttributeCompletionItem.InsertText = snippetText;
-                            directiveAttributeCompletionItem.InsertTextFormat = InsertTextFormat.Snippet;
-                        }
-
                         directiveAttributeCompletionItem.SetDescriptionInfo(descriptionInfo);
                         directiveAttributeCompletionItem.SetRazorCompletionKind(razorCompletionItem.Kind);
                         completionItem = directiveAttributeCompletionItem;
@@ -325,41 +318,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             completionItem = null;
             return false;
-        }
-
-        private bool TryResolveDirectiveAttributeInsertionSnippet(
-            string insertText,
-            bool indexerCompletion,
-            AttributeCompletionDescription attributeCompletionDescription,
-            out string snippetText)
-        {
-            if (_capability?.CompletionItem?.SnippetSupport == null || !_capability.CompletionItem.SnippetSupport)
-            {
-                snippetText = null;
-                return false;
-            }
-
-            const string BoolTypeName = "System.Boolean";
-            var attributeInfos = attributeCompletionDescription.DescriptionInfos;
-
-            // Boolean returning bound attribute, auto-complete to just the attribute name.
-            if (attributeInfos.All(info => info.ReturnTypeName == BoolTypeName))
-            {
-                snippetText = null;
-                return false;
-            }
-
-            if (indexerCompletion)
-            {
-                // Indexer completion
-                snippetText = string.Concat(insertText, "$1=\"$2\"$0");
-            }
-            else
-            {
-                snippetText = string.Concat(insertText, "=\"$1\"$0");
-            }
-
-            return true;
         }
 
         private CompletionItem SetIcon(CompletionItem item)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     insertText = insertText.Substring(1);
                 }
 
-                (var attributeDescriptionInfos, var commitCharacters) = completion.Value;
+                var (attributeDescriptionInfos, commitCharacters) = completion.Value;
 
                 var razorCompletionItem = new RazorCompletionItem(
                     completion.Key,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperCompletionServiceTest.cs
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public void GetCompletionAt_AtAttributeEdge_IntAttribute_ReturnsCompletionsWithSnippet()
+        public void GetCompletionAt_AtAttributeEdge_IntAttribute_ReturnsCompletionsWithoutSnippet()
         {
             // Arrange
             var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
@@ -179,8 +179,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 },
                 completion =>
                 {
-                    Assert.Equal("int-val=\"$1\"", completion.InsertText);
-                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                    Assert.Equal("int-val", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
                     Assert.Equal(new[] { "=" }, completion.CommitCharacters);
                 });
         }
@@ -207,8 +207,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 },
                 completion =>
                 {
-                    Assert.Equal("int-val=\"$1\"", completion.InsertText);
-                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                    Assert.Equal("int-val", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
                     Assert.Equal(new[] { "=" }, completion.CommitCharacters);
                 });
         }
@@ -239,8 +239,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 completions,
                 completion =>
                 {
-                    Assert.Equal("bool-val=\"$1\"", completion.InsertText);
-                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                    Assert.Equal("bool-val", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
                 },
                 completion =>
                 {
@@ -250,65 +250,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public void GetCompletionAt_AtAttributeEdge_IndexerAttribute_WithoutSnippetSupport_ReturnsCompletionsWithoutSnippet()
-        {
-            // Arrange
-            var tagHelper = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
-            tagHelper.TagMatchingRule(rule => rule.TagName = "test");
-            tagHelper.SetTypeName("TestTagHelper");
-            tagHelper.BindAttribute(attribute =>
-            {
-                attribute.Name = "int-val";
-                attribute.SetPropertyName("IntVal");
-                attribute.TypeName = ("System.Collections.Generic.IDictionary<System.String, System.Int32>");
-                attribute.AsDictionary("int-val-", typeof(int).FullName);
-            });
-
-            var languageServer = new Mock<ILanguageServer>();
-            languageServer.SetupGet(server => server.ClientSettings)
-                .Returns(new InitializeParams {
-                    Capabilities = new ClientCapabilities {
-                        TextDocument = new TextDocumentClientCapabilities {
-                            Completion = new CompletionCapability
-                            {
-                                CompletionItem = new CompletionItemCapability
-                                {
-                                    SnippetSupport = false
-                                }
-                            }
-                        }
-                    }
-                }).Verifiable();
-
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, languageServer.Object);
-
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", tagHelper.Build());
-            var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
-
-            // Act
-            var completions = service.GetCompletionsAt(sourceSpan, codeDocument);
-
-            // Assert
-            Assert.Collection(
-                completions,
-                completion =>
-                {
-                    Assert.Equal("int-val", completion.InsertText);
-                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
-                    Assert.Equal(new[] { "=" }, completion.CommitCharacters);
-                },
-                completion =>
-                {
-                    Assert.Equal("int-val-", completion.InsertText);
-                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
-                    Assert.Equal(Array.Empty<String>(), completion.CommitCharacters);
-                });
-
-            languageServer.Verify();
-        }
-
-        [Fact]
-        public void GetCompletionAt_AtAttributeEdge_IndexerAttribute_ReturnsCompletionsWithSnippet()
+        public void GetCompletionAt_AtAttributeEdge_IndexerAttribute_ReturnsCompletionsWithoutSnippet()
         {
             // Arrange
             var tagHelper = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
@@ -333,14 +275,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 completions,
                 completion =>
                 {
-                    Assert.Equal("int-val=\"$1\"", completion.InsertText);
-                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                    Assert.Equal("int-val", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
                     Assert.Equal(new[] { "=" }, completion.CommitCharacters);
                 },
                 completion =>
                 {
-                    Assert.Equal("int-val-$1=\"$2\"", completion.InsertText);
-                    Assert.Equal(InsertTextFormat.Snippet, completion.InsertTextFormat);
+                    Assert.Equal("int-val-", completion.InsertText);
+                    Assert.Equal(InsertTextFormat.PlainText, completion.InsertTextFormat);
                     Assert.Equal(Array.Empty<string>(), completion.CommitCharacters);
                 });
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperCompletionServiceTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_AtEmptyTagName_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
 
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_OutsideOfTagName_DoesNotReturnCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<br />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(33 + Environment.NewLine.Length, 0);
 
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_AtHtmlElementNameEdge_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<br />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(32 + Environment.NewLine.Length, 0);
 
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_AtTagHelperElementNameEdge_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
 
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_AtAttributeEdge_IntAttribute_ReturnsCompletionsWithoutSnippet()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
 
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_AtAttributeEdge_BoolAttribute_ReturnsCompletionsWithoutSnippet()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
 
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 attribute.TypeName = ("System.Collections.Generic.IDictionary<System.String, System.Boolean>");
                 attribute.AsDictionary("bool-val-", typeof(bool).FullName);
             });
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", tagHelper.Build());
             var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
 
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 attribute.TypeName = ("System.Collections.Generic.IDictionary<System.String, System.Int32>");
                 attribute.AsDictionary("int-val-", typeof(int).FullName);
             });
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", tagHelper.Build());
             var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
 
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_MinimizedAttribute_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 unbound />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
 
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_MinimizedTagHelperAttribute_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 bool-val />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
 
@@ -321,7 +321,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_HtmlAttribute_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
 
@@ -336,7 +336,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_TagHelperAttribute_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int-val='123' />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
 
@@ -351,7 +351,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionsAt_MalformedAttributeValue_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int-val='>";
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
@@ -367,7 +367,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionsAt_MalformedAttributeName_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int->", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
 
@@ -382,7 +382,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionAt_HtmlAttributeValue_DoesNotReturnCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", DefaultTagHelpers);
             var sourceSpan = new SourceSpan(43 + Environment.NewLine.Length, 0);
 
@@ -397,7 +397,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionsAt_AttributePrefix_ReturnsCompletions()
         {
             // Arrange
-            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService, LanguageServer);
+            var service = new DefaultTagHelperCompletionService(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2        class=''>";
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         private readonly CompletionCapability DefaultCapability = new CompletionCapability
         {
             CompletionItem = new CompletionItemCapability {
-                SnippetSupport = true
+                SnippetSupport = false
             }
         };
 
@@ -179,7 +179,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 }
             };
             completionEndpoint.SetCapability(capability);
-            var expectedInsert = "testInsert$1=\"$2\"$0";
 
             // Act
             var result = completionEndpoint.TryConvert(completionItem, out var converted);
@@ -187,7 +186,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Assert
             Assert.True(result);
             Assert.Equal(completionItem.DisplayText, converted.Label);
-            Assert.Equal(expectedInsert, converted.InsertText);
+            Assert.Equal(completionItem.InsertText, converted.InsertText);
             Assert.Equal(completionItem.InsertText, converted.FilterText);
             Assert.Equal(completionItem.InsertText, converted.SortText);
             Assert.Null(converted.Detail);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
@@ -2,12 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Xunit;
 using Microsoft.VisualStudio.Editor.Razor;
 


### PR DESCRIPTION
Removed to avoid issues like:
- `<button @attrib|` press `=` -> `<button @attributes="=|"`
- `@onkey|` press `:` -> `@onkeydown=":|"`
- Taghelper attribute `<form ap-anti` press ` ` -> `<form asp-antiforgery=" |"`
- Taghelper attribute `<form ap-ar` press `=` -> `<form asp-area="=|"`

As discussed here: https://github.com/dotnet/aspnetcore/issues/22150

There's nothing in the LSP spec which allows different [CompletionItem.InsertText](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.languageserver.protocol.completionitem.inserttext?view=visualstudiosdk-2019#Microsoft_VisualStudio_LanguageServer_Protocol_CompletionItem_InsertText) snippets for different commit characters. However, for the commit characters `:` and `=`, we need snippet texts of `:|` and `="|"` respectively. Right now it's indiscriminately applying the `="|"` to everything.

Fixes: https://github.com/dotnet/aspnetcore/issues/22228
