### PR TITLE
ProjectSupportsLSP Internal Memory Cache Implementation

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -47,7 +47,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
 
             var semanticRanges = TagHelperSemanticRangeVisitor.VisitAllNodes(codeDocument);
 
-            var previousResults = previousResultId is null ? null : _semanticTokensCache.Get(previousResultId);
+            IReadOnlyList<uint> previousResults = null;
+
+            if (previousResultId != null)
+            {
+                _semanticTokensCache.TryGetValue(previousResultId, out previousResults);
+            }
             var newTokens = ConvertSemanticRangesToSemanticTokens(semanticRanges, codeDocument);
 
             if (previousResults is null)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MemoryCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MemoryCacheTest.cs
@@ -4,10 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Services;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
 {
     public class MemoryCacheTest
     {
@@ -23,7 +22,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
 
             Thread.Sleep(millisecondsTimeout: 10);
 
-            cache.Get(key);
+            cache.TryGetValue(key, out _);
             var newAccessTime = cache.GetAccessTime(key);
 
             Assert.True(newAccessTime > oldAccessTime, "New AccessTime should be greater than old");
@@ -38,7 +37,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
 
             cache.Set(key, value);
 
-            var result = cache.Get(key);
+            cache.TryGetValue(key, out var result);
 
             Assert.Same(value, result);
         }
@@ -67,7 +66,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             var cache = new TestMemoryCache();
             var key = GetKey();
 
-            var value = cache.Get(key);
+            cache.TryGetValue(key, out var value);
 
             Assert.Null(value);
         }
@@ -79,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var value = cache.Get(key: null);
+                cache.TryGetValue(key: null, out var result);
             });
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorFeatureDetectorTest.cs
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             private protected override bool EnvironmentFeatureEnabled() => EnvironmentFeatureEnabledValue;
 
-            private protected override bool IsFeatureFlagEnabled() => IsFeatureFlagEnabledValue;
+            private protected override bool IsFeatureFlagEnabledCached() => IsFeatureFlagEnabledValue;
 
             private protected override bool IsLiveShareGuest() => IsLiveShareGuestValue;
 


### PR DESCRIPTION
Using internal memory cache instead of `Microsoft.Extensions.Caching.Memory`.

Worked with @ryanbrandenburg to rework and generalize our memory cache implementation. Thanks!

Fixes: dotnet/aspnetcore#24033