### PR TITLE
Remove references to Roslyn TextChange type in contained language code

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -131,6 +131,7 @@
     <OmniSharpExtensionsLanguageServerPackageVersion>0.14.2</OmniSharpExtensionsLanguageServerPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.33.0</OmniSharpMSBuildPackageVersion>
     <SystemPrivateUriPackageVersion>4.3.2</SystemPrivateUriPackageVersion>
+    <SystemCompositionPackageVersion>1.0.31.0</SystemCompositionPackageVersion>
     <VS_NewtonsoftJsonPackageVersion>12.0.2</VS_NewtonsoftJsonPackageVersion>
     <VSMAC_NewtonsoftJsonPackageVersion>12.0.2</VSMAC_NewtonsoftJsonPackageVersion>
     <StreamJsonRpcPackageVersion>2.4.34</StreamJsonRpcPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -135,7 +135,6 @@
     <VS_NewtonsoftJsonPackageVersion>12.0.2</VS_NewtonsoftJsonPackageVersion>
     <VSMAC_NewtonsoftJsonPackageVersion>12.0.2</VSMAC_NewtonsoftJsonPackageVersion>
     <StreamJsonRpcPackageVersion>2.4.34</StreamJsonRpcPackageVersion>
-    <SystemCompositionPackageVersion>1.0.31.0</SystemCompositionPackageVersion>
     <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.0.0</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -135,6 +135,7 @@
     <VS_NewtonsoftJsonPackageVersion>12.0.2</VS_NewtonsoftJsonPackageVersion>
     <VSMAC_NewtonsoftJsonPackageVersion>12.0.2</VSMAC_NewtonsoftJsonPackageVersion>
     <StreamJsonRpcPackageVersion>2.4.34</StreamJsonRpcPackageVersion>
+    <SystemCompositionPackageVersion>1.0.31.0</SystemCompositionPackageVersion>
     <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.0.0</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>3.7.0-2.20257.6</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocument.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
@@ -58,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             }
         }
 
