### PR TITLE
Updated Progress Tests for Reliability

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -17,12 +17,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     [ExportLspMethod(Methods.TextDocumentReferencesName)]
     internal class FindAllReferencesHandler : IRequestHandler<ReferenceParams, VSReferenceItem[]>
     {
-        // Roslyn sends Progress Notifications every 0.5s *only* if results have been found.
-        // Consequently, at ~ time > 0.5s ~ after the last notification, we don't know whether Roslyn is
-        // done searching for results, or just hasn't found any additional results yet.
-        // To work around this, we wait for up to 3.5s since the last notification before timing out.
-        private static readonly TimeSpan WaitForProgressNotificationTimeout = TimeSpan.FromSeconds(3.5);
-
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly LSPDocumentManager _documentManager;
         private readonly LSPProjectionProvider _projectionProvider;
@@ -68,6 +62,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             _documentMappingProvider = documentMappingProvider;
             _lspProgressListener = lspProgressListener;
         }
+
+        // Roslyn sends Progress Notifications every 0.5s *only* if results have been found.
+        // Consequently, at ~ time > 0.5s ~ after the last notification, we don't know whether Roslyn is
+        // done searching for results, or just hasn't found any additional results yet.
+        // To work around this, we wait for up to 3.5s since the last notification before timing out.
+        //
+        // Internal for testing
+        internal TimeSpan WaitForProgressNotificationTimeout { private get; set; } = TimeSpan.FromSeconds(3.5);
 
         public async Task<VSReferenceItem[]> HandleRequestAsync(ReferenceParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProgressListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProgressListenerTest.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Client;
@@ -183,7 +185,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(onProgressNotifyAsyncCalled);
         }
 
-        [Fact (Skip = "https://github.com/dotnet/aspnetcore/issues/23523")]
+        [Fact]
         public async Task TryListenForProgress_MultipleProgressNotificationReported()
         {
             // Arrange
@@ -205,7 +207,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 });
             }
 
-            var receivedResults = new List<int>();
+            var receivedResults = new ConcurrentBag<int>();
             Func<JToken, CancellationToken, Task> onProgressNotifyAsync = (value, ct) => {
                 receivedResults.Add(value.ToObject<int>());
                 return Task.CompletedTask;
@@ -227,10 +229,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.True(listenerAdded);
-            receivedResults.Sort();
+            var sortedResults = receivedResults.ToList();
+            sortedResults.Sort();
             for (var i = 0; i < NUM_NOTIFICATIONS; ++i)
             {
-                Assert.Equal(i, receivedResults[i]);
+                Assert.Equal(i, sortedResults[i]);
             }
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -554,7 +554,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestInvoker = new Mock<LSPRequestInvoker>();
             requestInvoker
                 .Setup(r => r.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, VSReferenceItem[]>(It.IsAny<string>(), It.IsAny<LanguageServerKind>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
-                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>(async (method, serverKind, definitionParams, ct) =>
+                .Callback<string, LanguageServerKind, TextDocumentPositionParams, CancellationToken>((method, serverKind, definitionParams, ct) =>
                 {
                     Assert.Equal(Methods.TextDocumentReferencesName, method);
                     Assert.Equal(LanguageServerKind.CSharp, serverKind);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Client;
@@ -20,9 +22,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         public FindAllReferencesHandlerTest()
         {
             Uri = new Uri("C:/path/to/file.razor");
+
+            // Long timeout after last notification to avoid triggering even in slow CI environments
+            TestWaitForProgressNotificationTimeout = TimeSpan.FromSeconds(30);
         }
 
         private Uri Uri { get; }
+        private TimeSpan TestWaitForProgressNotificationTimeout { get; }
 
         [Fact]
         public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
@@ -34,6 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var progressListener = Mock.Of<LSPProgressListener>();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
             var referenceRequest = new ReferenceParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -58,6 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var progressListener = Mock.Of<LSPProgressListener>();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
             var referenceRequest = new ReferenceParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -89,6 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
             var progressListener = Mock.Of<LSPProgressListener>();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
             var referenceRequest = new ReferenceParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -128,6 +137,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     out onCompleted) == false);
 
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
             var referenceRequest = new ReferenceParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -203,6 +213,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Returns<RazorLanguageKind, Uri, Range[], CancellationToken>((languageKind, uri, ranges, ct) => Task.FromResult(uri.LocalPath.Contains("file1") ? remappingResult1 : remappingResult2));
 
             var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object, lspProgressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -259,6 +270,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 Returns(Task.FromResult(remappingResult));
 
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -304,6 +316,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>();
 
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -358,6 +371,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>();
 
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -414,6 +428,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>();
 
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -462,6 +477,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>();
 
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -491,13 +507,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Arrange
             var lspFarEndpointCalled = false;
-            var progressBatchesReported = 0;
 
             const int BATCH_SIZE = 10;
             const int NUM_BATCHES = 10;
             const int NUM_DOCUMENTS = BATCH_SIZE * NUM_BATCHES;
             const int MAPPING_OFFSET = 10;
-            const int DELAY_BETWEEN_BATCHES_MS = 1250;
 
             var expectedUris = new Uri[NUM_DOCUMENTS];
             var virtualUris = new Uri[NUM_DOCUMENTS];
@@ -548,7 +562,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
                     for (var i = 0; i < NUM_BATCHES; ++i)
                     {
-                        await Task.Delay(DELAY_BETWEEN_BATCHES_MS);
                         _ = lspProgressListener.ProcessProgressNotificationAsync(Methods.ProgressNotificationName, parameterTokens[i]);
                     }
                 })
@@ -584,18 +597,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 });
 
             var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object, lspProgressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
 
