### PR TITLE
Stop publishing project information on every doc change.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -121,7 +121,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 case ProjectChangeKind.DocumentRemoved:
                 case ProjectChangeKind.DocumentAdded:
-                case ProjectChangeKind.DocumentChanged:
                 case ProjectChangeKind.ProjectChanged:
                     // These changes can come in bursts so we don't want to overload the publishing system. Therefore,
                     // we enqueue publishes and then publish the latest project after a delay.


### PR DESCRIPTION
- Found that our TagHelper/Project information harvester that serializes that info into files was reacting to every document change and serializing project.razor.json information. This seemed to be unexpected even from an implementation perspective because the tests also did not test that one variation (document changed) @ryanbrandenburg if you could confirm this last sentence I'd appreciate it 😄 .



Fixes dotnet/aspnetcore#23169
