### PR TITLE
Interim Fix for FAR Code Behind Leaking Through

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/ClassifiedTextElementComparer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/ClassifiedTextElementComparer.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Text.Adornments;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    internal class ClassifiedTextElementComparer : IEqualityComparer<ClassifiedTextElement>
+    {
+        public static ClassifiedTextElementComparer Default = new ClassifiedTextElementComparer();
+
+        public bool Equals(ClassifiedTextElement x, ClassifiedTextElement y)
+        {
+            if (x is null && y is null)
+            {
+                return true;
+            }
+            else if (x is null ^ y is null)
+            {
+                return false;
+            }
+            else if (x.Runs.Count() != y.Runs.Count())
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(ClassifiedTextElement obj)
+        {
+            var hashCodeCombiner = new HashCodeCombiner();
+            hashCodeCombiner.Add(obj.Runs);
+            return hashCodeCombiner.CombinedHash;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/ClassifiedTextRunComparer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/ClassifiedTextRunComparer.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    internal class ClassifiedTextRunComparer : IEqualityComparer<ClassifiedTextRun>
+    {
+        public static ClassifiedTextRunComparer Default = new ClassifiedTextRunComparer();
+
+        public bool Equals(ClassifiedTextRun x, ClassifiedTextRun y)
+        {
+            if (x is null && y is null)
+            {
+                return true;
+            }
+            else if (x is null ^ y is null)
+            {
+                return false;
+            }
+
+            return x.ClassificationTypeName == y.ClassificationTypeName &&
+                x.Text == y.Text;
+        }
+
+        public int GetHashCode(ClassifiedTextRun obj)
+        {
+            var hashCodeCombiner = new HashCodeCombiner();
+            hashCodeCombiner.Add(obj.Text);
+            hashCodeCombiner.Add(obj.ClassificationTypeName);
+            return hashCodeCombiner.CombinedHash;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -215,11 +215,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             if (referenceText is string text)
             {
-                if (text.Contains(codeBehindObjectPrefix))
+                if (text.StartsWith(codeBehindObjectPrefix))
                 {
                     return text
-                        .Replace(codeBehindObjectPrefix, string.Empty)
-                        .TrimEnd(';');
+                        .Substring(codeBehindObjectPrefix.Length, text.Length - codeBehindObjectPrefix.Length - 1); // -1 for trailing `;`
                 }
 
                 return text.Replace(codeBehindBackingFieldSuffix, string.Empty);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Uri = new Uri("C:/path/to/file.razor");
 
             // Long timeout after last notification to avoid triggering even in slow CI environments
-            TestWaitForProgressNotificationTimeout = TimeSpan.FromSeconds(3);
+            TestWaitForProgressNotificationTimeout = TimeSpan.FromSeconds(30);
         }
 
         private Uri Uri { get; }
@@ -295,7 +295,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         }
 
         [Theory]
-        [InlineData("__o = food", "food")]
+        [InlineData("__o = food;", "food")]
         [InlineData("string Todo.<Title>k__BackingField", "string Todo.<Title>")]
         public async Task HandleRequestAsync_CSharpProjection_FiltersReferenceText(string rawText, string filteredText)
         {
@@ -374,6 +374,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 new ClassifiedTextRun("operator", "="),
                 new ClassifiedTextRun("text", " "),
                 new ClassifiedTextRun("text", "counter"),
+                new ClassifiedTextRun("punctuation", ";"),
             });
             var virtualCSharpUri = new Uri("C:/path/to/someotherfile.razor.g.cs");
             var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri, text: virtualClassifiedRun);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -24,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Uri = new Uri("C:/path/to/file.razor");
 
             // Long timeout after last notification to avoid triggering even in slow CI environments
-            TestWaitForProgressNotificationTimeout = TimeSpan.FromSeconds(30);
+            TestWaitForProgressNotificationTimeout = TimeSpan.FromSeconds(3);
         }
 
         private Uri Uri { get; }
@@ -159,15 +160,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var progressReported = false;
             var expectedUri1 = new Uri("C:/path/to/file1.razor");
             var expectedUri2 = new Uri("C:/path/to/file2.razor");
-            var expectedLocation1 = GetReferenceItem(5, 5, 5, 5, expectedUri1);
-            var expectedLocation2 = GetReferenceItem(10, 10, 10, 10, expectedUri2);
+            var expectedLocation1 = GetReferenceItem(5, expectedUri1);
+            var expectedLocation2 = GetReferenceItem(10, expectedUri2);
             var documentManager = new TestDocumentManager();
             documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
 
             var virtualCSharpUri1 = new Uri("C:/path/to/file1.razor.g.cs");
             var virtualCSharpUri2 = new Uri("C:/path/to/file2.razor.g.cs");
-            var csharpLocation1 = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri1);
-            var csharpLocation2 = GetReferenceItem(200, 200, 200, 200, virtualCSharpUri2);
+            var csharpLocation1 = GetReferenceItem(100, virtualCSharpUri1);
+            var csharpLocation2 = GetReferenceItem(200, virtualCSharpUri2);
 
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>();
             var lspProgressListener = new DefaultLSPProgressListener(languageServiceBroker);
