### PR TITLE
Implement and register AddUsingsCodeActionResolver and add tests

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -38,6 +38,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             public const string ExtractToCodeBehindAction = "ExtractToCodeBehind";
 
             public const string CreateComponentFromTag = "CreateComponentFromTag";
+
+            public const string AddUsings = "AddUsings";
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionParams.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
+{
+    internal sealed class AddUsingsCodeActionParams
+    {
+        public Uri Uri { get; set; }
+        public string[] Namespaces { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionParams.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal sealed class AddUsingsCodeActionParams
     {
         public Uri Uri { get; set; }
-        public string[] Namespaces { get; set; }
+        public string Namespace { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
@@ -1,0 +1,239 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
+{
+    class AddUsingsCodeActionResolver : RazorCodeActionResolver
+    {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly DocumentResolver _documentResolver;
+
+        public AddUsingsCodeActionResolver(ForegroundDispatcher foregroundDispatcher, DocumentResolver documentResolver)
+        {
+            _foregroundDispatcher = foregroundDispatcher ?? throw new ArgumentNullException(nameof(foregroundDispatcher));
+            _documentResolver = documentResolver ?? throw new ArgumentNullException(nameof(documentResolver));
+        }
+
+        public override string Action => LanguageServerConstants.CodeActions.AddUsings;
+
+        public override async Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
+        {
+            var actionParams = data.ToObject<AddUsingsCodeActionParams>();
+            var path = actionParams.Uri.GetAbsoluteOrUNCPath();
+
+            var document = await Task.Factory.StartNew(() =>
+            {
+                _documentResolver.TryResolveDocument(path, out var documentSnapshot);
+                return documentSnapshot;
+            }, cancellationToken, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler).ConfigureAwait(false);
+            if (document is null)
+            {
+                return null;
+            }
+
+            var text = await document.GetTextAsync().ConfigureAwait(false);
+            if (text is null)
+            {
+                return null;
+            }
+
+            var codeDocument = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
+            if (codeDocument.IsUnsupported())
+            {
+                return null;
+            }
+
+            if (!FileKinds.IsComponent(codeDocument.GetFileKind()))
+            {
+                return null;
+            }
+
+            var codeDocumentIdentifier = new VersionedTextDocumentIdentifier() { Uri = actionParams.Uri, Version = 0 };
+            var documentChanges = new List<WorkspaceEditDocumentChange>();
+
+            var namespaceList = actionParams.Namespaces;
+
+            var usingDirectives = FindUsingDirectives(codeDocument);
+            if (usingDirectives.Count > 0)
+            {
+                documentChanges.Add(GenerateUsingEditsInterpolated(codeDocument, codeDocumentIdentifier, actionParams.Namespaces, usingDirectives));
+            }
+            else
+            {
+                documentChanges.Add(GenerateUsingEditsAtTop(codeDocument, codeDocumentIdentifier, actionParams.Namespaces));
+            }
+
+            return new WorkspaceEdit()
+            {
+                DocumentChanges = documentChanges
+            };
+        }
+
+        private static WorkspaceEditDocumentChange GenerateUsingEditsInterpolated(
+            RazorCodeDocument codeDocument,
+            VersionedTextDocumentIdentifier codeDocumentIdentifier,
+            string[] namespaceArray,
+            List<RazorUsingDirective> usingDirectives)
+        {
+            // Sort and queue namespaces
+            var namespaceList = namespaceArray.ToList();
+            namespaceList.Sort();
+            var namespaces = new Queue<string>(namespaceList);
+
+            var edits = new List<TextEdit>();
+            foreach (var usingDirective in usingDirectives)
+            {
+                // Break early if we're done
+                if (namespaces.Count == 0)
+                {
+                    break;
+                }
+
+                // Skip using directives 
+                var usingDirectiveNamespace = usingDirective.Statement.ParsedNamespace;
+                if (usingDirectiveNamespace.StartsWith("System") || usingDirectiveNamespace.Contains("="))
+                {
+                    continue;
+                }
+
+                // Insert all using directives that fit before the next using
+                if (namespaces.Peek().CompareTo(usingDirectiveNamespace) < 0)
+                {
+                    var usingDirectiveLineIndex = codeDocument.Source.Lines.GetLocation(usingDirective.Node.Span.Start).LineIndex;
+                    var head = new Position(usingDirectiveLineIndex, 0);
+                    var edit = new TextEdit() { Range = new Range(head, head), NewText = "" };
+                    do
+                    {
+                        edit.NewText += $"@using {namespaces.Dequeue()}{Environment.NewLine}";
+                    } while (namespaces.Count > 0 && namespaces.Peek().CompareTo(usingDirectiveNamespace) < 0);
+                    edits.Add(edit);
+                }
+            }
+
+            // Add the remaining usings to the end
+            if (namespaces.Count > 0)
+            {
+                var endIndex = usingDirectives.Last().Node.Span.End;
+                var lineIndex = GetLineIndexOrEnd(codeDocument, endIndex - 1) + 1;
+                var head = new Position(lineIndex, 0);
+                var edit = new TextEdit() { Range = new Range(head, head), NewText = "" };
+                do
+                {
+                    edit.NewText += $"@using {namespaces.Dequeue()}{Environment.NewLine}";
+                } while (namespaces.Count > 0);
+                edits.Add(edit);
+            }
+
+            return new WorkspaceEditDocumentChange(new TextDocumentEdit()
+            {
+                TextDocument = codeDocumentIdentifier,
+                Edits = edits,
+            });
+        }
+
+        private static WorkspaceEditDocumentChange GenerateUsingEditsAtTop(
+            RazorCodeDocument codeDocument,
+            VersionedTextDocumentIdentifier codeDocumentIdentifier,
+            string[] namespaceArray)
+        {
+            var namespaceList = namespaceArray.ToList();
+            namespaceList.Sort();
+
+            // If we don't have usings, insert after the last namespace or page directive, which ever comes later
+            var head = new Position(1, 0);
+            var lastNamespaceOrPageDirective = codeDocument.GetSyntaxTree().Root
+                .DescendantNodes()
+                .Where(n => IsNamespaceOrPageDirective(n))
+                .LastOrDefault();
+            if (lastNamespaceOrPageDirective != null)
+            {
+                var lineIndex = GetLineIndexOrEnd(codeDocument, lastNamespaceOrPageDirective.Span.End - 1) + 1;
+                head = new Position(lineIndex, 0);
+            }
+
+            // Insert all usings at the given point
+            var range = new Range(head, head);
+            return new WorkspaceEditDocumentChange(new TextDocumentEdit
+            {
+                TextDocument = codeDocumentIdentifier,
+                Edits = new[]
+                {
+                    new TextEdit()
+                    {
+                        NewText = string.Concat(namespaceList.Select(n => $"@using {n}{Environment.NewLine}")),
+                        Range = range,
+                    }
+                }
+            });
+        }
+
+        private static int GetLineIndexOrEnd(RazorCodeDocument codeDocument, int endIndex)
+        {
+            if (endIndex < codeDocument.Source.Length)
+            {
+                return codeDocument.Source.Lines.GetLocation(endIndex).LineIndex;
+            }
+            else
+            {
+                return codeDocument.Source.Lines.Count;
+            }
+        }
+
+        private static List<RazorUsingDirective> FindUsingDirectives(RazorCodeDocument codeDocument)
+        {
+            var directives = new List<RazorUsingDirective>();
+            foreach (var node in codeDocument.GetSyntaxTree().Root.DescendantNodes())
+            {
+                if (node is RazorDirectiveSyntax directiveNode)
+                {
+                    foreach (var child in directiveNode.DescendantNodes())
+                    {
+                        var context = child.GetSpanContext();
+                        if (context != null && context.ChunkGenerator is AddImportChunkGenerator usingStatement && !usingStatement.IsStatic)
+                        {
+                            directives.Add(new RazorUsingDirective(directiveNode, usingStatement));
+                        }
+                    }
+                }
+            }
+            return directives;
+        }
+
+        private static bool IsNamespaceOrPageDirective(SyntaxNode node)
+        {
+            if (node is RazorDirectiveSyntax directiveNode)
+            {
+                return directiveNode.DirectiveDescriptor == ComponentPageDirective.Directive || directiveNode.DirectiveDescriptor == NamespaceDirective.Directive;
+            }
+            return false;
+        }
+
+        private struct RazorUsingDirective
+        {
+            readonly public RazorDirectiveSyntax Node { get; }
+            readonly public AddImportChunkGenerator Statement { get; }
+
+            public RazorUsingDirective(RazorDirectiveSyntax node, AddImportChunkGenerator statement)
+            {
+                Node = node;
+                Statement = statement;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
@@ -111,11 +111,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         private static WorkspaceEditDocumentChange GenerateSingleUsingEditsInterpolated(
             RazorCodeDocument codeDocument,
             VersionedTextDocumentIdentifier codeDocumentIdentifier,
-            string @namespace,
+            string newUsingNamespace,
             List<RazorUsingDirective> existingUsingDirectives)
         {
             var edits = new List<TextEdit>();
-            var newText = $"@using {@namespace}{Environment.NewLine}";
+            var newText = $"@using {newUsingNamespace}{Environment.NewLine}";
 
             foreach (var usingDirective in existingUsingDirectives)
             {
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     continue;
                 }
 
-                if (@namespace.CompareTo(usingDirectiveNamespace) < 0)
+                if (newUsingNamespace.CompareTo(usingDirectiveNamespace) < 0)
                 {
                     var usingDirectiveLineIndex = codeDocument.Source.Lines.GetLocation(usingDirective.Node.Span.Start).LineIndex;
                     var head = new Position(usingDirectiveLineIndex, 0);
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         private static WorkspaceEditDocumentChange GenerateSingleUsingEditsAtTop(
             RazorCodeDocument codeDocument,
             VersionedTextDocumentIdentifier codeDocumentIdentifier,
-            string @namespace)
+            string newUsingNamespace)
         {
             // If we don't have usings, insert after the last namespace or page directive, which ever comes later
             var head = new Position(1, 0);
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 {
                     new TextEdit()
                     {
-                        NewText = string.Concat($"@using {@namespace}{Environment.NewLine}"),
+                        NewText = string.Concat($"@using {newUsingNamespace}{Environment.NewLine}"),
                         Range = range,
                     }
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             {
                 // Skip System directives; if they're at the top we don't want to insert before them
                 var usingDirectiveNamespace = usingDirective.Statement.ParsedNamespace;
-                if (usingDirectiveNamespace.StartsWith("System"))
+                if (usingDirectiveNamespace.StartsWith("System", StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -136,6 +136,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 }
             }
 
+            // If we haven't actually found a place to insert the using directive, do so at the end
             if (edits.Count == 0)
             {
                 var endIndex = existingUsingDirectives.Last().Node.Span.End;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CreateComponentCodeActionResolver.cs
@@ -34,6 +34,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         public override async Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
         {
+            if (data is null)
+            {
+                return null;
+            }
+
             var actionParams = data.ToObject<CreateComponentCodeActionParams>();
             var path = actionParams.Uri.GetAbsoluteOrUNCPath();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ExtractToCodeBehindCodeActionResolver.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using CSharpSyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -45,6 +44,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         public override async Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
         {
+            if (data is null)
+            {
+                return null;
+            }
+
             var actionParams = data.ToObject<ExtractToCodeBehindCodeActionParams>();
             var path = _filePathNormalizer.Normalize(actionParams.Uri.GetAbsoluteOrUNCPath());
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -178,6 +178,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RazorCodeActionProvider, ExtractToCodeBehindCodeActionProvider>();
                         services.AddSingleton<RazorCodeActionResolver, ExtractToCodeBehindCodeActionResolver>();
                         services.AddSingleton<RazorCodeActionResolver, CreateComponentCodeActionResolver>();
+                        services.AddSingleton<RazorCodeActionResolver, AddUsingsCodeActionResolver>();
 
                         // Other
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
@@ -1,0 +1,470 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using System.Runtime.ExceptionServices;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
+{
+    public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
+    {
+        private readonly DocumentResolver EmptyDocumentResolver = Mock.Of<DocumentResolver>();
+
+        [Fact]
+        public async Task Handle_MissingFile()
+        {
+            // Arrange
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), EmptyDocumentResolver);
+            var data = JObject.FromObject(new CreateComponentCodeActionParams()
+            {
+                Uri = new Uri("c:/Test.razor"),
+                Path = "c:/Another.razor",
+            });
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.Null(workspaceEdit);
+        }
+
+        [Fact]
+        public async Task Handle_Unsupported()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var contents = $"@page \"/test\"";
+            var codeDocument = CreateCodeDocument(contents);
+            codeDocument.SetUnsupported();
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var data = JObject.FromObject(new CreateComponentCodeActionParams()
+            {
+                Uri = new Uri(documentPath),
+                Path = "c:/Another.razor",
+            });
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.Null(workspaceEdit);
+        }
+
+        [Fact]
+        public async Task Handle_InvalidFileKind()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var contents = $"@page \"/test\"";
+            var codeDocument = CreateCodeDocument(contents);
+            codeDocument.SetFileKind(FileKinds.Legacy);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var data = JObject.FromObject(new CreateComponentCodeActionParams()
+            {
+                Uri = new Uri(documentPath),
+                Path = "c:/Another.razor",
+            });
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.Null(workspaceEdit);
+        }
+
+        [Fact]
+        public async Task Handle_AddOneUsingToEmpty()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "System"
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(1, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        }
+
+        [Fact]
+        public async Task Handle_AddMultipleUsingsToEmpty()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "System",
+                    "System.Linq",
+                    "System.Threading.Task"
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(1, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using System{Environment.NewLine}@using System.Linq{Environment.NewLine}@using System.Threading.Task{Environment.NewLine}", firstEdit.NewText);
+        }
+
+        [Fact]
+        public async Task Handle_AddOneUsingToPage()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"@page \"/\"{Environment.NewLine}";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "System"
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(1, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        }
+
+        [Fact]
+        public async Task Handle_AddOneUsingToNamespace()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"@namespace Testing{Environment.NewLine}";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "System"
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(1, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        }
+
+        [Fact]
+        public async Task Handle_AddOneUsingToPageAndNamespace()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"@page \"/\"{Environment.NewLine}@namespace Testing{Environment.NewLine}";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "System"
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(2, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        }
+
+        [Fact]
+        public async Task Handle_AddOneUsingToUsings()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"@using System";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "System.Linq"
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(1, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using System.Linq{Environment.NewLine}", firstEdit.NewText);
+        }
+
+        [Fact]
+        public async Task Handle_AddOneNonSystemUsingToSystemUsings()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"@using System{Environment.NewLine}@using System.Linq{Environment.NewLine}";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "Microsoft.AspNetCore.Razor.Language"
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(2, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using Microsoft.AspNetCore.Razor.Language{Environment.NewLine}", firstEdit.NewText);
+        }
+
+        [Fact]
+        public async Task Handle_AddMultipleUsingsToUsingsNonSystem()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"@using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions{Environment.NewLine}@using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem{Environment.NewLine}";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "Microsoft.AspNetCore.Razor.Language",
+                    "Microsoft.AspNetCore.Razor.LanguageServer.Common",
+                    "Microsoft.AspNetCore.Razor.Test.Common",
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            Assert.Equal(3, addUsingsChange.TextDocumentEdit.Edits.Count());
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(0, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using Microsoft.AspNetCore.Razor.Language{Environment.NewLine}", firstEdit.NewText);
+            var secondEdit = addUsingsChange.TextDocumentEdit.Edits.ElementAt(1);
+            Assert.Equal(1, secondEdit.Range.Start.Line);
+            Assert.Equal($"@using Microsoft.AspNetCore.Razor.LanguageServer.Common{Environment.NewLine}", secondEdit.NewText);
+            var thirdEdit = addUsingsChange.TextDocumentEdit.Edits.ElementAt(2);
+            Assert.Equal(2, thirdEdit.Range.Start.Line);
+            Assert.Equal($"@using Microsoft.AspNetCore.Razor.Test.Common{Environment.NewLine}", thirdEdit.NewText);
+        }
+
+        [Fact]
+        public async Task Handle_AddMultipleUsingsToUsingsSkippingSystem()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var documentUri = new Uri(documentPath);
+            var contents = $"@using System{Environment.NewLine}@using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions{Environment.NewLine}@using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem{Environment.NewLine}";
+            var codeDocument = CreateCodeDocument(contents);
+
+            var resolver = new AddUsingsCodeActionResolver(new DefaultForegroundDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var actionParams = new AddUsingsCodeActionParams
+            {
+                Uri = documentUri,
+                Namespaces = new string[]
+                {
+                    "Microsoft.AspNetCore.Razor.Language",
+                    "Microsoft.AspNetCore.Razor.LanguageServer.Common",
+                    "Microsoft.AspNetCore.Razor.Test.Common",
+                }
+            };
+            var data = JObject.FromObject(actionParams);
+
+            // Act
+            var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+            // Assert
+            Assert.NotNull(workspaceEdit);
+            Assert.NotNull(workspaceEdit.DocumentChanges);
+            Assert.Single(workspaceEdit.DocumentChanges);
+
+            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var addUsingsChange = documentChanges[0];
+            Assert.True(addUsingsChange.IsTextDocumentEdit);
+            Assert.Equal(3, addUsingsChange.TextDocumentEdit.Edits.Count());
+            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            Assert.Equal(1, firstEdit.Range.Start.Line);
+            Assert.Equal($"@using Microsoft.AspNetCore.Razor.Language{Environment.NewLine}", firstEdit.NewText);
+            var secondEdit = addUsingsChange.TextDocumentEdit.Edits.ElementAt(1);
+            Assert.Equal(2, secondEdit.Range.Start.Line);
+            Assert.Equal($"@using Microsoft.AspNetCore.Razor.LanguageServer.Common{Environment.NewLine}", secondEdit.NewText);
+            var thirdEdit = addUsingsChange.TextDocumentEdit.Edits.ElementAt(2);
+            Assert.Equal(3, thirdEdit.Range.Start.Line);
+            Assert.Equal($"@using Microsoft.AspNetCore.Razor.Test.Common{Environment.NewLine}", thirdEdit.NewText);
+        }
+
+        private static DocumentResolver CreateDocumentResolver(string documentPath, RazorCodeDocument codeDocument)
+        {
+            var sourceTextChars = new char[codeDocument.Source.Length];
+            codeDocument.Source.CopyTo(0, sourceTextChars, 0, codeDocument.Source.Length);
+            var sourceText = SourceText.From(new string(sourceTextChars));
+            var documentSnapshot = Mock.Of<DocumentSnapshot>(document =>
+                document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
+                document.GetTextAsync() == Task.FromResult(sourceText));
+            var documentResolver = new Mock<DocumentResolver>();
+            documentResolver
+                .Setup(resolver => resolver.TryResolveDocument(documentPath, out documentSnapshot))
+                .Returns(true);
+            return documentResolver.Object;
+        }
+
+        private static RazorCodeDocument CreateCodeDocument(string text)
+        {
+            var projectItem = new TestRazorProjectItem("c:/Test.razor", "c:/Test.razor", "Test.razor") { Content = text };
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) =>
+            {
+                // NamespaceDirective.Register(builder);
+                PageDirective.Register(builder);
+            });
+            var codeDocument = projectEngine.Process(projectItem);
+            codeDocument.SetFileKind(FileKinds.Component);
+            return codeDocument;
+        }
+    }
+}


### PR DESCRIPTION
This is the second PR in the series outlined by [PR 2195](https://github.com/dotnet/aspnetcore-tooling/pull/2195). It introduces another `CodeActionResolver`, `AddUsingsCodeActionResolver`, which adds any number of using statements to a given Razor file in a context-sensitive manner. The heuristic is as follows:

- If no `@using`, `@namespace`, or `@page` directives are present, insert the statements at the top of the file in alphabetical order
- If a `@namespace` or `@page` are present, the statements are inserted after the last line-wise in alphabetical order
- If `@using` directives are present and alphabetized with `System` directives at the top, the statements will be placed in the correct locations according to that ordering
- Otherwise it's kinda undefined; it's only geared to insert based on alphabetization

This is generally sufficient for our current situation (inserting a single `@using` statement to include a component), however it has holes if we eventually use it for other purposes. If we want to deal with that now I can come up with a more sophisticated heuristic (something along the lines of checking if there's already an ordering, etc.).  