### PR TITLE
Fix VSIX insertion binaries.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.Shell;
+
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions",
+    GenerateCodeBase = true,
+    PublicKeyToken = "adb9793829ddae60",
+    OldVersionLowerBound = "0.0.0.0",
+    OldVersionUpperBound = "5.0.0.0",
+    NewVersion = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X",
+    GenerateCodeBase = true,
+    PublicKeyToken = "adb9793829ddae60",
+    OldVersionLowerBound = "0.0.0.0",
+    OldVersionUpperBound = "5.0.0.0",
+    NewVersion = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X",
+    GenerateCodeBase = true,
+    PublicKeyToken = "adb9793829ddae60",
+    OldVersionLowerBound = "0.0.0.0",
+    OldVersionUpperBound = "5.0.0.0",
+    NewVersion = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.AspNetCore.Razor.Language",
+    GenerateCodeBase = true,
+    PublicKeyToken = "adb9793829ddae60",
+    OldVersionLowerBound = "0.0.0.0",
+    OldVersionUpperBound = "5.0.0.0",
+    NewVersion = "5.0.0.0")]
+[assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.CodeAnalysis.Razor",
+    GenerateCodeBase = true,
+    PublicKeyToken = "adb9793829ddae60",
+    OldVersionLowerBound = "0.0.0.0",
+    OldVersionUpperBound = "5.0.0.0",
+    NewVersion = "5.0.0.0")]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -172,6 +172,15 @@
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
   </ItemGroup>
 
+  <!-- Include our Razor package dependency dlls in our extension -->
+  <ItemGroup>
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Razor.Language.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Razor.dll" />
+  </ItemGroup>
+
   <PropertyGroup>
     <_GeneratedVSIXBindingRedirectFile>$(IntermediateOutputPath)$(MSBuildProjectName).BindingRedirects.cs</_GeneratedVSIXBindingRedirectFile>
   </PropertyGroup>


### PR DESCRIPTION
- When we migrated from project references to package references for the Razor compiler dlls stopped being published as part of our VSIX insertion. Previously when using project references the VSIXSourceItem + binding redirect auto-generation was inferred.