### PR TITLE
Razor Config Serialization MVC 1.1 Support

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/JsonReaderExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/JsonReaderExtensions.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization
                 {
                     case JsonToken.PropertyName:
                         Debug.Assert(reader.Value.ToString() == propertyName);
+
                         if (reader.Read())
                         {
                             return reader.ReadArray<T>(serializer);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/RazorConfigurationJsonConverter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/RazorConfigurationJsonConverter.cs
@@ -108,7 +108,8 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization
                 return null;
             }
 
-            string version = string.Empty;
+            var major = string.Empty;
+            var minor = string.Empty;
 
             reader.ReadProperties(propertyName =>
             {
@@ -117,19 +118,19 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization
                     case "Major":
                         if (reader.Read())
                         {
-                            version = reader.Value.ToString();
+                            major = reader.Value.ToString();
                         }
                         break;
                     case "Minor":
                         if (reader.Read())
                         {
-                            version += $".{reader.Value}";
+                            minor = reader.Value.ToString();
                         }
                         break;
                 }
             });
 
-            return version;
+            return $"{major}.{minor}";
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/RazorConfigurationJsonConverter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/RazorConfigurationJsonConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Newtonsoft.Json;
 
@@ -23,9 +24,39 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization
                 return null;
             }
 
-            var configurationName = reader.ReadNextStringProperty(nameof(RazorConfiguration.ConfigurationName));
-            var languageVersionValue = reader.ReadNextStringProperty(nameof(RazorConfiguration.LanguageVersion));
-            var extensions = reader.ReadPropertyArray<RazorExtension>(serializer, nameof(RazorConfiguration.Extensions));
+            string configurationName = null;
+            string languageVersionValue = null;
+            IReadOnlyList<RazorExtension> extensions = null;
+
+            reader.ReadProperties(propertyName =>
+            {
+                switch (propertyName)
+                {
+                    case nameof(RazorConfiguration.ConfigurationName):
+                        if (reader.Read())
+                        {
+                            configurationName = (string)reader.Value;
+                        }
+                        break;
+                    case nameof(RazorConfiguration.LanguageVersion):
+                        if (reader.Read())
+                        {
+                            languageVersionValue = reader.Value as string ??
+                                RazorLanguageVersionObjectJsonConverter.Instance.ReadJson(
+                                    reader,
+                                    objectType: null,
+                                    existingValue: null,
+                                    serializer) as string;
+                        }
+                        break;
+                    case nameof(RazorConfiguration.Extensions):
+                        if (reader.Read())
+                        {
+                            extensions = serializer.Deserialize<RazorExtension[]>(reader);
+                        }
+                        break;
+                }
+            });
 
             if (!RazorLanguageVersion.TryParse(languageVersionValue, out var languageVersion))
             {
@@ -58,6 +89,52 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization
             serializer.Serialize(writer, configuration.Extensions);
 
             writer.WriteEndObject();
+        }
+    }
+
+    internal class RazorLanguageVersionObjectJsonConverter : JsonConverter
+    {
+        public static readonly RazorLanguageVersionObjectJsonConverter Instance = new RazorLanguageVersionObjectJsonConverter();
+
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType != JsonToken.StartObject)
+            {
+                return null;
+            }
+
+            string version = string.Empty;
+
+            reader.ReadProperties(propertyName =>
+            {
+                switch (propertyName)
+                {
+                    case "Major":
+                        if (reader.Read())
+                        {
+                            version = reader.Value.ToString();
+                        }
+                        break;
+                    case "Minor":
+                        if (reader.Read())
+                        {
+                            version += $".{reader.Value}";
+                        }
+                        break;
+                }
+            });
+
+            return version;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/RazorConfigurationJsonConverter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/RazorConfigurationJsonConverter.cs
@@ -90,52 +90,52 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization
 
             writer.WriteEndObject();
         }
-    }
 
-    internal class RazorLanguageVersionObjectJsonConverter : JsonConverter
-    {
-        public static readonly RazorLanguageVersionObjectJsonConverter Instance = new RazorLanguageVersionObjectJsonConverter();
-
-        public override bool CanConvert(Type objectType)
+        private class RazorLanguageVersionObjectJsonConverter : JsonConverter
         {
-            throw new NotImplementedException();
-        }
+            public static readonly RazorLanguageVersionObjectJsonConverter Instance = new RazorLanguageVersionObjectJsonConverter();
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            if (reader.TokenType != JsonToken.StartObject)
+            public override bool CanConvert(Type objectType)
             {
-                return null;
+                throw new NotImplementedException();
             }
 
-            var major = string.Empty;
-            var minor = string.Empty;
-
-            reader.ReadProperties(propertyName =>
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
             {
-                switch (propertyName)
+                if (reader.TokenType != JsonToken.StartObject)
                 {
-                    case "Major":
-                        if (reader.Read())
-                        {
-                            major = reader.Value.ToString();
-                        }
-                        break;
-                    case "Minor":
-                        if (reader.Read())
-                        {
-                            minor = reader.Value.ToString();
-                        }
-                        break;
+                    return null;
                 }
-            });
 
-            return $"{major}.{minor}";
-        }
+                var major = string.Empty;
+                var minor = string.Empty;
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
+                reader.ReadProperties(propertyName =>
+                {
+                    switch (propertyName)
+                    {
+                        case "Major":
+                            if (reader.Read())
+                            {
+                                major = reader.Value.ToString();
+                            }
+                            break;
+                        case "Minor":
+                            if (reader.Read())
+                            {
+                                minor = reader.Value.ToString();
+                            }
+                            break;
+                    }
+                });
+
+                return $"{major}.{minor}";
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -123,32 +123,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 result = SetResolveData(result.Value, serverKind);
             }
 
