### PR TITLE
Use custom semantic token types

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/SemanticTokensLegend.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/SemanticTokensLegend.cs
@@ -4,17 +4,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models
 {
     internal class SemanticTokensLegend
     {
-        public const string RazorTagHelperElement = "class";
-        public const string RazorTagHelperAttribute = "class";
-        public const string RazorTransition = "keyword";
-        public const string RazorDirectiveAttribute = "keyword";
-        public const string RazorDirectiveColon = "keyword";
+        public const string RazorTagHelperElement = "razorTagHelperElement";
+        public const string RazorTagHelperAttribute = "razorTagHelperAttribute";
+        public const string RazorTransition = "razorTransition";
+        public const string RazorDirectiveAttribute = "razorDirectiveAttribute";
+        public const string RazorDirectiveColon = "razorDirectiveColon";
 
         private static readonly IReadOnlyCollection<string> _tokenTypes = new string[] {
             RazorTagHelperElement,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
-                0, 8, 5, 1, 0
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
+                0, 8, 5, 0, 0
             };
 
             AssertSemanticTokens(txt, expectedData, isRazor: false, out var _);
@@ -35,9 +35,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true'></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
                 0, 6, 8, 1, 0,
-                0, 18, 5, 1, 0
+                0, 18, 5, 0, 0
             };
 
             AssertSemanticTokens(txt, expectedData, isRazor: false, out var _);
@@ -48,9 +48,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
                 0, 6, 8, 1, 0,
-                0, 11, 5, 1, 0
+                0, 11, 5, 0, 0
             };
 
             AssertSemanticTokens(txt, expectedData, isRazor: false, out var _);
@@ -61,9 +61,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val='true' class='display:none'></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
                 0, 6, 8, 1, 0,
-                0, 39, 5, 1, 0
+                0, 39, 5, 0, 0
             };
 
             AssertSemanticTokens(txt, expectedData, isRazor: false, out var _);
@@ -95,10 +95,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             // Capitalized, non-well-known-HTML elements are always marked as TagHelpers
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<NotATagHelp @minimized:something />";
             var expectedData = new List<uint> {
-                1, 1, 11, 1, 0,
-                0, 12, 1, 4, 0,
+                1, 1, 11, 0, 0,
+                0, 12, 1, 2, 0,
                 0, 1, 9, 4, 0,
-                0, 9, 1, 4, 0,
+                0, 9, 1, 3, 0,
                 0, 1, 9, 4, 0
             };
 
@@ -110,12 +110,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 @test:something='Function'></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
-                0, 6, 1, 4, 0,
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
+                0, 6, 1, 2, 0,
                 0, 1, 4, 4, 0,
-                0, 4, 1, 4, 0,
+                0, 4, 1, 3, 0,
                 0, 1, 9, 4, 0,
-                0, 23, 5, 1, 0
+                0, 23, 5, 0, 0
             };
 
             AssertSemanticTokens(txt, expectedData, isRazor: true, out var _);
@@ -135,10 +135,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 @test='Function'></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
-                0, 6, 1, 4, 0,
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
+                0, 6, 1, 2, 0,
                 0, 1, 4, 4, 0,
-                0, 18, 5, 1, 0
+                0, 18, 5, 0, 0
             };
 
             AssertSemanticTokens(txt, expectedData, isRazor: true, out var _);
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTaghelper *, TestAssembly{Environment.NewLine}<p @test='Function'></p>";
             var expectedData = new List<uint> {
-                1, 3, 1, 4, 0,
+                1, 3, 1, 2, 0,
                 0, 1, 4, 4, 0
             };
 
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
             };
 
             var startIndex = txt.IndexOf("test1");
@@ -194,8 +194,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
-                0, 8, 5, 1, 0
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
+                0, 8, 5, 0, 0
             };
 
             var previousResultId = AssertSemanticTokens(txt, expectedData, isRazor: false, out var service);
@@ -209,12 +209,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1><test1></test1><test1></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
-                0, 8, 5, 1, 0,
-                0, 7, 5, 1, 0,
-                0, 8, 5, 1, 0,
-                0, 7, 5, 1, 0,
-                0, 8, 5, 1, 0
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
+                0, 8, 5, 0, 0,
+                0, 7, 5, 0, 0,
+                0, 8, 5, 0, 0,
+                0, 7, 5, 0, 0,
+                0, 8, 5, 0, 0
             };
 
             var previousResultId = AssertSemanticTokens(txt, expectedData, isRazor: false, out var service);
@@ -236,8 +236,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
-                0, 8, 5, 1, 0
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
+                0, 8, 5, 0, 0
             };
 
             var previousResultId = AssertSemanticTokens(txt, expectedData, isRazor: false, out var service);
@@ -262,8 +262,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
-                0, 8, 5, 1, 0
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
+                0, 8, 5, 0, 0
             };
 
             var previousResultId = AssertSemanticTokens(txt, expectedData, isRazor: false, out var service);
@@ -276,8 +276,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                     {
                         Start = 10,
                         Data = new uint[]{
-                            0, 7, 5, 1, 0,
-                            0, 8, 5, 1, 0,
+                            0, 7, 5, 0, 0,
+                            0, 8, 5, 0, 0,
                         },
                         DeleteCount = 0,
                     }
@@ -292,8 +292,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var expectedData = new List<uint> {
-                1, 1, 5, 1, 0, //line, character pos, length, tokenType, modifier
-                0, 8, 5, 1, 0
+                1, 1, 5, 0, 0, //line, character pos, length, tokenType, modifier
+                0, 8, 5, 0, 0
             };
 
             var previousResultId = AssertSemanticTokens(txt, expectedData, isRazor: false, out var service);
@@ -307,8 +307,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                     {
                         Start = 10,
                         Data = new uint[]{
-                            1, 1, 5, 1, 0,
-                            0, 8, 5, 1, 0,
+                            1, 1, 5, 0, 0,
+                            0, 8, 5, 0, 0,
                         },
                         DeleteCount = 0,
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22893.

Once https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/257320 merges we'll be able to move back to the old more descriptive token types.