-        public override LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        public override LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<ITextChange> changes, long hostDocumentVersion)
         {
             if (!TryGetVirtualDocument<TVirtualDocument>(out var virtualDocument))
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentManager.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 
@@ -106,7 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
         public override void UpdateVirtualDocument<TVirtualDocument>(
             Uri hostDocumentUri,
-            IReadOnlyList<TextChange> changes,
+            IReadOnlyList<ITextChange> changes,
             long hostDocumentVersion)
         {
             if (hostDocumentUri is null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/LSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/LSPDocument.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
@@ -20,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
         public abstract IReadOnlyList<VirtualDocument> VirtualDocuments { get; }
 
-        public abstract LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<TextChange> changes, long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
+        public abstract LSPDocumentSnapshot UpdateVirtualDocument<TVirtualDocument>(IReadOnlyList<ITextChange> changes, long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
 
         public bool TryGetVirtualDocument<TVirtualDocument>(out TVirtualDocument virtualDocument) where TVirtualDocument : VirtualDocument
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(Tooling_MicrosoftCodeAnalysisPackageVersion)" NoWarn="NU1608" />
+    <PackageReference Include="System.Composition" Version="$(SystemCompositionPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.15.0" Version="$(MicrosoftVisualStudioPackageLanguageService150PackageVersion)" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/SimpleTextChange.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/SimpleTextChange.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
+{
+    internal class SimpleTextChange : ITextChange
+    {
+        public SimpleTextChange(int oldStart, int oldLength, string newText)
+        {
+            OldSpan = new Span(oldStart, oldLength);
+            NewText = newText;
+        }
+
+        public Span OldSpan { get; }
+        public int OldPosition => this.OldSpan.Start;
+        public int OldEnd => this.OldSpan.End;
+        public int OldLength => this.OldSpan.Length;
+        public string NewText { get; }
+        public int NewLength => this.NewText.Length;
+
+        public Span NewSpan => throw new NotImplementedException();
+
+        public int NewPosition => throw new NotImplementedException();
+        public int Delta => throw new NotImplementedException();
+        public int NewEnd => throw new NotImplementedException();
+        public string OldText => throw new NotImplementedException();
+        public int LineCountDelta => throw new NotImplementedException();
+
+        public override string ToString()
+        {
+            return this.OldSpan.ToString() + "->" + this.NewText;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/TrackingLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/TrackingLSPDocumentManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
@@ -16,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
         public abstract void UpdateVirtualDocument<TVirtualDocument>(
             Uri hostDocumentUri,
-            IReadOnlyList<TextChange> changes,
+            IReadOnlyList<ITextChange> changes,
             long hostDocumentVersion) where TVirtualDocument : VirtualDocument;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VirtualDocument.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
@@ -18,6 +17,6 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
         public abstract long? HostDocumentSyncVersion { get; }
 
-        public abstract VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion);
+        public abstract VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, long hostDocumentVersion);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VisualStudioTextChange.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VisualStudioTextChange.cs
@@ -6,9 +6,9 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 {
-    internal class SimpleTextChange : ITextChange
+    internal class VisualStudioTextChange : ITextChange
     {
-        public SimpleTextChange(int oldStart, int oldLength, string newText)
+        public VisualStudioTextChange(int oldStart, int oldLength, string newText)
         {
             OldSpan = new Span(oldStart, oldLength);
             NewText = newText;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Text;
 
@@ -39,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public override VirtualDocumentSnapshot CurrentSnapshot => _currentSnapshot;
 
-        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, long hostDocumentVersion)
         {
             if (changes is null)
             {
@@ -66,15 +65,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
                 if (change.IsDelete())
                 {
-                    edit.Delete(change.Span.Start, change.Span.Length);
+                    edit.Delete(change.OldSpan.Start, change.OldSpan.Length);
                 }
                 else if (change.IsReplace())
                 {
-                    edit.Replace(change.Span.Start, change.Span.Length, change.NewText);
+                    edit.Replace(change.OldSpan.Start, change.OldSpan.Length, change.NewText);
                 }
                 else if (change.IsInsert())
                 {
-                    edit.Insert(change.Span.Start, change.NewText);
+                    edit.Insert(change.OldSpan.Start, change.NewText);
                 }
                 else
                 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = new Uri(request.HostDocumentFilePath);
             _documentManager.UpdateVirtualDocument<CSharpVirtualDocument>(
                 hostDocumentUri,
-                request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
+                request.Changes?.Select(change => change.ToVisualStudioTextChange()).ToArray(),
                 request.HostDocumentVersion);
         }
 
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = new Uri(request.HostDocumentFilePath);
             _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(
                 hostDocumentUri,
-                request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
+                request.Changes?.Select(change => change.ToVisualStudioTextChange()).ToArray(),
                 request.HostDocumentVersion);
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = new Uri(request.HostDocumentFilePath);
             _documentManager.UpdateVirtualDocument<CSharpVirtualDocument>(
                 hostDocumentUri,
-                request.Changes,
+                request.Changes.ToVisualStudioTextChangeList(),
                 request.HostDocumentVersion);
         }
 
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = new Uri(request.HostDocumentFilePath);
             _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(
                 hostDocumentUri,
-                request.Changes,
+                request.Changes.ToVisualStudioTextChangeList(),
                 request.HostDocumentVersion);
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Composition;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
@@ -85,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = new Uri(request.HostDocumentFilePath);
             _documentManager.UpdateVirtualDocument<CSharpVirtualDocument>(
                 hostDocumentUri,
-                request.Changes.ToVisualStudioTextChangeList(),
+                request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
                 request.HostDocumentVersion);
         }
 
@@ -113,7 +114,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var hostDocumentUri = new Uri(request.HostDocumentFilePath);
             _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(
                 hostDocumentUri,
-                request.Changes.ToVisualStudioTextChangeList(),
+                request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
                 request.HostDocumentVersion);
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
@@ -161,7 +162,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             await _joinableTaskFactory.SwitchToMainThreadAsync();
 
-            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, new[] { addProvisionalDot }, previousCharacterProjection.HostDocumentVersion);
+            var textChanges = (new[] { addProvisionalDot }).ToVisualStudioTextChangeList();
+            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, textChanges, previousCharacterProjection.HostDocumentVersion);
 
             var provisionalCompletionParams = new CompletionParams()
             {
@@ -181,7 +183,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 TextSpan.FromBounds(previousCharacterProjection.PositionIndex, previousCharacterProjection.PositionIndex + 1),
                 string.Empty);
 
-            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, new[] { removeProvisionalDot }, previousCharacterProjection.HostDocumentVersion);
+            textChanges = (new[] { removeProvisionalDot }).ToVisualStudioTextChangeList();
+            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, textChanges, previousCharacterProjection.HostDocumentVersion);
 
             return (true, result);
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -156,14 +156,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Edit the CSharp projected document to contain a '.'. This allows C# completion to provide valid
             // completion items for moments when a user has typed a '.' that's typically interpreted as Html.
-            var addProvisionalDot = new TextChange(
-                TextSpan.FromBounds(previousCharacterProjection.PositionIndex, previousCharacterProjection.PositionIndex),
-                ".");
+            var addProvisionalDot = new VisualStudioTextChange(previousCharacterProjection.PositionIndex, 0, ".");
 
             await _joinableTaskFactory.SwitchToMainThreadAsync();
 
-            var textChanges = (new[] { addProvisionalDot }).ToVisualStudioTextChangeList();
-            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, textChanges, previousCharacterProjection.HostDocumentVersion);
+            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, new[] { addProvisionalDot }, previousCharacterProjection.HostDocumentVersion);
 
             var provisionalCompletionParams = new CompletionParams()
             {
@@ -179,12 +176,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(true);
 
             // We have now obtained the necessary completion items. We no longer need the provisional change. Revert.
-            var removeProvisionalDot = new TextChange(
-                TextSpan.FromBounds(previousCharacterProjection.PositionIndex, previousCharacterProjection.PositionIndex + 1),
-                string.Empty);
-
-            textChanges = (new[] { removeProvisionalDot }).ToVisualStudioTextChangeList();
-            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, textChanges, previousCharacterProjection.HostDocumentVersion);
+            var removeProvisionalDot = new VisualStudioTextChange(previousCharacterProjection.PositionIndex, 1, string.Empty);
+            
+            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, new[] { removeProvisionalDot }, previousCharacterProjection.HostDocumentVersion);
 
             return (true, result);
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Text;
 
