### PR TITLE
FileSystemWatcher Discarding Files to MISC Project

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -73,13 +73,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             workspaceDirectory = _filePathNormalizer.Normalize(workspaceDirectory);
             
-            // Without trimming trailling `/` from the workspace directory, the FileSystemWatcher 
+            // Without trimming trailing `/` from the workspace directory, the FileSystemWatcher 
             // returns with paths of the form   "workspaceDirectory/\\Pages\\Counter.razor"
             // which are normalized to          "workspaceDirectory//Pages/Counter.razor" (Invalid `//`)
             //
             // This format doesn't match the directoryFilePaths we store as part of the Project Snapshot ->
             //                                  "workspaceDirectory/Pages/Counter.razor"
             // https://github.com/dotnet/aspnetcore-tooling/blob/488cf6e/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs#L328
+            // Consequently, files are being discarded into the MISC project and subsequently re-generated
             workspaceDirectory = workspaceDirectory.TrimEnd('/');
             
             var existingRazorFiles = GetExistingRazorFiles(workspaceDirectory);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -72,6 +72,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Dive through existing Razor files and fabricate "added" events so listeners can accurately listen to state changes for them.
 
             workspaceDirectory = _filePathNormalizer.Normalize(workspaceDirectory);
+            
+            // Without trimming trailling `/` from the workspace directory, the FileSystemWatcher 
+            // returns with paths of the form   "workspaceDirectory/\\Pages\\Counter.razor"
+            // which are normalized to          "workspaceDirectory//Pages/Counter.razor" (Invalid `//`)
+            //
+            // This format doesn't match the directoryFilePaths we store as part of the Project Snapshot ->
+            //                                  "workspaceDirectory/Pages/Counter.razor"
+            // https://github.com/dotnet/aspnetcore-tooling/blob/488cf6e/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs#L328
+            workspaceDirectory = workspaceDirectory.TrimEnd('/');
+            
             var existingRazorFiles = GetExistingRazorFiles(workspaceDirectory);
 
             await Task.Factory.StartNew(() =>


### PR DESCRIPTION
Fix is fairly straightforward after identifying the underlying issue:

Without trimming trailling `/` from the workspace directory, the FileSystemWatcher returns with paths of the form
- "workspaceDirectory/\\Pages\\Counter.razor"
which are normalized to
- "workspaceDirectory//Pages/Counter.razor" (Invalid `//`)

This format doesn't match the directoryFilePaths we store as part of the Project Snapshot ->
- "workspaceDirectory/Pages/Counter.razor"

https://github.com/dotnet/aspnetcore-tooling/blob/488cf6e/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs#L328

Consequently files are being discarded into the MISC project and subsequently re-generated

Discovered while investigating: https://github.com/dotnet/aspnetcore/issues/21631

This issue is mostly a backfill for future reference.

Fixes: https://github.com/dotnet/aspnetcore/issues/22280
