### PR TITLE
Handle missing edits

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCSharpLanguageMiddleware.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCSharpLanguageMiddleware.ts
@@ -147,6 +147,10 @@ export class RazorCSharpLanguageMiddleware implements LanguageMiddleware {
     }
 
     private tryApplyingCodeActions(uri: vscode.Uri, edit: vscode.TextEdit): [ vscode.Uri?, vscode.TextEdit?] {
-        return this.compositeCodeActionTranslator.applyEdit(uri, edit);
+        if (this.compositeCodeActionTranslator.canHandleEdit(uri, edit)) {
+            return this.compositeCodeActionTranslator.applyEdit(uri, edit);
+        } else {
+            return [undefined, undefined];
+        }
     }
 }

--- a/src/Razor/test/VSCode.FunctionalTest/yarn.lock
+++ b/src/Razor/test/VSCode.FunctionalTest/yarn.lock
@@ -60,7 +60,7 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/vscode@^1.45.1":
+"@types/vscode@1.45.1":
   version "1.45.1"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.45.1.tgz#672fb8c2cc33cf14cd4d3bdaa19bb294fe2b2706"
   integrity sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==


### PR DESCRIPTION
This seems to have been exposed in https://github.com/dotnet/aspnetcore-tooling/commit/584aafdd321c34af17171806d9aff30b71b62b4c but the actual mistake here was introduced in my codeAction PR from way back. We named that function `tryApplyingCodeActions` but if you try calling it on an edit which doesn't apply it throws rather than returning undefined as one would expect.