### PR TITLE
Bring Back Preboot Language Servers

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [AppliesTo("(DotNetCoreRazor & DotNetCoreRazorConfiguration) | ((DotNetCoreRazor | DotNetCoreWeb) & !DotNetCoreRazorConfiguration)")]
+    [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
+    internal class LSPRazorProjectHost : IProjectDynamicLoadComponent
+    {
+        private static readonly string[] _applicableContentTypes = new string[]
+        {
+            RazorLSPConstants.RazorLSPContentTypeName,
+            RazorLSPConstants.CSharpLSPContentTypeName,
+            RazorLSPConstants.HtmlLSPContentTypeName,
+        };
+
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+        private readonly LSPEditorFeatureDetector _featureDetector;
+        private readonly Lazy<ILanguageClientBroker> _languageClientBroker;
+        private readonly IEnumerable<Lazy<ILanguageClient, IDictionary<string, object>>> _languageClients;
+
+        [ImportingConstructor]
+        public LSPRazorProjectHost(
+            JoinableTaskContext joinableTaskContext,
+            LSPEditorFeatureDetector featureDetector,
+            Lazy<ILanguageClientBroker> languageClientBroker,
+            [ImportMany] IEnumerable<Lazy<ILanguageClient, IDictionary<string, object>>> languageClients)
+        {
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            if (featureDetector is null)
+            {
+                throw new ArgumentNullException(nameof(featureDetector));
+            }
+
+            if (languageClientBroker is null)
+            {
+                throw new ArgumentNullException(nameof(languageClientBroker));
+            }
+
+            if (languageClients is null)
+            {
+                throw new ArgumentNullException(nameof(languageClients));
+            }
+
+            _joinableTaskFactory = joinableTaskContext.Factory;
+            _featureDetector = featureDetector;
+            _languageClientBroker = languageClientBroker;
+            _languageClients = languageClients;
+        }
+
+        private List<Lazy<ILanguageClient, ILanguageClientMetadata>> ApplicableLanguageClients { get; set; }
+
+        public async Task LoadAsync()
+        {
+            await _joinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (!_featureDetector.IsLSPEditorFeatureEnabled())
+            {
+                return;
+            }
+
+            ApplicableLanguageClients = GetApplicableClients(_languageClients);
+
+            foreach (var client in ApplicableLanguageClients)
+            {
+                _languageClientBroker.Value.LoadAsync(client.Metadata, client.Value).Forget();
+            }
+        }
+
+        public Task UnloadAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        private static List<Lazy<ILanguageClient, ILanguageClientMetadata>> GetApplicableClients(IEnumerable<Lazy<ILanguageClient, IDictionary<string, object>>> languageClients)
+        {
+            var applicableClients = new List<Lazy<ILanguageClient, ILanguageClientMetadata>>();
+            foreach (var client in languageClients)
+            {
+                if (!client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ContentTypes), out var contentTypeValue) ||
+                    !(contentTypeValue is IEnumerable<string> contentTypes) ||
+                    !contentTypes.Intersect(_applicableContentTypes).Any())
+                {
+                    continue;
+                }
+
+                string clientName = null;
+                if (client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ClientName), out var clientNameValue))
+                {
+                    clientName = clientNameValue.ToString();
+                }
+
+                applicableClients.Add(new Lazy<ILanguageClient, ILanguageClientMetadata>(
+                    () => { return client.Value; },
+                    new LanguageClientMetadata(clientName, contentTypes)));
+            }
+
+            return applicableClients;
+        }
+
+        private class LanguageClientMetadata : ILanguageClientMetadata
+        {
+            public LanguageClientMetadata(string clientName, IEnumerable<string> contentTypes)
+            {
+                ClientName = clientName;
+                ContentTypes = contentTypes;
+            }
+
+            public string ClientName { get; }
+
+            public IEnumerable<string> ContentTypes { get; }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/LSPRazorProjectHostTest.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class LSPRazorProjectHostTest
+    {
+        public LSPRazorProjectHostTest()
+        {
+            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
+            JoinableTaskContext = joinableTaskContext.Context;
+        }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        [Fact]
+        public async Task LoadAsync_NoopsWhenLSPEditorFeatureNotAvailable()
+        {
+            // Arrange
+            var featureDetector = Mock.Of<LSPEditorFeatureDetector>(f => f.IsLSPEditorFeatureEnabled() == false);
+            var broker = new Lazy<ILanguageClientBroker>();
+            var client = new Lazy<ILanguageClient, IDictionary<string, object>>(
+                () => throw new NotImplementedException(), new Dictionary<string, object>());
+            var languageClients = new[] { client };
+
+            var host = new LSPRazorProjectHost(JoinableTaskContext, featureDetector, broker, languageClients);
+
+            // Act & Assert (does not throw)
+            await host.LoadAsync().ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task LoadAsync_LSPEditorFeatureAvailable_LoadsClients()
+        {
+            // Arrange
+            var featureDetector = Mock.Of<LSPEditorFeatureDetector>(f => f.IsLSPEditorFeatureEnabled() == true);
+
+            var metadata = new Dictionary<string, object>()
+            {
+                { "ClientName", "RazorClient" },
+                { "ContentTypes", new[] { "RazorLSP" } }
+            };
+            var client = new Lazy<ILanguageClient, IDictionary<string, object>>(() => Mock.Of<ILanguageClient>(), metadata);
+            var languageClients = new[] { client };
+
+            var loaded = false;
+            var brokerMock = new Mock<ILanguageClientBroker>();
+            brokerMock
+                .Setup(b => b.LoadAsync(It.IsAny<ILanguageClientMetadata>(), It.IsAny<ILanguageClient>()))
+                .Returns(Task.CompletedTask)
+                .Callback<ILanguageClientMetadata, ILanguageClient>((metadata, c) =>
+                {
+                    loaded = true;
+                    Assert.Same(client.Value, c);
+                    Assert.Equal("RazorClient", metadata.ClientName);
+                    var contentType = Assert.Single(metadata.ContentTypes);
+                    Assert.Equal("RazorLSP", contentType);
+                });
+            var broker = new Lazy<ILanguageClientBroker>(() => brokerMock.Object);
+
+            var host = new LSPRazorProjectHost(JoinableTaskContext, featureDetector, broker, languageClients);
+
+            // Act
+            await host.LoadAsync().ConfigureAwait(false);
+
+            // Assert
+            Assert.True(loaded);
+        }
+    }
+}


### PR DESCRIPTION
Reverts the revert: https://github.com/dotnet/aspnetcore-tooling/pull/1940

Did validations on LSP Local + LSP Liveshare + Local Codespaces

Fixes: https://github.com/dotnet/aspnetcore/issues/22331