### PR TITLE
Transition Razor experimental editor feature flag to extension.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -10,3 +10,9 @@
 // language name is (partial value of the content type name).
 [$RootKey$\TextMate\LanguageConfiguration\ContentTypeMapping]
 "RazorLSP"="$PackageFolder$\language-configuration.json"
+
+[$RootKey$\FeatureFlags\Razor\LSP\Editor]
+"Description"="Enables the Razor Language Server Protocol powered editor experience for all Razor editors. Razor documents will have to be re-opened to use the new editor, but reopening the solution would not be sufficient."
+"Value"=dword:00000000
+"Title"="Enable experimental Razor editor"
+"PreviewPaneChannels"="*"


### PR DESCRIPTION
- Prior to this the feature flag was only defined in the VS repo. With these changes we override the default impl in the VS repo and expose it when our extension is available.
- Updated the preview pane channels to include every channel. This doesn't get us into the "release" channels as that's controlled by a whitelist but it does get us into every non-release channel.
- Note: How this mechanism of adding a feature flag works is that `[$RootKey$\FeatureFlags\` is the pre-requisite to identify that our extension is contributing a feature flag and then

Part of dotnet/aspnetcore#22522. The other part will involve whitelisting our feature flag for release channels and removing the VS repo feature flag.