### PR TITLE
Support rename from Razor files in VS LSP

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
@@ -102,23 +102,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             foreach (var entry in documentEdits)
             {
                 var uri = entry.TextDocument.Uri;
-                var edits = entry.Edits;
                 if (!CanRemap(uri))
                 {
                     // This location doesn't point to a background razor file. No need to remap.
-                    remappedDocumentEdits.Add(new TextDocumentEdit()
-                    {
-                        TextDocument = new VersionedTextDocumentIdentifier()
-                        {
-                            Uri = uri,
-                            Version = entry.TextDocument.Version
-                        },
-                        Edits = edits
-                    });
+                    remappedDocumentEdits.Add(entry);
 
                     continue;
                 }
 
+                var edits = entry.Edits;
                 var (documentSnapshot, remappedEdits) = await RemapTextEditsAsync(uri, edits, cancellationToken).ConfigureAwait(false);
                 if (documentSnapshot == null)
                 {
@@ -162,7 +154,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     continue;
                 }
 
-                remappedChanges[documentSnapshot.Uri.GetAbsoluteOrUNCPath()] = remappedEdits;
+                remappedChanges[documentSnapshot.Uri.AbsoluteUri] = remappedEdits;
             }
 
             return remappedChanges;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Composition;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
@@ -14,17 +17,26 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     [Export(typeof(LSPDocumentMappingProvider))]
     internal class DefaultLSPDocumentMappingProvider : LSPDocumentMappingProvider
     {
+        private static readonly TextEdit[] EmptyEdits = Array.Empty<TextEdit>();
+
         private readonly LSPRequestInvoker _requestInvoker;
+        private readonly LSPDocumentManager _documentManager;
 
         [ImportingConstructor]
-        public DefaultLSPDocumentMappingProvider(LSPRequestInvoker requestInvoker)
+        public DefaultLSPDocumentMappingProvider(LSPRequestInvoker requestInvoker, LSPDocumentManager documentManager)
         {
             if (requestInvoker is null)
             {
                 throw new ArgumentNullException(nameof(requestInvoker));
             }
 
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
             _requestInvoker = requestInvoker;
+            _documentManager = documentManager;
         }
 
         public async override Task<RazorMapToDocumentRangeResponse> MapToDocumentRangeAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range projectedRange, CancellationToken cancellationToken)
@@ -57,6 +69,157 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(false);
 
             return documentMappingResponse;
