### PR TITLE
C# FAR From Razor to External C# Show All Results

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -123,12 +123,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
                 if (mappingResult == null ||
                     mappingResult.Ranges[0].IsUndefined() ||
-
-                    // Only verify HostDocumentVersion when the FAR request was initiated from the same
-                    // document as the reference item. This assumes that background document changed while this
-                    // request was performed. We could fetch other razor docs with the DocumentManager however
-                    // that may incur a performance/accuracy penalty with limited benefit. 
-                    (documentSnapshot.Uri == razorDocumentUri && mappingResult.HostDocumentVersion != documentSnapshot.Version))
+                    (_documentManager.TryGetDocument(razorDocumentUri, out var mappedDocumentSnapshot) &&
+                    mappingResult.HostDocumentVersion != mappedDocumentSnapshot.Version))
                 {
                     // Couldn't remap the location or the document changed in the meantime. Discard this location.
                     continue;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -122,8 +122,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     cancellationToken).ConfigureAwait(false);
 
                 if (mappingResult == null ||
-                    mappingResult.HostDocumentVersion != documentSnapshot.Version ||
-                    mappingResult.Ranges[0].IsUndefined())
+                    mappingResult.Ranges[0].IsUndefined() ||
+
+                    // Only verify HostDocumentVersion when the FAR request was initiated from the same
+                    // document as the reference item. This assumes that background document changed while this
+                    // request was performed. We could fetch other razor docs with the DocumentManager however
+                    // that may incur a performance/accuracy penalty with limited benefit. 
+                    (documentSnapshot.Uri == razorDocumentUri && mappingResult.HostDocumentVersion != documentSnapshot.Version))
                 {
                     // Couldn't remap the location or the document changed in the meantime. Discard this location.
                     continue;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -280,6 +280,50 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         }
 
         [Fact]
+        public async Task HandleRequestAsync_VersionMismatch_DiscardsExternalRazorFiles()
+        {
+            // Arrange
+            var externalUri = new Uri("C:/path/to/someotherfile.razor");
+            var expectedLocation = GetReferenceItem(5, 5, 5, 5, externalUri);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 2));
+            documentManager.AddDocument(externalUri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 5));
+
+            var virtualCSharpUri = new Uri("C:/path/to/someotherfile.razor.g.cs");
+            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var requestInvoker = MockLSPRequestInvoker(csharpLocation);
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangesResponse()
+            {
+                Ranges = new[] { expectedLocation.Location.Range },
+                HostDocumentVersion = 6
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
+            documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, externalUri, new[] { csharpLocation.Location.Range }, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object);
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5)
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
         public async Task HandleRequestAsync_RemapFailure_DiscardsLocation()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -164,8 +164,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var externalUri = new Uri("C:/path/to/someotherfile.razor");
             var expectedLocation = GetReferenceItem(5, 5, 5, 5, externalUri);
             var documentManager = new TestDocumentManager();
-            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
-            documentManager.AddDocument(externalUri, Mock.Of<LSPDocumentSnapshot>());
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 2));
+            documentManager.AddDocument(externalUri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 5));
 
             var virtualCSharpUri = new Uri("C:/path/to/someotherfile.razor.g.cs");
             var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
@@ -180,7 +180,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var remappingResult = new RazorMapToDocumentRangesResponse()
             {
-                Ranges = new[] { expectedLocation.Location.Range }
+                Ranges = new[] { expectedLocation.Location.Range },
+                HostDocumentVersion = 5
             };
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
             documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, externalUri, new[] { csharpLocation.Location.Range }, It.IsAny<CancellationToken>())).


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/23065

Previously, for FAR queries initiated from razor, we only showed results from that razor file and other .cs files. Now showing results from all razor & .cs files.