### PR TITLE
Add infrastructure for adding VS specific capabilities.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ExtendableServerCapabilities.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ExtendableServerCapabilities.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class ExtendableServerCapabilities : ServerCapabilities
+    {
+        public ExtendableServerCapabilities(ServerCapabilities inner, IEnumerable<IRegistrationExtension> registrationExtensions)
+        {
+            FoldingRangeProvider = inner.FoldingRangeProvider;
+            ColorProvider = inner.ColorProvider;
+            ImplementationProvider = inner.ImplementationProvider;
+            TypeDefinitionProvider = inner.TypeDefinitionProvider;
+            Experimental = inner.Experimental;
+            ExecuteCommandProvider = inner.ExecuteCommandProvider;
+            DocumentLinkProvider = inner.DocumentLinkProvider;
+            RenameProvider = inner.RenameProvider;
+            DocumentOnTypeFormattingProvider = inner.DocumentOnTypeFormattingProvider;
+            DocumentRangeFormattingProvider = inner.DocumentRangeFormattingProvider;
+            DeclarationProvider = inner.DeclarationProvider;
+            DocumentFormattingProvider = inner.DocumentFormattingProvider;
+            CodeActionProvider = inner.CodeActionProvider;
+            WorkspaceSymbolProvider = inner.WorkspaceSymbolProvider;
+            DocumentSymbolProvider = inner.DocumentSymbolProvider;
+            DocumentHighlightProvider = inner.DocumentHighlightProvider;
+            ReferencesProvider = inner.ReferencesProvider;
+            DefinitionProvider = inner.DefinitionProvider;
+            SignatureHelpProvider = inner.SignatureHelpProvider;
+            CompletionProvider = inner.CompletionProvider;
+            HoverProvider = inner.HoverProvider;
+            TextDocumentSync = inner.TextDocumentSync;
+            CodeLensProvider = inner.CodeLensProvider;
+            Workspace = inner.Workspace;
+
+            CapabilityExtensions = new Dictionary<string, object>(StringComparer.Ordinal);
+            foreach (var registrationExtension in registrationExtensions)
+            {
+                var optionsResult = registrationExtension.GetRegistration();
+                CapabilityExtensions[optionsResult.ServerCapability] = optionsResult.Options;
+            }
+        }
+
+        [JsonExtensionData]
+        public Dictionary<string, object> CapabilityExtensions { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Text;
@@ -37,6 +35,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             ILanguageServer server,
             ILoggerFactory loggerFactory)
         {
+            if (formatOnTypeProviders is null)
+            {
+                throw new ArgumentNullException(nameof(formatOnTypeProviders));
+            }
+
             if (documentMappingService is null)
             {
                 throw new ArgumentNullException(nameof(documentMappingService));
@@ -111,7 +114,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 return Task.FromResult(EmptyArray);
             }
 
-            var formattingContext = CreateFormattingContext(uri, codeDocument, new Range(position, position), options);
+            var formattingContext = FormattingContext.Create(uri, codeDocument, new Range(position, position), options);
             for (var i = 0; i < applicableProviders.Count; i++)
             {
                 if (applicableProviders[i].TryFormatOnType(position, formattingContext, out var textEdits))
@@ -148,7 +151,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(options));
             }
 
-            var formattingContext = CreateFormattingContext(uri, codeDocument, range, options);
+            var formattingContext = FormattingContext.Create(uri, codeDocument, range, options);
             var edits = await FormatCodeBlockDirectivesAsync(formattingContext);
             return edits;
         }
@@ -507,97 +510,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var precedingWhitespaceLength = precedingLineText.GetTrailingWhitespace().Length;
 
             return TextSpan.FromBounds(start - precedingWhitespaceLength, end);
