### PR TITLE
Cache result from call to IVsFeatureFlags.IsFeatureEnabled

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly ProjectHierarchyInspector _projectHierarchyInspector;
         private readonly Lazy<IVsUIShellOpenDocument> _vsUIShellOpenDocument;
         private readonly IVsFeatureFlags _featureFlags;
+        private bool? _featureFlagEnabled;
         private bool? _environmentFeatureEnabled;
         private bool? _isVSServer;
 
@@ -160,12 +161,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         // Private protected virtual for testing
         private protected virtual bool IsFeatureFlagEnabled()
         {
-            if (_featureFlags.IsFeatureEnabled(RazorLSPEditorFeatureFlag, defaultValue: false))
+            if (!_featureFlagEnabled.HasValue)
             {
-                return true;
+                _featureFlagEnabled = _featureFlags.IsFeatureEnabled(RazorLSPEditorFeatureFlag, defaultValue: false);
             }
 
-            return false;
+            return _featureFlagEnabled.Value;
         }
 
         // Private protected virtual for testing

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -12,7 +12,7 @@
 "RazorLSP"="$PackageFolder$\language-configuration.json"
 
 [$RootKey$\FeatureFlags\Razor\LSP\Editor]
-"Description"="Enables the Razor Language Server Protocol powered editor experience for all Razor editors. Razor documents will have to be re-opened to use the new editor, but reopening the solution would not be sufficient."
+"Description"="Enables the Razor Language Server Protocol powered editor experience for all Razor editors."
 "Value"=dword:00000000
-"Title"="Enable experimental Razor editor"
+"Title"="Enable experimental Razor editor (requires restart)"
 "PreviewPaneChannels"="*"


### PR DESCRIPTION
This call is very slow and shows up in the webtools razor typing perf test. There is an existing issue logged against the feature flags implementation, but it is prioritized low and guidance is to add your own cache around calls to it if you don't neeed them to respond to changes in the value.

Fixes https://github.com/dotnet/aspnetcore/issues/21704