+        }
+
+        public async override Task<WorkspaceEdit> RemapWorkspaceEditAsync(WorkspaceEdit workspaceEdit, CancellationToken cancellationToken)
+        {
+            if (workspaceEdit == null)
+            {
+                return workspaceEdit;
+            }
+            else if (workspaceEdit.DocumentChanges != null)
+            {
+                // The LSP spec says, we should prefer `DocumentChanges` property over `Changes` if available.
+                var remappedEdits = await RemapVersionedDocumentEditsAsync(workspaceEdit.DocumentChanges, cancellationToken).ConfigureAwait(false);
+                return new WorkspaceEdit()
+                {
+                    DocumentChanges = remappedEdits
+                };
+            }
+            else
+            {
+                var remappedEdits = await RemapDocumentEditsAsync(workspaceEdit.Changes, cancellationToken).ConfigureAwait(false);
+                return new WorkspaceEdit()
+                {
+                    Changes = remappedEdits
+                };
+            }
+        }
+
+        private async Task<TextDocumentEdit[]> RemapVersionedDocumentEditsAsync(TextDocumentEdit[] documentEdits, CancellationToken cancellationToken)
+        {
+            var remappedDocumentEdits = new List<TextDocumentEdit>();
+            foreach (var entry in documentEdits)
+            {
+                var uri = entry.TextDocument.Uri;
+                var edits = entry.Edits;
+                if (!CanRemap(uri))
+                {
+                    // This location doesn't point to a background razor file. No need to remap.
+                    remappedDocumentEdits.Add(new TextDocumentEdit()
+                    {
+                        TextDocument = new VersionedTextDocumentIdentifier()
+                        {
+                            Uri = uri,
+                            Version = entry.TextDocument.Version
+                        },
+                        Edits = edits
+                    });
+
+                    continue;
+                }
+
+                var (documentSnapshot, remappedEdits) = await RemapTextEditsAsync(uri, edits, cancellationToken).ConfigureAwait(false);
+                if (documentSnapshot == null)
+                {
+                    // Couldn't find the document. Ignore this edit.
+                    continue;
+                }
+
+                remappedDocumentEdits.Add(new TextDocumentEdit()
+                {
+                    TextDocument = new VersionedTextDocumentIdentifier()
+                    {
+                        Uri = documentSnapshot.Uri,
+                        Version = documentSnapshot.Version
+                    },
+                    Edits = remappedEdits
+                });
+            }
+
+            return remappedDocumentEdits.ToArray();
+        }
+
+        private async Task<Dictionary<string, TextEdit[]>> RemapDocumentEditsAsync(Dictionary<string, TextEdit[]> changes, CancellationToken cancellationToken)
+        {
+            var remappedChanges = new Dictionary<string, TextEdit[]>();
+            foreach (var entry in changes)
+            {
+                var uri = new Uri(entry.Key);
+                var edits = entry.Value;
+
+                if (!CanRemap(uri))
+                {
+                    // This location doesn't point to a background razor file. No need to remap.
+                    remappedChanges[entry.Key] = entry.Value;
+                    continue;
+                }
+
+                var (documentSnapshot, remappedEdits) = await RemapTextEditsAsync(uri, edits, cancellationToken).ConfigureAwait(false);
+                if (documentSnapshot == null)
+                {
+                    // Couldn't find the document. Ignore this edit.
+                    continue;
+                }
+
+                remappedChanges[documentSnapshot.Uri.GetAbsoluteOrUNCPath()] = remappedEdits;
+            }
+
+            return remappedChanges;
+        }
+
+        private async Task<(LSPDocumentSnapshot, TextEdit[])> RemapTextEditsAsync(Uri uri, TextEdit[] edits, CancellationToken cancellationToken)
+        {
+            var languageKind = RazorLanguageKind.Razor;
+            if (RazorLSPConventions.IsRazorCSharpFile(uri))
+            {
+                languageKind = RazorLanguageKind.CSharp;
+            }
+            else if (RazorLSPConventions.IsRazorHtmlFile(uri))
+            {
+                languageKind = RazorLanguageKind.Html;
+            }
+            else
+            {
+                Debug.Fail("This method should only be called for Razor background files.");
+            }
+
+            var razorDocumentUri = RazorLSPConventions.GetRazorDocumentUri(uri);
+            if (!_documentManager.TryGetDocument(razorDocumentUri, out var documentSnapshot))
+            {
+                return (null, EmptyEdits);
+            }
+
+            var remappedEdits = new List<TextEdit>();
+            foreach (var edit in edits)
+            {
+                var mappingResult = await MapToDocumentRangeAsync(
+                languageKind,
+                razorDocumentUri,
+                edit.Range,
+                cancellationToken).ConfigureAwait(false);
+
+                if (mappingResult == null || mappingResult.HostDocumentVersion != documentSnapshot.Version)
+                {
+                    // Couldn't remap the location or the document changed in the meantime. Discard this location.
+                    continue;
+                }
+
+                var remappedEdit = new TextEdit()
+                {
+                    Range = mappingResult.Range,
+                    NewText = edit.NewText
+                };
+
+                remappedEdits.Add(remappedEdit);
+            }
+
+            return (documentSnapshot, remappedEdits.ToArray());
+        }
+
+        private static bool CanRemap(Uri uri)
+        {
+            return RazorLSPConventions.IsRazorCSharpFile(uri) || RazorLSPConventions.IsRazorHtmlFile(uri);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -30,6 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 HoverProvider = true,
                 DefinitionProvider = true,
                 DocumentHighlightProvider = true,
+                RenameProvider = true,
             }
         };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
@@ -11,5 +11,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     internal abstract class LSPDocumentMappingProvider
     {
         public abstract Task<RazorMapToDocumentRangeResponse> MapToDocumentRangeAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range projectedRange, CancellationToken cancellationToken);
+
+        public abstract Task<WorkspaceEdit> RemapWorkspaceEditAsync(WorkspaceEdit workspaceEdit, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -137,6 +137,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<DocumentHighlightParams, DocumentHighlight[]>(Methods.TextDocumentDocumentHighlightName, documentHighlightParams, _clientCapabilities, cancellationToken);
         }
 
+        [JsonRpcMethod(Methods.TextDocumentRenameName, UseSingleObjectParameterDeserialization = true)]
+        public Task<WorkspaceEdit> RenameAsync(RenameParams renameParams, CancellationToken cancellationToken)
+        {
+            if (renameParams is null)
+            {
+                throw new ArgumentNullException(nameof(renameParams));
+            }
+
+            return ExecuteRequestAsync<RenameParams, WorkspaceEdit>(Methods.TextDocumentRenameName, renameParams, _clientCapabilities, cancellationToken);
+        }
+
         // Internal for testing
         internal Task<ResponseType> ExecuteRequestAsync<RequestType, ResponseType>(
             string methodName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangeParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangeParams.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
-    internal class RazorMapToDocumentRangeParams
+    internal struct RazorMapToDocumentRangeParams
     {
         public RazorLanguageKind Kind { get; set; }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(virtualDocumentUri));
             }
 
