### PR TITLE
Remove unnecessary switches to main thread

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly JoinableTaskContext _joinableTaskContext;
         private readonly FileUriProvider _fileUriProvider;
         private readonly LSPDocumentFactory _documentFactory;
-        private readonly Dictionary<Uri, LSPDocument> _documents;
+        private readonly ConcurrentDictionary<Uri, LSPDocument> _documents;
 
         public override event EventHandler<LSPDocumentChangeEventArgs> Changed;
 
@@ -47,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             _joinableTaskContext = joinableTaskContext;
             _fileUriProvider = fileUriProvider;
             _documentFactory = documentFactory;
-            _documents = new Dictionary<Uri, LSPDocument>();
+            _documents = new ConcurrentDictionary<Uri, LSPDocument>();
 
             foreach (var trigger in changeTriggers)
             {
@@ -92,10 +93,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return;
             }
 
-            _documents.Remove(uri);
-
-            var args = new LSPDocumentChangeEventArgs(lspDocument.CurrentSnapshot, @new: null, LSPDocumentChangeKind.Removed);
-            Changed?.Invoke(this, args);
+            if (_documents.TryRemove(uri, out _))
+            {
+                var args = new LSPDocumentChangeEventArgs(lspDocument.CurrentSnapshot, @new: null, LSPDocumentChangeKind.Removed);
+                Changed?.Invoke(this, args);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Couldn't remove {uri.AbsolutePath}. This should never ever happen.");
+            }
         }
 
         public override void UpdateVirtualDocument<TVirtualDocument>(
@@ -156,8 +162,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public override bool TryGetDocument(Uri uri, out LSPDocumentSnapshot lspDocumentSnapshot)
         {
-            Debug.Assert(_joinableTaskContext.IsOnMainThread);
-
             if (!_documents.TryGetValue(uri, out var lspDocument))
             {
                 // This should never happen in practice but return `null` so our tests can validate

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPDocumentManager.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
             else
             {
-                throw new InvalidOperationException($"Couldn't remove {uri.AbsolutePath}. This should never ever happen.");
+                Debug.Fail($"Couldn't remove {uri.AbsolutePath}. This should never ever happen.");
             }
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
@@ -77,8 +77,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     return emptyResult;
                 }
 
-                await _joinableTaskFactory.SwitchToMainThreadAsync();
-
                 if (!_documentManager.TryGetDocument(requestParams.TextDocument.Uri, out var documentSnapshot))
                 {
                     return emptyResult;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -61,15 +61,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public async Task<SumType<CompletionItem[], CompletionList>?> HandleRequestAsync(CompletionParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
         {
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
                 return null;
             }
-
-            // Switch to a background thread.
-            await TaskScheduler.Default;
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
             if (projectionResult == null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
@@ -73,15 +73,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
                 return null;
             }
-
-            // Switch to a background thread.
-            await TaskScheduler.Default;
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
             if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.CSharp)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
@@ -62,15 +62,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public async Task<Hover> HandleRequestAsync(TextDocumentPositionParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
         {
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
                 return null;
             }
-
-            // Switch to a background thread.
-            await TaskScheduler.Default;
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
             if (projectionResult == null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
@@ -7,12 +7,9 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
@@ -85,14 +82,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return EmptyEdits;
             }
 
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
                 return EmptyEdits;
             }
-
-            await SwitchToBackgroundThread().ConfigureAwait(false);
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
             if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.Html)
@@ -156,8 +149,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return EmptyEdits;
             }
 
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var newDocumentSnapshot) ||
                 newDocumentSnapshot.Version != documentSnapshot.Version)
             {
@@ -169,11 +160,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // We would have already applied the edits and moved the cursor. Return empty.
             return EmptyEdits;
-        }
-
-        protected async virtual Task SwitchToBackgroundThread()
-        {
-            await TaskScheduler.Default;
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text;
@@ -50,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = "?",
@@ -90,7 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -136,7 +135,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -183,7 +182,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -240,7 +239,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             editorService.Setup(e => e.ApplyTextEditsAsync(Uri, It.IsAny<ITextSnapshot>(), It.IsAny<IEnumerable<TextEdit>>())).Callback(() => { appliedTextEdits = true; })
                 .Returns(Task.CompletedTask);
 
-            var handler = new TestOnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider.Object, editorService.Object);
+            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider.Object, editorService.Object);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = "=",
@@ -278,31 +277,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 _documents.Add(uri, documentSnapshot);
 
                 Changed?.Invoke(this, null);
-            }
-        }
-
-        private class TestOnTypeFormattingHandler : OnTypeFormattingHandler
-        {
-            public TestOnTypeFormattingHandler(
-            JoinableTaskContext joinableTaskContext,
-            LSPDocumentManager documentManager,
-            LSPRequestInvoker requestInvoker,
-            LSPProjectionProvider projectionProvider,
-            LSPDocumentMappingProvider documentMappingProvider,
-            LSPEditorService editorService) : base(
-                joinableTaskContext,
-                documentManager,
-                requestInvoker,
-                projectionProvider,
-                documentMappingProvider,
-                editorService)
-            {
-            }
-
-            protected override Task SwitchToBackgroundThread()
-            {
-                // Let it stay on the foreground thread because our fake JoinableTaskContext cannot handle switching back to the foreground thread.
-                return Task.CompletedTask;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22106

We no longer require the main thread for most cases.
Exceptions are,
- Tracking/untracking documents
- Updating C#/HTML buffers
- Provisional completions (adding/removing provisional dot)
- Applying text edits and moving the cursor
- Logging to the VS Activity logger

Theoretically there is a slight chance that this could cause issues during completions etc but those are very unlikely and I have not seen that happen during testing. Plus we get a good performance boost from not having to switch to the main thread. So the plan is to make this change and keep watch for any threading issues in the editing experience. 