@@ -39,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public override VirtualDocumentSnapshot CurrentSnapshot => _currentSnapshot;
 
-        public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, long hostDocumentVersion)
         {
             if (changes is null)
             {
@@ -66,15 +65,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
                 if (change.IsDelete())
                 {
-                    edit.Delete(change.Span.Start, change.Span.Length);
+                    edit.Delete(change.OldSpan.Start, change.OldSpan.Length);
                 }
                 else if (change.IsReplace())
                 {
-                    edit.Replace(change.Span.Start, change.Span.Length, change.NewText);
+                    edit.Replace(change.OldSpan.Start, change.OldSpan.Length, change.NewText);
                 }
                 else if (change.IsInsert())
                 {
-                    edit.Insert(change.Span.Start, change.NewText);
+                    edit.Insert(change.OldSpan.Start, change.NewText);
                 }
                 else
                 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Composition" Version="$(SystemCompositionPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIPackageVersion)" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextChangeExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextChangeExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             for (var i = 0; i < roslynTextChanges.Count; i++)
             {
                 var roslynTextChange = roslynTextChanges[i];
-                textChanges.Add(new SimpleTextChange(roslynTextChange.Span.Start, roslynTextChange.Span.Length, roslynTextChange.NewText));
+                textChanges.Add(new VisualStudioTextChange(roslynTextChange.Span.Start, roslynTextChange.Span.Length, roslynTextChange.NewText));
             }
 
             return textChanges;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextChangeExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextChangeExtensions.cs
@@ -26,26 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return textChange.OldSpan.Length > 0 && textChange.NewText.Length > 0;
         }
 
-        public static IReadOnlyList<ITextChange> ToVisualStudioTextChangeList(this IReadOnlyList<RoslynTextChange> roslynTextChanges)
-        {
-            if (roslynTextChanges == null)
-            {
-                return null;
-            }
-
-            if (roslynTextChanges.Count == 0)
-            {
-                return Array.Empty<ITextChange>();
-            }
-
-            var textChanges = new List<ITextChange>(roslynTextChanges.Count);
-            for (var i = 0; i < roslynTextChanges.Count; i++)
-            {
-                var roslynTextChange = roslynTextChanges[i];
-                textChanges.Add(new VisualStudioTextChange(roslynTextChange.Span.Start, roslynTextChange.Span.Length, roslynTextChange.NewText));
-            }
-
-            return textChanges;
-        }
+        public static ITextChange ToVisualStudioTextChange(this RoslynTextChange roslynTextChange) =>
+            new VisualStudioTextChange(roslynTextChange.Span.Start, roslynTextChange.Span.Length, roslynTextChange.NewText);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextChangeExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TextChangeExtensions.cs
@@ -1,25 +1,51 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.Text;
+using RoslynTextChange = Microsoft.CodeAnalysis.Text.TextChange;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     public static class TextChangeExtensions
     {
-        public static bool IsDelete(this TextChange textChange)
+        public static bool IsDelete(this ITextChange textChange)
         {
-            return textChange.Span.Length > 0 && textChange.NewText.Length == 0;
+            return textChange.OldSpan.Length > 0 && textChange.NewText.Length == 0;
         }
 
-        public static bool IsInsert(this TextChange textChange)
+        public static bool IsInsert(this ITextChange textChange)
         {
-            return textChange.Span.Length == 0 && textChange.NewText.Length > 0;
+            return textChange.OldSpan.Length == 0 && textChange.NewText.Length > 0;
         }
 
-        public static bool IsReplace(this TextChange textChange)
+        public static bool IsReplace(this ITextChange textChange)
         {
-            return textChange.Span.Length > 0 && textChange.NewText.Length > 0;
+            return textChange.OldSpan.Length > 0 && textChange.NewText.Length > 0;
+        }
+
+        public static IReadOnlyList<ITextChange> ToVisualStudioTextChangeList(this IReadOnlyList<RoslynTextChange> roslynTextChanges)
+        {
+            if (roslynTextChanges == null)
+            {
+                return null;
+            }
+
+            if (roslynTextChanges.Count == 0)
+            {
+                return Array.Empty<ITextChange>();
+            }
+
+            var textChanges = new List<ITextChange>(roslynTextChanges.Count);
+            for (var i = 0; i < roslynTextChanges.Count; i++)
+            {
+                var roslynTextChange = roslynTextChanges[i];
+                textChanges.Add(new SimpleTextChange(roslynTextChange.Span.Start, roslynTextChange.Span.Length, roslynTextChange.NewText));
+            }
+
+            return textChanges;
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common/TestDocumentManager.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common/TestDocumentManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
@@ -38,7 +37,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             throw new NotImplementedException();
         }
 
-        public override void UpdateVirtualDocument<TVirtualDocument>(Uri hostDocumentUri, IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+        public override void UpdateVirtualDocument<TVirtualDocument>(Uri hostDocumentUri, IReadOnlyList<ITextChange> changes, long hostDocumentVersion)
         {
             UpdateVirtualDocumentCallCount++;
         }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultLSPDocumentManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultLSPDocumentManagerTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             {
                 changedCalled = true;
             };
-            var changes = new[] { new SimpleTextChange(1, 1, string.Empty) };
+            var changes = new[] { new VisualStudioTextChange(1, 1, string.Empty) };
 
             // Act
             manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123);
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                 Assert.NotSame(LSPDocumentSnapshot, args.New);
                 Assert.Equal(LSPDocumentChangeKind.VirtualDocumentChanged, args.Kind);
             };
-            var changes = new[] { new SimpleTextChange(1, 1, string.Empty) };
+            var changes = new[] { new VisualStudioTextChange(1, 1, string.Empty) };
 
             // Act
             manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultLSPDocumentManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultLSPDocumentManagerTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 using Moq;
@@ -27,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                 document.Uri == Uri &&
                 document.CurrentSnapshot == LSPDocumentSnapshot &&
                 document.VirtualDocuments == new[] { new TestVirtualDocument() } &&
-                document.UpdateVirtualDocument<TestVirtualDocument>(It.IsAny<IReadOnlyList<TextChange>>(), It.IsAny<long>()) == Mock.Of<LSPDocumentSnapshot>());
+                document.UpdateVirtualDocument<TestVirtualDocument>(It.IsAny<IReadOnlyList<ITextChange>>(), It.IsAny<long>()) == Mock.Of<LSPDocumentSnapshot>());
             LSPDocumentFactory = Mock.Of<LSPDocumentFactory>(factory => factory.Create(TextBuffer) == LSPDocument);
         }
 
