### PR TITLE
Extend test timeout to rule-out variants of flakiness.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Assert
             fileChangeDetector.BlockNotificationWorkStart.Set();
-            Assert.True(fileChangeDetector.NotifyNotificationNoop.Wait(TimeSpan.FromSeconds(2)));
+            Assert.True(fileChangeDetector.NotifyNotificationNoop.Wait(TimeSpan.FromSeconds(10)));
             Assert.False(listenerCalled);
         }
 


### PR DESCRIPTION
- Extending the timeout of this test to see if there's an unexpected case actually preventing this test from failing or if the CI machines are just truly dragging their feet.
