### PR TITLE
Fix smart-indent for C# generics.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -22,7 +22,7 @@
     { "open": "<", "close": ">" }
   ],
   "indentationRules": {
-    "increaseIndentPattern": "(?:<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$)|(?:\\{\\s*$)",
+    "increaseIndentPattern": "(?:\\s<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w[\\w\\d]*)([^/>]*(?!/)>)\\s*$)|(?:\\{\\s*$)",
     "decreaseIndentPattern": "(?:</([_:\\w][_:\\w-.\\d]*)\\s*>)|(?:\\})"
   }
 }


### PR DESCRIPTION
- Updated our regex to only apply our HTML indentation recognition to HTML tags that are "mostly" on their own line. I say "mostly" because we'll still indent cases where two HTML tags are on the same line but we'll only indent them once.
- Given this is validating smart indent in Visual Studio I was unable to write tests for this case.
![32CEFIUHRu](https://user-images.githubusercontent.com/2008729/84448309-2bea3180-abff-11ea-92a1-fc18e15a7d7f.gif)

Fixes dotnet/aspnetcore#22748
