### PR TITLE
Find all references from C# inside of a Razor file into & outside of a Razor file

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -61,6 +61,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public async Task<SumType<CompletionItem[], CompletionList>?> HandleRequestAsync(CompletionParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
         {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (clientCapabilities is null)
+            {
+                throw new ArgumentNullException(nameof(clientCapabilities));
+            }
+
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
                 return null;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,8 +11,8 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     [Shared]
-    [ExportLspMethod(Methods.TextDocumentHoverName)]
-    internal class HoverHandler : IRequestHandler<TextDocumentPositionParams, Hover>
+    [ExportLspMethod(Methods.TextDocumentReferencesName)]
+    internal class FindAllReferencesHandler : IRequestHandler<ReferenceParams, VSReferenceItem[]>
     {
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly LSPDocumentManager _documentManager;
@@ -19,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         private readonly LSPDocumentMappingProvider _documentMappingProvider;
 
         [ImportingConstructor]
-        public HoverHandler(
+        public FindAllReferencesHandler(
             LSPRequestInvoker requestInvoker,
             LSPDocumentManager documentManager,
             LSPProjectionProvider projectionProvider,
@@ -51,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             _documentMappingProvider = documentMappingProvider;
         }
 
-        public async Task<Hover> HandleRequestAsync(TextDocumentPositionParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+        public async Task<VSReferenceItem[]> HandleRequestAsync(ReferenceParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
         {
             if (request is null)
             {
@@ -69,59 +70,65 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
-            if (projectionResult == null)
+            if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.CSharp)
             {
                 return null;
             }
 
-            var serverKind = projectionResult.LanguageKind == RazorLanguageKind.CSharp ? LanguageServerKind.CSharp : LanguageServerKind.Html;
-
-            var textDocumentPositionParams = new TextDocumentPositionParams()
+            var serverKind = LanguageServerKind.CSharp;
+            var referenceParams = new ReferenceParams()
             {
                 Position = projectionResult.Position,
                 TextDocument = new TextDocumentIdentifier()
                 {
                     Uri = projectionResult.Uri
-                }
+                },
+                Context = request.Context,
+                PartialResultToken = request.PartialResultToken
             };
 
-            var result = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Hover>(
-                Methods.TextDocumentHoverName,
+            var result = await _requestInvoker.ReinvokeRequestOnServerAsync<ReferenceParams, VSReferenceItem[]>(
+                Methods.TextDocumentReferencesName,
                 serverKind,
-                textDocumentPositionParams,
+                referenceParams,
                 cancellationToken).ConfigureAwait(false);
 
-            if (result?.Range == null || result?.Contents == null)
+            if (result == null || result.Length == 0)
             {
-                return null;
+                return result;
             }
 
-            var mappingResult = await _documentMappingProvider.MapToDocumentRangeAsync(projectionResult.LanguageKind, request.TextDocument.Uri, result.Range, cancellationToken).ConfigureAwait(false);
+            var remappedLocations = new List<VSReferenceItem>();
 
-            if (mappingResult == null)
+            foreach (var referenceItem in result)
             {
-                // Couldn't remap the edits properly. Returning hover at initial request position.
-                return new Hover
+                if (!RazorLSPConventions.IsRazorCSharpFile(referenceItem.Location.Uri))
                 {
-                    Contents = result.Contents,
-                    Range = new Range()
-                    {
-                        Start = request.Position,
-                        End = request.Position
-                    }
-                };
-            }
-            else if (mappingResult.HostDocumentVersion != documentSnapshot.Version)
-            {
-                // Discard hover if document has changed.
-                return null;
+                    // This location doesn't point to a virtual cs file. No need to remap.
+                    remappedLocations.Add(referenceItem);
+                    continue;
+                }
+
+                var razorDocumentUri = RazorLSPConventions.GetRazorDocumentUri(referenceItem.Location.Uri);
+                var mappingResult = await _documentMappingProvider.MapToDocumentRangeAsync(
+                    projectionResult.LanguageKind,
+                    razorDocumentUri,
+                    referenceItem.Location.Range,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (mappingResult == null || mappingResult.HostDocumentVersion != documentSnapshot.Version)
+                {
+                    // Couldn't remap the location or the document changed in the meantime. Discard this location.
+                    continue;
+                }
+
+                referenceItem.Location.Uri = razorDocumentUri;
+                referenceItem.Location.Range = mappingResult.Range;
+
+                remappedLocations.Add(referenceItem);
             }
 
-            return new Hover
-            {
-                Contents = result.Contents,
-                Range = mappingResult.Range
-            };
+            return remappedLocations.ToArray();
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -75,6 +75,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             var serverKind = LanguageServerKind.CSharp;
             var referenceParams = new ReferenceParams()
             {
@@ -92,6 +94,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 serverKind,
                 referenceParams,
                 cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (result == null || result.Length == 0)
             {
@@ -123,6 +127,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
 
                 referenceItem.Location.Uri = razorDocumentUri;
+                referenceItem.DisplayPath = razorDocumentUri.AbsolutePath;
                 referenceItem.Location.Range = mappingResult.Range;
 
                 remappedLocations.Add(referenceItem);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 DefinitionProvider = true,
                 DocumentHighlightProvider = true,
                 RenameProvider = true,
+                ReferencesProvider = true
             }
         };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -126,6 +126,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<TextDocumentPositionParams, Location[]>(Methods.TextDocumentDefinitionName, positionParams, _clientCapabilities, cancellationToken);
         }
 
+        [JsonRpcMethod(Methods.TextDocumentReferencesName, UseSingleObjectParameterDeserialization = true)]
+        public Task<VSReferenceItem[]> FindAllReferencesAsync(ReferenceParams referenceParams, CancellationToken cancellationToken)
+        {
+            if (referenceParams is null)
+            {
+                throw new ArgumentNullException(nameof(referenceParams));
+            }
+
+            return ExecuteRequestAsync<ReferenceParams, VSReferenceItem[]>(Methods.TextDocumentReferencesName, referenceParams, _clientCapabilities, cancellationToken);
+        }
+
         [JsonRpcMethod(Methods.TextDocumentDocumentHighlightName, UseSingleObjectParameterDeserialization = true)]
         public Task<DocumentHighlight[]> HighlightDocumentAsync(DocumentHighlightParams documentHighlightParams, CancellationToken cancellationToken)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -1,0 +1,392 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class FindAllReferencesHandlerTest
+    {
+        public FindAllReferencesHandlerTest()
+        {
+            Uri = new Uri("C:/path/to/file.razor");
+        }
+
+        private Uri Uri { get; }
+
+        [Fact]
+        public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_ProjectionNotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+            var projectionProvider = Mock.Of<LSPProjectionProvider>();
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_HtmlProjection_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.Html,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(0, 1)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_InvokesCSharpLanguageServer()
+        {
+            // Arrange
+            var called = false;
+            var expectedLocation1 = GetReferenceItem(5, 5, 5, 5, Uri);
+            var expectedLocation2 = GetReferenceItem(10, 10, 10, 10, Uri);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var virtualCSharpUri = new Uri("C:/path/to/file.razor.g.cs");
+            var csharpLocation1 = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var csharpLocation2 = GetReferenceItem(200, 200, 200, 200, virtualCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<ReferenceParams, VSReferenceItem[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<ReferenceParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, ReferenceParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentReferencesName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { csharpLocation1, csharpLocation2 }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult1 = new RazorMapToDocumentRangeResponse()
+            {
+
+                Range = expectedLocation1.Location.Range
+            };
+            var remappingResult2 = new RazorMapToDocumentRangeResponse()
+            {
+                Range = expectedLocation2.Location.Range
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider
+                .Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, It.IsAny<Range>(), It.IsAny<CancellationToken>()))
+                .Returns<RazorLanguageKind, Uri, Range, CancellationToken>((languageKind, uri, range, ct) => Task.FromResult(range == csharpLocation1.Location.Range ? remappingResult1 : remappingResult2));
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Collection(result,
+                a => AssertVSReferenceItem(expectedLocation1, a),
+                b => AssertVSReferenceItem(expectedLocation2, b));
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_RemapsExternalRazorFiles()
+        {
+            // Arrange
+            var called = false;
+            var externalUri = new Uri("C:/path/to/someotherfile.razor");
+            var expectedLocation = GetReferenceItem(5, 5, 5, 5, externalUri);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+            documentManager.AddDocument(externalUri, Mock.Of<LSPDocumentSnapshot>());
+
+            var virtualCSharpUri = new Uri("C:/path/to/someotherfile.razor.g.cs");
+            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<ReferenceParams, VSReferenceItem[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<ReferenceParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, ReferenceParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentReferencesName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { csharpLocation }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangeResponse()
+            {
+                Range = expectedLocation.Location.Range
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, externalUri, csharpLocation.Location.Range, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            var actualLocation = Assert.Single(result);
+            AssertVSReferenceItem(expectedLocation, actualLocation);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_DoesNotRemapNonRazorFiles()
+        {
+            // Arrange
+            var called = false;
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var externalCSharpUri = new Uri("C:/path/to/someotherfile.cs");
+            var externalCsharpLocation = GetReferenceItem(100, 100, 100, 100, externalCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<ReferenceParams, VSReferenceItem[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<ReferenceParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, ReferenceParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentReferencesName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { externalCsharpLocation }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            var actualLocation = Assert.Single(result);
+            AssertVSReferenceItem(externalCsharpLocation, actualLocation);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_VersionMismatch_DiscardsLocation()
+        {
+            // Arrange
+            var called = false;
+            var expectedLocation = GetReferenceItem(5, 5, 5, 5, Uri);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 123));
+
+            var virtualCSharpUri = new Uri("C:/path/to/file.razor.g.cs");
+            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<ReferenceParams, VSReferenceItem[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<ReferenceParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, ReferenceParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentReferencesName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { csharpLocation }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangeResponse()
+            {
+                Range = expectedLocation.Location.Range,
+                HostDocumentVersion = 122 // Different from document version (123)
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Location.Range, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_RemapFailure_DiscardsLocation()
+        {
+            // Arrange
+            var called = false;
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
+
+            var virtualCSharpUri = new Uri("C:/path/to/file.razor.g.cs");
+            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<ReferenceParams, VSReferenceItem[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<ReferenceParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, LanguageServerKind, ReferenceParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentReferencesName, method);
+                    Assert.Equal(LanguageServerKind.CSharp, serverKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new[] { csharpLocation }));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.MapToDocumentRangeAsync(RazorLanguageKind.CSharp, Uri, csharpLocation.Location.Range, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult<RazorMapToDocumentRangeResponse>(null));
+
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            Assert.Empty(result);
+        }
+
+        private void AssertVSReferenceItem(VSReferenceItem expected, VSReferenceItem actual)
+        {
+            Assert.Equal(expected.Location, actual.Location);
+            Assert.Equal(expected.DisplayPath, actual.DisplayPath);
+        }
+
+        private VSReferenceItem GetReferenceItem(int startLine,
+                                                    int startCharacter,
+                                                    int endLine,
+                                                    int endCharacter,
+                                                    Uri uri,
+                                                    string documentName = "document",
+                                                    string projectName = "project")
+        {
+            return new VSReferenceItem()
+            {
+                Location = new Location()
+                {
+                    Uri = uri,
+                    Range = new Range()
+                    {
+                        Start = new Position(startLine, startCharacter),
+                        End = new Position(endLine, endCharacter)
+                    }
+                },
+                DocumentName = documentName,
+                ProjectName = projectName,
+                DisplayPath = uri.AbsolutePath
+            };
+        }
+    }
+}


### PR DESCRIPTION
FAR Implementation for Razor -> Razor and Razor -> C#. 

## Razor to Razor
![razor_to_razor_far](https://user-images.githubusercontent.com/14852843/83462301-b2dd2400-a41f-11ea-81bf-23dfdc7e3ced.gif)

## Razor to C#
![razor_to_csharp_far](https://user-images.githubusercontent.com/14852843/83462300-b2448d80-a41f-11ea-9fba-f8893e290e4c.gif)


Created [this](https://github.com/dotnet/aspnetcore/issues/22436) for `IProgress<T>` support.

Fixes: https://github.com/dotnet/aspnetcore/issues/22003
