### PR TITLE
Fix parallel LSP document synchronization requests failing due to can…

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentHighlightHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentHighlightHandler.cs
@@ -77,6 +77,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             var serverKind = LanguageServerKind.CSharp;
             var documentHighlightParams = new DocumentHighlightParams()
             {


### PR DESCRIPTION
…cellations.

- Prior to this when a user would attempt to get signtuare help by typing `(` the LSP platform would issue two requests, one for "highlight" and one for "signature help". The problem is we have a separate mechanism in place that after typing `(` the `)` is auto-inserted; this in turn causes the "highlight" request to be canceled. Because of how our synchronizer works it would memoize synchronization requests and when the highlight request would cancel it would also cancel the signature help request.
- The fix here is to no longer memoize our synchronizing requests. Because there could be N number of synchronizing requests for a given document and the platform underneath us may cancel some of them we need to track each synchronizing request separately. This means our tracked synchronizing requests becomes a single document -> list of synchronizing contexts instead of just a single synchronizing context.
- The majority of testing here was already written and given the significant changes to the synchronizing code it was nice to see how everything pre-existingly "worked". However, I did add an additional test to account for the platform issuing multiple requests for the same document and then canceling one of them.

Fixes dotnet/aspnetcore#23322