### PR TITLE
Safely handle DirectoryNotFound

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
@@ -78,6 +78,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                     // in us trying to refresh the "closed" files buffer with what's on disk; however, there's nothing actually on disk because the file was renamed.
                     textAndVersion = TextAndVersion.Create(SourceText.From(string.Empty), VersionStamp.Default, filePath: _filePath);
                 }
+                catch (DirectoryNotFoundException)
+                {
+                    var directory = Path.GetDirectoryName(_filePath);
+                    Directory.CreateDirectory(directory);
+                    textAndVersion = TextAndVersion.Create(SourceText.From(string.Empty), VersionStamp.Default, filePath: _filePath);
+                }
 
                 return Task.FromResult(textAndVersion);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
@@ -72,16 +72,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                         throw new IOException($"File was externally modified: {_filePath}");
                     }
                 }
-                catch (FileNotFoundException)
+                catch (IOException e) when (e is DirectoryNotFoundException || e is FileNotFoundException)
                 {
                     // This can typically occur when a file is renamed. What happens is the client "closes" the old file before any file system "rename" event makes it to us. Resulting
                     // in us trying to refresh the "closed" files buffer with what's on disk; however, there's nothing actually on disk because the file was renamed.
-                    textAndVersion = TextAndVersion.Create(SourceText.From(string.Empty), VersionStamp.Default, filePath: _filePath);
-                }
-                catch (DirectoryNotFoundException)
-                {
-                    var directory = Path.GetDirectoryName(_filePath);
-                    Directory.CreateDirectory(directory);
                     textAndVersion = TextAndVersion.Create(SourceText.From(string.Empty), VersionStamp.Default, filePath: _filePath);
                 }
 


### PR DESCRIPTION
Essentially the same thing as our `FileNotFoundException` handling, however here we also have to fabricate the directory tree.

Fixes https://github.com/dotnet/aspnetcore/issues/22795
