### PR TITLE
Fix directive completion serialization.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -248,8 +248,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             SortText = razorCompletionItem.DisplayText,
                             Documentation = descriptionInfo.Description,
                             Kind = CompletionItemKind.Struct,
-                            CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters),
                         };
+
+                        if (razorCompletionItem.CommitCharacters != null && razorCompletionItem.CommitCharacters.Count > 0)
+                        {
+                            directiveCompletionItem.CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters);
+                        }
 
                         if (razorCompletionItem == DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem)
                         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -277,8 +277,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             FilterText = razorCompletionItem.InsertText,
                             SortText = razorCompletionItem.InsertText,
                             Kind = CompletionItemKind.TypeParameter,
-                            CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters),
                         };
+
+                        if (razorCompletionItem.CommitCharacters != null && razorCompletionItem.CommitCharacters.Count > 0)
+                        {
+                            directiveAttributeCompletionItem.CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters);
+                        }
 
                         directiveAttributeCompletionItem.SetDescriptionInfo(descriptionInfo);
                         directiveAttributeCompletionItem.SetRazorCompletionKind(razorCompletionItem.Kind);
@@ -313,8 +317,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             SortText = razorCompletionItem.DisplayText,
                             Documentation = descriptionInfo.Description,
                             Kind = CompletionItemKind.TypeParameter,
-                            CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters)
                         };
+
+                        if (razorCompletionItem.CommitCharacters != null && razorCompletionItem.CommitCharacters.Count > 0)
+                        {
+                            markupTransitionCompletionItem.CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters);
+                        }
 
                         completionItem = markupTransitionCompletionItem;
                         return true;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -97,6 +97,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        public void TryConvert_DirectiveAttributeTransition_SerializationDoesNotThrow()
+        {
+            // Arrange
+            var completionItem = DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem;
+            var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
+            completionEndpoint.TryConvert(completionItem, out var converted);
+
+            // Act & Assert
+            JsonConvert.SerializeObject(converted);
+        }
+
+        [Fact]
         public void TryConvert_DirectiveAttributeTransition_ReturnsTrue()
         {
             // Arrange
@@ -143,6 +156,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Null(converted.Detail);
             Assert.Equal(description, converted.Documentation.String);
             Assert.Equal(converted.CommitCharacters, completionItem.CommitCharacters);
+        }
+
+        [Fact]
+        public void TryConvert_MarkupTransition_SerializationDoesNotThrow()
+        {
+            // Arrange
+            var completionItem = MarkupTransitionCompletionItemProvider.MarkupTransitionCompletionItem;
+            var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
+            completionEndpoint.TryConvert(completionItem, out var converted);
+
+            // Act & Assert
+            JsonConvert.SerializeObject(converted);
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor.Razor;
 using Moq;
+using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
@@ -77,6 +78,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(description, converted.Documentation.String);
             Assert.True(converted.TryGetRazorCompletionKind(out var convertedKind));
             Assert.Equal(RazorCompletionItemKind.Directive, convertedKind);
+        }
+
+        [Fact]
+        public void TryConvert_Directive_SerializationDoesNotThrow()
+        {
+            // Arrange
+            var completionItem = new RazorCompletionItem("testDisplay", "testInsert", RazorCompletionItemKind.Directive);
+            var description = "Something";
+            completionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription(description));
+            var descriptionFactory = new Mock<TagHelperDescriptionFactory>();
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperCompletionService, descriptionFactory.Object, LoggerFactory);
+            completionEndpoint.SetCapability(DefaultCapability);
+            completionEndpoint.TryConvert(completionItem, out var converted);
+
+            // Act & Assert
+            JsonConvert.SerializeObject(converted);
         }
 
         [Fact]


### PR DESCRIPTION
- TagHelper attributes would result in a null-ref exception at deserialization time because there are some Razor directives without commit characters. In the case that there were no commit characters (null) we'd create a collection with a `null` inner collection. When O#'s output handler then tried to serialize that collection it'd explode and would abort it's output publishing loop resulting in all LSP functionality ceasing.
- Added a serialization test to cover this case.

Fixes dotnet/aspnetcore#23174