@@ -244,13 +245,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Arrange
             var progressReported = false;
             var externalUri = new Uri("C:/path/to/someotherfile.razor");
-            var expectedLocation = GetReferenceItem(5, 5, 5, 5, externalUri);
+            var expectedLocation = GetReferenceItem(5, externalUri);
             var documentManager = new TestDocumentManager();
             documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 2));
             documentManager.AddDocument(externalUri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 5));
 
             var virtualCSharpUri = new Uri("C:/path/to/someotherfile.razor.g.cs");
-            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var csharpLocation = GetReferenceItem(100, virtualCSharpUri);
             var (requestInvoker, progressListener) = MockServices(csharpLocation, out var token);
 
             var projectionResult = new ProjectionResult()
@@ -293,6 +294,131 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(progressReported);
         }
 
+        [Theory]
+        [InlineData("__o = food", "food")]
+        [InlineData("string Todo.<Title>k__BackingField", "string Todo.<Title>")]
+        public async Task HandleRequestAsync_CSharpProjection_FiltersReferenceText(string rawText, string filteredText)
+        {
+            // Arrange
+            var progressReported = false;
+            var externalUri = new Uri("C:/path/to/someotherfile.razor");
+            var expectedReferenceItem = GetReferenceItem(5, 5, 5, 5, externalUri, text: filteredText);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 2));
+            documentManager.AddDocument(externalUri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 5));
+
+            var virtualCSharpUri = new Uri("C:/path/to/someotherfile.razor.g.cs");
+            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri, text: rawText);
+            var (requestInvoker, progressListener) = MockServices(csharpLocation, out var token);
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangesResponse()
+            {
+                Ranges = new[] { expectedReferenceItem.Location.Range },
+                HostDocumentVersion = 5
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+            documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, externalUri, new[] { csharpLocation.Location.Range }, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+
+            var progressToken = new ProgressWithCompletion<object>((val) =>
+            {
+                var results = Assert.IsType<VSReferenceItem[]>(val);
+                var actualReferenceItem = Assert.Single(results);
+                AssertVSReferenceItem(expectedReferenceItem, actualReferenceItem);
+                progressReported = true;
+            });
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5),
+                PartialResultToken = progressToken
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), token, CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(progressReported);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_CSharpProjection_FiltersReferenceClassifiedRuns()
+        {
+            // Arrange
+            var progressReported = false;
+            var externalUri = new Uri("C:/path/to/someotherfile.razor");
+
+            var expectedClassifiedRun = new ClassifiedTextElement(new ClassifiedTextRun[]
+            {
+                new ClassifiedTextRun("text", "counter"),
+            });
+            var expectedReferenceItem = GetReferenceItem(5, 5, 5, 5, externalUri, text: expectedClassifiedRun);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 2));
+            documentManager.AddDocument(externalUri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 5));
+
+            var virtualClassifiedRun = new ClassifiedTextElement(new ClassifiedTextRun[]
+            {
+                new ClassifiedTextRun("field name", "__o"),
+                new ClassifiedTextRun("text", " "),
+                new ClassifiedTextRun("operator", "="),
+                new ClassifiedTextRun("text", " "),
+                new ClassifiedTextRun("text", "counter"),
+            });
+            var virtualCSharpUri = new Uri("C:/path/to/someotherfile.razor.g.cs");
+            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri, text: virtualClassifiedRun);
+            var (requestInvoker, progressListener) = MockServices(csharpLocation, out var token);
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = RazorLanguageKind.CSharp,
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>();
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var remappingResult = new RazorMapToDocumentRangesResponse()
+            {
+                Ranges = new[] { expectedReferenceItem.Location.Range },
+                HostDocumentVersion = 5
+            };
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+            documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, externalUri, new[] { csharpLocation.Location.Range }, It.IsAny<CancellationToken>())).
+                Returns(Task.FromResult(remappingResult));
+
+            var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
+            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+
+            var progressToken = new ProgressWithCompletion<object>((val) =>
+            {
+                var results = Assert.IsType<VSReferenceItem[]>(val);
+                var actualReferenceItem = Assert.Single(results);
+                AssertVSReferenceItem(expectedReferenceItem, actualReferenceItem);
+                progressReported = true;
+            });
+            var referenceRequest = new ReferenceParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Position = new Position(10, 5),
+                PartialResultToken = progressToken
+            };
+
+            // Act
+            var result = await referencesHandler.HandleRequestAsync(referenceRequest, new ClientCapabilities(), token, CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(progressReported);
+        }
+
         [Fact]
         public async Task HandleRequestAsync_CSharpProjection_DoesNotRemapNonRazorFiles()
         {
@@ -302,7 +428,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
 
             var externalCSharpUri = new Uri("C:/path/to/someotherfile.cs");
-            var externalCsharpLocation = GetReferenceItem(100, 100, 100, 100, externalCSharpUri);
+            var externalCsharpLocation = GetReferenceItem(100, externalCSharpUri);
             var (requestInvoker, progressListener) = MockServices(externalCsharpLocation, out var token);
 
             var projectionResult = new ProjectionResult()
@@ -344,12 +470,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var progressReported = false;
-            var expectedLocation = GetReferenceItem(5, 5, 5, 5, Uri);
+            var expectedLocation = GetReferenceItem(5, Uri);
             var documentManager = new TestDocumentManager();
             documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 123));
 
             var virtualCSharpUri = new Uri("C:/path/to/file.razor.g.cs");
