### PR TITLE
Use the TelemetryErrorEvent when reporting errors.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/HostEventStream.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/HostEventStream.ts
@@ -19,6 +19,16 @@ export class TelemetryEvent implements BaseEvent {
     }
 }
 
+export class TelemetryErrorEvent implements BaseEvent {
+    type = EventType.TelemetryErrorEvent;
+    constructor(
+        public eventName: string,
+        public properties?: { [key: string]: string },
+        public measures?: { [key: string]: number },
+        public errorProps?: string[]) {
+    }
+}
+
 interface BaseEvent {
     type: any;
 }
@@ -26,4 +36,5 @@ interface BaseEvent {
 // This is a sub-copied portion of OmniSharp's EventType class.
 enum EventType {
     TelemetryEvent = 1,
+    TelemetryErrorEvent = 78
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/HostEventStream.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/HostEventStream.ts
@@ -9,24 +9,49 @@ export interface HostEventStream {
     post(event: BaseEvent): void;
 }
 
-export class TelemetryEvent implements BaseEvent {
-    public type = EventType.TelemetryEvent;
+export function createTelemetryEvent(
+    eventName: string,
+    properties?: { [key: string]: string },
+    measures?: { [key: string]: number }): TelemetryEvent {
 
-    constructor(
-        public eventName: string,
-        public properties?: { [key: string]: string },
-        public measures?: { [key: string]: number }) {
-    }
+    return {
+        type: EventType.TelemetryEvent,
+        eventName,
+        properties,
+        measures,
+    };
 }
 
-export class TelemetryErrorEvent implements BaseEvent {
-    type = EventType.TelemetryErrorEvent;
-    constructor(
-        public eventName: string,
-        public properties?: { [key: string]: string },
-        public measures?: { [key: string]: number },
-        public errorProps?: string[]) {
-    }
+export function createTelemetryErrorEvent(
+    eventName: string,
+    properties?: { [key: string]: string },
+    measures?: { [key: string]: number },
+    errorProps?: string[]): TelemetryErrorEvent {
+
+    return {
+        type: EventType.TelemetryErrorEvent,
+        eventName,
+        properties,
+        measures,
+        errorProps,
+    };
+}
+
+interface TelemetryEvent extends BaseEvent {
+    type: EventType.TelemetryEvent;
+
+    eventName: string;
+    properties?: { [key: string]: string };
+    measures?: { [key: string]: number };
+}
+
+interface TelemetryErrorEvent extends BaseEvent {
+    type: EventType.TelemetryErrorEvent;
+
+    eventName: string;
+    properties?: { [key: string]: string };
+    measures?: { [key: string]: number };
+    errorProps?: string[];
 }
 
 interface BaseEvent {
@@ -36,5 +61,5 @@ interface BaseEvent {
 // This is a sub-copied portion of OmniSharp's EventType class.
 enum EventType {
     TelemetryEvent = 1,
-    TelemetryErrorEvent = 78
+    TelemetryErrorEvent = 78,
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { HostEventStream, TelemetryEvent } from './HostEventStream';
+import { HostEventStream, TelemetryEvent, TelemetryErrorEvent } from './HostEventStream';
 import { Trace } from './Trace';
 
 export class TelemetryReporter {
@@ -49,11 +49,13 @@ export class TelemetryReporter {
     }
 
     private reportError(eventName: string, error: Error) {
-        const errorOnActivationEvent = new TelemetryEvent(
+        const errorOnActivationEvent = new TelemetryErrorEvent(
             eventName,
             {
                 error: JSON.stringify(error),
-            });
+            },
+            /*measures*/ undefined,
+            /*errorProps*/['error']);
 
         this.eventStream.post(errorOnActivationEvent);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/TelemetryReporter.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { HostEventStream, TelemetryEvent, TelemetryErrorEvent } from './HostEventStream';
+import { createTelemetryErrorEvent, createTelemetryEvent, HostEventStream } from './HostEventStream';
 import { Trace } from './Trace';
 
 export class TelemetryReporter {
-    private readonly razorExtensionActivated = new TelemetryEvent('VSCode.Razor.RazorExtensionActivated');
-    private readonly debugLanguageServerEvent = new TelemetryEvent('VSCode.Razor.DebugLanguageServer');
-    private readonly workspaceContainsRazorEvent = new TelemetryEvent('VSCode.Razor.WorkspaceContainsRazor');
+    private readonly razorExtensionActivated = createTelemetryEvent('VSCode.Razor.RazorExtensionActivated');
+    private readonly debugLanguageServerEvent = createTelemetryEvent('VSCode.Razor.DebugLanguageServer');
+    private readonly workspaceContainsRazorEvent = createTelemetryEvent('VSCode.Razor.WorkspaceContainsRazor');
     private reportedWorkspaceContainsRazor = false;
 
     constructor(
@@ -19,7 +19,7 @@ export class TelemetryReporter {
     }
 
     public reportTraceLevel(trace: Trace) {
-        const traceLevelEvent = new TelemetryEvent(
+        const traceLevelEvent = createTelemetryEvent(
             'VSCode.Razor.TraceLevel',
             {
                 trace: Trace[trace],
@@ -49,7 +49,7 @@ export class TelemetryReporter {
     }
 
     private reportError(eventName: string, error: Error) {
-        const errorOnActivationEvent = new TelemetryErrorEvent(
+        const errorOnActivationEvent = createTelemetryErrorEvent(
             eventName,
             {
                 error: JSON.stringify(error),


### PR DESCRIPTION
omnisharp-vscode is adding a new EventType for reporting errors. Updated the report error code to use the new TelemetryErrorEvents.

Addresses https://github.com/dotnet/aspnetcore/issues/21247
