### PR TITLE
Implement naive per-project component search

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -31,6 +31,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         /// <returns>The corresponding DocumentSnapshot if found, null otherwise.</returns>
         public override async Task<DocumentSnapshot> TryLocateComponentAsync(TagHelperDescriptor tagHelper)
         {
+            if (tagHelper is null)
+            {
+                return null;
+            }
+
             DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(tagHelper.Name, out _, out var typeSpan);
             var typeName = tagHelper.Name.Substring(typeSpan.Start, typeSpan.Length);
 
@@ -78,7 +83,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var namespaceNode = (NamespaceDeclarationIntermediateNode)razorCodeDocument
                 .GetDocumentIntermediateNode()
                 .FindDescendantNodes<IntermediateNode>()
-                .FirstOrDefault(n => n is NamespaceDeclarationIntermediateNode);
+                .First(n => n is NamespaceDeclarationIntermediateNode);
 
             DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(fullyQualifiedComponentName, out var namespaceNameSpan, out var typeNameSpan);
             var namespaceName = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(namespaceNameSpan, fullyQualifiedComponentName);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultRazorComponentSearchEngine : RazorComponentSearchEngine
+    {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+
+        public DefaultRazorComponentSearchEngine(ForegroundDispatcher dispatcher)
+        {
+            _foregroundDispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        }
+
+        /// <summary>Search for a component in a project based on its tag name and fully qualified name.</summary>
+        /// <remarks>
+        /// This method makes several assumptions about the nature of components. First, it assumes that a component
+        /// a given name `Name` will be located in a file `Name.razor`. Second, it assumes that the namespace the
+        /// component is present in has the same name as the assembly its corresponding tag helper is loaded from.
+        /// Implicitly, this method inherits any assumptions made by TrySplitNamespaceAndType.
+        /// </remarks>
+        /// <param name="project">A project to search for the component in.</param>
+        /// <param name="componentName">The name of the component.</param>
+        /// <param name="fullyQualifiedComponentName">The fully qualified name of the component.</param>
+        /// <param name="cancellationToken">A cancellation token, primarily for the document resolver.</param>
+        /// <returns>A tuple containing the document URI and related resources loaded during search.</returns>
+        public async override Task<Tuple<Uri, DocumentSnapshot, RazorCodeDocument>> TryLocateComponent(ProjectSnapshot project, string componentName, string fullyQualifiedComponentName, CancellationToken cancellationToken)
+        {
+            foreach (var path in project.DocumentFilePaths)
+            {
+                // Rule out if not Razor component with correct name
+                if (!IsPathCandidateForComponent(path, componentName))
+                {
+                    continue;
+                }
+
+                // Get document and code document
+                var documentSnapshot = await Task.Factory.StartNew(() => project.GetDocument(path), cancellationToken, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler).ConfigureAwait(false);
+                var razorCodeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+
+                // Make sure we have the right namespace of the fully qualified name
+                if (!ComponentNamespaceMatchesFullyQualifiedName(razorCodeDocument, fullyQualifiedComponentName))
+                {
+                    continue;
+                }
+
+                var uri = new UriBuilder
+                {
+                    Scheme = "file",
+                    Path = path,
+                    Host = string.Empty,
+                }.Uri;
+                return Tuple.Create(uri, documentSnapshot, razorCodeDocument);
+            }
+            return null;
+        }
+
+        public static bool IsPathCandidateForComponent(string path, string componentName)
+        {
+            return Path.GetFileName(path).Equals($"{componentName}.razor", StringComparison.Ordinal);
+        }
+
+        public static bool ComponentNamespaceMatchesFullyQualifiedName(RazorCodeDocument razorCodeDocument, string fullyQualifiedComponentName)
+        {
+            var namespaceNode = (NamespaceDeclarationIntermediateNode)razorCodeDocument
+                .GetDocumentIntermediateNode()
+                .FindDescendantNodes<IntermediateNode>()
+                .FirstOrDefault(n => n is NamespaceDeclarationIntermediateNode);
+
+            DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(fullyQualifiedComponentName, out var namespaceNameSpan, out var typeNameSpan);
+            var namespaceName = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(namespaceNameSpan, fullyQualifiedComponentName);
+            return $"{namespaceNode.Content}".Equals(namespaceName, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorComponentSearchEngine.cs
@@ -1,10 +1,14 @@
-﻿using Microsoft.AspNetCore.Razor.Language;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal abstract class RazorComponentSearchEngine
     {
-        public abstract bool TryLocateComponent(TagHelperDescriptor tagHelper, out DocumentSnapshot documentSnapshot);
+        public abstract Task<DocumentSnapshot> TryLocateComponentAsync(TagHelperDescriptor tagHelper);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorComponentSearchEngine.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
+﻿using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal abstract class RazorComponentSearchEngine
     {
-        public abstract Task<Tuple<Uri, DocumentSnapshot, RazorCodeDocument>> TryLocateComponent(ProjectSnapshot project, string componentName, string fullyQualifiedComponentName, CancellationToken cancellationToken);
+        public abstract bool TryLocateComponent(TagHelperDescriptor tagHelper, out DocumentSnapshot documentSnapshot);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorComponentSearchEngine.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class RazorComponentSearchEngine
+    {
+        public abstract Task<Tuple<Uri, DocumentSnapshot, RazorCodeDocument>> TryLocateComponent(ProjectSnapshot project, string componentName, string fullyQualifiedComponentName, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -179,15 +179,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RazorCodeActionResolver, ExtractToCodeBehindCodeActionResolver>();
                         services.AddSingleton<RazorCodeActionResolver, CreateComponentCodeActionResolver>();
 
-                        // Refactoring
-                        services.AddSingleton<RazorComponentSearchEngine, DefaultRazorComponentSearchEngine>();
-
                         // Other
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();
                         services.AddSingleton<RazorSemanticTokensInfoService, DefaultRazorSemanticTokensInfoService>();
                         services.AddSingleton<RazorHoverInfoService, DefaultRazorHoverInfoService>();
                         services.AddSingleton<HtmlFactsService, DefaultHtmlFactsService>();
                         services.AddSingleton<WorkspaceDirectoryPathResolver, DefaultWorkspaceDirectoryPathResolver>();
+                        services.AddSingleton<RazorComponentSearchEngine, DefaultRazorComponentSearchEngine>();
                     }));
 
             try

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -179,6 +179,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RazorCodeActionResolver, ExtractToCodeBehindCodeActionResolver>();
                         services.AddSingleton<RazorCodeActionResolver, CreateComponentCodeActionResolver>();
 
+                        // Refactoring
+                        services.AddSingleton<RazorComponentSearchEngine, DefaultRazorComponentSearchEngine>();
+
                         // Other
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();
                         services.AddSingleton<RazorSemanticTokensInfoService, DefaultRazorSemanticTokensInfoService>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -111,9 +111,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
                 .FirstOrDefault(n => n is NamespaceDeclarationIntermediateNode);
             namespaceNode.Content = rootNamespaceName;
 
-            var documentSnapshot = new Mock<DocumentSnapshot>();
-            documentSnapshot.Setup(d => d.GetGeneratedOutputAsync()).Returns(Task.FromResult(codeDocument));
-            return documentSnapshot.Object;
+            var documentSnapshot = Mock.Of<DocumentSnapshot>(d =>
+                d.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
+                d.FilePath == filePath &&
+                d.FileKind == FileKinds.Component);
+            return documentSnapshot;
         }
     
         internal static ProjectSnapshotManager CreateProjectSnapshotManager()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Refactoring
+{
+    public class DefaultRazorComponentSearchEngineTest : LanguageServerTestBase
+    {
+        private static ProjectSnapshotManager _projectSnapshotManager = CreateProjectSnapshotManager();
+        private static readonly DefaultRazorComponentSearchEngine _searchEngine = new DefaultRazorComponentSearchEngine(_projectSnapshotManager);
+
+        [Theory]
+        [InlineData("First", "First.Components", "Component1")]
+        [InlineData("First", "Test", "Component2")]
+        [InlineData("Second", "Second.Components", "Component3")]
+        public void Handle_SearchBasic(string assemblyName, string namespaceName, string tagName)
+        {
+            // Arrange
+            var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor(assemblyName, namespaceName, tagName);
+
+            // Act
+            var found = _searchEngine.TryLocateComponent(tagHelperDescriptor, out var documentSnapshot);
+
+            // Assert
+            Assert.True(found);
+            Assert.NotNull(documentSnapshot);
+        }
+
+        [Theory]
+        [InlineData("Third", "First.Components", "Component3")]  // Incorrect assembly name
+        [InlineData("First", "First.Components", "Component2")]  // Incorrect namespace
+        [InlineData("First", "First.Components", "Component3")]  // Incorrect tag name
+        public void Handle_SearchBasicMissing(string assemblyName, string namespaceName, string tagName)
+        {
+            // Arrange
+            var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor(assemblyName, namespaceName, tagName);
+
+            // Act
+            var found = _searchEngine.TryLocateComponent(tagHelperDescriptor, out var documentSnapshot);
+
+            // Assert
+            Assert.False(found);
+        }
+
+        internal static TagHelperDescriptor CreateRazorComponentTagHelperDescriptor(string assemblyName, string namespaceName, string tagName)
+        {
+            var fullyQualifiedName = $"{namespaceName}.{tagName}";
+            var builder1 = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
+            builder1.TagMatchingRule(rule => rule.TagName = tagName);
+            return builder1.Build();
+        }
+
+        internal static DocumentSnapshot CreateRazorDocumentSnapshot(string text, string filePath, string rootNamespaceName)
+        {
+            var sourceDocument = TestRazorSourceDocument.Create(text, filePath: filePath, relativePath: filePath);
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, builder => {
+                builder.AddDirective(NamespaceDirective.Directive);
+                builder.SetRootNamespace(rootNamespaceName);
+            });
+            var codeDocument = projectEngine.Process(sourceDocument, FileKinds.Component, Array.Empty<RazorSourceDocument>(), Array.Empty<TagHelperDescriptor>());
+
+            var namespaceNode = (NamespaceDeclarationIntermediateNode)codeDocument
+                .GetDocumentIntermediateNode()
+                .FindDescendantNodes<IntermediateNode>()
+                .FirstOrDefault(n => n is NamespaceDeclarationIntermediateNode);
+            namespaceNode.Content = rootNamespaceName;
+
+            var documentSnapshot = new Mock<DocumentSnapshot>();
+            documentSnapshot.Setup(d => d.TryGetGeneratedOutput(out codeDocument)).Returns(true);
+            return documentSnapshot.Object;
+        }
+    
+        internal static ProjectSnapshotManager CreateProjectSnapshotManager()
+        {
+            var firstProject = Mock.Of<ProjectSnapshot>(p =>
+                p.FilePath == "c:/First/First.csproj" &&
+                p.DocumentFilePaths == new[] { "c:/First/Component1.razor", "c:/First/Component2.razor" } &&
+                p.GetDocument("c:/First/Component1.razor") == CreateRazorDocumentSnapshot("", "c:/First/Component1.razor", "First.Components") &&
+                p.GetDocument("c:/First/Component2.razor") == CreateRazorDocumentSnapshot("@namespace Test", "c:/First/Component2.razor", "Test"));
+
+            var secondProject = Mock.Of<ProjectSnapshot>(p =>
+                p.FilePath == "c:/Second/Second.csproj" &&
+                p.DocumentFilePaths == new[] { "c:/Second/Component3.razor" } &&
+                p.GetDocument("c:/Second/Component3.razor") == CreateRazorDocumentSnapshot("", "c:/Second/Component3.razor", "Second.Components"));
+
+            return Mock.Of<ProjectSnapshotManager>(p => p.Projects == new[] { firstProject, secondProject });
+        }
+    }
+}


### PR DESCRIPTION
This pull request implements a rudimentary component search service. The scope is fairly limited; the search only looks through the provided project and makes several assumptions (documented in code) about what it's looking for. However, our goal is to provide this service with as few false positives as possible rather than catch every case.
