### PR TITLE
Make Razor edge handling more strict.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -225,7 +225,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                                 // Non-marker spans do not own the edges after it unless they're whitespace sensitive. For instance:
                                 //      <p>@DateTi|</p>
                                 // The above example is whitespace sensitive because adding any sort of whitespace at that location will result in a different langauge experience.
-                                // At its core this check is semi-hacky because we're assuming that if something breaks down when whitespace is inserted that the edge should belong
+                                // At its core this check is semi-hacky because we're assuming that if something breaks down when whitespace is inserted then the edge should belong
                                 // to the left-hand-side. In practice, Razor almost always has this assumption.
                                 continue;
                             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -215,10 +215,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         {
                             // We're at an edge.
 
-                            if (span.Length > 0 &&
-                                classifiedSpan.AcceptedCharacters == AcceptedCharactersInternal.None)
+                            if (i == classifiedSpans.Count - 1)
                             {
-                                // Non-marker spans do not own the edges after it
+                                // Last classified span in the document. The last span always owns the edge because there's nothing to the right.
+                            }
+                            else if (span.Length > 0 &&
+                                classifiedSpan.AcceptedCharacters != AcceptedCharactersInternal.NonWhitespace)
+                            {
+                                // Non-marker spans do not own the edges after it unless they're whitespace sensitive. For instance:
+                                //      <p>@DateTi|</p>
+                                // The above example is whitespace sensitive because adding any sort of whitespace at that location will result in a different langauge experience.
+                                // At its core this check is semi-hacky because we're assuming that if something breaks down when whitespace is inserted that the edge should belong
+                                // to the left-hand-side. In practice, Razor almost always has this assumption.
                                 continue;
                             }
                         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ProvisionalCompletionOrchestrator.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ProvisionalCompletionOrchestrator.ts
@@ -86,25 +86,25 @@ export class ProvisionalCompletionOrchestrator {
             return null;
         }
 
-        const previousCharacterPosition = new vscode.Position(
+        const characterBeforeTriggerPosition = new vscode.Position(
             htmlPosition.line,
-            htmlPosition.character - 1,
+            htmlPosition.character - 2,
         );
-        const previousCharacterQuery = await this.serviceClient.languageQuery(
-            previousCharacterPosition,
+        const characterBeforeTriggerProjection = await this.serviceClient.languageQuery(
+            characterBeforeTriggerPosition,
             hostDocumentUri);
 
-        if (previousCharacterQuery.kind !== LanguageKind.CSharp) {
+        if (characterBeforeTriggerProjection.kind !== LanguageKind.CSharp) {
             return null;
         }
 
         const document = await this.documentManager.getDocument(hostDocumentUri);
         const projectedDocument = document.csharpDocument as CSharpProjectedDocument;
-        const absoluteIndex = previousCharacterQuery.positionIndex;
+        const provisionalDotInsertIndex = characterBeforeTriggerProjection.positionIndex + 1;
 
         if (this.logger.verboseEnabled) {
             this.logger.logVerbose(`Applying provisional completion on ${projectedDocument.uri} ` +
-                `at (${previousCharacterQuery.position.line}, ${previousCharacterQuery.position.character})`);
+                `at (${characterBeforeTriggerProjection.position.line}, ${characterBeforeTriggerProjection.position.character})`);
         }
 
         // Edit the projected document to contain a '.'. This allows C# completion to provide valid completion items
@@ -114,7 +114,7 @@ export class ProvisionalCompletionOrchestrator {
         //  2. The user swaps active documents
         //  3. The user selects different content
         //  4. The projected document gets an update request
-        projectedDocument.addProvisionalDotAt(absoluteIndex);
+        projectedDocument.addProvisionalDotAt(provisionalDotInsertIndex);
         this.projectedCSharpProvider.ensureDocumentContent(projectedDocument.uri);
 
         // We open and then re-save because we're adding content to the text document within an event.
@@ -122,13 +122,13 @@ export class ProvisionalCompletionOrchestrator {
         const newDocument = await vscode.workspace.openTextDocument(projectedDocument.uri);
         await newDocument.save();
 
-        const provisionalPosition = new vscode.Position(
-            previousCharacterQuery.position.line,
-            previousCharacterQuery.position.character + 1);
+        const completionRetriggerLocation = new vscode.Position(
+            characterBeforeTriggerProjection.position.line,
+            characterBeforeTriggerProjection.position.character + 2);
         const completionList = await RazorCompletionItemProvider.getCompletions(
             projectedDocument.uri,
             htmlPosition,
-            provisionalPosition,
+            completionRetriggerLocation,
             completionContext.triggerCharacter);
 
         // We track when we add provisional dots to avoid doing unnecessary work on commonly invoked events.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -136,15 +136,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return (false, result);
             }
 
-            if (projection.Position.Character == 0)
+            if (projection.Position.Character <= 2)
             {
                 // We're at the start of line. Can't have provisional completions here.
+                // i.e:
+                // .|
+                // @.|
                 return (false, result);
             }
 
-            var previousCharacterPosition = new Position(projection.Position.Line, projection.Position.Character - 1);
-            var previousCharacterProjection = await _projectionProvider.GetProjectionAsync(documentSnapshot, previousCharacterPosition, cancellationToken).ConfigureAwait(false);
-            if (previousCharacterProjection == null || previousCharacterProjection.LanguageKind != RazorLanguageKind.CSharp)
+            var characterBeforeTriggerPosition = new Position(projection.Position.Line, projection.Position.Character - 2);
+            var characterBeforeTriggerProjection = await _projectionProvider.GetProjectionAsync(documentSnapshot, characterBeforeTriggerPosition, cancellationToken).ConfigureAwait(false);
+            if (characterBeforeTriggerProjection == null || characterBeforeTriggerProjection.LanguageKind != RazorLanguageKind.CSharp)
             {
                 return (false, result);
             }
@@ -156,17 +159,20 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Edit the CSharp projected document to contain a '.'. This allows C# completion to provide valid
             // completion items for moments when a user has typed a '.' that's typically interpreted as Html.
-            var addProvisionalDot = new VisualStudioTextChange(previousCharacterProjection.PositionIndex, 0, ".");
 
             await _joinableTaskFactory.SwitchToMainThreadAsync();
+            var provisionalDotInsertIndex = characterBeforeTriggerProjection.PositionIndex + 1;
+            var addProvisionalDot = new VisualStudioTextChange(provisionalDotInsertIndex, 0, ".");
+            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, new[] { addProvisionalDot }, characterBeforeTriggerProjection.HostDocumentVersion);
 
-            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, new[] { addProvisionalDot }, previousCharacterProjection.HostDocumentVersion);
-
+            var provisionalDotInsertPosition = new Position(
+                characterBeforeTriggerProjection.Position.Line,
+                characterBeforeTriggerProjection.Position.Character + 1);
             var provisionalCompletionParams = new CompletionParams()
             {
                 Context = request.Context,
-                Position = new Position(previousCharacterProjection.Position.Line, previousCharacterProjection.Position.Character + 1),
-                TextDocument = new TextDocumentIdentifier() { Uri = previousCharacterProjection.Uri }
+                Position = new Position(provisionalDotInsertPosition.Line, provisionalDotInsertPosition.Character + 1),
+                TextDocument = new TextDocumentIdentifier() { Uri = characterBeforeTriggerProjection.Uri }
             };
 
             result = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(
@@ -176,9 +182,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(true);
 
             // We have now obtained the necessary completion items. We no longer need the provisional change. Revert.
-            var removeProvisionalDot = new VisualStudioTextChange(previousCharacterProjection.PositionIndex, 1, string.Empty);
+            var removeProvisionalDot = new VisualStudioTextChange(provisionalDotInsertIndex, 1, string.Empty);
             
-            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, new[] { removeProvisionalDot }, previousCharacterProjection.HostDocumentVersion);
+            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(documentSnapshot.Uri, new[] { removeProvisionalDot }, characterBeforeTriggerProjection.HostDocumentVersion);
 
             return (true, result);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -471,6 +471,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void GetLanguageKind_RazorEdgeWithCSharp()
         {
             // Arrange
+            var text = "@{var x = 1;}";
+            var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
+
+            // Act
+            var languageKind = RazorLanguageEndpoint.GetLanguageKind(classifiedSpans, tagHelperSpans, 12);
+
+            // Assert
+            Assert.Equal(RazorLanguageKind.Razor, languageKind);
+        }
+
+        [Fact]
+        public void GetLanguageKind_RazorEdgeWithCSharpMarker()
+        {
+            // Arrange
             var text = "@{}";
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 


### PR DESCRIPTION
- Ajay and I found that when working on the edge of Razor metacode aka `@{if (true) { } |}` our language queries would return C# as the language being operated on. The root cause of this issue is that our edge handling was a little too naive, we were restricting edge handling to only special variants of non-marker spans. That's still true after this change but we've expanded the accepted left-hand-side ownership of edge scenarios to include whitespace sensitive content (typically implicit expressions).
- Because of the new edge handling we stopped allowing the left-hand side to default to owning the edge. For the EOF case I had to special case that in our language query to ensure that at the end of the document users still get the IntelliSense they expect.
- This is an experimental change. If we find this causes more harm then good I plan to revert this.