### PR TITLE
Publish only minimal changes from the Razor language server to the client

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/Microsoft.AspNetCore.Razor.Performance.csproj
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/Microsoft.AspNetCore.Razor.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -29,6 +29,16 @@
     <Compile Include="..\..\test\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common\TestWorkspaceServices.cs">
       <Link>TestServices\%(FileName)%(Extension)</Link>
     </Compile>
+    <Compile Include="..\..\src\Microsoft.AspNetCore.Razor.LanguageServer\SourceTextDiffer.cs">
+      <Link>LanguageServer\%(FileName)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\..\src\Microsoft.AspNetCore.Razor.LanguageServer\TextDiffer.cs">
+      <Link>LanguageServer\%(FileName)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\..\src\Microsoft.AspNetCore.Razor.LanguageServer\DiffEdit.cs">
+      <Link>LanguageServer\%(FileName)%(Extension)</Link>
+    </Compile>
+    <None Include="MSN.cshtml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/SourceTextDifferBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/SourceTextDifferBenchmark.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.Performance
+{
+    public class SourceTextDifferBenchmark
+    {
+        private SourceText _largeFileOriginal;
+        private SourceText _largeFileMinimalChanges;
+        private SourceText _largeFileSignificantChanges;
+
+        public SourceTextDifferBenchmark()
+        {
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+            while (current != null && !File.Exists(Path.Combine(current.FullName, "MSN.cshtml")))
+            {
+                current = current.Parent;
+            }
+
+            var largeFilePath = Path.Combine(current.FullName, "MSN.cshtml");
+            var largeFileText = File.ReadAllText(largeFilePath);
+
+            _largeFileOriginal = SourceText.From(largeFileText);
+
+            var changedText = largeFileText.Insert(100, "<");
+            _largeFileMinimalChanges = SourceText.From(changedText);
+
+            changedText = largeFileText.Substring(largeFileText.Length / 2).Reverse().ToString();
+            _largeFileSignificantChanges = SourceText.From(changedText);
+        }
+
+        [Benchmark(Description = "Line Diff - One line change (Typing)")]
+        public void LineDiff_LargeFile_OneLineChanged()
+        {
+            SourceTextDiffer.GetMinimalTextChanges(_largeFileOriginal, _largeFileMinimalChanges, lineDiffOnly: true);
+        }
+
+        [Benchmark(Description = "Line Diff - Significant Changes (Copy-paste)")]
+        public void LineDiff_LargeFile_SignificantlyDifferent()
+        {
+            SourceTextDiffer.GetMinimalTextChanges(_largeFileOriginal, _largeFileSignificantChanges, lineDiffOnly: true);
+        }
+
+        [Benchmark(Description = "Character Diff - One character change (Typing)")]
+        public void CharDiff_LargeFile_OneCharChanged()
+        {
+            SourceTextDiffer.GetMinimalTextChanges(_largeFileOriginal, _largeFileMinimalChanges, lineDiffOnly: false);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -65,14 +65,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 previouslyPublishedData = PublishData.Default;
             }
 
-            IReadOnlyList<TextChange> textChanges = Array.Empty<TextChange>();
-            if (!sourceText.ContentEquals(previouslyPublishedData.SourceText))
+            var textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
+            if (textChanges.Count == 0 && hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
             {
-                textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
-            }
-            else if (hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
-            {
-                // Source texts match along with host documetn versions. We've already published something that looks like this. No-op.
+                // Source texts match along with host document versions. We've already published something that looks like this. No-op.
                 return;
             }
 
@@ -107,12 +103,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 previouslyPublishedData = PublishData.Default;
             }
 
-            IReadOnlyList<TextChange> textChanges = Array.Empty<TextChange>();
-            if (!sourceText.ContentEquals(previouslyPublishedData.SourceText))
-            {
-                textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
-            }
-            else if (hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
+            var textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
+            if (textChanges.Count == 0 && hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
             {
                 // Source texts match along with host document versions. We've already published something that looks like this. No-op.
                 return;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             IReadOnlyList<TextChange> textChanges = Array.Empty<TextChange>();
             if (!sourceText.ContentEquals(previouslyPublishedData.SourceText))
             {
-                textChanges = sourceText.GetTextChanges(previouslyPublishedData.SourceText);
+                textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
             }
             else if (hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
             {
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             IReadOnlyList<TextChange> textChanges = Array.Empty<TextChange>();
             if (!sourceText.ContentEquals(previouslyPublishedData.SourceText))
             {
-                textChanges = sourceText.GetTextChanges(previouslyPublishedData.SourceText);
+                textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
             }
             else if (hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DiffEdit.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DiffEdit.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal struct DiffEdit
+    {
+        public DiffEdit(Type operation, int pos, int? newTextPosition)
+        {
+            Operation = operation;
+            Position = pos;
+            NewTextPosition = newTextPosition;
+        }
+
+        public Type Operation { get; }
+
+        public int Position { get; }
+
+        public int? NewTextPosition { get; }
+
+        public static DiffEdit Insert(int pos, int newTextPos)
+        {
+            return new DiffEdit(Type.Insert, pos, newTextPos);
+        }
+
+        public static DiffEdit Delete(int pos)
+        {
+            return new DiffEdit(Type.Delete, pos, newTextPosition: null);
+        }
+
+        internal enum Type
+        {
+            Insert,
+            Delete,
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DiffEdit.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DiffEdit.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal struct DiffEdit
+    internal readonly struct DiffEdit
     {
         public DiffEdit(Type operation, int pos, int? newTextPosition)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextDiffer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextDiffer.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class SourceTextDiffer : TextDiffer
+    {
+        private bool _lineDiffOnly;
+
+        private SourceTextDiffer(SourceText oldText, SourceText newText, bool lineDiffOnly)
+        {
+            OldText = oldText;
+            NewText = newText;
+            _lineDiffOnly = lineDiffOnly;
+        }
+
+        private SourceText OldText { get; }
+
+        private SourceText NewText { get; }
+
+        protected override int OldTextLength => _lineDiffOnly ? OldText.Lines.Count : OldText.Length;
+
+        protected override int NewTextLength => _lineDiffOnly ? NewText.Lines.Count : NewText.Length;
+
+        public static IReadOnlyList<TextChange> GetMinimalTextChanges(SourceText oldText, SourceText newText, bool lineDiffOnly = true)
+        {
+            if (oldText is null)
+            {
+                throw new ArgumentNullException(nameof(oldText));
+            }
+
+            if (newText is null)
+            {
+                throw new ArgumentNullException(nameof(newText));
+            }
+
+            if (oldText.ContentEquals(newText))
+            {
+                return Array.Empty<TextChange>();
+            }
+            else if (oldText.Length == 0 || newText.Length == 0)
+            {
+                return newText.GetTextChanges(oldText);
+            }
+
+            var differ = new SourceTextDiffer(oldText, newText, lineDiffOnly);
+            var edits = differ.ComputeDiff();
+
+            var changes = differ.ProcessChanges(edits);
+
+            Debug.Assert(oldText.WithChanges(changes).ContentEquals(newText), "Incorrect minimal changes");
+
+            return changes;
+        }
+
+        protected override bool ContentEquals(int oldTextIndex, int newTextIndex)
+        {
+            if (_lineDiffOnly)
+            {
+                var oldLine = OldText.Lines[oldTextIndex];
+                var oldLineText = oldLine.Text.GetSubText(oldLine.SpanIncludingLineBreak);
+
+                var newLine = NewText.Lines[newTextIndex];
+                var newLineText = newLine.Text.GetSubText(newLine.SpanIncludingLineBreak);
+
+                return oldLineText.ContentEquals(newLineText);
+            }
+
+            return OldText[oldTextIndex] == NewText[newTextIndex];
+        }
+
+        private IReadOnlyList<TextChange> ProcessChanges(IReadOnlyList<DiffEdit> edits)
+        {
+            // Scan through the list of edits and collapse them into a minimal set of TextChanges.
+            // This method assumes that there are no overlapping changes and the changes are sorted.
+
+            var minimalChanges = new List<TextChange>();
+
+            var start = 0;
+            var end = 0;
+            var builder = new StringBuilder();
+            foreach (var edit in edits)
+            {
+                var startPosition = _lineDiffOnly ? OldText.Lines[edit.Position].Start : edit.Position;
+                if (startPosition != end)
+                {
+                    // Previous edit's end doesn't match the new edit's start.
+                    // Output the text change we were tracking.
+                    if (start != end || builder.Length > 0)
+                    {
+                        minimalChanges.Add(new TextChange(TextSpan.FromBounds(start, end), builder.ToString()));
+                        builder.Clear();
+                    }
+
+                    start = startPosition;
+                }
+
+                end = AppendEdit(edit);
+            }
+
+            if (start != end || builder.Length > 0)
+            {
+                minimalChanges.Add(new TextChange(TextSpan.FromBounds(start, end), builder.ToString()));
+            }
+
+            return minimalChanges;
+
+            // Appends the new edit's content to the buffer and returns the end position.
+            int AppendEdit(DiffEdit edit)
+            {
+                if (_lineDiffOnly)
+                {
+                    if (edit.Operation == DiffEdit.Type.Insert)
+                    {
+                        var newLine = NewText.Lines[edit.NewTextPosition.Value];
+                        builder.Append(newLine.Text.ToString(newLine.SpanIncludingLineBreak));
+                        return OldText.Lines[edit.Position].Start;
+                    }
+                    else
+                    {
+                        return OldText.Lines[edit.Position].EndIncludingLineBreak;
+                    }
+                }
+                else
+                {
+                    if (edit.Operation == DiffEdit.Type.Insert)
+                    {
+                        builder.Append(NewText[edit.NewTextPosition.Value]);
+                        return edit.Position;
+                    }
+
+                    return edit.Position + 1;
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextDiffer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextDiffer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class SourceTextDiffer : TextDiffer
     {
-        private bool _lineDiffOnly;
+        private readonly bool _lineDiffOnly;
 
         private SourceTextDiffer(SourceText oldText, SourceText newText, bool lineDiffOnly)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextDiffer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextDiffer.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    //
+    // This class implements the linear space variation of the difference algorithm described in
+    // "An O(ND) Difference Algorithm and its Variations" by Eugene W. Myers
+    //
+    // Note: Some variable names in this class are not be fully compliant with the C# naming guidelines
+    // in the interest of using the same terminology discussed in the paper for ease of understanding.
+    // 
+    internal abstract class TextDiffer
+    {
+        protected abstract int OldTextLength { get; }
+
+        protected abstract int NewTextLength { get; }
+
+        protected abstract bool ContentEquals(int oldTextIndex, int newTextIndex);
+
+        protected IReadOnlyList<DiffEdit> ComputeDiff()
+        {
+            var edits = new List<DiffEdit>();
+
+            // Initialize the vectors to use for forward and reverse searches.
+            var MAX = NewTextLength + OldTextLength;
+            var Vf = new int[(2 * MAX) + 1];
+            var Vr = new int[(2 * MAX) + 1];
+
+            ComputeDiffRecursive(edits, 0, OldTextLength, 0, NewTextLength, Vf, Vr);
+
+            return edits;
+        }
+
+        private void ComputeDiffRecursive(List<DiffEdit> edits, int lowA, int highA, int lowB, int highB, int[] Vf, int[] Vr)
+        {
+            while (lowA < highA && lowB < highB && ContentEquals(lowA, lowB))
+            {
+                // Skip equal text at the start.
+                lowA++;
+                lowB++;
+            }
+
+            while (lowA < highA && lowB < highB && ContentEquals(highA - 1, highB - 1))
+            {
+                // Skip equal text at the end.
+                highA--;
+                highB--;
+            }
+
+            if (lowA == highA)
+            {
+                // Base case 1: We've reached the end of original text. Insert whatever is remaining in the new text.
+                while (lowB < highB)
+                {
+                    edits.Add(DiffEdit.Insert(lowA, lowB));
+                    lowB++;
+                }
+            }
+            else if (lowB == highB)
+            {
+                // Base case 2: We've reached the end of new text. Delete whatever is remaining in the original text.
+                while (lowA < highA)
+                {
+                    edits.Add(DiffEdit.Delete(lowA));
+                    lowA++;
+                }
+            }
+            else
+            {
+                // Find the midpoint of the optimal path.
+                var (middleX, middleY) = FindMiddleSnake(lowA, highA, lowB, highB, Vf, Vr);
+
+                // Recursively find the midpoint of the left half.
+                ComputeDiffRecursive(edits, lowA, middleX, lowB, middleY, Vf, Vr);
+
+                // Recursively find the midpoint of the right half.
+                ComputeDiffRecursive(edits, middleX, highA, middleY, highB, Vf, Vr);
+            }
+        }
+
+        private (int, int) FindMiddleSnake(int lowA, int highA, int lowB, int highB, int[] Vf, int[] Vr)
+        {
+            var N = highA - lowA;
+            var M = highB - lowB;
+            var delta = N - M;
+            var deltaIsEven = delta % 2 == 0;
+
+            var MAX = N + M;
+
+            // Compute the k-line to start the forward and reverse searches.
+            var forwardK = lowA - lowB;
+            var reverseK = highA - highB;
+
+            // The paper uses negative indexes but we can't do that here. So we'll add an offset.
+            var forwardOffset = MAX - forwardK;
+            var reverseOffset = MAX - reverseK;
+
+            // Initialize the vector
+            Vf[forwardOffset + forwardK + 1] = lowA;
+            Vr[reverseOffset + reverseK - 1] = highA;
+
+            var maxD = Math.Ceiling((double)(M + N) / 2);
+            for (var D = 0; D <= maxD; D++) // For D ← 0 to ceil((M + N)/2) Do
+            {
+                // Run the algorithm in forward direction.
+                for (var k = forwardK - D; k <= forwardK + D; k += 2) // For k ← −D to D in steps of 2 Do
+                {
+                    // Find the end of the furthest reaching forward D-path in diagonal k.
+                    int x;
+                    if (k == forwardK - D ||
+                        (k != forwardK + D && Vf[forwardOffset + k - 1] < Vf[forwardOffset + k + 1]))
+                    {
+                        // Down
+                        x = Vf[forwardOffset + k + 1];
+                    }
+                    else
+                    {
+                        // Right
+                        x = Vf[forwardOffset + k - 1] + 1;
+                    }
+
+                    var y = x - k;
+
+                    // Traverse diagonal if possible.
+                    while (x < highA && y < highB && ContentEquals(x, y))
+                    {
+                        x++;
+                        y++;
+                    }
+
+                    Vf[forwardOffset + k] = x;
+                    if (deltaIsEven)
+                    {
+                        // Can't have overlap here.
+                    }
+                    else if (k > reverseK - D && k < reverseK + D) // If ∆ is odd and k ∈ [∆ − (D − 1) , ∆ + (D − 1)] Then
+                    {
+                        if (Vr[reverseOffset + k] <= Vf[forwardOffset + k]) // If the path overlaps the furthest reaching reverse (D − 1)-path in diagonal k Then
+                        {
+                            // The last snake of the forward path is the middle snake.
+                            x = Vf[forwardOffset + k];
+                            y = x - k;
+                            return (x, y);
+                        }
+                    }
+                }
+
+                // Run the algorithm in reverse direction.
+                for (var k = reverseK - D; k <= reverseK + D; k += 2) // For k ← −D to D in steps of 2 Do
+                {
+                    // Find the end of the furthest reaching reverse D-path in diagonal k+∆.
+                    int x;
+                    if (k == reverseK + D ||
+                        (k != reverseK - D && Vr[reverseOffset + k - 1] < Vr[reverseOffset + k + 1] - 1))
+                    {
+                        // Up
+                        x = Vr[reverseOffset + k - 1];
+                    }
+                    else
+                    {
+                        // Left
+                        x = Vr[reverseOffset + k + 1] - 1;
+                    }
+
+                    var y = x - k;
+
+                    // Traverse diagonal if possible.
+                    while (x > lowA && y > lowB && ContentEquals(x - 1, y - 1))
+                    {
+                        x--;
+                        y--;
+                    }
+
+                    Vr[reverseOffset + k] = x;
+                    if (!deltaIsEven)
+                    {
+                        // Can't have overlap here.
+                    }
+                    else if (k >= forwardK - D && k <= forwardK + D) // If ∆ is even and k + ∆ ∈ [−D, D] Then
+                    {
+                        if (Vr[reverseOffset + k] <= Vf[forwardOffset + k]) // If the path overlaps the furthest reaching forward D-path in diagonal k+∆ Then
+                        {
+                            // The last snake of the reverse path is the middle snake.
+                            x = Vf[forwardOffset + k];
+                            y = x - k;
+                            return (x, y);
+                        }
+                    }
+                }
+            }
+
+            throw new InvalidOperationException("Shouldn't reach here.");
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
@@ -81,11 +81,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
-            var initialSourceText = SourceText.From("// Initial content");
+            var initialSourceText = SourceText.From("// Initial content\n");
             generatedDocumentPublisher.PublishCSharp("/path/to/file.razor", initialSourceText, 123);
             var change = new TextChange(
                 new TextSpan(initialSourceText.Length, 0),
-                "!!");
+                "// Another line");
             var changedSourceText = initialSourceText.WithChanges(change);
 
             // Act
@@ -105,11 +105,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(Dispatcher, new Lazy<ILanguageServer>(() => Server));
-            var initialSourceText = SourceText.From("HTML content");
+            var initialSourceText = SourceText.From("HTML content\n");
             generatedDocumentPublisher.PublishHtml("/path/to/file.razor", initialSourceText, 123);
             var change = new TextChange(
                 new TextSpan(initialSourceText.Length, 0),
-                "!!");
+                "More content!!");
             var changedSourceText = initialSourceText.WithChanges(change);
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SourceTextDifferTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SourceTextDifferTest.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class SourceTextDifferTest
+    {
+        [Theory]
+        [InlineData("asdf", ";lkj")]
+        [InlineData("asdf", ";asd")]
+        [InlineData("", "")]
+        [InlineData("", "a")]
+        [InlineData("a", "b")]
+        [InlineData("a", "a")]
+        [InlineData("a", "")]
+        [InlineData("aabd", "abc")]
+        [InlineData("aabd", "a")]
+        [InlineData("aabd", "h")]
+        [InlineData("aabd", "trtrt45rtt()")]
+        [InlineData("trtrt4 5rtt()", "atbd")]
+        [InlineData(@"trtrt4\n5rtt()", "atb\nd")]
+        [InlineData(@"Hello\r\nWorld\r\n123", "Hola\r\nWorld\r\n\r\n1234")]
+        public void GetMinimalTextChanges_ReturnsAccurateResults(string oldStr, string newStr)
+        {
+            // Arrange
+            var oldText = SourceText.From(oldStr);
+            var newText = SourceText.From(newStr);
+
+            // Act 1
+            var characterChanges = SourceTextDiffer.GetMinimalTextChanges(oldText, newText, lineDiffOnly: false);
+
+            // Assert 1
+            var changedText = oldText.WithChanges(characterChanges);
+            Assert.Equal(newStr, changedText.ToString());
+
+            // Act 2
+            var lineChanges = SourceTextDiffer.GetMinimalTextChanges(oldText, newText, lineDiffOnly: false);
+
+            // Assert 2
+            changedText = oldText.WithChanges(lineChanges);
+            Assert.Equal(newStr, changedText.ToString());
+        }
+
+        [Fact]
+        public void GetMinimalTextChanges_ReturnsExpectedResults()
+        {
+            // Arrange
+            var oldText = SourceText.From(@"
+<div>
+  Hello!
+</div>
+".Replace(Environment.NewLine, "\r\n"));
+            var newText = SourceText.From(@"
+<div>
+  Hola!
+</div>".Replace(Environment.NewLine, "\r\n"));
+
+            // Act 1
+            var characterChanges = SourceTextDiffer.GetMinimalTextChanges(oldText, newText, lineDiffOnly: false);
+
+            // Assert 1
+            Assert.Collection(characterChanges,
+                change => Assert.Equal(new TextChange(TextSpan.FromBounds(12, 13), "o"), change),
+                change => Assert.Equal(new TextChange(TextSpan.FromBounds(14, 16), "a"), change),
+                change => Assert.Equal(new TextChange(TextSpan.FromBounds(25, 27), string.Empty), change));
+
+            // Act 2
+            var lineChanges = SourceTextDiffer.GetMinimalTextChanges(oldText, newText, lineDiffOnly: true);
+
+            // Assert 2
+            var change = Assert.Single(lineChanges);
+            Assert.Equal(new TextChange(TextSpan.FromBounds(9, 27), "  Hola!\r\n</div>"), change);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/21407

- Implemented the linear space variation of [Myer's diff algorithm](http://www.xmailserver.org/diff2.pdf). I found [this blog](https://blog.robertelder.org/diff-algorithm/) super useful to help understand the paper. This algorithm runs in linear time and is especially good for typing scenarios because, the fewer the differences in the text, the faster it runs.
- The algorithm is fully contained in `TextDiffer`. `SourceTextDiffer` implements that class and provides both character-wise and line-wise diffing functionality. I had this separation because we might likely use this for formatting in the future.
- Added tests
- Added benchmarks. Here is the benchmark results for MSN.cshtml (~3000 lines and ~350000 characters),
```
                                           Method |      Mean |     Error |    StdDev |   Op/s |    Gen 0 |    Gen 1 |    Gen 2 |   Allocated |
------------------------------------------------- |----------:|----------:|----------:|-------:|---------:|---------:|---------:|------------:|
           'Line Diff - One line change (Typing)' |  1.006 ms | 0.0023 ms | 0.0021 ms | 993.63 |   7.8125 |        - |        - |   686.61 KB |
   'Line Diff - Significant Changes (Copy-paste)' | 18.909 ms | 0.0364 ms | 0.0340 ms |  52.89 |        - |        - |        - |   754.62 KB |
 'Character Diff - One character change (Typing)' |  2.192 ms | 0.0424 ms | 0.0634 ms | 456.23 | 140.6250 | 140.6250 | 140.6250 | 10159.15 KB |
```
Looking at the above benchmarks, I think we should go with line-wise diffing as that is good enough for our scenarios. Character diffing is pretty fast as well but it allocates way more than when doing line diffing.