-            var path = virtualDocumentUri.GetAbsoluteOrUNCPath();
+            var path = virtualDocumentUri.AbsoluteUri;
             path = path.Replace(RazorLSPConstants.VirtualCSharpFileNameSuffix, string.Empty);
             path = path.Replace(RazorLSPConstants.VirtualHtmlFileNameSuffix, string.Empty);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
@@ -2,9 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -14,6 +17,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     public class DefaultLSPDocumentMappingProviderTest
     {
+        public Uri RazorFile => new Uri("file:///some/folder/to/file.razor");
+
+        public Uri RazorVirtualCSharpFile => new Uri("file:///some/folder/to/file.razor.g.cs");
+
+        public Uri AnotherRazorFile => new Uri("file:///some/folder/to/anotherfile.razor");
+
+        public Uri AnotherRazorVirtualCSharpFile => new Uri("file:///some/folder/to/anotherfile.razor.g.cs");
+
+        public Uri CSharpFile => new Uri("file:///some/folder/to/csharpfile.cs");
+
         [Fact]
         public async Task RazorMapToDocumentRangeAsync_InvokesLanguageServer()
         {
@@ -34,7 +47,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(r => r.CustomRequestServerAsync<RazorMapToDocumentRangeParams, RazorMapToDocumentRangeResponse>(LanguageServerConstants.RazorMapToDocumentRangeEndpoint, LanguageServerKind.Razor, It.IsAny<RazorMapToDocumentRangeParams>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
 
-            var mappingProvider = new DefaultLSPDocumentMappingProvider(requestInvoker.Object);
+            var documentManager = new TestDocumentManager();
+            var mappingProvider = new DefaultLSPDocumentMappingProvider(requestInvoker.Object, documentManager);
             var projectedRange = new Range()
             {
                 Start = new Position(10, 10),
@@ -49,6 +63,110 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.Equal(1, result.HostDocumentVersion);
             Assert.Equal(new Position(1, 1), result.Range.Start);
             Assert.Equal(new Position(3, 3), result.Range.End);
+        }
+
+        [Fact]
+        public async Task RemapWorkspaceEditAsync_RemapsEditsAsExpected()
+        {
+            // Arrange
+            var expectedRange = new TestRange(1, 1, 1, 5);
+            var expectedVersion = 1;
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(RazorFile, Mock.Of<LSPDocumentSnapshot>(d => d.Version == expectedVersion && d.Uri == RazorFile));
+
+            var requestInvoker = GetRequestInvoker(new[]
+            {
+                ((RazorLanguageKind.CSharp, RazorFile, new TestRange(10, 10, 10, 15)), (expectedRange, expectedVersion))
+            });
+            var mappingProvider = new DefaultLSPDocumentMappingProvider(requestInvoker, documentManager);
+
+            var workspaceEdit = new TestWorkspaceEdit(versionedEdits: true);
+            workspaceEdit.AddEdits(RazorVirtualCSharpFile, 10, new TestTextEdit("newText", new TestRange(10, 10, 10, 15)));
+
+            // Act
+            var result = await mappingProvider.RemapWorkspaceEditAsync(workspaceEdit, CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            var documentEdit = Assert.Single(result.DocumentChanges);
+            Assert.Equal(RazorFile, documentEdit.TextDocument.Uri);
+            Assert.Equal(expectedVersion, documentEdit.TextDocument.Version);
+
+            var actualEdit = Assert.Single(documentEdit.Edits);
+            Assert.Equal("newText", actualEdit.NewText);
+            Assert.Equal(expectedRange, actualEdit.Range);
+        }
+
+        private LSPRequestInvoker GetRequestInvoker(((RazorLanguageKind, Uri, TestRange), (TestRange, int))[] mappingPairs)
+        {
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+
+            // mappingPairs will contain the request/response pair for each of MapToDocumentRange LSP request we want to mock.
+            foreach (var ((kind, uri, projectedRange), (mappedRange, version)) in mappingPairs)
+            {
+                var requestParams = new RazorMapToDocumentRangeParams()
+                {
+                    Kind = kind,
+                    RazorDocumentUri = uri,
+                    ProjectedRange = projectedRange
+                };
+                var response = new RazorMapToDocumentRangeResponse()
+                {
+                    Range = mappedRange,
+                    HostDocumentVersion = version
+                };
+
+                requestInvoker
+                    .Setup(r => r.CustomRequestServerAsync<RazorMapToDocumentRangeParams, RazorMapToDocumentRangeResponse>(LanguageServerConstants.RazorMapToDocumentRangeEndpoint, LanguageServerKind.Razor, requestParams, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+            }
+
+            return requestInvoker.Object;
+        }
+
+        private class TestWorkspaceEdit : WorkspaceEdit
+        {
+            public TestWorkspaceEdit(bool versionedEdits = false)
+            {
+                if (versionedEdits)
+                {
+                    DocumentChanges = Array.Empty<TextDocumentEdit>();
+                }
+
+                Changes = new Dictionary<string, TextEdit[]>();
+            }
+
+            public void AddEdits(Uri uri, int version, params TextEdit[] edits)
+            {
+                Changes[uri.GetAbsoluteOrUNCPath()] = edits;
+
+                DocumentChanges = DocumentChanges?.Append(new TextDocumentEdit()
+                {
+                    Edits = edits,
+                    TextDocument = new VersionedTextDocumentIdentifier()
+                    {
+                        Uri = uri,
+                        Version = version
+                    }
+                }).ToArray();
+            }
+        }
+
+        private class TestTextEdit : TextEdit
+        {
+            public TestTextEdit(string newText, Range range)
+            {
+                NewText = newText;
+                Range = range;
+            }
+        }
+
+        private class TestRange : Range
+        {
+            public TestRange(int startLine, int startCharacter, int endLine, int endCharacter)
+            {
+                Start = new Position(startLine, startCharacter);
+                End = new Position(endLine, endCharacter);
+            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/RenameHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/RenameHandlerTest.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class RenameHandlerTest
+    {
+        public RenameHandlerTest()
+        {
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var renameHandler = new RenameHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var renameRequest = new RenameParams()
+            {
+                Position = new Position(0, 1),
+                NewName = "NewName",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+            };
+
+            // Act
+            var result = await renameHandler.HandleRequestAsync(renameRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_ProjectionNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var renameHandler = new RenameHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var renameRequest = new RenameParams()
+            {
+                Position = new Position(0, 1),
+                NewName = "NewName",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+            };
+
+            // Act
+            var result = await renameHandler.HandleRequestAsync(renameRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_HtmlProjection_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = GetProjectionProvider(new ProjectionResult() { LanguageKind = RazorLanguageKind.Html });
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var renameHandler = new RenameHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var renameRequest = new RenameParams()
+            {
+                Position = new Position(0, 1),
+                NewName = "NewName",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+            };
+
+            // Act
+            var result = await renameHandler.HandleRequestAsync(renameRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_RemapsWorkspaceEdit()
+        {
+            // Arrange
+            var called = false;
+            var expectedEdit = new WorkspaceEdit();
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var requestInvoker = GetRequestInvoker<RenameParams, WorkspaceEdit>(
+                new WorkspaceEdit(),
+                (method, serverKind, renameParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentRenameName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                });
+
+            var projectionProvider = GetProjectionProvider(new ProjectionResult() { LanguageKind = RazorLanguageKind.CSharp });
+            var documentMappingProvider = GetDocumentMappingProvider(expectedEdit);
+
+            var renameHandler = new RenameHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var renameRequest = new RenameParams()
+            {
+                Position = new Position(0, 1),
+                NewName = "NewName",
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+            };
+
+            // Act
+            var result = await renameHandler.HandleRequestAsync(renameRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Equal(expectedEdit, result);
+
+            // Actual remapping behavior is tested in LSPDocumentMappingProvider tests.
+        }
+
+        private LSPProjectionProvider GetProjectionProvider(ProjectionResult expectedResult)
+        {
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
+
+            return projectionProvider.Object;
+        }
+
+        private LSPRequestInvoker GetRequestInvoker<TParams, TResult>(TResult expectedResponse, Action<string, LanguageServerKind, TParams, CancellationToken> callback)
+        {
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<TParams, TResult>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TParams>(), It.IsAny<CancellationToken>()))
+                .Callback(callback)
+                .Returns(Task.FromResult(expectedResponse));
+
+            return requestInvoker.Object;
+        }
+
+        private LSPDocumentMappingProvider GetDocumentMappingProvider(WorkspaceEdit expectedEdit)
+        {
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.RemapWorkspaceEditAsync(It.IsAny<WorkspaceEdit>(), It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(expectedEdit));
+
+            return documentMappingProvider.Object;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22377

![628aed99-cd1c-4355-83a0-879aca55f36a](https://user-images.githubusercontent.com/1579269/83313577-a791ba80-a1cb-11ea-9c0f-aebb3bbc21e2.gif)

Also updated LSPMappingProvider to support remapping `WorkspaceEdit`. This will also support remapping `Location[]` in the future (@TanayParikh, this is what you'll be doing for FAR).