### PR TITLE
Fix drag from sln closing active solution.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDropHandlerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDropHandlerProvider.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.DragDrop;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Export(typeof(IDropHandlerProvider))]
+    [ContentType(RazorLSPConstants.RazorLSPContentTypeName)]
+    [DropFormat(RazorLSPConstants.VSProjectItemsIdentifier)]
+    [Name(nameof(RazorDropHandlerProvider))]
+    [Order(Before = "LanguageServiceTextDropHandler")]
+    internal sealed class RazorDropHandlerProvider : IDropHandlerProvider
+    {
+        public IDropHandler GetAssociatedDropHandler(IWpfTextView wpfTextView) => new DisabledDropHandler();
+
+        private sealed class DisabledDropHandler : IDropHandler
+        {
+            public DragDropPointerEffects HandleDataDropped(DragDropInfo dragDropInfo)
+            {
+                return DragDropPointerEffects.None;
+            }
+
+            public void HandleDragCanceled()
+            {
+            }
+
+            public DragDropPointerEffects HandleDraggingOver(DragDropInfo dragDropInfo)
+            {
+                return DragDropPointerEffects.None;
+            }
+
+            public DragDropPointerEffects HandleDragStarted(DragDropInfo dragDropInfo)
+            {
+                return DragDropPointerEffects.None;
+            }
+
+            public bool IsDropEnabled(DragDropInfo dragDropInfo)
+            {
+                // We specifically return true here because the default handling (what would be used if we returned false) of drag & drop ends up resulting in an error dialog.
+                return true;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -20,5 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public const string VirtualCSharpFileNameSuffix = ".g.cs";
 
         public const string VirtualHtmlFileNameSuffix = "__virtual.html";
+
+        public const string VSProjectItemsIdentifier = "CF_VSSTGPROJECTITEMS";
     }
 }


### PR DESCRIPTION
- Prior to this dragging a Razor file from the solution would result in the solution closing and prompting an error dialog:
![image](https://i.imgur.com/U7gA7Zn.gif)

- This does not resolve dragging a file from outside of the IDE. That's tracked in https://github.com/dotnet/aspnetcore/issues/23501. Once that's fixed we can revert this commit entirely because this fix is more of a workaroudn to temporarily enable the solution dragging scenario.
- Given this is at the scenario integration levels I didn't write tests.

Fixes dotnet/aspnetcore#23494