### PR TITLE
Trimming workspaceDirectory final directory separator

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultFileSystemWatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultFileSystemWatcher.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System.IO;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultFileSystemWatcher : FileSystemWatcher
+    {
+        // Without trimming trailing `/`, `\\` from the workspace directory, the FileSystemWatcher
+        // returns with paths of the form   "workspaceDirectory/\\Pages\\Counter.razor"
+        // which are normalized to          "workspaceDirectory//Pages/Counter.razor" (Invalid `//`)
+        //
+        // This format doesn't match the directoryFilePaths we store as part of the Project Snapshot ->
+        //                                  "workspaceDirectory/Pages/Counter.razor"
+        // https://github.com/dotnet/aspnetcore-tooling/blob/488cf6e/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs#L328
+        // Consequently, files are being discarded into the MISC project and subsequently re-generated
+        public DefaultFileSystemWatcher(string path)
+            : base(path.TrimEnd('/','\\'))
+        {
+        }
+
+        public DefaultFileSystemWatcher(string path, string filter)
+            : base(path.TrimEnd('/','\\'), filter)
+        {
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return;
             }
 
-            _watcher = new DefaultFileSystemWatcher(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile)
+            _watcher = new RazorFileSystemWatcher(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile)
             {
                 NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                 IncludeSubdirectories = true,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -72,12 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return;
             }
 
-            // Start listening for file changes. If a project configuration file changes in any way we'll notify listeners.
-
-            // If we don't trim workspaceDirectory before passing it to FileSystemWatcher then when it eventually finds
-            // the file it reports the path as something like C:\some\dir\/deeper/dir/project.razor.json, while we'll be
-            // comparing it against C:\some\dir/deeper/dir/project.razor.json, and they won't match due to the extra \.
-            _watcher = new FileSystemWatcher(workspaceDirectory.TrimEnd('/','\\'), LanguageServerConstants.ProjectConfigurationFile)
+            _watcher = new DefaultFileSystemWatcher(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile)
             {
                 NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                 IncludeSubdirectories = true,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Start listening for project file changes (added/removed/renamed).
 
-            _watcher = new FileSystemWatcher(workspaceDirectory, ProjectFileExtensionPattern)
+            _watcher = new DefaultFileSystemWatcher(workspaceDirectory, ProjectFileExtensionPattern)
             {
                 NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                 IncludeSubdirectories = true,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Start listening for project file changes (added/removed/renamed).
 
-            _watcher = new DefaultFileSystemWatcher(workspaceDirectory, ProjectFileExtensionPattern)
+            _watcher = new RazorFileSystemWatcher(workspaceDirectory, ProjectFileExtensionPattern)
             {
                 NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                 IncludeSubdirectories = true,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             for (var i = 0; i < RazorFileExtensions.Count; i++)
             {
                 var extension = RazorFileExtensions[i];
-                var watcher = new FileSystemWatcher(workspaceDirectory, "*" + extension)
+                var watcher = new DefaultFileSystemWatcher(workspaceDirectory, "*" + extension)
                 {
                     NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                     IncludeSubdirectories = true,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             for (var i = 0; i < RazorFileExtensions.Count; i++)
             {
                 var extension = RazorFileExtensions[i];
-                var watcher = new DefaultFileSystemWatcher(workspaceDirectory, "*" + extension)
+                var watcher = new RazorFileSystemWatcher(workspaceDirectory, "*" + extension)
                 {
                     NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                     IncludeSubdirectories = true,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileSystemWatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileSystemWatcher.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal class DefaultFileSystemWatcher : FileSystemWatcher
+    internal class RazorFileSystemWatcher : FileSystemWatcher
     {
         // Without trimming trailing `/`, `\\` from the workspace directory, the FileSystemWatcher
         // returns with paths of the form   "workspaceDirectory/\\Pages\\Counter.razor"
@@ -14,12 +14,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         //                                  "workspaceDirectory/Pages/Counter.razor"
         // https://github.com/dotnet/aspnetcore-tooling/blob/488cf6e/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs#L328
         // Consequently, files are being discarded into the MISC project and subsequently re-generated
-        public DefaultFileSystemWatcher(string path)
+        public RazorFileSystemWatcher(string path)
             : base(path.TrimEnd('/','\\'))
         {
         }
 
-        public DefaultFileSystemWatcher(string path, string filter)
+        public RazorFileSystemWatcher(string path, string filter)
             : base(path.TrimEnd('/','\\'), filter)
         {
         }


### PR DESCRIPTION
Previous PR was reverted due to suspected flakiness. Fears don't seem to be substantiated given repeated successful CI retries here.

Also added/consolidated the `FileSystemWatcher` across this project to use a new `DefaultFileSystemWatcher` which just trims the last `/` `\`.

Fixes: https://github.com/dotnet/aspnetcore/issues/22280