### PR TITLE
Add HTML & Curly brace smart indent.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -78,6 +78,13 @@
       <VSIXSubPath>Grammars\</VSIXSubPath>
     </Content>
 
+    <!-- Language configurations -->
+
+    <Content Include="language-configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -178,16 +185,6 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <IncludeInVSIX>true</IncludeInVSIX>
         <VSIXSubPath>Grammars\</VSIXSubPath>
-      </Content>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_IncludeRazorLanguageConfiguration" DependsOnTargets="PrepareForBuild" BeforeTargets="CoreCompile">
-    <ItemGroup>
-      <Content Include="..\Microsoft.AspNetCore.Razor.VSCode.Extension\language-configuration.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <IncludeInVSIX>true</IncludeInVSIX>
-        <VSIXSubPath>\</VSIXSubPath>
       </Content>
     </ItemGroup>
   </Target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -1,0 +1,28 @@
+﻿{
+  "comments": {
+    "blockComment": [ "@*", "*@" ]
+  },
+  "brackets": [
+    ["<!--", "-->"],
+    ["<", ">"],
+    ["{", "}"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}"},
+    { "open": "[", "close": "]"},
+    { "open": "(", "close": ")" },
+    { "open": "'", "close": "'" },
+    { "open": "\"", "close": "\"" },
+    { "open": "@*", "close": "*@" }
+  ],
+  "surroundingPairs": [
+    { "open": "'", "close": "'" },
+    { "open": "\"", "close": "\"" },
+    { "open": "<", "close": ">" }
+  ],
+  "indentationRules": {
+    "increaseIndentPattern": "(?:<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$)|(?:\\{\\s*$)",
+    "decreaseIndentPattern": "(?:</([_:\\w][_:\\w-.\\d]*)\\s*>)|(?:\\})"
+  }
+}


### PR DESCRIPTION
- Created a VS specific `langauge-configuration.json` file because the way we make smart indent work in a VS world is different from VSCode.

For HTML elements we have two aspects to smart indent behavior:
1. [Pre-existing to this PR] We have an `OnTypeFormatter` that understands newlines being entered in the document and applies indentation + extra newline edits to turn
```HTML
<strong>|</strong>
```
into
```HTML
<strong>
    |
</strong>
```
2. [Done in this PR] We add a `langauge-configuration.json` to indicate if a user hits enter in the already `OnTypeFormatted` HTML that you stay in the correct location. Aka:

```HTML
<strong>
    |
</strong>
```
After hitting enter
```HTML
<strong>

    |
</strong>
```

Now for Razor constructs (`@{}`, `@code {}`) & C# there's two parts to the smart indent behavior that we make use of in Visual Studio
1. [Pre-existing to this PR] There's a brace completion manager in Visual Studio that applies to every editor and every variant of curly braces. It's smart enough to do mostly the right thing on enter. For instance if you do:
```
{|}
```

And then press "enter" it makes sure you come out with:
```
{
|
}
```
2. [Done in this PR] We add a `langauge-configuration.json` to indicate if a user hits enter in the already brace completed text that you get smart indented into the correct location.

Aka in the middle state of:
```
{
|
}
```

The CoreEditor respects our `language-configuration.json`  settings and turns it into:
```
{
    |
}
```

- These changes in combination with VS' built-in brace completion support end up enabling correct smart indent behavior for
    - `@{|}`
    - `@code {|}`
    - `@if {|}`
    - `@{ if (true) {|} }`

- Given there are several CoreEditor integration at play it's not something we can test by hand or programatically. Because of this I've filed https://github.com/dotnet/aspnetcore/issues/22334 to track updating our CTI tests to include VS Windows Codespaces scenarios.

![jFFZXYPwT8](https://user-images.githubusercontent.com/2008729/83197484-65e11100-a0f2-11ea-98ea-a436d9b17746.gif)


Fixes dotnet/aspnetcore#21757
Fixes dotnet/aspnetcore#22120
Fixes dotnet/aspnetcore#22121
Fixes dotnet/aspnetcore#22122