### PR TITLE
Add ability to monitor project.razor.json's outside of workspace directory.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public const string RazorLanguageQueryEndpoint = "razor/languageQuery";
 
+        public const string RazorMonitorProjectConfigurationFilePathEndpoint = "razor/monitorProjectConfigurationFilePath";
+
         public const string RazorMapToDocumentRangesEndpoint = "razor/mapToDocumentRanges";
 
         public const string SemanticTokensProviderName = "semanticTokensProvider";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IMonitorProjectConfigurationFilePathHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IMonitorProjectConfigurationFilePathHandler.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    [Parallel, Method(LanguageServerConstants.RazorMonitorProjectConfigurationFilePathEndpoint)]
+    internal interface IMonitorProjectConfigurationFilePathHandler : IJsonRpcNotificationHandler<MonitorProjectConfigurationFilePathParams>
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class MonitorProjectConfigurationFilePathEndpoint : IMonitorProjectConfigurationFilePathHandler, IDisposable
+    {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly FilePathNormalizer _filePathNormalizer;
+        private readonly WorkspaceDirectoryPathResolver _workspaceDirectoryPathResolver;
+        private readonly IEnumerable<IProjectConfigurationFileChangeListener> _listeners;
+        private readonly ConcurrentDictionary<string, (string ConfigurationDirectory, IFileChangeDetector Detector)> _outputPathMonitors;
+        private readonly object _disposeLock;
+        private bool _disposed;
+
+        public MonitorProjectConfigurationFilePathEndpoint(
+            ForegroundDispatcher foregroundDispatcher,
+            FilePathNormalizer filePathNormalizer,
+            WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
+            IEnumerable<IProjectConfigurationFileChangeListener> listeners)
+        {
+            if (foregroundDispatcher is null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (filePathNormalizer is null)
+            {
+                throw new ArgumentNullException(nameof(filePathNormalizer));
+            }
+
+            if (workspaceDirectoryPathResolver is null)
+            {
+                throw new ArgumentNullException(nameof(workspaceDirectoryPathResolver));
+            }
+
+            if (listeners is null)
+            {
+                throw new ArgumentNullException(nameof(listeners));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _filePathNormalizer = filePathNormalizer;
+            _workspaceDirectoryPathResolver = workspaceDirectoryPathResolver;
+            _listeners = listeners;
+            _outputPathMonitors = new ConcurrentDictionary<string, (string, IFileChangeDetector)>(FilePathComparer.Instance);
+            _disposeLock = new object();
+        }
+
+        public async Task<Unit> Handle(MonitorProjectConfigurationFilePathParams request, CancellationToken cancellationToken)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            lock (_disposeLock)
+            {
+                if (_disposed)
+                {
+                    return Unit.Value;
+                }
+            }
+
+            if (request.ConfigurationFilePath == null)
+            {
+                RemoveMonitor(request.ProjectFilePath);
+
+                return Unit.Value;
+            }
+
+            if (!request.ConfigurationFilePath.EndsWith(LanguageServerConstants.ProjectConfigurationFile, StringComparison.Ordinal))
+            {
+                Debug.Fail("We should only ever be given configuration file paths with a project.razor.json suffix.");
+                return Unit.Value;
+            }
+
+            var configurationDirectory = Path.GetDirectoryName(request.ConfigurationFilePath);
+            var normalizedConfigurationDirectory = _filePathNormalizer.NormalizeDirectory(configurationDirectory);
+            var workspaceDirectory = _workspaceDirectoryPathResolver.Resolve();
+            var normalizedWorkspaceDirectory = _filePathNormalizer.NormalizeDirectory(workspaceDirectory);
+
+            var previousMonitorExists = _outputPathMonitors.TryGetValue(request.ProjectFilePath, out var entry);
+
+            if (normalizedConfigurationDirectory.StartsWith(normalizedWorkspaceDirectory, FilePathComparison.Instance))
+            {
+                if (previousMonitorExists)
+                {
+                    // Configuration directory changed from an external directory -> internal directory.
+                    RemoveMonitor(request.ProjectFilePath);
+                }
+
+                // Configuration directory is already in the workspace directory. We already monitor everything in the workspace directory.
+                return Unit.Value;
+            }
+
+            if (previousMonitorExists)
+            {
+                if (FilePathComparer.Instance.Equals(configurationDirectory, entry.ConfigurationDirectory))
+                {
+                    // Already tracking the requested configuration output path for this project
+                    return Unit.Value;
+                }
+
+                // Projects configuration output path has changed. Stop existing detector so we can restart it with a new directory.
+                entry.Detector.Stop();
+            }
+            else
+            {
+                var detector = CreateFileChangeDetector();
+                entry = (configurationDirectory, detector);
+
+                if (!_outputPathMonitors.TryAdd(request.ProjectFilePath, entry))
+                {
+                    // There's a concurrent request going on for this specific project. To avoid calling "StartAsync" twice we return early.
+                    // Note: This is an extremely edge case race condition that should in practice never happen due to how long it takes to calculate project state changes
+                    return Unit.Value;
+                }
+            }
+
+            await entry.Detector.StartAsync(configurationDirectory, cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                // Request was cancelled while starting the detector. Need to stop it so we don't leak.
+                entry.Detector.Stop();
+            }
+
+            if (!_outputPathMonitors.ContainsKey(request.ProjectFilePath))
+            {
+                // This can happen if there were multiple concurrent requests to "remove" and "update" file change detectors for the same project path.
+                // In that case we need to stop the detector to ensure we don't leak.
+                entry.Detector.Stop();
+            }
+
+            lock (_disposeLock)
+            {
+                if (_disposed)
+                {
+                    // Server's being stopped.
+                    entry.Detector.Stop();
+                }
+            }
+
+            return Unit.Value;
+        }
+
+        private void RemoveMonitor(string projectFilePath)
+        {
+            // Should no longer monitor configuration output paths for the project
+            if (_outputPathMonitors.TryRemove(projectFilePath, out var removedEntry))
+            {
+                removedEntry.Detector.Stop();
+            }
+            else
+            {
+                // Concurrent requests to remove the same configuration output path for the project.  We've already
+                // done the removal so we can just return gracefully.
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_disposeLock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+            }
+
+            foreach (var entry in _outputPathMonitors)
+            {
+                entry.Value.Detector.Stop();
+            }
+        }
+
+        // Protected virtual for testing
+        protected virtual IFileChangeDetector CreateFileChangeDetector() => new ProjectConfigurationFileChangeDetector(_foregroundDispatcher, _filePathNormalizer, _listeners);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
@@ -135,6 +135,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 // Request was cancelled while starting the detector. Need to stop it so we don't leak.
                 entry.Detector.Stop();
+                return Unit.Value;
             }
 
             if (!_outputPathMonitors.ContainsKey(request.ProjectFilePath))
@@ -142,6 +143,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 // This can happen if there were multiple concurrent requests to "remove" and "update" file change detectors for the same project path.
                 // In that case we need to stop the detector to ensure we don't leak.
                 entry.Detector.Stop();
+                return Unit.Value;
             }
 
             lock (_disposeLock)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathParams.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using MediatR;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class MonitorProjectConfigurationFilePathParams : IRequest
