### PR TITLE
Add telemetry and process exists checks to blazorwasm debugger

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
@@ -6,14 +6,16 @@
 import * as vscode from 'vscode';
 
 import { RazorLogger } from '../RazorLogger';
+import { TelemetryReporter } from '../TelemetryReporter';
 import { HOSTED_APP_NAME, JS_DEBUG_NAME } from './Constants';
 import { onDidTerminateDebugSession } from './TerminateDebugHandler';
 
 export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
-    constructor(private readonly logger: RazorLogger, private readonly vscodeType: typeof vscode) { }
+    constructor(private readonly logger: RazorLogger, private readonly vscodeType: typeof vscode, private readonly telemetryReporter: TelemetryReporter) { }
 
     public async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, configuration: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration | undefined> {
+        this.telemetryReporter.reportBlazorWasmDebugStarted();
         /**
          * The Blazor WebAssembly app should only be launched if the
          * launch configuration is a launch request. Attach requests will

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
@@ -10,6 +10,7 @@ export class TelemetryReporter {
     private readonly razorExtensionActivated = createTelemetryEvent('VSCode.Razor.RazorExtensionActivated');
     private readonly debugLanguageServerEvent = createTelemetryEvent('VSCode.Razor.DebugLanguageServer');
     private readonly workspaceContainsRazorEvent = createTelemetryEvent('VSCode.Razor.WorkspaceContainsRazor');
+    private readonly blazorWasmDebugStartedEvent = createTelemetryEvent('VSCode.Razor.BlazorWASMDebugger.Started');
     private reportedWorkspaceContainsRazor = false;
 
     constructor(
@@ -37,6 +38,10 @@ export class TelemetryReporter {
 
     public reportDebugLanguageServer() {
         this.eventStream.post(this.debugLanguageServerEvent);
+    }
+
+    public reportBlazorWasmDebugStarted() {
+        this.eventStream.post(this.blazorWasmDebugStartedEvent);
     }
 
     public reportWorkspaceContainsRazor() {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -189,7 +189,7 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
             localRegistrations.length = 0;
         });
 
-        const provider = new BlazorDebugConfigurationProvider(logger, vscodeType);
+        const provider = new BlazorDebugConfigurationProvider(logger, vscodeType, telemetryReporter);
         context.subscriptions.push(vscodeType.debug.registerDebugConfigurationProvider('blazorwasm', provider));
 
         languageServerClient.onStarted(async () => {


### PR DESCRIPTION
Summary of the changes
- Adds `processExists` checks to kill steps
- Send telemetry event when `blazorwasm` debug session started