-            // This is a bit fraught. Basically in the scenario That someone types "@<slight pause>{" they'll get @__builder because '{' is a commit character.
-            // Our solution is to make the results in this case empty, which is a bit of a lie.
-            // It's the best we can do for now, if a user complains we can revisit.
-            if (result.HasValue && request.Context.TriggerCharacter != null && request.Context.TriggerCharacter.Equals("@"))
-            {
-                var items = result.Value.Match(
-                    itemArray => itemArray,
-                    list =>
-                    {
-                        return list?.Items;
-                    });
-
-                foreach(var item in items)
-                {
-                    item.InsertText = string.Empty;
-                }
-
-                var list = new CompletionList
-                {
-                    IsIncomplete = true,
-                    Items = items,
-                };
-
-                return list;
-            }
-
             return result;
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Serialization/RazorConfigurationSerializationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Serialization/RazorConfigurationSerializationTest.cs
@@ -41,10 +41,85 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
             // Assert
             Assert.Equal(configuration.ConfigurationName, obj.ConfigurationName);
             Assert.Collection(
-                configuration.Extensions, 
+                configuration.Extensions,
                 e => Assert.Equal("Test-Extension1", e.ExtensionName),
                 e => Assert.Equal("Test-Extension2", e.ExtensionName));
             Assert.Equal(configuration.LanguageVersion, obj.LanguageVersion);
+        }
+
+        [Fact]
+        public void RazorConfigurationJsonConverter_Serialization_MVC3_CanRead()
+        {
+            // Arrange
+            var configurationJson = @"{
+  ""ConfigurationName"": ""MVC-3.0"",
+  ""LanguageVersion"": ""3.0"",
+  ""Extensions"": [
+    {
+      ""ExtensionName"": ""MVC-3.0""
+    }
+  ]
+}";
+
+            // Act
+            var obj = JsonConvert.DeserializeObject<RazorConfiguration>(configurationJson, Converters);
+
+            // Assert
+            Assert.Equal("MVC-3.0", obj.ConfigurationName);
+            var extension = Assert.Single(obj.Extensions);
+            Assert.Equal("MVC-3.0", extension.ExtensionName);
+            Assert.Equal(RazorLanguageVersion.Parse("3.0"), obj.LanguageVersion);
+        }
+
+        [Fact]
+        public void RazorConfigurationJsonConverter_Serialization_MVC2_CanRead()
+        {
+            // Arrange
+            var configurationJson = @"{
+  ""ConfigurationName"": ""MVC-2.1"",
+  ""LanguageVersion"": ""2.1"",
+  ""Extensions"": [
+    {
+      ""ExtensionName"": ""MVC-2.1""
+    }
+  ]
+}";
+
+            // Act
+            var obj = JsonConvert.DeserializeObject<RazorConfiguration>(configurationJson, Converters);
+
+            // Assert
+            Assert.Equal("MVC-2.1", obj.ConfigurationName);
+            var extension = Assert.Single(obj.Extensions);
+            Assert.Equal("MVC-2.1", extension.ExtensionName);
+            Assert.Equal(RazorLanguageVersion.Parse("2.1"), obj.LanguageVersion);
+        }
+
+        [Fact]
+        public void RazorConfigurationJsonConverter_Serialization_MVC1_CanRead()
+        {
+            // Arrange
+            var configurationJson = @"{
+  ""ConfigurationName"": ""MVC-1.1"",
+  ""Extensions"": [
+    {
+      ""ExtensionName"": ""MVC-1.1""
+    }
+  ],
+  ""LanguageVersion"": {
+    ""Major"": 1,
+    ""Minor"": 1
+  }
+}";
+
+            // Act
+            var obj = JsonConvert.DeserializeObject<RazorConfiguration>(configurationJson, Converters);
+
+            // Assert
+            Assert.Equal("MVC-1.1", obj.ConfigurationName);
+            var extension = Assert.Single(obj.Extensions);
+            Assert.Equal("MVC-1.1", extension.ExtensionName);
+            Assert.Equal(RazorLanguageVersion.Parse("1.1"), obj.LanguageVersion);
         }
     }
 }


### PR DESCRIPTION
MVC 1.1 has a different razor configuration format (order of fields + language version structure). We must add support for that format.

```json
{
  "ConfigurationName": "MVC-3.0",
  "LanguageVersion": "3.0",
  "Extensions": [
    {
      "ExtensionName": "MVC-3.0"
    }
  ]
}
{
  "ConfigurationName": "MVC-2.1",
  "LanguageVersion": "2.1",
  "Extensions": [
    {
      "ExtensionName": "MVC-2.1"
    }
  ]
}
{
  "ConfigurationName": "MVC-1.1",
  "Extensions": [
    {
      "ExtensionName": "MVC-1.1"
    }
  ],
  "LanguageVersion": {
    "Major": 1,
    "Minor": 1
  }
}
```

Fixes: https://github.com/dotnet/aspnetcore/issues/24178


Thanks @ToddGrun!