-        }
-
-        // Internal for testing
-        internal static FormattingContext CreateFormattingContext(Uri uri, RazorCodeDocument codedocument, Range range, FormattingOptions options)
-        {
-            var result = new FormattingContext()
-            {
-                Uri = uri,
-                CodeDocument = codedocument,
-                Range = range,
-                Options = options
-            };
-
-            var source = codedocument.Source;
-            var syntaxTree = codedocument.GetSyntaxTree();
-            var formattingSpans = syntaxTree.GetFormattingSpans();
-
-            var total = 0;
-            var previousIndentationLevel = 0;
-            for (var i = 0; i < source.Lines.Count; i++)
-            {
-                // Get first non-whitespace character position
-                var lineLength = source.Lines.GetLineLength(i);
-                var nonWsChar = 0;
-                for (var j = 0; j < lineLength; j++)
-                {
-                    var ch = source[total + j];
-                    if (!char.IsWhiteSpace(ch) && !ParserHelpers.IsNewLine(ch))
-                    {
-                        nonWsChar = j;
-                        break;
-                    }
-                }
-
-                // position now contains the first non-whitespace character or 0. Get the corresponding FormattingSpan.
-                if (TryGetFormattingSpan(total + nonWsChar, formattingSpans, out var span))
-                {
-                    result.Indentations[i] = new IndentationContext
-                    {
-                        Line = i,
-                        IndentationLevel = span.IndentationLevel,
-                        RelativeIndentationLevel = span.IndentationLevel - previousIndentationLevel,
-                        ExistingIndentation = nonWsChar,
-                        FirstSpan = span,
-                    };
-                    previousIndentationLevel = span.IndentationLevel;
-                }
-                else
-                {
-                    // Couldn't find a corresponding FormattingSpan.
-                    result.Indentations[i] = new IndentationContext
-                    {
-                        Line = i,
-                        IndentationLevel = -1,
-                        RelativeIndentationLevel = previousIndentationLevel,
-                        ExistingIndentation = nonWsChar,
-                    };
-                }
-
-                total += lineLength;
-            }
-
-            return result;
-        }
-
-        private static bool TryGetFormattingSpan(int absoluteIndex, IReadOnlyList<FormattingSpan> formattingspans, out FormattingSpan result)
-        {
-            result = null;
-            for (var i = 0; i < formattingspans.Count; i++)
-            {
-                var formattingspan = formattingspans[i];
-                var span = formattingspan.Span;
-
-                if (span.Start <= absoluteIndex)
-                {
-                    if (span.End >= absoluteIndex)
-                    {
-                        if (span.End == absoluteIndex && span.Length > 0)
-                        {
-                            // We're at an edge.
-                            // Non-marker spans (spans.length == 0) do not own the edges after it
-                            continue;
-                        }
-
-                        result = formattingspan;
-                        return true;
-                    }
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -59,6 +60,116 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 var combined = string.Concat(tabPrefix, spaceSuffix);
                 return combined;
             }
+        }
+
+        public static FormattingContext Create(Uri uri, RazorCodeDocument codedocument, Range range, FormattingOptions options)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (codedocument is null)
+            {
+                throw new ArgumentNullException(nameof(codedocument));
+            }
+
+            if (range is null)
+            {
+                throw new ArgumentNullException(nameof(range));
+            }
+
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var result = new FormattingContext()
+            {
+                Uri = uri,
+                CodeDocument = codedocument,
+                Range = range,
+                Options = options
+            };
+
+            var source = codedocument.Source;
+            var syntaxTree = codedocument.GetSyntaxTree();
+            var formattingSpans = syntaxTree.GetFormattingSpans();
+
+            var total = 0;
+            var previousIndentationLevel = 0;
+            for (var i = 0; i < source.Lines.Count; i++)
+            {
+                // Get first non-whitespace character position
+                var lineLength = source.Lines.GetLineLength(i);
+                var nonWsChar = 0;
+                for (var j = 0; j < lineLength; j++)
+                {
+                    var ch = source[total + j];
+                    if (!char.IsWhiteSpace(ch) && !ParserHelpers.IsNewLine(ch))
+                    {
+                        nonWsChar = j;
+                        break;
+                    }
+                }
+
+                // position now contains the first non-whitespace character or 0. Get the corresponding FormattingSpan.
+                if (TryGetFormattingSpan(total + nonWsChar, formattingSpans, out var span))
+                {
+                    result.Indentations[i] = new IndentationContext
+                    {
+                        Line = i,
+                        IndentationLevel = span.IndentationLevel,
+                        RelativeIndentationLevel = span.IndentationLevel - previousIndentationLevel,
+                        ExistingIndentation = nonWsChar,
+                        FirstSpan = span,
+                    };
+                    previousIndentationLevel = span.IndentationLevel;
+                }
+                else
+                {
+                    // Couldn't find a corresponding FormattingSpan.
+                    result.Indentations[i] = new IndentationContext
+                    {
+                        Line = i,
+                        IndentationLevel = -1,
+                        RelativeIndentationLevel = previousIndentationLevel,
+                        ExistingIndentation = nonWsChar,
+                    };
+                }
+
+                total += lineLength;
+            }
+
+            return result;
+        }
+
+        private static bool TryGetFormattingSpan(int absoluteIndex, IReadOnlyList<FormattingSpan> formattingspans, out FormattingSpan result)
+        {
+            result = null;
+            for (var i = 0; i < formattingspans.Count; i++)
+            {
+                var formattingspan = formattingspans[i];
+                var span = formattingspan.Span;
+
+                if (span.Start <= absoluteIndex)
+                {
+                    if (span.End >= absoluteIndex)
+                    {
+                        if (span.End == absoluteIndex && span.Length > 0)
+                        {
+                            // We're at an edge.
+                            // Non-marker spans (spans.length == 0) do not own the edges after it
+                            continue;
+                        }
+
+                        result = formattingspan;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRegistrationExtension.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRegistrationExtension.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal interface IRegistrationExtension
+    {
+        RegistrationExtensionResult GetRegistration();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RegistrationExtensionResult.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RegistrationExtensionResult.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal sealed class RegistrationExtensionResult
+    {
+        public RegistrationExtensionResult(string serverCapability, object options)
+        {
+            if (serverCapability is null)
+            {
+                throw new ArgumentNullException(nameof(serverCapability));
+            }
+
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            ServerCapability = serverCapability;
+            Options = options;
+        }
+
+        public string ServerCapability { get; }
+
+        public object Options { get; }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ExtendableServerCapabilitiesTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ExtendableServerCapabilitiesTest.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class ExtendableServerCapabilitiesTest
+    {
+        [Fact]
+        public void Constructor_RegistrationExtensions_Populates()
+        {
+            // Arrange
+            var registrationExtension1 = new TestRegistrationExtension("test1");
+            var registrationExtension2 = new TestRegistrationExtension("test2");
+            var registrations = new IRegistrationExtension[] { registrationExtension1, registrationExtension2 };
+            var baseCapability = new ServerCapabilities();
+
+            // Act
+            var extendableCapabilities = new ExtendableServerCapabilities(baseCapability, registrations);
+
+            // Assert
+            Assert.Equal(new[] { "test1", "test2" }, extendableCapabilities.CapabilityExtensions.Keys.ToArray());
+        }
+
+        [Fact]
+        public void CapabilityExtensions_RoundTripsCorrectly()
+        {
+            // Arrange
+            var registrationExtension = new TestRegistrationExtension("test1");
+            var registrations = new IRegistrationExtension[] { registrationExtension };
+            var baseCapability = new ServerCapabilities();
+            var extendableCapabilities = new ExtendableServerCapabilities(baseCapability, registrations);
+
+            // Act
+            var serialized = JsonConvert.SerializeObject(extendableCapabilities);
+            var deserialized = JsonConvert.DeserializeObject<VSCapabilities>(serialized);
+
+            // Assert
+            Assert.True(deserialized.Test1);
+        }
+
+        private class VSCapabilities : ServerCapabilities
+        {
+            public bool Test1 { get; set; }
+        }
+
+        private class TestRegistrationExtension : IRegistrationExtension
+        {
+            private readonly string _capabilityName;
+
+            public TestRegistrationExtension(string capabilityName)
+            {
+                _capabilityName = capabilityName;
+            }
+
+            public RegistrationExtensionResult GetRegistration() => new RegistrationExtensionResult(_capabilityName, true);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormatOnTypeProviderTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormatOnTypeProviderTestBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             options[LanguageServerConstants.ExpectsCursorPlaceholderKey] = expectCursorPlaceholder;
 
             var provider = CreateProvider();
-            var context = DefaultRazorFormattingService.CreateFormattingContext(uri, codeDocument, new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(position, position), options);
+            var context = FormattingContext.Create(uri, codeDocument, new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(position, position), options);
 
             // Act
             if (!provider.TryFormatOnType(position, context, out var edits))


### PR DESCRIPTION
- With the onset of VS specific capabilities that do not follow the common LSP spec for extending server capabilities (they don't use the "Experimental" object) we had to build infrastructure to expand the default server capabilities that we push down to the client.
- Added an `IRegistrationExtension`  that a `IJsonRpcHandler` is expected to implement (parallels the existing `IRegistration<>` type). It exposes a new `GetRegistration` method that allows the handler to return a server capability key and value.
- Added wire-up logic to the `RazorLanguageServer` initialization flow to extract all `IRegistrationExtension`s and query all of their registration's and corresponding server capabilities to populate a new `ExtendableServerCapabilities` object.
- Added tests to verify that the new `ExtendableServerCapabilities` does as expected.

dotnet/aspnetcore#22761

/cc @ToddGrun @jimmylewis @alexgav 