@@ -100,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             {
                 changedCalled = true;
             };
-            var changes = new[] { new TextChange(new TextSpan(1, 1), string.Empty) };
+            var changes = new[] { new SimpleTextChange(1, 1, string.Empty) };
 
             // Act
             manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123);
@@ -120,7 +119,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             {
                 changedCalled = true;
             };
-            var changes = Array.Empty<TextChange>();
+            var changes = Array.Empty<ITextChange>();
 
             // Act
             manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123);
@@ -143,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                 Assert.NotSame(LSPDocumentSnapshot, args.New);
                 Assert.Equal(LSPDocumentChangeKind.VirtualDocumentChanged, args.Kind);
             };
-            var changes = new[] { new TextChange(new TextSpan(1, 1), string.Empty) };
+            var changes = new[] { new SimpleTextChange(1, 1, string.Empty) };
 
             // Act
             manager.UpdateVirtualDocument<TestVirtualDocument>(Uri, changes, 123);
@@ -207,7 +206,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
             public override long? HostDocumentSyncVersion => 123;
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, long hostDocumentVersion)
             {
                 throw new NotImplementedException();
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultLSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultLSPDocumentTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Xunit;
@@ -27,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             var textBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == snapshot);
             var virtualDocument = new TestVirtualDocument();
             var document = new DefaultLSPDocument(Uri, textBuffer, new[] { virtualDocument });