+    {
+        public string ProjectFilePath { get; set; }
+
+        public string ConfigurationFilePath { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -83,6 +83,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<OnAutoInsertEndpoint>()
                     .WithHandler<CodeActionEndpoint>()
                     .WithHandler<CodeActionResolutionEndpoint>()
+                    .WithHandler<MonitorProjectConfigurationFilePathEndpoint>()
                     .WithServices(services =>
                     {
                         var filePathNormalizer = new FilePathNormalizer();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/MonitorProjectConfigurationFilePathParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/MonitorProjectConfigurationFilePathParams.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class MonitorProjectConfigurationFilePathParams
+    {
+        public string ProjectFilePath { get; set; }
+
+        public string ConfigurationFilePath { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -4,14 +4,19 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
 using Nerdbank.Streams;
+using OmniSharp.Extensions.LanguageServer.Server;
 using StreamJsonRpc;
 using Trace = Microsoft.AspNetCore.Razor.LanguageServer.Trace;
 
@@ -23,9 +28,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         private readonly RazorLanguageServerCustomMessageTarget _customMessageTarget;
         private readonly ILanguageClientMiddleLayer _middleLayer;
+        private readonly LSPRequestInvoker _requestInvoker;
+        private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
+        private object _shutdownLock;
+        private ILanguageServer _server;
+        private IDisposable _serverShutdownDisposable;
 
         [ImportingConstructor]
-        public RazorLanguageServerClient(RazorLanguageServerCustomMessageTarget customTarget, RazorLanguageClientMiddleLayer middleLayer)
+        public RazorLanguageServerClient(
+            RazorLanguageServerCustomMessageTarget customTarget,
+            RazorLanguageClientMiddleLayer middleLayer,
+            LSPRequestInvoker requestInvoker,
+            ProjectConfigurationFilePathStore projectConfigurationFilePathStore)
         {
             if (customTarget is null)
             {
@@ -37,8 +51,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(middleLayer));
             }
 
+            if (requestInvoker is null)
+            {
+                throw new ArgumentNullException(nameof(requestInvoker));
+            }
+
+            if (projectConfigurationFilePathStore is null)
+            {
+                throw new ArgumentNullException(nameof(projectConfigurationFilePathStore));
+            }
+
             _customMessageTarget = customTarget;
             _middleLayer = middleLayer;
+            _requestInvoker = requestInvoker;
+            _projectConfigurationFilePathStore = projectConfigurationFilePathStore;
+            _shutdownLock = new object();
         }
 
         public string Name => "Razor Language Server Client";
@@ -68,14 +95,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public async Task<Connection> ActivateAsync(CancellationToken token)
         {
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
-
             // Need an auto-flushing stream for the server because O# doesn't currently flush after writing responses. Without this
             // performing the Initialize handshake with the LanguageServer hangs.
             var autoFlushingStream = new AutoFlushingNerdbankStream(serverStream);
-            var server = await RazorLanguageServer.CreateAsync(autoFlushingStream, autoFlushingStream, Trace.Verbose).ConfigureAwait(false);
+            _server = await RazorLanguageServer.CreateAsync(autoFlushingStream, autoFlushingStream, Trace.Verbose).ConfigureAwait(false);
 
             // Fire and forget for Initialized. Need to allow the LSP infrastructure to run in order to actually Initialize.
-            _ = server.InitializedAsync(token);
+            _ = _server.InitializedAsync(token);
+
             var connection = new Connection(clientStream, clientStream);
             return connection;
         }
@@ -92,7 +119,62 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public Task OnServerInitializedAsync()
         {
+            _serverShutdownDisposable = _server.Shutdown.Subscribe((_) => ServerShutdown());
+
+            ServerStarted();
+
             return Task.CompletedTask;
+        }
+
+        private void ServerStarted()
+        {
+            _projectConfigurationFilePathStore.Changed += ProjectConfigurationFilePathStore_Changed;
+
+            var mappings = _projectConfigurationFilePathStore.GetMappings();
+            foreach (var mapping in mappings)
+            {
+                var args = new ProjectConfigurationFilePathChangedEventArgs(mapping.Key, mapping.Value);
+                ProjectConfigurationFilePathStore_Changed(this, args);
+            }
+        }
+
+        private void ServerShutdown()
+        {
+            lock (_shutdownLock)
+            {
+                if (_server == null)
+                {
+                    // Already shutdown
+                    return;
+                }
+
+                _projectConfigurationFilePathStore.Changed -= ProjectConfigurationFilePathStore_Changed;
+                _serverShutdownDisposable?.Dispose();
+                _serverShutdownDisposable = null;
+                _server = null;
+            }
+        }
+
+        private async void ProjectConfigurationFilePathStore_Changed(object sender, ProjectConfigurationFilePathChangedEventArgs args)
+        {
+            try
+            {
+                var parameter = new MonitorProjectConfigurationFilePathParams()
+                {
+                    ProjectFilePath = args.ProjectFilePath,
+                    ConfigurationFilePath = args.ConfigurationFilePath,
+                };
+
+                await _requestInvoker.CustomRequestServerAsync<MonitorProjectConfigurationFilePathParams, object>(
+                    LanguageServerConstants.RazorMonitorProjectConfigurationFilePathEndpoint,
+                    LanguageServerKind.Razor,
+                    parameter,
+                    CancellationToken.None);
+            }
+            catch (Exception)
+            {
+                // We're fire and forgetting here, if the request fails we're ok with that.
+            }
         }
 
         public Task AttachForCustomMessageAsync(JsonRpc rpc) => Task.CompletedTask;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -13,11 +13,13 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
 using Nerdbank.Streams;
 using OmniSharp.Extensions.LanguageServer.Server;
 using StreamJsonRpc;
+using Task = System.Threading.Tasks.Task;
 using Trace = Microsoft.AspNetCore.Razor.LanguageServer.Trace;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
@@ -101,7 +103,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             _server = await RazorLanguageServer.CreateAsync(autoFlushingStream, autoFlushingStream, Trace.Verbose).ConfigureAwait(false);
 
             // Fire and forget for Initialized. Need to allow the LSP infrastructure to run in order to actually Initialize.
-            _ = _server.InitializedAsync(token);
+            _server.InitializedAsync(token).FileAndForget("RazorLanguageServerClient_ActivateAsync");
 
             var connection = new Connection(clientStream, clientStream);
             return connection;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
@@ -1,0 +1,310 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor;
+using Moq;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTestBase
+    {
+        public MonitorProjectConfigurationFilePathEndpointTest()
+        {
+            DirectoryPathResolver = Mock.Of<WorkspaceDirectoryPathResolver>(resolver => resolver.Resolve() == "C:/dir");
+        }
+
+        private WorkspaceDirectoryPathResolver DirectoryPathResolver { get; }
+
+        [Fact]
+        public async Task Handle_Disposed_Noops()
+        {
+            // Arrange
+            var directoryPathResolver = new Mock<WorkspaceDirectoryPathResolver>();
+            directoryPathResolver.Setup(resolver => resolver.Resolve())
+                .Throws<XunitException>();
+            var configurationFileEndpoint = new MonitorProjectConfigurationFilePathEndpoint(
+                Dispatcher,
+                FilePathNormalizer,
+                directoryPathResolver.Object,
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+            configurationFileEndpoint.Dispose();
+            var request = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:/dir/project.csproj",
+                ConfigurationFilePath = "C:/dir/obj/Debug/project.razor.json",
+            };
+
+            // Act & Assert
+            await configurationFileEndpoint.Handle(request, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task Handle_ConfigurationFilePath_UntrackedMonitorNoops()
+        {
+            // Arrange
+            var directoryPathResolver = new Mock<WorkspaceDirectoryPathResolver>();
+            directoryPathResolver.Setup(resolver => resolver.Resolve())
+                .Throws<XunitException>();
+            var configurationFileEndpoint = new MonitorProjectConfigurationFilePathEndpoint(
+                Dispatcher,
+                FilePathNormalizer,
+                directoryPathResolver.Object,
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+            var request = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:/dir/project.csproj",
+                ConfigurationFilePath = null,
+            };
+
+            // Act & Assert
+            await configurationFileEndpoint.Handle(request, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task Handle_ConfigurationFilePath_TrackedMonitor_StopsMonitor()
+        {
+            // Arrange
+            var detector = new TestFileChangeDetector();
+            var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
+                () => detector,
+                Dispatcher,
+                FilePathNormalizer,
+                DirectoryPathResolver,
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+            var startRequest = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:/dir/project.csproj",
+                ConfigurationFilePath = "C:/externaldir/obj/Debug/project.razor.json",
+            };
+            await configurationFileEndpoint.Handle(startRequest, CancellationToken.None);
+            var stopRequest = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:/dir/project.csproj",
+                ConfigurationFilePath = null,
+            };
+
+            // Act
+            await configurationFileEndpoint.Handle(stopRequest, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(1, detector.StartCount);
+            Assert.Equal(1, detector.StopCount);
+        }
+
+        [Fact]
+        public async Task Handle_InWorkspaceDirectory_Noops()
+        {
+            // Arrange
+            var detector = new TestFileChangeDetector();
+            var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
+                () => detector,
+                Dispatcher,
+                FilePathNormalizer,
+                DirectoryPathResolver,
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+            var startRequest = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:/dir/project.csproj",
+                ConfigurationFilePath = "C:/dir/obj/Debug/project.razor.json",
+            };
+
+            // Act
+            await configurationFileEndpoint.Handle(startRequest, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(0, detector.StartCount);
+        }
+
+        [Fact]
+        public async Task Handle_DuplicateMonitors_Noops()
+        {
+            // Arrange
+            var detector = new TestFileChangeDetector();
+            var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
+                () => detector,
+                Dispatcher,
+                FilePathNormalizer,
+                DirectoryPathResolver,
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+            var startRequest = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:/dir/project.csproj",
+                ConfigurationFilePath = "C:/externaldir/obj/Debug/project.razor.json",
+            };
+
+            // Act
+            await configurationFileEndpoint.Handle(startRequest, CancellationToken.None);
+            await configurationFileEndpoint.Handle(startRequest, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(1, detector.StartCount);
+            Assert.Equal(0, detector.StopCount);
+        }
+
+        [Fact]
+        public async Task Handle_ChangedConfigurationOutputPath_StartsWithNewPath()
+        {
+            // Arrange
+            var detector = new TestFileChangeDetector();
+            var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
+                () => detector,
+                Dispatcher,
+                FilePathNormalizer,
+                DirectoryPathResolver,
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+            var debugOutputPath = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:\\dir\\project.csproj",
+                ConfigurationFilePath = "C:\\externaldir\\obj\\Debug\\project.razor.json",
+            };
+            var releaseOutputPath = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = debugOutputPath.ProjectFilePath,
+                ConfigurationFilePath = "C:\\externaldir\\obj\\Release\\project.razor.json",
+            };
+
+            // Act
+            await configurationFileEndpoint.Handle(debugOutputPath, CancellationToken.None);
+            await configurationFileEndpoint.Handle(releaseOutputPath, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(new[] { "C:\\externaldir\\obj\\Debug", "C:\\externaldir\\obj\\Release" }, detector.StartedWithDirectory);
+            Assert.Equal(1, detector.StopCount);
+        }
+
+        [Fact]
+        public async Task Handle_ChangedConfigurationExternalToInternal_StopsWithoutRestarting()
+        {
+            // Arrange
+            var detector = new TestFileChangeDetector();
+            var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
+                () => detector,
+                Dispatcher,
+                FilePathNormalizer,
+                DirectoryPathResolver,
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+            var externalRequest = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:\\dir\\project.csproj",
+                ConfigurationFilePath = "C:\\externaldir\\obj\\Debug\\project.razor.json",
+            };
+            var internalRequest = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = externalRequest.ProjectFilePath,
+                ConfigurationFilePath = "C:\\dir\\obj\\Release\\project.razor.json",
+            };
+
+            // Act
+            await configurationFileEndpoint.Handle(externalRequest, CancellationToken.None);
+            await configurationFileEndpoint.Handle(internalRequest, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(new[] { "C:\\externaldir\\obj\\Debug" }, detector.StartedWithDirectory);
+            Assert.Equal(1, detector.StopCount);
+        }
+
+        [Fact]
+        public async Task Handle_MultipleProjects_StartedAndStopped()
+        {
+            // Arrange
+            var callCount = 0;
+            var detectors = new[] { new TestFileChangeDetector(), new TestFileChangeDetector() };
+            var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
+                () => detectors[callCount++],
+                Dispatcher,
+                FilePathNormalizer,
+                DirectoryPathResolver,
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+            var debugOutputPath1 = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:\\dir\\project1.csproj",
+                ConfigurationFilePath = "C:\\externaldir1\\obj\\Debug\\project.razor.json",
+            };
+            var releaseOutputPath1 = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = debugOutputPath1.ProjectFilePath,
+                ConfigurationFilePath = "C:\\externaldir1\\obj\\Release\\project.razor.json",
+            };
+            var debugOutputPath2 = new MonitorProjectConfigurationFilePathParams()
+            {
+                ProjectFilePath = "C:\\dir\\project2.csproj",
+                ConfigurationFilePath = "C:\\externaldir2\\obj\\Debug\\project.razor.json",
+            };
+
+            // Act
+            await configurationFileEndpoint.Handle(debugOutputPath1, CancellationToken.None);
+            await configurationFileEndpoint.Handle(debugOutputPath2, CancellationToken.None);
+            await configurationFileEndpoint.Handle(releaseOutputPath1, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, detectors[0].StartCount);
+            Assert.Equal(1, detectors[0].StopCount);
+            Assert.Equal(1, detectors[1].StartCount);
+            Assert.Equal(0, detectors[1].StopCount);
+        }
+
+        private class TestMonitorProjectConfigurationFilePathEndpoint : MonitorProjectConfigurationFilePathEndpoint
+        {
+            private readonly Func<IFileChangeDetector> _fileChangeDetectorFactory;
+
+            public TestMonitorProjectConfigurationFilePathEndpoint(
+                ForegroundDispatcher foregroundDispatcher,
+                FilePathNormalizer filePathNormalizer,
+                WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
+                IEnumerable<IProjectConfigurationFileChangeListener> listeners) : this(
+                    fileChangeDetectorFactory: null,
+                    foregroundDispatcher,
+                    filePathNormalizer,
+                    workspaceDirectoryPathResolver,
+                    listeners)
+            {
+            }
+
+            public TestMonitorProjectConfigurationFilePathEndpoint(
+                Func<IFileChangeDetector> fileChangeDetectorFactory,
+                ForegroundDispatcher foregroundDispatcher,
+                FilePathNormalizer filePathNormalizer,
+                WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
+                IEnumerable<IProjectConfigurationFileChangeListener> listeners) : base(
+                    foregroundDispatcher,
+                    filePathNormalizer,
+                    workspaceDirectoryPathResolver,
+                    listeners)
+            {
+                _fileChangeDetectorFactory = fileChangeDetectorFactory ?? (() => Mock.Of<IFileChangeDetector>());
+            }
+
+            protected override IFileChangeDetector CreateFileChangeDetector() => _fileChangeDetectorFactory();
+        }
+
+        private class TestFileChangeDetector : IFileChangeDetector
+        {
+            public int StartCount => StartedWithDirectory.Count;
+
+            public List<string> StartedWithDirectory { get; } = new List<string>();
+
+            public int StopCount { get; private set; }
+
+            public Task StartAsync(string workspaceDirectory, CancellationToken cancellationToken)
+            {
+                StartedWithDirectory.Add(workspaceDirectory);
+                return Task.CompletedTask;
+            }
+
+            public void Stop()
+            {
+                StopCount++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added a `MonitorProjectConfigurationFilePathEndpoint` that can be called at any time to track an external directory for a project.razor.json. Therefore to account for this I've tried to account for every variation of concurrent requests flowing through it while simultaneously attempting to lock as infrequently as possible (only on dispose).
    - One interesting aspect of the endpoint is that if a request comes in and tries to monitor a configuration file path that's within the workspace directory we no-op. The reason being we don't want to be doubly deserializign the `project.razor.json's` in that directory + don't want to be reparsing every file known when they change twice over.
    - When a "monitor" request comes in we track the provided configuration file path for the project and when it changes from external -> external or internal -> external or external -> internal: we start/stop it accordingly.
- In order to hookup the monitor endpoint I had to expand our VS language server client to populate all external directories on start and then statefully attach/detatch to our project configuration file path store to listen for any changes in those configuration file path. On change we notify our language server of the configuration file path to watch for any project.razor.json changes.
- Added tests for the monitor endpoint for all the various call paths
- Could not add tests for the language server client given its coupling with the LSP platform.

Fixes dotnet/aspnetcore#23281