### PR TITLE
Support C# highlights in Razor VS LSP

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageClientMiddleLayer.cs
@@ -7,7 +7,6 @@ using System.Composition;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json.Linq;
 using Task = System.Threading.Tasks.Task;
 
@@ -17,21 +16,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [Export(typeof(RazorLanguageClientMiddleLayer))]
     internal class DefaultRazorLanguageClientMiddleLayer : RazorLanguageClientMiddleLayer
     {
-        private readonly JoinableTaskFactory _joinableTaskFactory;
         private readonly LSPDocumentManager _documentManager;
         private readonly LSPEditorService _editorService;
 
         [ImportingConstructor]
-        public DefaultRazorLanguageClientMiddleLayer(
-            JoinableTaskContext joinableTaskContext,
-            LSPDocumentManager documentManager,
-            LSPEditorService editorService)
+        public DefaultRazorLanguageClientMiddleLayer(LSPDocumentManager documentManager, LSPEditorService editorService)
         {
-            if (joinableTaskContext is null)
-            {
-                throw new ArgumentNullException(nameof(joinableTaskContext));
-            }
-
             if (documentManager is null)
             {
                 throw new ArgumentNullException(nameof(documentManager));
@@ -42,7 +32,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(editorService));
             }
 
-            _joinableTaskFactory = joinableTaskContext.Factory;
             _documentManager = documentManager;
             _editorService = editorService;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     [ExportLspMethod(Methods.TextDocumentDefinitionName)]
     internal class GoToDefinitionHandler : IRequestHandler<TextDocumentPositionParams, Location[]>
     {
-        private readonly JoinableTaskFactory _joinableTaskFactory;
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly LSPDocumentManager _documentManager;
         private readonly LSPProjectionProvider _projectionProvider;
@@ -23,17 +22,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         [ImportingConstructor]
         public GoToDefinitionHandler(
-            JoinableTaskContext joinableTaskContext,
             LSPRequestInvoker requestInvoker,
             LSPDocumentManager documentManager,
             LSPProjectionProvider projectionProvider,
             LSPDocumentMappingProvider documentMappingProvider)
         {
-            if (joinableTaskContext is null)
-            {
-                throw new ArgumentNullException(nameof(joinableTaskContext));
-            }
-
             if (requestInvoker is null)
             {
                 throw new ArgumentNullException(nameof(requestInvoker));
@@ -54,7 +47,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(documentMappingProvider));
             }
 
-            _joinableTaskFactory = joinableTaskContext.Factory;
             _requestInvoker = requestInvoker;
             _documentManager = documentManager;
             _projectionProvider = projectionProvider;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 },
                 HoverProvider = true,
                 DefinitionProvider = true,
+                DocumentHighlightProvider = true,
             }
         };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         private static readonly TextEdit[] EmptyEdits = Array.Empty<TextEdit>();
         private static readonly IReadOnlyList<string> AllowedTriggerCharacters = new[] { ">", "=", "-" };
 
-        private readonly JoinableTaskFactory _joinableTaskFactory;
         private readonly LSPDocumentManager _documentManager;
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly LSPProjectionProvider _projectionProvider;
@@ -29,18 +28,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         [ImportingConstructor]
         public OnTypeFormattingHandler(
-            JoinableTaskContext joinableTaskContext,
             LSPDocumentManager documentManager,
             LSPRequestInvoker requestInvoker,
             LSPProjectionProvider projectionProvider,
             LSPDocumentMappingProvider documentMappingProvider,
             LSPEditorService editorService)
         {
-            if (joinableTaskContext is null)
-            {
-                throw new ArgumentNullException(nameof(joinableTaskContext));
-            }
-
             if (documentManager is null)
             {
                 throw new ArgumentNullException(nameof(documentManager));
@@ -66,7 +59,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(editorService));
             }
 
-            _joinableTaskFactory = joinableTaskContext.Factory;
             _documentManager = documentManager;
             _requestInvoker = requestInvoker;
             _projectionProvider = projectionProvider;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -126,6 +126,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<TextDocumentPositionParams, Location[]>(Methods.TextDocumentDefinitionName, positionParams, _clientCapabilities, cancellationToken);
         }
 
+        [JsonRpcMethod(Methods.TextDocumentDocumentHighlightName, UseSingleObjectParameterDeserialization = true)]
+        public Task<DocumentHighlight[]> HighlightDocumentAsync(DocumentHighlightParams documentHighlightParams, CancellationToken cancellationToken)
+        {
+            if (documentHighlightParams is null)
+            {
+                throw new ArgumentNullException(nameof(documentHighlightParams));
+            }
+
+            return ExecuteRequestAsync<DocumentHighlightParams, DocumentHighlight[]>(Methods.TextDocumentDocumentHighlightName, documentHighlightParams, _clientCapabilities, cancellationToken);
+        }
+
         // Internal for testing
         internal Task<ResponseType> ExecuteRequestAsync<RequestType, ResponseType>(
             string methodName,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageClientMiddleLayerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageClientMiddleLayerTest.cs
@@ -18,12 +18,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         public DefaultRazorLanguageClientMiddleLayerTest()
         {
-            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
-            JoinableTaskContext = joinableTaskContext.Context;
             Uri = new Uri("C:/path/to/file.razor");
         }
-
-        private JoinableTaskContext JoinableTaskContext { get; }
 
         private Uri Uri { get; }
 
@@ -61,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return Task.FromResult(actualTextEdits);
             };
 