-            var changes = Array.Empty<TextChange>();
+            var changes = Array.Empty<ITextChange>();
             var originalSnapshot = document.CurrentSnapshot;
 
             // Act
@@ -43,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         {
             private long? _hostDocumentVersion;
 
-            public IReadOnlyList<TextChange> Changes { get; private set; }
+            public IReadOnlyList<ITextChange> Changes { get; private set; }
 
             public override Uri Uri => throw new NotImplementedException();
 
@@ -53,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
             public override long? HostDocumentSyncVersion => _hostDocumentVersion;
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, long hostDocumentVersion)
             {
                 _hostDocumentVersion = hostDocumentVersion;
                 Changes = changes;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/LSPDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/LSPDocumentTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Xunit;
@@ -58,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
             public override VirtualDocumentSnapshot CurrentSnapshot => throw new NotImplementedException();
 
-            public override VirtualDocumentSnapshot Update(IReadOnlyList<TextChange> changes, long hostDocumentVersion)
+            public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, long hostDocumentVersion)
             {
                 throw new NotImplementedException();
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Xunit;
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var originalSnapshot = document.CurrentSnapshot;
 
             // Act
-            document.Update(Array.Empty<TextChange>(), hostDocumentVersion: 1337);
+            document.Update(Array.Empty<ITextChange>(), hostDocumentVersion: 1337);
 
             // Assert
             Assert.NotSame(originalSnapshot, document.CurrentSnapshot);
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void Update_Insert()
         {
             // Arrange
-            var insert = new TextChange(new TextSpan(0, 0), "inserted text");
+            var insert = new SimpleTextChange(0, 0, "inserted text");
             var textBuffer = new TestTextBuffer(StringTextSnapshot.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("original"));
-            var replace = new TextChange(new TextSpan(0, textBuffer.CurrentSnapshot.Length), "replaced text");
+            var replace = new SimpleTextChange(0, textBuffer.CurrentSnapshot.Length, "replaced text");
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
-            var delete = new TextChange(new TextSpan(6, 5), string.Empty);
+            var delete = new SimpleTextChange(6, 5, string.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -87,8 +87,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
-            var replace = new TextChange(new TextSpan(6, 5), "Replaced");
-            var delete = new TextChange(new TextSpan(0, 6), string.Empty);
+            var replace = new SimpleTextChange(6, 5, "Replaced");
+            var delete = new SimpleTextChange(0, 6, string.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
-            document.Update(Array.Empty<TextChange>(), hostDocumentVersion: 1);
+            document.Update(Array.Empty<ITextChange>(), hostDocumentVersion: 1);
 
             // Assert
             Assert.Equal(2, called);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void Update_Insert()
         {
             // Arrange
-            var insert = new SimpleTextChange(0, 0, "inserted text");
+            var insert = new VisualStudioTextChange(0, 0, "inserted text");
             var textBuffer = new TestTextBuffer(StringTextSnapshot.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("original"));
-            var replace = new SimpleTextChange(0, textBuffer.CurrentSnapshot.Length, "replaced text");
+            var replace = new VisualStudioTextChange(0, textBuffer.CurrentSnapshot.Length, "replaced text");
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
-            var delete = new SimpleTextChange(6, 5, string.Empty);
+            var delete = new VisualStudioTextChange(6, 5, string.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -87,8 +87,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
-            var replace = new SimpleTextChange(6, 5, "Replaced");
-            var delete = new SimpleTextChange(0, 6, string.Empty);
+            var replace = new VisualStudioTextChange(6, 5, "Replaced");
+            var delete = new VisualStudioTextChange(0, 6, string.Empty);
             var document = new CSharpVirtualDocument(Uri, textBuffer);
 
             // Act

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var documentManager = new Mock<TrackingLSPDocumentManager>();
-            documentManager.Setup(manager => manager.UpdateVirtualDocument<CSharpVirtualDocument>(It.IsAny<Uri>(), It.IsAny<IReadOnlyList<TextChange>>(), 1337))
+            documentManager.Setup(manager => manager.UpdateVirtualDocument<CSharpVirtualDocument>(It.IsAny<Uri>(), It.IsAny<IReadOnlyList<ITextChange>>(), 1337))
                 .Verifiable();
             var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
             var request = new UpdateBufferRequest()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Xunit;
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var originalSnapshot = document.CurrentSnapshot;
 
             // Act
-            document.Update(Array.Empty<TextChange>(), hostDocumentVersion: 1337);
+            document.Update(Array.Empty<ITextChange>(), hostDocumentVersion: 1337);
 
             // Assert
             Assert.NotSame(originalSnapshot, document.CurrentSnapshot);
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void Update_Insert()
         {
             // Arrange
-            var insert = new TextChange(new TextSpan(0, 0), "inserted text");
+            var insert = new SimpleTextChange(0, 0, "inserted text");
             var textBuffer = new TestTextBuffer(StringTextSnapshot.Empty);
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("original"));
-            var replace = new TextChange(new TextSpan(0, textBuffer.CurrentSnapshot.Length), "replaced text");
+            var replace = new SimpleTextChange(0, textBuffer.CurrentSnapshot.Length, "replaced text");
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
-            var delete = new TextChange(new TextSpan(6, 5), string.Empty);
+            var delete = new SimpleTextChange(6, 5, string.Empty);
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -87,8 +87,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
-            var replace = new TextChange(new TextSpan(6, 5), "Replaced");
-            var delete = new TextChange(new TextSpan(0, 6), string.Empty);
+            var replace = new SimpleTextChange(6, 5, "Replaced");
+            var delete = new SimpleTextChange(0, 6, string.Empty);
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
             // Act
-            document.Update(Array.Empty<TextChange>(), hostDocumentVersion: 1);
+            document.Update(Array.Empty<ITextChange>(), hostDocumentVersion: 1);
 
             // Assert
             Assert.Equal(2, called);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void Update_Insert()
         {
             // Arrange
-            var insert = new SimpleTextChange(0, 0, "inserted text");
+            var insert = new VisualStudioTextChange(0, 0, "inserted text");
             var textBuffer = new TestTextBuffer(StringTextSnapshot.Empty);
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("original"));
-            var replace = new SimpleTextChange(0, textBuffer.CurrentSnapshot.Length, "replaced text");
+            var replace = new VisualStudioTextChange(0, textBuffer.CurrentSnapshot.Length, "replaced text");
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
-            var delete = new SimpleTextChange(6, 5, string.Empty);
+            var delete = new VisualStudioTextChange(6, 5, string.Empty);
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
             // Act
@@ -87,8 +87,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
-            var replace = new SimpleTextChange(6, 5, "Replaced");
-            var delete = new SimpleTextChange(0, 6, string.Empty);
+            var replace = new VisualStudioTextChange(6, 5, "Replaced");
+            var delete = new VisualStudioTextChange(0, 6, string.Empty);
             var document = new HtmlVirtualDocument(Uri, textBuffer);
 
             // Act


### PR DESCRIPTION
This removes mixing of Roslyn and VS Platform text change APIs in common contained language code.

