### PR TITLE
Fix Razor language server leaking memory on solution close/reopen.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
@@ -12,12 +12,13 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal class DefaultProjectSnapshotManagerAccessor : ProjectSnapshotManagerAccessor
+    internal class DefaultProjectSnapshotManagerAccessor : ProjectSnapshotManagerAccessor, IDisposable
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly IEnumerable<ProjectSnapshotChangeTrigger> _changeTriggers;
         private readonly FilePathNormalizer _filePathNormalizer;
         private ProjectSnapshotManagerBase _instance;
+        private bool _disposed;
 
         public DefaultProjectSnapshotManagerAccessor(
             ForegroundDispatcher foregroundDispatcher,
@@ -66,6 +67,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                 return _instance;
             }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            _instance?.Workspace.Dispose();
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IFileChangeDetector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,5 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal interface IFileChangeDetector
     {
         Task StartAsync(string workspaceDirectory, CancellationToken cancellationToken);
+
+        void Stop();
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -100,6 +100,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _watcher.EnableRaisingEvents = true;
         }
 
+        public void Stop()
+        {
+            // We're relying on callers to synchronize start/stops so we don't need to ensure one happens before the other.
+
+            _watcher?.Dispose();
+            _watcher = null;
+        }
+
         // Protected virtual for testing
         protected virtual void OnInitializationFinished()
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -102,6 +103,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             };
 
             _watcher.EnableRaisingEvents = true;
+        }
+
+        public void Stop()
+        {
+            // We're relying on callers to synchronize start/stops so we don't need to ensure one happens before the other.
+
+            _watcher?.Dispose();
+            _watcher = null;
         }
 
         // Protected virtual for testing

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -128,6 +128,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
         }
 
+        public void Stop()
+        {
+            // We're relying on callers to synchronize start/stops so we don't need to ensure one happens before the other.
+
+            for (var i = 0; i < _watchers.Count; i++)
+            {
+                _watchers[i].Dispose();
+            }
+
+            _watchers.Clear();
+        }
+
         // Protected virtual for testing
         protected virtual void OnInitializationFinished()
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -154,23 +154,37 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<HtmlFactsService, DefaultHtmlFactsService>();
                     }));
 
-            server.OnShutdown(() =>
-            {
-                TempDirectory.Instance.Dispose();
-                return Unit.Task;
-            });
-
             try
             {
                 var factory = new LoggerFactory();
                 var logger = factory.CreateLogger<RazorLanguageServer>();
                 var assemblyInformationAttribute = typeof(RazorLanguageServer).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
                 logger.LogInformation("Razor Language Server version " + assemblyInformationAttribute.InformationalVersion);
+                factory.Dispose();
             }
             catch
             {
                 // Swallow exceptions from determining assembly information.
             }
+
+            IDisposable shutdownSubscription = null;
+            shutdownSubscription = server.Shutdown.Subscribe((_) =>
+            {
+                shutdownSubscription.Dispose();
+                TempDirectory.Instance.Dispose();
+            });
+
+            IDisposable exitSubscription = null;
+            exitSubscription = server.Exit.Subscribe((_) =>
+            {
+                exitSubscription.Dispose();
+                server.Dispose();
+
+                // Disposing the server doesn't actually dispose the servers Services for whatever reason. We cast the services collection
+                // to IDisposable and try to dispose it ourselves to account for this.
+                var disposableServices = server.Services as IDisposable;
+                disposableServices?.Dispose();
+            });
 
             return Task.FromResult(server);
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/AutoFlushingNerdbankStream.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/AutoFlushingNerdbankStream.cs
@@ -47,13 +47,23 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return await _inner.ReadAsync(buffer, offset, count).ConfigureAwait(false);
+            return await _inner.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
         public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            await _inner.WriteAsync(buffer, offset, count).ConfigureAwait(false);
-            await FlushAsync().ConfigureAwait(false);
+            await _inner.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            await FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
- The general feeling of these changesets is that we weren't disposing things properly and therefore relying on processes exit to tear down our state. To account for this we now implement `IDisposable` on several of our types to allow for them to cleanup state when the server is shutdown.
- Found that disposing the language server doesn't actually dispose of its service provider collection so I had to manually dispose of that collection to ensure all of our services `Dispose` method was invoked on server exit.
- Added `Stop` methods to the `IFileChangeDetector` APIs in an effort to follow a common pattern of start/stop and have the management class (`RazorFileChangeDetectorManager`) control when to start/stop. Otherwise we'd need to have overtly complex logic in each of the `IFileChangeDetector`s.
- Found that the way we were previously detecting langauge server shutdown didn't actually work on our current O# bits. Instead found that if we subscribe to the Shutdown observable we were able to do work on shutdown. Because of this I also added a similar observable for handling language server exit (where we dispose a lot of our state).
- Didn't add tests because you can't easily validate that certain managed resources have been cleaned up after calling a dispose equivalent.

Fixes dotnet/aspnetcore#23054
