### PR TITLE
Fix prepareRename to properly return a word range.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorRenameProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorRenameProvider.ts
@@ -34,7 +34,10 @@ export class RazorRenameProvider
             return Promise.reject('Cannot rename this symbol.');
         }
 
-        // Let the rename go through.
+        // Let the rename go through. OmniSharp doesn't currently support "prepareRename" so we need to utilize document
+        // APIs in order to resolve the appropriate rename range.
+        const range = document.getWordRangeAtPosition(position);
+        return range;
     }
 
     public async provideRenameEdits(


### PR DESCRIPTION
I already created a release/vscode-16.7-preview3 branch, this is the merge back into master for it.

- Given that O# doesn't support "prepareRename" we have to utilize platform APIs in order to resolve the appropriate rename range.