+            var progressBatchesReported = new ConcurrentBag<VSReferenceItem[]>();
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
                 var results = Assert.IsType<VSReferenceItem[]>(val);
                 Assert.Equal(BATCH_SIZE, results.Length);
-
-                for (var i = 0; i < BATCH_SIZE; ++i)
-                {
-                    AssertVSReferenceItem(expectedReferences[progressBatchesReported][i], results[i]);
-                }
-
-                ++progressBatchesReported;
+                progressBatchesReported.Add(results);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -609,7 +618,26 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.True(lspFarEndpointCalled);
-            Assert.Equal(NUM_BATCHES, progressBatchesReported);
+
+            var sortedBatchesReported = progressBatchesReported.ToList();
+            sortedBatchesReported.Sort((VSReferenceItem[] a, VSReferenceItem[] b) =>
+            {
+                var indexA = a[0].Location.Range.Start.Character;
+                var indexB = b[0].Location.Range.Start.Character;
+                return indexA.CompareTo(indexB);
+            });
+
+            Assert.Equal(NUM_BATCHES, sortedBatchesReported.Count);
+
+            for (var batch = 0; batch < NUM_BATCHES; ++batch)
+            {
+                for (var documentInBatch = 0; documentInBatch < BATCH_SIZE; ++documentInBatch)
+                {
+                    AssertVSReferenceItem(
+                        expectedReferences[batch][documentInBatch],
+                        sortedBatchesReported[batch][documentInBatch]);
+                }
+            }
         }
 
         private bool AssertVSReferenceItem(VSReferenceItem expected, VSReferenceItem actual)


### PR DESCRIPTION
- Issue was with using [`List.Add`](https://github.com/dotnet/aspnetcore-tooling/blob/master/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProgressListenerTest.cs#L208-L210) which isn't thread safe. Updated to using `ConcurrentBag` and repeated test run 100 times to ensure issue was resolved.
- Updated tests in FARHandler to increase resilience (defensive)
    - Increased default timeout from 3.5 secs used in PROD to 30 secs for CI
    - Implemented the same `ConcurrentBag` fix for the large batches tests to remove reliance on `Task.Delay` which may not work well in the CI.

Fixes: https://github.com/dotnet/aspnetcore/issues/23523