### PR TITLE
Fix `[ ]`, `{ }`, `!` brackets removed when committing completions

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 CompletionProvider = new CompletionOptions()
                 {
-                    AllCommitCharacters = new[] { " ", ".", ";", ">", "=", ":", "(", ")" }, // This is necessary to workaround a bug where the commit character in CompletionItem is not respected.
+                    AllCommitCharacters = new[] { " ", ".", ";", ">", "=", ":", "(", ")", "[", "]" }, // This is necessary to workaround a bug where the commit character in CompletionItem is not respected. https://github.com/dotnet/aspnetcore/issues/21346
                     ResolveProvider = true,
                     TriggerCharacters = new[] { ".", "@", "<", "&", "\\", "/", "'", "\"", "=", ":", " " }
                 },

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 CompletionProvider = new CompletionOptions()
                 {
-                    AllCommitCharacters = new[] { " ", ".", ";", ">", "=", ":", "(", ")", "[", "]", "{", "}" }, // This is necessary to workaround a bug where the commit character in CompletionItem is not respected. https://github.com/dotnet/aspnetcore/issues/21346
+                    AllCommitCharacters = new[] { " ", ".", ";", ">", "=", ":", "(", ")", "[", "]", "{", "}", "!" }, // This is necessary to workaround a bug where the commit character in CompletionItem is not respected. https://github.com/dotnet/aspnetcore/issues/21346
                     ResolveProvider = true,
                     TriggerCharacters = new[] { ".", "@", "<", "&", "\\", "/", "'", "\"", "=", ":", " " }
                 },

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 CompletionProvider = new CompletionOptions()
                 {
-                    AllCommitCharacters = new[] { " ", ".", ";", ">", "=", ":", "(", ")", "[", "]" }, // This is necessary to workaround a bug where the commit character in CompletionItem is not respected. https://github.com/dotnet/aspnetcore/issues/21346
+                    AllCommitCharacters = new[] { " ", ".", ";", ">", "=", ":", "(", ")", "[", "]", "{", "}" }, // This is necessary to workaround a bug where the commit character in CompletionItem is not respected. https://github.com/dotnet/aspnetcore/issues/21346
                     ResolveProvider = true,
                     TriggerCharacters = new[] { ".", "@", "<", "&", "\\", "/", "'", "\"", "=", ":", " " }
                 },


### PR DESCRIPTION
Based on https://github.com/dotnet/aspnetcore-tooling/pull/1847 & https://github.com/dotnet/aspnetcore-tooling/pull/1852 / https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/245745

### Before:
![nOWjmmHue2](https://user-images.githubusercontent.com/2008729/83481168-f05aa500-a451-11ea-9cc9-4ade4e660d8c.gif)

### After:
![ParameterCompletion](https://user-images.githubusercontent.com/14852843/84209435-fd3b5200-aa6a-11ea-846e-a3ba6da25e50.gif)

Copying over from [PR](https://github.com/dotnet/aspnetcore-tooling/pull/1852):
We need `[` and `]` to be commit characters to make extent calculations happen correctly on VS Client side. Having them as trigger characters work but it is not the correct fix.

This shouldn't affect HTML completions because the HTML language server provides CommitCharacters on individual `CompletionItem`s which overrrides what is set in AllCommitCharacters.

Fixes: https://github.com/dotnet/aspnetcore/issues/22455
Fixes: https://github.com/dotnet/aspnetcore/issues/22752