-            var middleLayer = new DefaultRazorLanguageClientMiddleLayer(JoinableTaskContext, documentManager, editorService.Object);
+            var middleLayer = new DefaultRazorLanguageClientMiddleLayer(documentManager, editorService.Object);
 
             // Act
             await middleLayer.HandleRequestAsync(Methods.TextDocumentOnTypeFormattingName, JToken.FromObject(inputParams), actualRequest).ConfigureAwait(false);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
@@ -1,0 +1,271 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Moq;
+using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class DocumentHighlightHandlerTest
+    {
+        public DocumentHighlightHandlerTest()
+        {
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var highlightHandler = new DocumentHighlightHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var highlightRequest = new DocumentHighlightParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await highlightHandler.HandleRequestAsync(highlightRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_ProjectionNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var highlightHandler = new DocumentHighlightHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var highlightRequest = new DocumentHighlightParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await highlightHandler.HandleRequestAsync(highlightRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_HtmlProjection_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.Html,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var highlightHandler = new DocumentHighlightHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
+            var highlightRequest = new DocumentHighlightParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await highlightHandler.HandleRequestAsync(highlightRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_RemapsHighlightRange()
+        {
+            // Arrange
+            var called = false;
+            var expectedHighlight = GetHighlight(5, 5, 5, 5);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 0));
+
+            var csharpHighlight = GetHighlight(100, 100, 100, 100);
+            var requestInvoker = GetRequestInvoker<DocumentHighlightParams, DocumentHighlight[]>(
+                new[] { csharpHighlight },
+                (method, serverKind, highlightParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentDocumentHighlightName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                });
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = GetProjectionProvider(projectionResult);
+
+            var documentMappingProvider = GetDocumentMappingProvider(expectedHighlight.Range, 0);
+
+            var highlightHandler = new DocumentHighlightHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var highlightRequest = new DocumentHighlightParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await highlightHandler.HandleRequestAsync(highlightRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            var actualHighlight = Assert.Single(result);
+            Assert.Equal(expectedHighlight.Range, actualHighlight.Range);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_VersionMismatch_DiscardsLocation()
+        {
+            // Arrange
+            var called = false;
+            var expectedHighlight = GetHighlight(5, 5, 5, 5);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 1));
+
+            var csharpHighlight = GetHighlight(100, 100, 100, 100);
+            var requestInvoker = GetRequestInvoker<DocumentHighlightParams, DocumentHighlight[]>(
+                new[] { csharpHighlight },
+                (method, serverKind, highlightParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentDocumentHighlightName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                });
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = GetProjectionProvider(projectionResult);
+
+            var documentMappingProvider = GetDocumentMappingProvider(expectedHighlight.Range, 0 /* Different from document version (1) */);
+
+            var highlightHandler = new DocumentHighlightHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var highlightRequest = new DocumentHighlightParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await highlightHandler.HandleRequestAsync(highlightRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_RemapFailure_DiscardsLocation()
+        {
+            // Arrange
+            var called = false;
+            var expectedHighlight = GetHighlight(5, 5, 5, 5);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 0));
+
+            var csharpHighlight = GetHighlight(100, 100, 100, 100);
+            var requestInvoker = GetRequestInvoker<DocumentHighlightParams, DocumentHighlight[]>(
+                new[] { csharpHighlight },
+                (method, serverKind, highlightParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentDocumentHighlightName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                });
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = GetProjectionProvider(projectionResult);
+
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+
+            var highlightHandler = new DocumentHighlightHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var highlightRequest = new DocumentHighlightParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await highlightHandler.HandleRequestAsync(highlightRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Empty(result);
+        }
+
+        private LSPProjectionProvider GetProjectionProvider(ProjectionResult expectedResult)
+        {
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
+
+            return projectionProvider.Object;
+        }
+
+        private LSPRequestInvoker GetRequestInvoker<TParams, TResult>(TResult expectedResponse, Action<string, LanguageServerKind, TParams, CancellationToken> callback)
+        {
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<TParams, TResult>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TParams>(), It.IsAny<CancellationToken>()))
+                .Callback(callback)
+                .Returns(Task.FromResult(expectedResponse));
+
+            return requestInvoker.Object;
+        }
+
+        private LSPDocumentMappingProvider GetDocumentMappingProvider(Range expectedRange, int expectedVersion)
+        {
+            var remappingResult = new RazorMapToDocumentRangeResponse()
+            {
+                Range = expectedRange
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, It.IsAny<Range>(), It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            return documentMappingProvider.Object;
+        }
+
+        private DocumentHighlight GetHighlight(int startLine, int startCharacter, int endLine, int endCharacter)
+        {
+            return new DocumentHighlight()
+            {
+                Range = new Range()
+                {
+                    Start = new Position(startLine, startCharacter),
+                    End = new Position(endLine, endCharacter)
+                }
+            };
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToDefinitionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToDefinitionHandlerTest.cs
@@ -16,12 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     {
         public GoToDefinitionHandlerTest()
         {
-            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
-            JoinableTaskContext = joinableTaskContext.Context;
             Uri = new Uri("C:/path/to/file.razor");
         }
-
-        private JoinableTaskContext JoinableTaskContext { get; }
 
         private Uri Uri { get; }
 
@@ -33,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestInvoker = Mock.Of<LSPRequestInvoker>();
             var projectionProvider = Mock.Of<LSPProjectionProvider>();
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -56,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestInvoker = Mock.Of<LSPRequestInvoker>();
             var projectionProvider = Mock.Of<LSPProjectionProvider>();
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -86,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -137,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -192,7 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, externalUri, csharpLocation.Range, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -238,7 +234,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
 
-            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -292,7 +288,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -339,7 +335,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Range, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult<RazorMapToDocumentRangeResponse>(null));
 
-            var definitionHandler = new GoToDefinitionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
@@ -16,12 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     {
         public HoverHandlerTest()
         {
-            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
-            JoinableTaskContext = joinableTaskContext.Context;
             Uri = new Uri("C:/path/to/file.razor");
         }
-
-        private JoinableTaskContext JoinableTaskContext { get; }
 
         private Uri Uri { get; }
 
@@ -33,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestInvoker = Mock.Of<LSPRequestInvoker>();
             var projectionProvider = Mock.Of<LSPProjectionProvider>();
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var hoverhandler = new HoverHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var hoverhandler = new HoverHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
             var hoverRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -56,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestInvoker = Mock.Of<LSPRequestInvoker>();
             var projectionProvider = Mock.Of<LSPProjectionProvider>();
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var hoverhandler = new HoverHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var hoverhandler = new HoverHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
             var hoverRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -143,7 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range>(), It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var hoverHandler = new HoverHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
 
             // Act
             var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -227,7 +223,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.Html, It.IsAny<Uri>(), It.IsAny<Range>(), It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var hoverHandler = new HoverHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
 
             // Act
             var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -272,7 +268,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
 
-            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var hoverHandler = new HoverHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
 
             // Act
             var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -347,7 +343,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range>(), It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult<RazorMapToDocumentRangeResponse>(null));
 
-            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var hoverHandler = new HoverHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
 
             // Act
             var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -417,7 +413,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range>(), It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
-            var hoverHandler = new HoverHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var hoverHandler = new HoverHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
 
             // Act
             var result = await hoverHandler.HandleRequestAsync(hoverRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
@@ -19,12 +19,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     {
         public OnTypeFormattingHandlerTest()
         {
-            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
-            JoinableTaskContext = joinableTaskContext.Context;
             Uri = new Uri("C:/path/to/file.razor");
         }
-
-        private JoinableTaskContext JoinableTaskContext { get; }
 
         private Uri Uri { get; }
 
@@ -49,7 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
+            var handler = new OnTypeFormattingHandler(documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = "?",
@@ -89,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
+            var handler = new OnTypeFormattingHandler(documentManager, requestInvoker.Object, projectionProvider, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -135,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
+            var handler = new OnTypeFormattingHandler(documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -182,7 +178,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var editorService = Mock.Of<LSPEditorService>();
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
+            var handler = new OnTypeFormattingHandler(documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider, editorService);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = ">",
@@ -239,7 +235,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             editorService.Setup(e => e.ApplyTextEditsAsync(Uri, It.IsAny<ITextSnapshot>(), It.IsAny<IEnumerable<TextEdit>>())).Callback(() => { appliedTextEdits = true; })
                 .Returns(Task.CompletedTask);
 
-            var handler = new OnTypeFormattingHandler(JoinableTaskContext, documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider.Object, editorService.Object);
+            var handler = new OnTypeFormattingHandler(documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider.Object, editorService.Object);
             var request = new DocumentOnTypeFormattingParams()
             {
                 Character = "=",


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22257

![image](https://user-images.githubusercontent.com/1579269/82965929-71133000-9f7e-11ea-951e-083052637d82.png)

I know this wasn't part of the plan for this release but this seemed simple enough and it looks a lot nicer with this.