### PR TITLE
Fix 1116448: Create new Blazor WebAssembly app and open Counter.razor…

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacEditorDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacEditorDocumentManager.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.Editor.Razor.Documents;
 using Microsoft.VisualStudio.Text;
+using MonoDevelop.Ide;
 
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
 {
@@ -26,8 +27,8 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
                 throw new ArgumentNullException(nameof(filePath));
             }
 
-            // VS for Mac doesn't currently support find all references support yet.
-            return null;
+            var document = IdeApp.Workbench.GetDocument(filePath);
+            return document?.GetContent<ITextBuffer>();
         }
 
         protected override void OnDocumentOpened(EditorDocument document)


### PR DESCRIPTION
…, you get squiggles about ambiguity related to currentCount variable

Problem was that if file was opened before project was loaded `ProcessOpen` was not called.