-            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var csharpLocation = GetReferenceItem(100, virtualCSharpUri);
             var (requestInvoker, progressListener) = MockServices(csharpLocation, out var token);
 
             var projectionResult = new ProjectionResult()
@@ -400,13 +526,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Arrange
             var progressReported = false;
             var externalUri = new Uri("C:/path/to/someotherfile.razor");
-            var expectedLocation = GetReferenceItem(5, 5, 5, 5, externalUri);
+            var expectedLocation = GetReferenceItem(5, externalUri);
             var documentManager = new TestDocumentManager();
             documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 2));
             documentManager.AddDocument(externalUri, Mock.Of<LSPDocumentSnapshot>(d => d.Version == 5));
 
             var virtualCSharpUri = new Uri("C:/path/to/someotherfile.razor.g.cs");
-            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var csharpLocation = GetReferenceItem(100, virtualCSharpUri);
             var (requestInvoker, progressListener) = MockServices(csharpLocation, out var token);
 
             var projectionResult = new ProjectionResult()
@@ -460,7 +586,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
 
             var virtualCSharpUri = new Uri("C:/path/to/file.razor.g.cs");
-            var csharpLocation = GetReferenceItem(100, 100, 100, 100, virtualCSharpUri);
+            var csharpLocation = GetReferenceItem(100, virtualCSharpUri);
             var (requestInvoker, progressListener) = MockServices(csharpLocation, out var token);
 
             var projectionResult = new ProjectionResult()
@@ -644,6 +770,24 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             Assert.Equal(expected.Location, actual.Location);
             Assert.Equal(expected.DisplayPath, actual.DisplayPath);
+
+            if (actual.Text is string)
+            {
+                Assert.Equal(expected.Text, actual.Text);
+                Assert.Equal(expected.DefinitionText, actual.DefinitionText);
+            }
+            else
+            {
+                Assert.Equal(
+                    expected.Text as ClassifiedTextElement,
+                    actual.Text as ClassifiedTextElement,
+                    ClassifiedTextElementComparer.Default);
+                Assert.Equal(
+                    expected.DefinitionText as ClassifiedTextElement,
+                    actual.DefinitionText as ClassifiedTextElement,
+                    ClassifiedTextElementComparer.Default);
+            }
+
             return true;
         }
 
@@ -674,9 +818,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return (requestInvoker.Object, lspProgressListener);
         }
 
-        private VSReferenceItem GetReferenceItem(int position, Uri uri)
+        private VSReferenceItem GetReferenceItem(int position, Uri uri, string text = "text")
         {
-            return GetReferenceItem(position, position, position, position, uri);
+            return GetReferenceItem(position, position, position, position, uri, text);
         }
 
         private VSReferenceItem GetReferenceItem(
@@ -685,9 +829,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             int endLine,
             int endCharacter,
             Uri uri,
+            object text,
             string documentName = "document",
-            string projectName = "project",
-            string text = "text")
+            string projectName = "project")
         {
             return new VSReferenceItem()
             {
@@ -703,7 +847,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 DocumentName = documentName,
                 ProjectName = projectName,
                 DisplayPath = uri.AbsolutePath,
-                Text = text
+                Text = text,
+                DefinitionText = text
             };
         }
     }


### PR DESCRIPTION
Fixes code behind leaking through:

### After
![image](https://user-images.githubusercontent.com/14852843/87816022-7886e500-c81b-11ea-82df-a4e8bd84c3b5.png)

![image](https://user-images.githubusercontent.com/14852843/87814058-ea5d2f80-c817-11ea-83ba-720491c57fe2.png)

### Before:
![image](https://user-images.githubusercontent.com/14852843/83667489-56931500-a583-11ea-804b-9e216f18aad8.png)
![image](https://user-images.githubusercontent.com/14852843/87718762-356b3a00-c767-11ea-9798-0f2656201aca.png)

Note; we had to accomodate ClassifiedTextElement(s) along with normal string text for the reference content.
![image](https://user-images.githubusercontent.com/14852843/87815997-6c028c80-c81b-11ea-9ed2-06be2c6b76fb.png)

I've updated https://github.com/dotnet/aspnetcore/issues/22512 to include reverting this change once that issue is fixed.

Fixes: https://github.com/dotnet/aspnetcore/issues/24073