### PR TITLE
Ngen Razor compiler binaries.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -175,11 +175,18 @@
 
   <!-- Include our Razor package dependency dlls in our extension -->
   <ItemGroup>
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Razor.Language.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Razor.dll" />
+    <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
+    <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
+    <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll" />
+    <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.AspNetCore.Razor.Language.dll" />
+    <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Razor.dll" />
+
+    <VSIXSourceItem Include="@(RazorNgendVSIXSourceItem)">
+      <Ngen>$(Ngen)</Ngen>
+      <NgenApplication>$(NgenApplication)</NgenApplication>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
+      <NgenPriority>$(NgenPriority)</NgenPriority>
+    </VSIXSourceItem>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- When the aspnetcore-tooling repo had its compiler binaries migrated over to aspnetcore we had to move from project references to `<VSIXSourceItem>` inclusions. The unknown problem at the time with doing that happened to be that project references automatically get turned into VSIXSourceItem's that should be ngen'd where as manually specifying the items would not result in that.
- Could not add tests for this because ngening is validated at the integration level. Therefore, to 100% validate that this resolves our ngen issues we'll need to inspect perf logs at VS insertion time.

Fixes dotnet/aspnetcore#23314