### PR TITLE
Don't update project.razor.json for unprepared projects

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectChangePublisher.cs
@@ -71,26 +71,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         }
 
         // Virtual for testing
-        protected virtual void DeleteFile(string publishFilePath)
-        {
-            var info = new FileInfo(publishFilePath);
-            if (info.Exists)
-            {
-                try
-                {
-                    // Try catch around the delete in case it was deleted between the Exists and this delete call. This also
-                    // protects against unauthorized access issues.
-                    info.Delete();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning($@"Failed to delete Razor configuration file '{publishFilePath}':
-{ex}");
-                }
-            }
-        }
-
-        // Virtual for testing
         protected virtual void SerializeToFile(OmniSharpProjectSnapshot projectSnapshot, string publishFilePath)
         {
             var fileInfo = new FileInfo(publishFilePath);
@@ -167,8 +147,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                                 // Project was removed while a delayed publish was in flight. Clear the in-flight publish so it noops.
                                 _pendingProjectPublishes.Remove(oldProjectFilePath);
                             }
-
-                            DeleteFile(publishFilePath);
                         }
                     }
                     break;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -117,20 +117,25 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return;
             }
 
+            // All the below Publish's (except ProjectRemoved) wait until our project has been initialized (ProjectWorkspaceState != null)
+            // so that we don't publish half-finished projects, which can cause things like Semantic coloring to "flash"
+            // when they update repeatedly as they load.
             switch (args.Kind)
             {
                 case ProjectChangeKind.DocumentRemoved:
                 case ProjectChangeKind.DocumentAdded:
                 case ProjectChangeKind.ProjectChanged:
-                    // These changes can come in bursts so we don't want to overload the publishing system. Therefore,
-                    // we enqueue publishes and then publish the latest project after a delay.
 
-                    EnqueuePublish(args.Newer);
+                    if (args.Newer.ProjectWorkspaceState != null)
+                    {
+                        // These changes can come in bursts so we don't want to overload the publishing system. Therefore,
+                        // we enqueue publishes and then publish the latest project after a delay.
+                        EnqueuePublish(args.Newer);
+                    }
                     break;
 
                 case ProjectChangeKind.ProjectAdded:
-                    // This causes us to  wait until our project has been initialized
-                    // so that we don't publish half-finished projects, which can cause things like Semantic coloring to "flash".
+
                     if (args.Newer.ProjectWorkspaceState != null)
                     {
                         Publish(args.Newer);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -129,7 +129,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     break;
 
                 case ProjectChangeKind.ProjectAdded:
-                    Publish(args.Newer);
+                    if (args.Newer.ProjectWorkspaceState != null)
+                    {
+                        Publish(args.Newer);
+                    }
                     break;
 
                 case ProjectChangeKind.ProjectRemoved:
@@ -182,28 +185,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 {
                     // Project was removed while a delayed publish was in flight. Clear the in-flight publish so it noops.
                     _pendingProjectPublishes.Remove(oldProjectFilePath);
-                }
-
-                DeleteFile(publishFilePath);
-            }
-        }
-
-        // Virtual for testing
-        protected virtual void DeleteFile(string publishFilePath)
-        {
-            var info = new FileInfo(publishFilePath);
-            if (info.Exists)
-            {
-                try
-                {
-                    // Try catch around the delete in case it was deleted between the Exists and this delete call. This also
-                    // protects against unauthorized access issues.
-                    info.Delete();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning($@"Failed to delete Razor configuration file '{publishFilePath}':
-{ex}");
                 }
             }
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -129,6 +129,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     break;
 
                 case ProjectChangeKind.ProjectAdded:
+                    // This causes us to  wait until our project has been initialized
+                    // so that we don't publish half-finished projects, which can cause things like Semantic coloring to "flash".
                     if (args.Newer.ProjectWorkspaceState != null)
                     {
                         Publish(args.Newer);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
@@ -14,10 +14,10 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
 {
     internal class TestProjectSnapshot : DefaultProjectSnapshot
     {
-        public static TestProjectSnapshot Create(string filePath) => Create(filePath, new string[0]);
+        public static TestProjectSnapshot Create(string filePath, ProjectWorkspaceState projectWorkspaceState = null) => Create(filePath, new string[0], projectWorkspaceState);
 
-        public static TestProjectSnapshot Create(string filePath, string[] documentFilePaths) =>
-            Create(filePath, documentFilePaths, RazorConfiguration.Default, projectWorkspaceState: null);
+        public static TestProjectSnapshot Create(string filePath, string[] documentFilePaths, ProjectWorkspaceState projectWorkspaceState = null) =>
+            Create(filePath, documentFilePaths, RazorConfiguration.Default, projectWorkspaceState);
 
         public static TestProjectSnapshot Create(
             string filePath,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
@@ -27,12 +30,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         {
             var commonTestAssembly = Assembly.Load("Microsoft.AspNetCore.Razor.LanguageServer.Test.Common");
             var testProjectSnapshotType = commonTestAssembly.GetType("Microsoft.AspNetCore.Razor.Test.Common.TestProjectSnapshot");
+  
             var testProjectSnapshotManagerType = commonTestAssembly.GetType("Microsoft.AspNetCore.Razor.Test.Common.TestProjectSnapshotManager");
             var strongNamedAssembly = Assembly.Load("Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed");
             var defaultSnapshotManagerType = strongNamedAssembly.GetType("Microsoft.AspNetCore.Razor.OmniSharpPlugin.DefaultOmniSharpProjectSnapshotManager");
 
-            _createTestProjectSnapshotMethod = testProjectSnapshotType.GetMethod("Create", new[] { typeof(string) });
-            _createWithDocumentsTestProjectSnapshotMethod = testProjectSnapshotType.GetMethod("Create", new[] { typeof(string), typeof(string[]) });
+            _createTestProjectSnapshotMethod = testProjectSnapshotType.GetMethod("Create", new[] { typeof(string), typeof(ProjectWorkspaceState) });
+            _createWithDocumentsTestProjectSnapshotMethod = testProjectSnapshotType.GetMethod("Create", new[] { typeof(string), typeof(string[]), typeof(ProjectWorkspaceState) });
             _createProjectSnapshotManagerMethod = testProjectSnapshotManagerType.GetMethod("Create");
             _allowNotifyListenersProperty = testProjectSnapshotManagerType.GetProperty("AllowNotifyListeners");
             _dispatcherProperty = typeof(OmniSharpForegroundDispatcher).GetProperty("InternalDispatcher", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -46,7 +50,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
         protected OmniSharpProjectSnapshot CreateProjectSnapshot(string projectFilePath)
         {
-            var projectSnapshot = _createTestProjectSnapshotMethod.Invoke(null, new[] { projectFilePath });
+            var projectWorkspaceState = new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, CodeAnalysis.CSharp.LanguageVersion.Default);
+            var projectSnapshot = _createTestProjectSnapshotMethod.Invoke(null, new object[] { projectFilePath, projectWorkspaceState });
             var omniSharpProjectSnapshot = (OmniSharpProjectSnapshot)_omniSharpSnapshotConstructor.Invoke(new[] { projectSnapshot });
 
             return omniSharpProjectSnapshot;
@@ -54,7 +59,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
         protected OmniSharpProjectSnapshot CreateProjectSnapshot(string projectFilePath, string[] documentFilePaths)
         {
-            var projectSnapshot = _createWithDocumentsTestProjectSnapshotMethod.Invoke(null, new object[] { projectFilePath, documentFilePaths });
+            var projectWorkspaceState = new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, CodeAnalysis.CSharp.LanguageVersion.Default);
+            var projectSnapshot = _createWithDocumentsTestProjectSnapshotMethod.Invoke(null, new object[] { projectFilePath, documentFilePaths, projectWorkspaceState });
             var omniSharpProjectSnapshot = (OmniSharpProjectSnapshot)_omniSharpSnapshotConstructor.Invoke(new[] { projectSnapshot });
 
             return omniSharpProjectSnapshot;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             var expectedPublishFilePath = "/path/to/obj/bin/Debug/project.razor.json";
 
             var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
-            var snapshotManager = CreateProjectSnapshotManager(hostProject.FilePath, allowNotifyListeners: true);
+            var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
 
             var publisher = new TestDefaultRazorProjectChangePublisher(
                 JoinableTaskContext,
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
         {
             // Arrange
             var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
-            var snapshotManager = CreateProjectSnapshotManager(hostProject.FilePath, allowNotifyListeners: true);
+            var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var publisher = new TestDefaultRazorProjectChangePublisher(JoinableTaskContext, RazorLogger);
             publisher.Initialize(snapshotManager);
             await RunOnForegroundAsync(() => snapshotManager.ProjectAdded(hostProject)).ConfigureAwait(false);
@@ -207,12 +207,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             return testProjectSnapshot;
         }
 
-        internal ProjectSnapshotManagerBase CreateProjectSnapshotManager(string projectFilePath, bool allowNotifyListeners = false)
+        internal ProjectSnapshotManagerBase CreateProjectSnapshotManager(bool allowNotifyListeners = false)
         {
             var snapshotManager = TestProjectSnapshotManager.Create(Dispatcher);
             snapshotManager.AllowNotifyListeners = allowNotifyListeners;
-            var projectWorkspaceState = new ProjectWorkspaceState(new TagHelperDescriptor[] { }, CodeAnalysis.CSharp.LanguageVersion.Default);
-            snapshotManager.ProjectWorkspaceStateChanged(projectFilePath, projectWorkspaceState);
 
             return snapshotManager;
         }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
@@ -155,11 +155,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
         public async Task ProjectAdded_DoesNotPublishWithoutProjectWorkspaceStateAsync()
         {
             // Arrange
+            var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var serializationSuccessful = false;
             var expectedPublishFilePath = "/path/to/obj/bin/Debug/project.razor.json";
-
-            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
-            var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
 
             var publisher = new TestDefaultRazorProjectChangePublisher(
                 JoinableTaskContext,
@@ -170,6 +168,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
                     serializationSuccessful = true;
                 });
             publisher.Initialize(snapshotManager);
+            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             publisher.SetPublishFilePath(hostProject.FilePath, expectedPublishFilePath);
 
             // Act
@@ -183,10 +182,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
         public async Task ProjectRemoved_UnSetPublishFilePath_NoopsAsync()
         {
             // Arrange
-            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var publisher = new TestDefaultRazorProjectChangePublisher(JoinableTaskContext, RazorLogger);
             publisher.Initialize(snapshotManager);
+            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             await RunOnForegroundAsync(() => snapshotManager.ProjectAdded(hostProject)).ConfigureAwait(false);
 
             // Act & Assert


### PR DESCRIPTION
Edit: Sorry for lack of original description, it was a busy day.

SO, we're seeing a race condition where when you open up a VS solution with a document that's pre-opened that document might not be colorized. We determined that that's because we delete the project.razor.json file when we close VS, so when we re-open and ask for Semantic's the project.razor.json probably hasn't been opened yet and even more likely doesn't have any TagHelpers/Components in it, so we don't report and Semantic Tokens, and VS doesn't know to ask for them again until an edit is made. By not deleting the project.razor.json and not publishing updates to it until the project state is loaded we greatly reduce the chance that things "aren't ready". It's not a guarantee (we've talked before about how it's hard to know if things are "ready"), but it should be much more likely to present a consistent state.