### PR TITLE
Support C# onTypeFormatting in Razor LSP (Part 2)

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             var uri = request.TextDocument.Uri;
             var position = request.Position;
 
-            var formattingContext = FormattingContext.Create(uri, codeDocument, new Range(position, position), request.Options);
+            var formattingContext = FormattingContext.Create(uri, document, codeDocument, request.Options, new Range(position, position));
             for (var i = 0; i < applicableProviders.Count; i++)
             {
                 if (applicableProviders[i].TryResolveInsertion(position, formattingContext, out var textEdit, out var format))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class CSharpOnTypeFormattingPass : FormattingPassBase
+    {
+        private readonly ILogger _logger;
+
+        public CSharpOnTypeFormattingPass(
+            RazorDocumentMappingService documentMappingService,
+            FilePathNormalizer filePathNormalizer,
+            ILanguageServer server,
+            ILoggerFactory loggerFactory)
+            : base(documentMappingService, filePathNormalizer, server)
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<CSharpOnTypeFormattingPass>();
+        }
+
+        public async override Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result)
+        {
+            if (!context.IsFormatOnType || result.Kind != RazorLanguageKind.CSharp)
+            {
+                // We don't want to handle regular formatting or non-C# on type formatting here.
+                return result;
+            }
+
+            // Normalize and re-map the C# edits.
+            var codeDocument = context.CodeDocument;
+            var csharpText = SourceText.From(codeDocument.GetCSharpDocument().GeneratedCode);
+            var normalizedEdits = NormalizeTextEdits(csharpText, result.Edits);
+            var mappedEdits = RemapTextEdits(codeDocument, normalizedEdits, result.Kind);
+
+            // Find the lines that were affected by these edits.
+            var originalText = codeDocument.GetSourceText();
+            var changes = mappedEdits.Select(e => e.AsTextChange(originalText));
+            var changedText = originalText.WithChanges(changes);
+            TrackEncompassingChange(originalText, changedText, out var spanBeforeChange, out var spanAfterChange);
+            var rangeBeforeEdit = spanBeforeChange.AsRange(originalText);
+            var rangeAfterEdit = spanAfterChange.AsRange(changedText);
+
+            // Create a new formatting context for the changed razor document.
+            var changedContext = await context.WithTextAsync(changedText);
+
+            // Now, for each affected line in the edited version of the document, remove x amount of spaces
+            // at the front to account for extra indentation applied by the C# formatter.
+            // This should be based on context.
+            // For instance, lines inside @code/@functions block should be reduced one level
+            // and lines inside @{} should be reduced by two levels.
+            var indentationChanges = AdjustCSharpIndentation(changedContext, (int)rangeAfterEdit.Start.Line, (int)rangeAfterEdit.End.Line);
+
+            // Apply the edits that remove indentation.
+            changedText = changedText.WithChanges(indentationChanges);
+            changedContext = await changedContext.WithTextAsync(changedText);
+
+            // We make an optimistic attempt at fixing corner cases.
+            changedText = CleanupDocument(changedContext, rangeAfterEdit);
+
+            // Now that we have made all the necessary changes to the document. Let's diff the original vs final version and return the diff.
+            var finalChanges = SourceTextDiffer.GetMinimalTextChanges(originalText, changedText, lineDiffOnly: false);
+            var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
+
+            return new FormattingResult(finalEdits);
+        }
+
+        private SourceText CleanupDocument(FormattingContext context, Range range = null)
+        {
+            var text = context.SourceText;
+            range ??= TextSpan.FromBounds(0, text.Length).AsRange(text);
+            var csharpDocument = context.CodeDocument.GetCSharpDocument();
+
+            var changes = new List<TextChange>();
+            foreach (var mapping in csharpDocument.SourceMappings)
+            {
+                var mappingSpan = new TextSpan(mapping.OriginalSpan.AbsoluteIndex, mapping.OriginalSpan.Length);
+                var mappingRange = mappingSpan.AsRange(text);
+                if (!range.OverlapsWith(mappingRange))
+                {
+                    // We don't care about this range. It didn't change.
+                    continue;
+                }
+
+                var mappingStartLineIndex = (int)mappingRange.Start.Line;
+                if (context.Indentations[mappingStartLineIndex].StartsInCSharpContext)
+                {
+                    // Doesn't need cleaning up.
+                    continue;
+                }
+
+                var mappingStartLine = text.Lines[mappingStartLineIndex];
+                var contentStart = mappingStartLine.GetFirstNonWhitespaceOffset((int)mappingRange.Start.Character);
+                if (contentStart == null)
+                {
+                    // There was no content here. Skip.
+                    continue;
+                }
+
+                var spanToReplace = new TextSpan(mappingSpan.Start, contentStart.Value);
+                if (!context.TryGetIndentationLevel(spanToReplace.End, out var contentIndentLevel))
+                {
+                    // Can't find the correct indentation for this content. Leave it alone.
+                    continue;
+                }
+
+                var replacement = Environment.NewLine + context.GetIndentationLevelString(contentIndentLevel);
+                var change = new TextChange(spanToReplace, replacement);
+                changes.Add(change);
+            }
+
+            var changedText = text.WithChanges(changes);
+            return changedText;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -45,7 +45,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = context.CodeDocument;
             var csharpText = SourceText.From(codeDocument.GetCSharpDocument().GeneratedCode);
             var normalizedEdits = NormalizeTextEdits(csharpText, result.Edits);
-            var tempText = csharpText.WithChanges(normalizedEdits.Select(c => c.AsTextChange(csharpText)));
             var mappedEdits = RemapTextEdits(codeDocument, normalizedEdits, result.Kind);
             if (mappedEdits.Length == 0)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CodeBlockDirectiveFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CodeBlockDirectiveFormattingPass.cs
@@ -1,0 +1,410 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using TextSpan = Microsoft.CodeAnalysis.Text.TextSpan;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class CodeBlockDirectiveFormattingPass : FormattingPassBase
+    {
+        private readonly ILogger _logger;
+
+        public CodeBlockDirectiveFormattingPass(
+            RazorDocumentMappingService documentMappingService,
+            FilePathNormalizer filePathNormalizer,
+            ILanguageServer server,
+            ILoggerFactory loggerFactory)
+            : base(documentMappingService, filePathNormalizer, server)
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<CodeBlockDirectiveFormattingPass>();
+        }
+
+        // We want this to run first because it uses the client C# formatter.
+        public override int Order => DefaultOrder - 10;
+
+        public async override Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result)
+        {
+            if (context.IsFormatOnType)
+            {
+                // We don't want to handle OnTypeFormatting here.
+                return result;
+            }
+
+            Debug.Assert(result.Edits.Length == 0, "CodeBlockDirectiveFormatter should be invoked first.");
+
+            var edits = RemapTextEdits(context.CodeDocument, result.Edits, result.Kind);
+
+            // A code block directive is any extensible directive that can contain C# code. Here is how we represent it,
+            // E.g,
+            //
+            //     @code {  public class Foo { }  }
+            // ^                                  ^ ----> Full code block directive range (Includes preceding whitespace)
+            //     ^                              ^ ----> Directive range
+            //      ^                             ^ ----> DirectiveBody range
+            //            ^                      ^  ----> inner codeblock range
+            //
+            // In this method, we are going to do the following for each code block directive,
+            // 1. Format the inner codeblock using the C# formatter
+            // 2. Adjust the absolute indentation of the lines formatted by the C# formatter while maintaining the relative indentation
+            // 3. Indent the start of the code block (@code {) correctly and move any succeeding code to a separate line
+            // 4. Indent the end of the code block (}) correctly and move it to a separate line if necessary
+            // 5. Once all the edits are applied, compute the diff for this particular code block and add it to the global list of edits
+            //
+            var source = context.CodeDocument.Source;
+            var syntaxTree = context.CodeDocument.GetSyntaxTree();
+            var nodes = syntaxTree.GetCodeBlockDirectives();
+
+            var allEdits = new List<TextEdit>();
+
+            // Iterate in reverse so that the newline changes don't affect the next code block directive.
+            for (var i = nodes.Length - 1; i >= 0; i--)
+            {
+                var directive = nodes[i];
+                if (!(directive.Body is RazorDirectiveBodySyntax directiveBody))
+                {
+                    // This can't happen realistically. Just being defensive.
+                    continue;
+                }
+
+                var directiveRange = directive.GetRange(source);
+                if (!directiveRange.OverlapsWith(context.Range))
+                {
+                    // This block isn't in the selected range.
+                    continue;
+                }
+
+                // Get the inner code block node that contains the actual code.
+                var innerCodeBlockNode = directiveBody.CSharpCode.DescendantNodes().FirstOrDefault(n => n is CSharpCodeBlockSyntax);
+                if (innerCodeBlockNode == null)
+                {
+                    // Nothing to indent.
+                    continue;
+                }
+
+                if (innerCodeBlockNode.DescendantNodes().Any(n =>
+                    n is MarkupBlockSyntax ||
+                    n is CSharpTransitionSyntax ||
+                    n is RazorCommentBlockSyntax))
+                {
+                    // We currently don't support formatting code block directives with Markup or other Razor constructs.
+                    continue;
+                }
+
+                var originalText = context.SourceText;
+                var changedText = originalText;
+                var innerCodeBlockRange = innerCodeBlockNode.GetRange(source);
+
+                // Compute the range inside the code block that overlaps with the provided input range.
+                var csharprangeToFormat = innerCodeBlockRange.Overlap(context.Range);
+                if (csharprangeToFormat != null)
+                {
+                    var codeEdits = await CSharpFormatter.FormatAsync(context.CodeDocument, csharprangeToFormat, context.Uri, context.Options);
+                    changedText = ApplyCSharpEdits(context, innerCodeBlockRange, codeEdits, minCSharpIndentLevel: 2);
+                }
+
+                var newEdits = new List<TextEdit>();
+                FormatCodeBlockStart(context, changedText, directiveBody, innerCodeBlockNode, newEdits);
+                FormatCodeBlockEnd(context, changedText, directiveBody, innerCodeBlockNode, newEdits);
+                changedText = ApplyChanges(changedText, newEdits.Select(e => e.AsTextChange(changedText)));
+
+                // We've now applied all the edits we wanted to do. We now need to identify everything that changed in the given code block.
+                // We need to include the preceding newline in our input range because we could have unindented the code block to achieve the correct indentation.
+                // Without including the preceding newline, that edit would be lost.
+                var fullCodeBlockDirectiveSpan = GetSpanIncludingPrecedingWhitespaceInLine(originalText, directive.Position, directive.EndPosition);
+                var changes = Diff(originalText, changedText, fullCodeBlockDirectiveSpan);
+
+                var transformedEdits = changes.Select(c => c.AsTextEdit(originalText));
+                allEdits.AddRange(transformedEdits);
+            }
+
+            var normalizedEdits = NormalizeTextEdits(context.SourceText, allEdits.ToArray());
+            return new FormattingResult(normalizedEdits);
+        }
+
+        //
+        // 'minCSharpIndentLevel' refers to the minimum level of how much the C# formatter would indent code.
+        // @code/@functions blocks contain class members and so are typically indented by 2 levels.
+        // @{} blocks are put inside method body which means they are typically indented by 3 levels.
+        //
+        private SourceText ApplyCSharpEdits(FormattingContext context, Range codeBlockRange, TextEdit[] edits, int minCSharpIndentLevel)
+        {
+            var originalText = context.SourceText;
+            var originalCodeBlockSpan = codeBlockRange.AsTextSpan(originalText);
+
+            // Sometimes the C# formatter edits outside the range we supply. Filter out those edits.
+            var changes = edits.Select(e => e.AsTextChange(originalText)).Where(c => originalCodeBlockSpan.Contains(c.Span)).ToArray();
+            if (changes.Length == 0)
+            {
+                return originalText;
+            }
+
+            // Apply the C# edits to the document.
+            var changedText = originalText.WithChanges(changes);
+            TrackChangeInSpan(originalText, originalCodeBlockSpan, changedText, out var changedCodeBlockSpan, out var changeEncompassingSpan);
+
+            // We now have the changed document with C# edits. But it might be indented more/less than what we want depending on the context.
+            // So, we want to bring each line to the right level of indentation based on where the block is in the document.
+            // We also need to only do this for the lines that are part of the input range to respect range formatting.
+            var desiredIndentationLevel = context.Indentations[(int)codeBlockRange.Start.Line].IndentationLevel + 1;
+            var editsToApply = new List<TextChange>();
+            var inputSpan = context.Range.AsTextSpan(originalText);
+            TrackChangeInSpan(originalText, inputSpan, changedText, out var changedInputSpan, out _);
+            var changedInputRange = changedInputSpan.AsRange(changedText);
+
+            for (var i = (int)changedInputRange.Start.Line; i <= changedInputRange.End.Line; i++)
+            {
+                var line = changedText.Lines[i];
+                if (line.Span.Length == 0)
+                {
+                    // Empty line. C# formatter didn't remove it so we won't either.
+                    continue;
+                }
+
+                if (!changedCodeBlockSpan.Contains(line.Start))
+                {
+                    // Defensive check to make sure we're not handling lines that are not part of the current code block.
+                    continue;
+                }
+
+                var leadingWhitespace = line.GetLeadingWhitespace();
+                var minCSharpIndentLength = context.GetIndentationLevelString(minCSharpIndentLevel).Length;
+                if (leadingWhitespace.Length < minCSharpIndentLength)
+                {
+                    // For whatever reason, the C# formatter decided to not indent this. Leave it as is.
+                    continue;
+                }
+                else
+                {
+                    // At this point we assume the C# formatter has relatively indented this line to the correct level.
+                    // All we want to do at this point is to indent/unindent this line based on the absolute indentation of the block
+                    // and the minimum C# indent level. We don't need to worry about the actual existing indentation here because it doesn't matter.
+                    var effectiveDesiredIndentationLevel = desiredIndentationLevel - minCSharpIndentLevel;
+                    var effectiveDesiredIndentation = context.GetIndentationLevelString(Math.Abs(effectiveDesiredIndentationLevel));
+                    if (effectiveDesiredIndentationLevel < 0)
+                    {
+                        // This means that we need to unindent.
+                        var span = new TextSpan(line.Start, effectiveDesiredIndentation.Length);
+                        editsToApply.Add(new TextChange(span, string.Empty));
+                    }
+                    else if (effectiveDesiredIndentationLevel > 0)
+                    {
+                        // This means that we need to indent.
+                        var span = new TextSpan(line.Start, 0);
+                        editsToApply.Add(new TextChange(span, effectiveDesiredIndentation));
+                    }
+                }
+            }
+
+            changedText = ApplyChanges(changedText, editsToApply);
+            return changedText;
+        }
+
+        private void FormatCodeBlockStart(FormattingContext context, SourceText changedText, RazorDirectiveBodySyntax directiveBody, SyntaxNode innerCodeBlock, List<TextEdit> edits)
+        {
+            var sourceText = context.SourceText;
+            var originalBodySpan = TextSpan.FromBounds(directiveBody.Position, directiveBody.EndPosition);
+            var originalBodyRange = originalBodySpan.AsRange(sourceText);
+            if (context.Range.Start.Line > originalBodyRange.Start.Line)
+            {
+                return;
+            }
+
+            // First line is within the selected range. Let's try and format the start.
+
+            TrackChangeInSpan(sourceText, originalBodySpan, changedText, out var changedBodySpan, out _);
+            var changedBodyRange = changedBodySpan.AsRange(changedText);
+
+            // First, make sure the first line is indented correctly.
+            var firstLine = changedText.Lines[(int)changedBodyRange.Start.Line];
+            var desiredIndentationLevel = context.Indentations[firstLine.LineNumber].IndentationLevel;
+            var desiredIndentation = context.GetIndentationLevelString(desiredIndentationLevel);
+            var firstNonWhitespaceOffset = firstLine.GetFirstNonWhitespaceOffset();
+            if (firstNonWhitespaceOffset.HasValue)
+            {
+                var edit = new TextEdit()
+                {
+                    Range = new Range(
+                        new Position(firstLine.LineNumber, 0),
+                        new Position(firstLine.LineNumber, firstNonWhitespaceOffset.Value)),
+                    NewText = desiredIndentation
+                };
+                edits.Add(edit);
+            }
+
+            // We should also move any code that comes after '{' down to its own line.
+            var originalInnerCodeBlockSpan = TextSpan.FromBounds(innerCodeBlock.Position, innerCodeBlock.EndPosition);
+            TrackChangeInSpan(sourceText, originalInnerCodeBlockSpan, changedText, out var changedInnerCodeBlockSpan, out _);
+            var innerCodeBlockRange = changedInnerCodeBlockSpan.AsRange(changedText);
+
+            var innerCodeBlockLine = changedText.Lines[(int)innerCodeBlockRange.Start.Line];
+            var textAfterBlockStart = innerCodeBlockLine.ToString().Substring(innerCodeBlock.Position - innerCodeBlockLine.Start);
+            var isBlockStartOnSeparateLine = string.IsNullOrWhiteSpace(textAfterBlockStart);
+            var innerCodeBlockIndentationLevel = desiredIndentationLevel + 1;
+            var desiredInnerCodeBlockIndentation = context.GetIndentationLevelString(innerCodeBlockIndentationLevel);
+            var whitespaceAfterBlockStart = textAfterBlockStart.GetLeadingWhitespace();
+
+            if (!isBlockStartOnSeparateLine)
+            {
+                // If the first line contains code, add a newline at the beginning and indent it.
+                var edit = new TextEdit()
+                {
+                    Range = new Range(
+                        new Position(innerCodeBlockLine.LineNumber, innerCodeBlock.Position - innerCodeBlockLine.Start),
+                        new Position(innerCodeBlockLine.LineNumber, innerCodeBlock.Position + whitespaceAfterBlockStart.Length - innerCodeBlockLine.Start)),
+                    NewText = Environment.NewLine + desiredInnerCodeBlockIndentation
+                };
+                edits.Add(edit);
+            }
+            else
+            {
+                //
+                // The code inside the code block directive is on its own line. Ideally the C# formatter would have already taken care of it.
+                // Except, the first line of the code block is not indented because of how our SourceMappings work.
+                // E.g,
+                // @code {
+                //     ...
+                // }
+                // Our source mapping for this code block only ranges between the { and }, exclusive.
+                // If the C# formatter provides any edits that start from before the {, we won't be able to map it back and we will ignore it.
+                // Unfortunately because of this, we partially lose some edits which would have indented the first line of the code block correctly.
+                // So let's manually indent the first line here.
+                //
+                var innerCodeBlockText = changedText.GetSubTextString(changedInnerCodeBlockSpan);
+                if (!string.IsNullOrWhiteSpace(innerCodeBlockText))
+                {
+                    var codeStart = innerCodeBlockText.GetFirstNonWhitespaceOffset() + changedInnerCodeBlockSpan.Start;
+                    if (codeStart.HasValue && codeStart != changedInnerCodeBlockSpan.End)
+                    {
+                        // If we got here, it means this is a non-empty code block. We can safely indent the first line.
+                        var codeStartLine = changedText.Lines.GetLineFromPosition(codeStart.Value);
+                        var existingCodeStartIndentation = codeStartLine.GetFirstNonWhitespaceOffset() ?? 0;
+                        var edit = new TextEdit()
+                        {
+                            Range = new Range(
+                                new Position(codeStartLine.LineNumber, 0),
+                                new Position(codeStartLine.LineNumber, existingCodeStartIndentation)),
+                            NewText = desiredInnerCodeBlockIndentation
+                        };
+                        edits.Add(edit);
+                    }
+                }
+            }
+        }
+
+        private void FormatCodeBlockEnd(FormattingContext context, SourceText changedText, RazorDirectiveBodySyntax directiveBody, SyntaxNode innerCodeBlock, List<TextEdit> edits)
+        {
+            var sourceText = context.SourceText;
+            var originalBodySpan = TextSpan.FromBounds(directiveBody.Position, directiveBody.EndPosition);
+            var originalBodyRange = originalBodySpan.AsRange(sourceText);
+            if (context.Range.End.Line < originalBodyRange.End.Line)
+            {
+                return;
+            }
+
+            // Last line is within the selected range. Let's try and format the end.
+
+            TrackChangeInSpan(sourceText, originalBodySpan, changedText, out var changedBodySpan, out _);
+            var changedBodyRange = changedBodySpan.AsRange(changedText);
+
+            var firstLine = changedText.Lines[(int)changedBodyRange.Start.Line];
+            var desiredIndentationLevel = context.Indentations[firstLine.LineNumber].IndentationLevel;
+            var desiredIndentation = context.GetIndentationLevelString(desiredIndentationLevel);
+
+            // we want to keep the close '}' on its own line. So bring it to the next line.
+            var originalInnerCodeBlockSpan = TextSpan.FromBounds(innerCodeBlock.Position, innerCodeBlock.EndPosition);
+            TrackChangeInSpan(sourceText, originalInnerCodeBlockSpan, changedText, out var changedInnerCodeBlockSpan, out _);
+            var closeCurlyLocation = changedInnerCodeBlockSpan.End;
+            var closeCurlyLine = changedText.Lines.GetLineFromPosition(closeCurlyLocation);
+            var firstNonWhitespaceOffset = closeCurlyLine.GetFirstNonWhitespaceOffset() ?? 0;
+            if (closeCurlyLine.Start + firstNonWhitespaceOffset != closeCurlyLocation)
+            {
+                // This means the '}' is on the same line as some C# code.
+                // Bring it down to the next line and apply the desired indentation.
+                var edit = new TextEdit()
+                {
+                    Range = new Range(
+                        new Position(closeCurlyLine.LineNumber, closeCurlyLocation - closeCurlyLine.Start),
+                        new Position(closeCurlyLine.LineNumber, closeCurlyLocation - closeCurlyLine.Start)),
+                    NewText = Environment.NewLine + desiredIndentation
+                };
+                edits.Add(edit);
+            }
+            else if (firstNonWhitespaceOffset != desiredIndentation.Length)
+            {
+                // This means the '}' is on its own line but is not indented correctly. Correct it.
+                var edit = new TextEdit()
+                {
+                    Range = new Range(
+                    new Position(closeCurlyLine.LineNumber, 0),
+                    new Position(closeCurlyLine.LineNumber, firstNonWhitespaceOffset)),
+                    NewText = desiredIndentation
+                };
+                edits.Add(edit);
+            }
+        }
+
+        private void TrackChangeInSpan(SourceText oldText, TextSpan originalSpan, SourceText newText, out TextSpan changedSpan, out TextSpan changeEncompassingSpan)
+        {
+            var affectedRange = newText.GetEncompassingTextChangeRange(oldText);
+
+            // The span of text before the edit which is being changed
+            changeEncompassingSpan = affectedRange.Span;
+
+            if (!originalSpan.Contains(changeEncompassingSpan))
+            {
+                _logger.LogDebug($"The changed region {changeEncompassingSpan} was not a subset of the span {originalSpan} being tracked. This is unexpected.");
+            }
+
+            // We now know what was the range that changed and the length of that span after the change.
+            // Let's now compute what the original span looks like after the change.
+            // We know it still starts from the same location but could have grown or shrunk in length.
+            // Compute the change in length and then update the original span.
+            var changeInOriginalSpanLength = affectedRange.NewLength - changeEncompassingSpan.Length;
+            changedSpan = TextSpan.FromBounds(originalSpan.Start, originalSpan.End + changeInOriginalSpanLength);
+        }
+
+        private static TextSpan GetSpanIncludingPrecedingWhitespaceInLine(SourceText sourceText, int start, int end)
+        {
+            var line = sourceText.Lines.GetLineFromPosition(start);
+            var precedingLineText = sourceText.GetSubTextString(TextSpan.FromBounds(line.Start, start));
+            var precedingWhitespaceLength = precedingLineText.GetTrailingWhitespace().Length;
+
+            return TextSpan.FromBounds(start - precedingWhitespaceLength, end);
+        }
+
+        private TextChange[] Diff(SourceText oldText, SourceText newText, TextSpan? spanToDiff = default)
+        {
+            // Once https://github.com/dotnet/roslyn/issues/41413 is fixed,
+            // the following lines can be replaced with `newText.GetTextChanges(oldText)`.
+
+            var spanToTrack = spanToDiff ?? TextSpan.FromBounds(0, oldText.Length);
+            TrackChangeInSpan(oldText, spanToTrack, newText, out var changedSpanToTrack, out _);
+            var change = new TextChange(spanToTrack, newText.GetSubText(changedSpanToTrack).ToString());
+            return new[] { change };
+        }
+
+        private SourceText ApplyChanges(SourceText original, IEnumerable<TextChange> changes)
+        {
+            var changed = original.WithChanges(changes);
+            return changed;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CodeBlockDirectiveFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CodeBlockDirectiveFormattingPass.cs
@@ -269,7 +269,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     Range = new Range(
                         new Position(innerCodeBlockLine.LineNumber, innerCodeBlock.Position - innerCodeBlockLine.Start),
                         new Position(innerCodeBlockLine.LineNumber, innerCodeBlock.Position + whitespaceAfterBlockStart.Length - innerCodeBlockLine.Start)),
-                    NewText = Environment.NewLine + desiredInnerCodeBlockIndentation
+                    NewText = context.NewLineString + desiredInnerCodeBlockIndentation
                 };
                 edits.Add(edit);
             }
@@ -343,7 +343,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     Range = new Range(
                         new Position(closeCurlyLine.LineNumber, closeCurlyLocation - closeCurlyLine.Start),
                         new Position(closeCurlyLine.LineNumber, closeCurlyLocation - closeCurlyLine.Start)),
-                    NewText = Environment.NewLine + desiredIndentation
+                    NewText = context.NewLineString + desiredIndentation
                 };
                 edits.Add(edit);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -5,45 +5,23 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
-using TextSpan = Microsoft.CodeAnalysis.Text.TextSpan;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal class DefaultRazorFormattingService : RazorFormattingService
     {
-        private readonly RazorDocumentMappingService _documentMappingService;
-        private readonly ILanguageServer _server;
-        private readonly CSharpFormatter _csharpFormatter;
-        private readonly HtmlFormatter _htmlFormatter;
+        private readonly List<IFormattingPass> _formattingPasses;
         private readonly ILogger _logger;
 
-        public DefaultRazorFormattingService(
-            RazorDocumentMappingService documentMappingService,
-            FilePathNormalizer filePathNormalizer,
-            ILanguageServer server,
-            ILoggerFactory loggerFactory)
+        public DefaultRazorFormattingService(IEnumerable<IFormattingPass> formattingPasses, ILoggerFactory loggerFactory)
         {
-            if (documentMappingService is null)
+            if (formattingPasses is null)
             {
-                throw new ArgumentNullException(nameof(documentMappingService));
-            }
-
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
-            }
-
-            if (server is null)
-            {
-                throw new ArgumentNullException(nameof(server));
+                throw new ArgumentNullException(nameof(formattingPasses));
             }
 
             if (loggerFactory is null)
@@ -51,23 +29,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            _documentMappingService = documentMappingService;
-            _server = server;
-            _csharpFormatter = new CSharpFormatter(documentMappingService, server, filePathNormalizer);
-            _htmlFormatter = new HtmlFormatter(server, filePathNormalizer);
+            _formattingPasses = formattingPasses.OrderBy(f => f.Order).ToList();
             _logger = loggerFactory.CreateLogger<DefaultRazorFormattingService>();
         }
 
-        public override async Task<TextEdit[]> FormatAsync(Uri uri, RazorCodeDocument codeDocument, Range range, FormattingOptions options)
+        public override async Task<TextEdit[]> FormatAsync(Uri uri, DocumentSnapshot documentSnapshot, Range range, FormattingOptions options)
         {
             if (uri is null)
             {
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            if (codeDocument is null)
+            if (documentSnapshot is null)
             {
-                throw new ArgumentNullException(nameof(codeDocument));
+                throw new ArgumentNullException(nameof(documentSnapshot));
             }
 
             if (range is null)
@@ -80,396 +55,36 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(options));
             }
 
-            var formattingContext = FormattingContext.Create(uri, codeDocument, range, options);
-            var edits = await FormatCodeBlockDirectivesAsync(formattingContext);
-            return edits;
+            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
+            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, range);
+
+            var result = new FormattingResult(Array.Empty<TextEdit>());
+            foreach (var pass in _formattingPasses)
+            {
+                result = await pass.ExecuteAsync(context, result);
+            }
+
+            return result.Edits;
         }
 
-        public override Task<TextEdit[]> ApplyFormattedEditsAsync(Uri uri, RazorCodeDocument codeDocument, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options)
+        public override async Task<TextEdit[]> ApplyFormattedEditsAsync(Uri uri, DocumentSnapshot documentSnapshot, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options)
         {
-            var span = TextSpan.FromBounds(0, codeDocument.Source.Length);
-            var documentText = codeDocument.GetSourceText();
-            var range = span.AsRange(documentText);
-            var formattingContext = FormattingContext.Create(uri, codeDocument, range, options);
-
-            // TODO
-            var edits = new List<TextEdit>();
-            for (var i = 0; i < formattedEdits.Length; i++)
+            if (kind == RazorLanguageKind.Html)
             {
-                var projectedRange = formattedEdits[i].Range;
-                if (codeDocument.IsUnsupported() ||
-                    !_documentMappingService.TryMapFromProjectedDocumentRange(codeDocument, projectedRange, out var originalRange))
-                {
-                    // Can't map range. Discard this edit.
-                    continue;
-                }
-
-                var edit = new TextEdit()
-                {
-                    Range = originalRange,
-                    NewText = formattedEdits[i].NewText
-                };
-
-                edits.Add(edit);
+                // We don't support formatting HTML edits yet.
+                return formattedEdits;
             }
 
-            return Task.FromResult(edits.ToArray());
-        }
+            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
+            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, isFormatOnType: true);
+            var result = new FormattingResult(formattedEdits, kind);
 
-        private async Task<TextEdit[]> FormatCodeBlockDirectivesAsync(FormattingContext context)
-        {
-            // A code block directive is any extensible directive that can contain C# code. Here is how we represent it,
-            // E.g,
-            //
-            //     @code {  public class Foo { }  }
-            // ^                                  ^ ----> Full code block directive range (Includes preceding whitespace)
-            //     ^                              ^ ----> Directive range
-            //      ^                             ^ ----> DirectiveBody range
-            //            ^                      ^  ----> inner codeblock range
-            //
-            // In this method, we are going to do the following for each code block directive,
-            // 1. Format the inner codeblock using the C# formatter
-            // 2. Adjust the absolute indentation of the lines formatted by the C# formatter while maintaining the relative indentation
-            // 3. Indent the start of the code block (@code {) correctly and move any succeeding code to a separate line
-            // 4. Indent the end of the code block (}) correctly and move it to a separate line if necessary
-            // 5. Once all the edits are applied, compute the diff for this particular code block and add it to the global list of edits
-            //
-            var source = context.CodeDocument.Source;
-            var syntaxTree = context.CodeDocument.GetSyntaxTree();
-            var nodes = syntaxTree.GetCodeBlockDirectives();
-
-            var allEdits = new List<TextEdit>();
-
-            // Iterate in reverse so that the newline changes don't affect the next code block directive.
-            for (var i = nodes.Length - 1; i >= 0; i--)
+            foreach (var pass in _formattingPasses)
             {
-                var directive = nodes[i];
-                if (!(directive.Body is RazorDirectiveBodySyntax directiveBody))
-                {
-                    // This can't happen realistically. Just being defensive.
-                    continue;
-                }
-
-                var directiveRange = directive.GetRange(source);
-                if (!directiveRange.OverlapsWith(context.Range))
-                {
-                    // This block isn't in the selected range.
-                    continue;
-                }
-
-                // Get the inner code block node that contains the actual code.
-                var innerCodeBlockNode = directiveBody.CSharpCode.DescendantNodes().FirstOrDefault(n => n is CSharpCodeBlockSyntax);
-                if (innerCodeBlockNode == null)
-                {
-                    // Nothing to indent.
-                    continue;
-                }
-
-                if (innerCodeBlockNode.DescendantNodes().Any(n =>
-                    n is MarkupBlockSyntax ||
-                    n is CSharpTransitionSyntax ||
-                    n is RazorCommentBlockSyntax))
-                {
-                    // We currently don't support formatting code block directives with Markup or other Razor constructs.
-                    continue;
-                }
-
-                var originalText = context.SourceText;
-                var changedText = originalText;
-                var innerCodeBlockRange = innerCodeBlockNode.GetRange(source);
-
-                // Compute the range inside the code block that overlaps with the provided input range.
-                var csharprangeToFormat = innerCodeBlockRange.Overlap(context.Range);
-                if (csharprangeToFormat != null)
-                {
-                    var codeEdits = await _csharpFormatter.FormatAsync(context.CodeDocument, csharprangeToFormat, context.Uri, context.Options);
-                    changedText = ApplyCSharpEdits(context, innerCodeBlockRange, codeEdits, minCSharpIndentLevel: 2);
-                }
-
-                var edits = new List<TextEdit>();
-                FormatCodeBlockStart(context, changedText, directiveBody, innerCodeBlockNode, edits);
-                FormatCodeBlockEnd(context, changedText, directiveBody, innerCodeBlockNode, edits);
-                changedText = ApplyChanges(changedText, edits.Select(e => e.AsTextChange(changedText)));
-
-                // We've now applied all the edits we wanted to do. We now need to identify everything that changed in the given code block.
-                // We need to include the preceding newline in our input range because we could have unindented the code block to achieve the correct indentation.
-                // Without including the preceding newline, that edit would be lost.
-                var fullCodeBlockDirectiveSpan = GetSpanIncludingPrecedingWhitespaceInLine(originalText, directive.Position, directive.EndPosition);
-                var changes = Diff(originalText, changedText, fullCodeBlockDirectiveSpan);
-
-                var transformedEdits = changes.Select(c => c.AsTextEdit(originalText));
-                allEdits.AddRange(transformedEdits);
+                result = await pass.ExecuteAsync(context, result);
             }
 
-            return allEdits.ToArray();
-        }
-
-        //
-        // 'minCSharpIndentLevel' refers to the minimum level of how much the C# formatter would indent code.
-        // @code/@functions blocks contain class members and so are typically indented by 2 levels.
-        // @{} blocks are put inside method body which means they are typically indented by 3 levels.
-        //
-        private SourceText ApplyCSharpEdits(FormattingContext context, Range codeBlockRange, TextEdit[] edits, int minCSharpIndentLevel)
-        {
-            var originalText = context.SourceText;
-            var originalCodeBlockSpan = codeBlockRange.AsTextSpan(originalText);
-
-            // Sometimes the C# formatter edits outside the range we supply. Filter out those edits.
-            var changes = edits.Select(e => e.AsTextChange(originalText)).Where(c => originalCodeBlockSpan.Contains(c.Span)).ToArray();
-            if (changes.Length == 0)
-            {
-                return originalText;
-            }
-
-            // Apply the C# edits to the document.
-            var changedText = originalText.WithChanges(changes);
-            TrackChangeInSpan(originalText, originalCodeBlockSpan, changedText, out var changedCodeBlockSpan, out var changeEncompassingSpan);
-
-            // We now have the changed document with C# edits. But it might be indented more/less than what we want depending on the context.
-            // So, we want to bring each line to the right level of indentation based on where the block is in the document.
-            // We also need to only do this for the lines that are part of the input range to respect range formatting.
-            var desiredIndentationLevel = context.Indentations[(int)codeBlockRange.Start.Line].IndentationLevel + 1;
-            var editsToApply = new List<TextChange>();
-            var inputSpan = context.Range.AsTextSpan(originalText);
-            TrackChangeInSpan(originalText, inputSpan, changedText, out var changedInputSpan, out _);
-            var changedInputRange = changedInputSpan.AsRange(changedText);
-
-            for (var i = (int)changedInputRange.Start.Line; i <= changedInputRange.End.Line; i++)
-            {
-                var line = changedText.Lines[i];
-                if (line.Span.Length == 0)
-                {
-                    // Empty line. C# formatter didn't remove it so we won't either.
-                    continue;
-                }
-
-                if (!changedCodeBlockSpan.Contains(line.Start))
-                {
-                    // Defensive check to make sure we're not handling lines that are not part of the current code block.
-                    continue;
-                }
-
-                var leadingWhitespace = line.GetLeadingWhitespace();
-                var minCSharpIndentLength = context.GetIndentationLevelString(minCSharpIndentLevel).Length;
-                if (leadingWhitespace.Length < minCSharpIndentLength)
-                {
-                    // For whatever reason, the C# formatter decided to not indent this. Leave it as is.
-                    continue;
-                }
-                else
-                {
-                    // At this point we assume the C# formatter has relatively indented this line to the correct level.
-                    // All we want to do at this point is to indent/unindent this line based on the absolute indentation of the block
-                    // and the minimum C# indent level. We don't need to worry about the actual existing indentation here because it doesn't matter.
-                    var effectiveDesiredIndentationLevel = desiredIndentationLevel - minCSharpIndentLevel;
-                    var effectiveDesiredIndentation = context.GetIndentationLevelString(Math.Abs(effectiveDesiredIndentationLevel));
-                    if (effectiveDesiredIndentationLevel < 0)
-                    {
-                        // This means that we need to unindent.
-                        var span = new TextSpan(line.Start, effectiveDesiredIndentation.Length);
-                        editsToApply.Add(new TextChange(span, string.Empty));
-                    }
-                    else if (effectiveDesiredIndentationLevel > 0)
-                    {
-                        // This means that we need to indent.
-                        var span = new TextSpan(line.Start, 0);
-                        editsToApply.Add(new TextChange(span, effectiveDesiredIndentation));
-                    }
-                }
-            }
-
-            changedText = ApplyChanges(changedText, editsToApply);
-            return changedText;
-        }
-
-        private void FormatCodeBlockStart(FormattingContext context, SourceText changedText, RazorDirectiveBodySyntax directiveBody, SyntaxNode innerCodeBlock, List<TextEdit> edits)
-        {
-            var sourceText = context.SourceText;
-            var originalBodySpan = TextSpan.FromBounds(directiveBody.Position, directiveBody.EndPosition);
-            var originalBodyRange = originalBodySpan.AsRange(sourceText);
-            if (context.Range.Start.Line > originalBodyRange.Start.Line)
-            {
-                return;
-            }
-
-            // First line is within the selected range. Let's try and format the start.
-
-            TrackChangeInSpan(sourceText, originalBodySpan, changedText, out var changedBodySpan, out _);
-            var changedBodyRange = changedBodySpan.AsRange(changedText);
-
-            // First, make sure the first line is indented correctly.
-            var firstLine = changedText.Lines[(int)changedBodyRange.Start.Line];
-            var desiredIndentationLevel = context.Indentations[firstLine.LineNumber].IndentationLevel;
-            var desiredIndentation = context.GetIndentationLevelString(desiredIndentationLevel);
-            var firstNonWhitespaceOffset = firstLine.GetFirstNonWhitespaceOffset();
-            if (firstNonWhitespaceOffset.HasValue)
-            {
-                var edit = new TextEdit()
-                {
-                    Range = new Range(
-                        new Position(firstLine.LineNumber, 0),
-                        new Position(firstLine.LineNumber, firstNonWhitespaceOffset.Value)),
-                    NewText = desiredIndentation
-                };
-                edits.Add(edit);
-            }
-
-            // We should also move any code that comes after '{' down to its own line.
-            var originalInnerCodeBlockSpan = TextSpan.FromBounds(innerCodeBlock.Position, innerCodeBlock.EndPosition);
-            TrackChangeInSpan(sourceText, originalInnerCodeBlockSpan, changedText, out var changedInnerCodeBlockSpan, out _);
-            var innerCodeBlockRange = changedInnerCodeBlockSpan.AsRange(changedText);
-
-            var innerCodeBlockLine = changedText.Lines[(int)innerCodeBlockRange.Start.Line];
-            var textAfterBlockStart = innerCodeBlockLine.ToString().Substring(innerCodeBlock.Position - innerCodeBlockLine.Start);
-            var isBlockStartOnSeparateLine = string.IsNullOrWhiteSpace(textAfterBlockStart);
-            var innerCodeBlockIndentationLevel = desiredIndentationLevel + 1;
-            var desiredInnerCodeBlockIndentation = context.GetIndentationLevelString(innerCodeBlockIndentationLevel);
-            var whitespaceAfterBlockStart = textAfterBlockStart.GetLeadingWhitespace();
-
-            if (!isBlockStartOnSeparateLine)
-            {
-                // If the first line contains code, add a newline at the beginning and indent it.
-                var edit = new TextEdit()
-                {
-                    Range = new Range(
-                        new Position(innerCodeBlockLine.LineNumber, innerCodeBlock.Position - innerCodeBlockLine.Start),
-                        new Position(innerCodeBlockLine.LineNumber, innerCodeBlock.Position + whitespaceAfterBlockStart.Length - innerCodeBlockLine.Start)),
-                    NewText = Environment.NewLine + desiredInnerCodeBlockIndentation
-                };
-                edits.Add(edit);
-            }
-            else
-            {
-                //
-                // The code inside the code block directive is on its own line. Ideally the C# formatter would have already taken care of it.
-                // Except, the first line of the code block is not indented because of how our SourceMappings work.
-                // E.g,
-                // @code {
-                //     ...
-                // }
-                // Our source mapping for this code block only ranges between the { and }, exclusive.
-                // If the C# formatter provides any edits that start from before the {, we won't be able to map it back and we will ignore it.
-                // Unfortunately because of this, we partially lose some edits which would have indented the first line of the code block correctly.
-                // So let's manually indent the first line here.
-                //
-                var innerCodeBlockText = changedText.GetSubTextString(changedInnerCodeBlockSpan);
-                if (!string.IsNullOrWhiteSpace(innerCodeBlockText))
-                {
-                    var codeStart = innerCodeBlockText.GetFirstNonWhitespaceOffset() + changedInnerCodeBlockSpan.Start;
-                    if (codeStart.HasValue && codeStart != changedInnerCodeBlockSpan.End)
-                    {
-                        // If we got here, it means this is a non-empty code block. We can safely indent the first line.
-                        var codeStartLine = changedText.Lines.GetLineFromPosition(codeStart.Value);
-                        var existingCodeStartIndentation = codeStartLine.GetFirstNonWhitespaceOffset() ?? 0;
-                        var edit = new TextEdit()
-                        {
-                            Range = new Range(
-                                new Position(codeStartLine.LineNumber, 0),
-                                new Position(codeStartLine.LineNumber, existingCodeStartIndentation)),
-                            NewText = desiredInnerCodeBlockIndentation
-                        };
-                        edits.Add(edit);
-                    }
-                }
-            }
-        }
-
-        private void FormatCodeBlockEnd(FormattingContext context, SourceText changedText, RazorDirectiveBodySyntax directiveBody, SyntaxNode innerCodeBlock, List<TextEdit> edits)
-        {
-            var sourceText = context.SourceText;
-            var originalBodySpan = TextSpan.FromBounds(directiveBody.Position, directiveBody.EndPosition);
-            var originalBodyRange = originalBodySpan.AsRange(sourceText);
-            if (context.Range.End.Line < originalBodyRange.End.Line)
-            {
-                return;
-            }
-
-            // Last line is within the selected range. Let's try and format the end.
-
-            TrackChangeInSpan(sourceText, originalBodySpan, changedText, out var changedBodySpan, out _);
-            var changedBodyRange = changedBodySpan.AsRange(changedText);
-
-            var firstLine = changedText.Lines[(int)changedBodyRange.Start.Line];
-            var desiredIndentationLevel = context.Indentations[firstLine.LineNumber].IndentationLevel;
-            var desiredIndentation = context.GetIndentationLevelString(desiredIndentationLevel);
-
-            // we want to keep the close '}' on its own line. So bring it to the next line.
-            var originalInnerCodeBlockSpan = TextSpan.FromBounds(innerCodeBlock.Position, innerCodeBlock.EndPosition);
-            TrackChangeInSpan(sourceText, originalInnerCodeBlockSpan, changedText, out var changedInnerCodeBlockSpan, out _);
-            var closeCurlyLocation = changedInnerCodeBlockSpan.End;
-            var closeCurlyLine = changedText.Lines.GetLineFromPosition(closeCurlyLocation);
-            var firstNonWhitespaceOffset = closeCurlyLine.GetFirstNonWhitespaceOffset() ?? 0;
-            if (closeCurlyLine.Start + firstNonWhitespaceOffset != closeCurlyLocation)
-            {
-                // This means the '}' is on the same line as some C# code.
-                // Bring it down to the next line and apply the desired indentation.
-                var edit = new TextEdit()
-                {
-                    Range = new Range(
-                        new Position(closeCurlyLine.LineNumber, closeCurlyLocation - closeCurlyLine.Start),
-                        new Position(closeCurlyLine.LineNumber, closeCurlyLocation - closeCurlyLine.Start)),
-                    NewText = Environment.NewLine + desiredIndentation
-                };
-                edits.Add(edit);
-            }
-            else if (firstNonWhitespaceOffset != desiredIndentation.Length)
-            {
-                // This means the '}' is on its own line but is not indented correctly. Correct it.
-                var edit = new TextEdit()
-                {
-                    Range = new Range(
-                    new Position(closeCurlyLine.LineNumber, 0),
-                    new Position(closeCurlyLine.LineNumber, firstNonWhitespaceOffset)),
-                    NewText = desiredIndentation
-                };
-                edits.Add(edit);
-            }
-        }
-
-        private SourceText ApplyChanges(SourceText original, IEnumerable<TextChange> changes)
-        {
-            var changed = original.WithChanges(changes);
-            return changed;
-        }
-
-        private void TrackChangeInSpan(SourceText oldText, TextSpan originalSpan, SourceText newText, out TextSpan changedSpan, out TextSpan changeEncompassingSpan)
-        {
-            var affectedRange = newText.GetEncompassingTextChangeRange(oldText);
-
-            // The span of text before the edit which is being changed
-            changeEncompassingSpan = affectedRange.Span;
-
-            if (!originalSpan.Contains(changeEncompassingSpan))
-            {
-                _logger.LogDebug($"The changed region {changeEncompassingSpan} was not a subset of the span {originalSpan} being tracked. This is unexpected.");
-            }
-
-            // We now know what was the range that changed and the length of that span after the change.
-            // Let's now compute what the original span looks like after the change.
-            // We know it still starts from the same location but could have grown or shrunk in length.
-            // Compute the change in length and then update the original span.
-            var changeInOriginalSpanLength = affectedRange.NewLength - changeEncompassingSpan.Length;
-            changedSpan = TextSpan.FromBounds(originalSpan.Start, originalSpan.End + changeInOriginalSpanLength);
-        }
-
-        private TextChange[] Diff(SourceText oldText, SourceText newText, TextSpan? spanToDiff = default)
-        {
-            // Once https://github.com/dotnet/roslyn/issues/41413 is fixed,
-            // the following lines can be replaced with `newText.GetTextChanges(oldText)`.
-
-            var spanToTrack = spanToDiff ?? TextSpan.FromBounds(0, oldText.Length);
-            TrackChangeInSpan(oldText, spanToTrack, newText, out var changedSpanToTrack, out _);
-            var change = new TextChange(spanToTrack, newText.GetSubText(changedSpanToTrack).ToString());
-            return new[] { change };
-        }
-
-        private static TextSpan GetSpanIncludingPrecedingWhitespaceInLine(SourceText sourceText, int start, int end)
-        {
-            var line = sourceText.Lines.GetLineFromPosition(start);
-            var precedingLineText = sourceText.GetSubTextString(TextSpan.FromBounds(line.Start, start));
-            var precedingWhitespaceLength = precedingLineText.GetTrailingWhitespace().Length;
-
-            return TextSpan.FromBounds(start - precedingWhitespaceLength, end);
+            return result.Edits;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.Extensions.Logging;
@@ -50,7 +51,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 // Looks like we nuked some non-whitespace content as part of formatting. Oops.
                 // Discard this formatting result.
 
-                _logger.LogDebug("A formatting result was rejected because it was going to mess up the document.");
+                Debug.Fail("A formatting result was rejected because it was going to mess up the document.");
 
                 return new FormattingResult(Array.Empty<TextEdit>());
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class FormattingContentValidationPass : FormattingPassBase
+    {
+        private readonly ILogger _logger;
+
+        public FormattingContentValidationPass(
+            RazorDocumentMappingService documentMappingService,
+            FilePathNormalizer filePathNormalizer,
+            ILanguageServer server,
+            ILoggerFactory loggerFactory)
+            : base(documentMappingService, filePathNormalizer, server)
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<FormattingContentValidationPass>();
+        }
+
+        // We want this to run at the very end.
+        public override int Order => DefaultOrder + 1000;
+
+        public override FormattingResult Execute(FormattingContext context, FormattingResult result)
+        {
+            if (result.Kind != RazorLanguageKind.Razor)
+            {
+                // We don't care about changes to projected documents here.
+                return result;
+            }
+
+            var text = context.SourceText;
+            var edits = result.Edits;
+            var changes = edits.Select(e => e.AsTextChange(text));
+            var changedText = text.WithChanges(changes);
+
+            if (!text.NonWhitespaceContentEquals(changedText))
+            {
+                // Looks like we nuked some non-whitespace content as part of formatting. Oops.
+                // Discard this formatting result.
+
+                _logger.LogDebug("A formatting result was rejected because it was going to mess up the document.");
+
+                return new FormattingResult(Array.Empty<TextEdit>());
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
@@ -16,11 +18,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
     {
         public Uri Uri { get; set; }
 
+        public DocumentSnapshot OriginalSnapshot { get; set; }
+
         public RazorCodeDocument CodeDocument { get; set; }
 
         public SourceText SourceText => CodeDocument?.GetSourceText();
 
         public FormattingOptions Options { get; set; }
+
+        public bool IsFormatOnType { get; set; }
 
         public Range Range { get; set; }
 
@@ -62,11 +68,56 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
         }
 
-        public static FormattingContext Create(Uri uri, RazorCodeDocument codedocument, Range range, FormattingOptions options)
+        public bool TryGetIndentationLevel(int position, out int indentationLevel)
+        {
+            var syntaxTree = CodeDocument.GetSyntaxTree();
+            var formattingSpans = syntaxTree.GetFormattingSpans();
+            if (TryGetFormattingSpan(position, formattingSpans, out var span))
+            {
+                indentationLevel = span.IndentationLevel;
+                return true;
+            }
+
+            indentationLevel = 0;
+            return false;
+        }
+
+        public async Task<FormattingContext> WithTextAsync(SourceText changedText)
+        {
+            var engine = OriginalSnapshot.Project.GetProjectEngine();
+            var imports = ((DefaultDocumentSnapshot)OriginalSnapshot).State.GetImports((DefaultProjectSnapshot)OriginalSnapshot.Project);
+            var importSources = new List<RazorSourceDocument>();
+            foreach (var import in imports)
+            {
+                var sourceText = await import.GetTextAsync();
+                var source = sourceText.GetRazorSourceDocument(import.FilePath, import.TargetPath);
+                importSources.Add(source);
+            }
+
+            var changedSourceDocument = changedText.GetRazorSourceDocument(OriginalSnapshot.FilePath, OriginalSnapshot.TargetPath);
+
+            var codeDocument = engine.ProcessDesignTime(changedSourceDocument, OriginalSnapshot.FileKind, importSources, OriginalSnapshot.Project.TagHelpers);
+
+            var newContext = Create(Uri, OriginalSnapshot, codeDocument, Options, Range);
+            return newContext;
+        }
+
+        public static FormattingContext Create(
+            Uri uri,
+            DocumentSnapshot originalSnapshot,
+            RazorCodeDocument codedocument,
+            FormattingOptions options,
+            Range range = null,
+            bool isFormatOnType = false)
         {
             if (uri is null)
             {
                 throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (originalSnapshot is null)
+            {
+                throw new ArgumentNullException(nameof(originalSnapshot));
             }
 
             if (codedocument is null)
@@ -74,22 +125,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(codedocument));
             }
 
-            if (range is null)
-            {
-                throw new ArgumentNullException(nameof(range));
-            }
-
             if (options is null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
 
+            var text = codedocument.GetSourceText();
+            range ??= TextSpan.FromBounds(0, text.Length).AsRange(text);
+
             var result = new FormattingContext()
             {
                 Uri = uri,
+                OriginalSnapshot = originalSnapshot,
                 CodeDocument = codedocument,
                 Range = range,
-                Options = options
+                Options = options,
+                IsFormatOnType = isFormatOnType
             };
 
             var source = codedocument.Source;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -26,6 +26,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public FormattingOptions Options { get; set; }
 
+        public string NewLineString => Environment.NewLine;
+
         public bool IsFormatOnType { get; set; }
 
         public Range Range { get; set; }
@@ -84,6 +86,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public async Task<FormattingContext> WithTextAsync(SourceText changedText)
         {
+            if (changedText is null)
+            {
+                throw new ArgumentNullException(nameof(changedText));
+            }
+
             var engine = OriginalSnapshot.Project.GetProjectEngine();
             var imports = ((DefaultDocumentSnapshot)OriginalSnapshot).State.GetImports((DefaultProjectSnapshot)OriginalSnapshot.Project);
             var importSources = new List<RazorSourceDocument>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal abstract class FormattingPassBase : IFormattingPass
+    {
+        protected static readonly int DefaultOrder = 1000;
+
+        private readonly RazorDocumentMappingService _documentMappingService;
+
+        public FormattingPassBase(
+            RazorDocumentMappingService documentMappingService,
+            FilePathNormalizer filePathNormalizer,
+            ILanguageServer server)
+        {
+            if (documentMappingService is null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingService));
+            }
+
+            if (filePathNormalizer is null)
+            {
+                throw new ArgumentNullException(nameof(filePathNormalizer));
+            }
+
+            if (server is null)
+            {
+                throw new ArgumentNullException(nameof(server));
+            }
+
+            _documentMappingService = documentMappingService;
+            CSharpFormatter = new CSharpFormatter(documentMappingService, server, filePathNormalizer);
+            HtmlFormatter = new HtmlFormatter(server, filePathNormalizer);
+        }
+
+        public virtual int Order => DefaultOrder;
+
+        protected CSharpFormatter CSharpFormatter { get; }
+
+        protected HtmlFormatter HtmlFormatter { get; }
+
+        public virtual Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result)
+        {
+            return Task.FromResult(Execute(context, result));
+        }
+
+        public virtual FormattingResult Execute(FormattingContext context, FormattingResult result)
+        {
+            return result;
+        }
+
+        protected TextEdit[] RemapTextEdits(RazorCodeDocument codeDocument, TextEdit[] projectedTextEdits, RazorLanguageKind projectedKind)
+        {
+            if (projectedKind != RazorLanguageKind.CSharp)
+            {
+                // Non C# projections map directly to Razor. No need to remap.
+                return projectedTextEdits;
+            }
+
+            var edits = new List<TextEdit>();
+            for (var i = 0; i < projectedTextEdits.Length; i++)
+            {
+                var projectedRange = projectedTextEdits[i].Range;
+                if (codeDocument.IsUnsupported() ||
+                    !_documentMappingService.TryMapFromProjectedDocumentRange(codeDocument, projectedRange, out var originalRange))
+                {
+                    // Can't map range. Discard this edit.
+                    continue;
+                }
+
+                var edit = new TextEdit()
+                {
+                    Range = originalRange,
+                    NewText = projectedTextEdits[i].NewText
+                };
+
+                edits.Add(edit);
+            }
+
+            return edits.ToArray();
+        }
+
+        protected static TextEdit[] NormalizeTextEdits(SourceText originalText, TextEdit[] edits)
+        {
+            var changes = edits.Select(e => e.AsTextChange(originalText));
+            var changedText = originalText.WithChanges(changes);
+            var cleanChanges = SourceTextDiffer.GetMinimalTextChanges(originalText, changedText, lineDiffOnly: false);
+            var cleanEdits = cleanChanges.Select(c => c.AsTextEdit(originalText)).ToArray();
+            return cleanEdits;
+        }
+
+        // Returns the minimal TextSpan that encompasses all the differences between the old and the new text.
+        protected static void TrackEncompassingChange(SourceText oldText, SourceText newText, out TextSpan spanBeforeChange, out TextSpan spanAfterChange)
+        {
+            var affectedRange = newText.GetEncompassingTextChangeRange(oldText);
+
+            spanBeforeChange = affectedRange.Span;
+            spanAfterChange = new TextSpan(spanBeforeChange.Start, affectedRange.NewLength);
+        }
+
+        // This method handles adjusting of indentation of Razor blocks after C# formatter has finished formatting the document.
+        // For instance, lines inside @code/@functions block should be reduced one level
+        // and lines inside @{} should be reduced by two levels.
+        protected static List<TextChange> AdjustCSharpIndentation(FormattingContext context, int startLine, int endLine)
+        {
+            var sourceText = context.SourceText;
+            var editsToApply = new List<TextChange>();
+
+            for (var i = startLine; i <= endLine; i++)
+            {
+                var line = sourceText.Lines[i];
+                if (line.Span.Length == 0)
+                {
+                    // Empty line. C# formatter didn't remove it so we won't either.
+                    continue;
+                }
+
+                var leadingWhitespace = line.GetLeadingWhitespace();
+                var minCSharpIndentLevel = context.Indentations[i].MinCSharpIndentLevel;
+                var minCSharpIndentLength = context.GetIndentationLevelString(minCSharpIndentLevel).Length;
+                var desiredIndentationLevel = context.Indentations[i].IndentationLevel;
+                if (leadingWhitespace.Length < minCSharpIndentLength)
+                {
+                    // For whatever reason, the C# formatter decided to not indent this. Leave it as is.
+                    continue;
+                }
+                else
+                {
+                    // At this point we assume the C# formatter has relatively indented this line to the correct level.
+                    // All we want to do at this point is to indent/unindent this line based on the absolute indentation of the block
+                    // and the minimum C# indent level. We don't need to worry about the actual existing indentation here because it doesn't matter.
+                    var effectiveDesiredIndentationLevel = desiredIndentationLevel - minCSharpIndentLevel;
+                    var effectiveDesiredIndentation = context.GetIndentationLevelString(Math.Abs(effectiveDesiredIndentationLevel));
+                    if (effectiveDesiredIndentationLevel < 0)
+                    {
+                        // This means that we need to unindent.
+                        var span = new TextSpan(line.Start, effectiveDesiredIndentation.Length);
+                        editsToApply.Add(new TextChange(span, string.Empty));
+                    }
+                    else if (effectiveDesiredIndentationLevel > 0)
+                    {
+                        // This means that we need to indent.
+                        var span = new TextSpan(line.Start, 0);
+                        editsToApply.Add(new TextChange(span, effectiveDesiredIndentation));
+                    }
+                }
+
+            }
+
+            return editsToApply;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
@@ -62,6 +62,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         protected TextEdit[] RemapTextEdits(RazorCodeDocument codeDocument, TextEdit[] projectedTextEdits, RazorLanguageKind projectedKind)
         {
+            if (codeDocument is null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            if (projectedTextEdits is null)
+            {
+                throw new ArgumentNullException(nameof(projectedTextEdits));
+            }
+
             if (projectedKind != RazorLanguageKind.CSharp)
             {
                 // Non C# projections map directly to Razor. No need to remap.
@@ -93,6 +103,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         protected static TextEdit[] NormalizeTextEdits(SourceText originalText, TextEdit[] edits)
         {
+            if (originalText is null)
+            {
+                throw new ArgumentNullException(nameof(originalText));
+            }
+
+            if (edits is null)
+            {
+                throw new ArgumentNullException(nameof(edits));
+            }
+
             var changes = edits.Select(e => e.AsTextChange(originalText));
             var changedText = originalText.WithChanges(changes);
             var cleanChanges = SourceTextDiffer.GetMinimalTextChanges(originalText, changedText, lineDiffOnly: false);
@@ -103,6 +123,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         // Returns the minimal TextSpan that encompasses all the differences between the old and the new text.
         protected static void TrackEncompassingChange(SourceText oldText, SourceText newText, out TextSpan spanBeforeChange, out TextSpan spanAfterChange)
         {
+            if (oldText is null)
+            {
+                throw new ArgumentNullException(nameof(oldText));
+            }
+
+            if (newText is null)
+            {
+                throw new ArgumentNullException(nameof(newText));
+            }
+
             var affectedRange = newText.GetEncompassingTextChangeRange(oldText);
 
             spanBeforeChange = affectedRange.Span;
@@ -114,6 +144,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         // and lines inside @{} should be reduced by two levels.
         protected static List<TextChange> AdjustCSharpIndentation(FormattingContext context, int startLine, int endLine)
         {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             var sourceText = context.SourceText;
             var editsToApply = new List<TextChange>();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingResult.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
@@ -9,6 +10,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
     {
         public FormattingResult(TextEdit[] edits, RazorLanguageKind kind = RazorLanguageKind.Razor)
         {
+            if (edits is null)
+            {
+                throw new ArgumentNullException(nameof(edits));
+            }
+
             Edits = edits;
             Kind = kind;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingResult.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingResult.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal struct FormattingResult
+    {
+        public FormattingResult(TextEdit[] edits, RazorLanguageKind kind = RazorLanguageKind.Razor)
+        {
+            Edits = edits;
+            Kind = kind;
+        }
+
+        public TextEdit[] Edits { get; }
+
+        public RazorLanguageKind Kind { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingSpan.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingSpan.cs
@@ -7,13 +7,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal class FormattingSpan
     {
-        public FormattingSpan(TextSpan span, TextSpan blockSpan, FormattingSpanKind spanKind, FormattingBlockKind blockKind, int indentationLevel)
+        public FormattingSpan(TextSpan span, TextSpan blockSpan, FormattingSpanKind spanKind, FormattingBlockKind blockKind, int indentationLevel, bool isInClassBody = false)
         {
             Span = span;
             BlockSpan = blockSpan;
             Kind = spanKind;
             BlockKind = blockKind;
             IndentationLevel = indentationLevel;
+            IsInClassBody = isInClassBody;
         }
 
         public TextSpan Span { get; }
@@ -25,5 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public FormattingSpanKind Kind { get; }
 
         public int IndentationLevel { get; }
+
+        public bool IsInClassBody { get; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingStructureValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingStructureValidationPass.cs
@@ -1,0 +1,115 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class FormattingStructureValidationPass : FormattingPassBase
+    {
+        private readonly ILogger _logger;
+
+        public FormattingStructureValidationPass(
+            RazorDocumentMappingService documentMappingService,
+            FilePathNormalizer filePathNormalizer,
+            ILanguageServer server,
+            ILoggerFactory loggerFactory)
+            : base(documentMappingService, filePathNormalizer, server)
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<CSharpOnTypeFormattingPass>();
+        }
+
+        // We want this to run at the very end.
+        public override int Order => DefaultOrder + 1000;
+
+        public override FormattingResult Execute(FormattingContext context, FormattingResult result)
+        {
+            Debug.Assert(result.Kind == RazorLanguageKind.Razor, "This method shouldn't be called for projected document edits.");
+
+            if (result.Edits.Length == 0)
+            {
+                // No op.
+                return result;
+            }
+
+            if (FormatsOutsidePureCSharpBlocks(context, result))
+            {
+                return new FormattingResult(Array.Empty<TextEdit>());
+            }
+
+            return result;
+        }
+
+        private bool FormatsOutsidePureCSharpBlocks(FormattingContext context, FormattingResult result)
+        {
+            if (!context.IsFormatOnType)
+            {
+                // We don't care about regular formatting for now.
+                return false;
+            }
+
+            var text = context.SourceText;
+            var changes = result.Edits.Select(e => e.AsTextChange(text));
+            var changedText = text.WithChanges(changes);
+            var affectedSpan = changedText.GetEncompassingTextChangeRange(text).Span;
+            var affectedRange = affectedSpan.AsRange(text);
+
+            var syntaxTree = context.CodeDocument.GetSyntaxTree();
+            var nodes = syntaxTree.GetCodeBlockDirectives();
+
+            var affectedCodeDirective = nodes.FirstOrDefault(n =>
+            {
+                var range = n.GetRange(context.CodeDocument.Source);
+                return range.Contains(affectedRange);
+            });
+
+            if (affectedCodeDirective == null)
+            {
+                _logger.LogDebug("A formatting result was rejected because it was going to format outside of a code block directive.");
+
+                return true;
+            }
+
+            if (!(affectedCodeDirective.Body is RazorDirectiveBodySyntax directiveBody))
+            {
+                // This can't happen realistically. Just being defensive.
+                return false;
+            }
+
+            // Get the inner code block node that contains the actual code.
+            var innerCodeBlockNode = directiveBody.CSharpCode.DescendantNodes().FirstOrDefault(n => n is CSharpCodeBlockSyntax);
+            if (innerCodeBlockNode == null)
+            {
+                // Nothing to check.
+                return false;
+            }
+
+            if (innerCodeBlockNode.DescendantNodes().Any(n =>
+                n is MarkupBlockSyntax ||
+                n is CSharpTransitionSyntax ||
+                n is RazorCommentBlockSyntax))
+            {
+                // We currently don't support formatting code block directives with Markup or other Razor constructs.
+
+                _logger.LogDebug("A formatting result was rejected because it was going to format code directive with mixed content.");
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingStructureValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingStructureValidationPass.cs
@@ -45,6 +45,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 return result;
             }
 
+            if (!context.IsFormatOnType)
+            {
+                // We don't care about regular formatting for now.
+                return result;
+            }
+
             if (FormatsOutsidePureCSharpBlocks(context, result))
             {
                 return new FormattingResult(Array.Empty<TextEdit>());
@@ -55,12 +61,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         private bool FormatsOutsidePureCSharpBlocks(FormattingContext context, FormattingResult result)
         {
-            if (!context.IsFormatOnType)
-            {
-                // We don't care about regular formatting for now.
-                return false;
-            }
-
             var text = context.SourceText;
             var changes = result.Edits.Select(e => e.AsTextChange(text));
             var changedText = text.WithChanges(changes);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IFormattingPass.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal interface IFormattingPass
     {
-        public int Order { get; }
+        int Order { get; }
 
         Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IFormattingPass.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal interface IFormattingPass
+    {
+        public int Order { get; }
+
+        Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IndentationContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IndentationContext.cs
@@ -15,6 +15,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public FormattingSpan FirstSpan { get; set; }
 
+        public bool StartsInHtmlContext => FirstSpan.Kind == FormattingSpanKind.Markup;
+
+        public bool StartsInCSharpContext => FirstSpan.Kind == FormattingSpanKind.Code;
+
+        public bool StartsInRazorContext => !StartsInHtmlContext && !StartsInCSharpContext;
+
+        public int MinCSharpIndentLevel => FirstSpan.IsInClassBody ? 2 : 3;
+
         public override string ToString()
         {
             return $"Line: {Line}, IndentationLevel: {IndentationLevel}, RelativeIndentationLevel: {RelativeIndentationLevel}, ExistingIndentation: {ExistingIndentation}";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             var span = TextSpan.FromBounds(0, codeDocument.Source.Length);
             var range = span.AsRange(codeDocument.GetSourceText());
-            var edits = await _razorFormattingService.FormatAsync(request.TextDocument.Uri, codeDocument, range, request.Options);
+            var edits = await _razorFormattingService.FormatAsync(request.TextDocument.Uri, document, range, request.Options);
 
             var editContainer = new TextEditContainer(edits);
             return editContainer;
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 return null;
             }
 
-            var edits = await _razorFormattingService.FormatAsync(request.TextDocument.Uri, codeDocument, request.Range, request.Options);
+            var edits = await _razorFormattingService.FormatAsync(request.TextDocument.Uri, document, request.Range, request.Options);
 
             var editContainer = new TextEditContainer(edits);
             return editContainer;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
@@ -11,8 +11,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal abstract class RazorFormattingService
     {
-        public abstract Task<TextEdit[]> FormatAsync(Uri uri, RazorCodeDocument codeDocument, Range range, FormattingOptions options);
+        public abstract Task<TextEdit[]> FormatAsync(
+            Uri uri,
+            DocumentSnapshot documentSnapshot,
+            Range range,
+            FormattingOptions options);
 
-        public abstract Task<TextEdit[]> ApplyFormattedEditsAsync(Uri uri, RazorCodeDocument codeDocument, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options);
+        public abstract Task<TextEdit[]> ApplyFormattedEditsAsync(
+            Uri uri,
+            DocumentSnapshot documentSnapshot,
+            RazorLanguageKind kind,
+            TextEdit[] formattedEdits,
+            FormattingOptions options);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RangeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RangeExtensions.cs
@@ -38,6 +38,33 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return overlapStart.CompareTo(overlapEnd) < 0;
         }
 
+        public static bool LineOverlapsWith(this Range range, Range other)
+        {
+            if (range is null)
+            {
+                throw new ArgumentNullException(nameof(range));
+            }
+
+            if (other is null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            var overlapStart = range.Start.Line;
+            if (range.Start.Line.CompareTo(other.Start.Line) < 0)
+            {
+                overlapStart = other.Start.Line;
+            }
+
+            var overlapEnd = range.End.Line;
+            if (range.End.Line.CompareTo(other.End.Line) > 0)
+            {
+                overlapEnd = other.End.Line;
+            }
+
+            return overlapStart.CompareTo(overlapEnd) <= 0;
+        }
+
         public static Range Overlap(this Range range, Range other)
         {
             if (range is null)
@@ -69,6 +96,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             return null;
+        }
+
+        public static bool Contains(this Range range, Range other)
+        {
+            if (range is null)
+            {
+                throw new ArgumentNullException(nameof(range));
+            }
+
+            if (other is null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            return range.Start.CompareTo(other.Start) <= 0 && range.End.CompareTo(other.End) >= 0;
         }
 
         public static TextSpan AsTextSpan(this Range range, SourceText sourceText)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (request.ShouldFormat)
             {
                 var mappedEdits = await _razorFormattingService.ApplyFormattedEditsAsync(
-                    request.RazorDocumentUri, codeDocument, request.Kind, request.ProjectedTextEdits, request.FormattingOptions);
+                    request.RazorDocumentUri, documentSnapshot, request.Kind, request.ProjectedTextEdits, request.FormattingOptions);
 
                 return new RazorMapToDocumentEditsResponse()
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -177,6 +177,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         // Formatting Passes
                         services.AddSingleton<IFormattingPass, CodeBlockDirectiveFormattingPass>();
                         services.AddSingleton<IFormattingPass, CSharpOnTypeFormattingPass>();
+                        services.AddSingleton<IFormattingPass, FormattingStructureValidationPass>();
                         services.AddSingleton<IFormattingPass, FormattingContentValidationPass>();
 
                         // Code actions

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -174,6 +174,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         // Formatting
                         services.AddSingleton<RazorFormattingService, DefaultRazorFormattingService>();
 
+                        // Formatting Passes
+                        services.AddSingleton<IFormattingPass, CodeBlockDirectiveFormattingPass>();
+                        services.AddSingleton<IFormattingPass, CSharpOnTypeFormattingPass>();
+                        services.AddSingleton<IFormattingPass, FormattingContentValidationPass>();
+
                         // Code actions
                         services.AddSingleton<RazorCodeActionProvider, ExtractToCodeBehindCodeActionProvider>();
                         services.AddSingleton<RazorCodeActionResolver, ExtractToCodeBehindCodeActionResolver>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextExtensions.cs
@@ -120,5 +120,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             return i == source.Length && j == other.Length;
         }
+
+        public static int? GetFirstNonWhitespaceOffset(this SourceText source, TextSpan? span = null)
+        {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            span ??= new TextSpan(0, source.Length);
+
+            for (var i = span.Value.Start; i <= span.Value.End; i++)
+            {
+                if (!char.IsWhiteSpace(source[i]))
+                {
+                    return i - span.Value.Start;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextExtensions.cs
@@ -79,5 +79,46 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             source.CopyTo(span.Start, charBuffer, 0, span.Length);
             return new string(charBuffer);
         }
+
+        public static bool NonWhitespaceContentEquals(this SourceText source, SourceText other)
+        {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (other is null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            var i = 0;
+            var j = 0;
+            while (i < source.Length && j < other.Length)
+            {
+                if (char.IsWhiteSpace(source[i]))
+                {
+                    i++;
+                    continue;
+                }
+                else if (char.IsWhiteSpace(other[j]))
+                {
+                    j++;
+                    continue;
+                }
+                else if (source[i] != other[j])
+                {
+                    return false;
+                }
+
+                i++;
+                j++;
+            }
+
+            while (i < source.Length && char.IsWhiteSpace(source[i])) i++;
+            while (j < other.Length && char.IsWhiteSpace(other[j])) j++;
+
+            return i == source.Length && j == other.Length;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextLineExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextLineExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.CodeAnalysis.Text;
 
@@ -22,9 +23,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 : null;
         }
 
-        public static int? GetFirstNonWhitespaceOffset(this TextLine line)
+        public static int? GetFirstNonWhitespaceOffset(this TextLine line, int startOffset = 0)
         {
-            return line.ToString().GetFirstNonWhitespaceOffset();
+            if (startOffset >= line.SpanIncludingLineBreak.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startOffset), "Invalid offset.");
+            }
+
+            return line.ToString().Substring(startOffset).GetFirstNonWhitespaceOffset();
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextLineExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextLineExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentOutOfRangeException(nameof(startOffset), "Invalid offset.");
             }
 
-            return line.ToString().Substring(startOffset).GetFirstNonWhitespaceOffset();
+            return line.Text.GetFirstNonWhitespaceOffset(TextSpan.FromBounds(line.Start + startOffset, line.EndIncludingLineBreak));
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
@@ -71,7 +71,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
+            // For onTypeFormatting, it makes more sense to look up the projection of the character that was inserted. Aka. request.Position.Character - 1
+            var position = new Position(request.Position.Line, request.Position.Character - 1);
+            var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, position, cancellationToken).ConfigureAwait(false);
             if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.CSharp)
             {
                 return null;
@@ -87,7 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 Character = request.Character,
                 Options = request.Options,
-                Position = projectionResult.Position,
+                Position = new Position(projectionResult.Position.Line, projectionResult.Position.Character + 1),
                 TextDocument = new TextDocumentIdentifier() { Uri = projectionResult.Uri }
             };
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
@@ -6,9 +6,12 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
+using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {
@@ -36,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             };
 
             var provider = CreateProvider();
-            var context = FormattingContext.Create(uri, codeDocument, new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(position, position), options);
+            var context = FormattingContext.Create(uri, Mock.Of<DocumentSnapshot>(), codeDocument, options, new Range(position, position));
 
             // Act
             if (!provider.TryResolveInsertion(position, context, out var edit, out var format))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
@@ -6,15 +6,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using Xunit;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
@@ -543,6 +542,8 @@ tabSize: 12);
             var path = "file:///path/to/document.razor";
             var uri = new Uri(path);
             var codeDocument = CreateCodeDocument(source, uri.AbsolutePath, fileKind: fileKind);
+            var documentSnapshot = new Mock<DocumentSnapshot>();
+            documentSnapshot.Setup(d => d.GetGeneratedOutputAsync()).Returns(Task.FromResult(codeDocument));
             var options = new FormattingOptions()
             {
                 TabSize = tabSize,
@@ -552,7 +553,7 @@ tabSize: 12);
             var formattingService = CreateFormattingService(codeDocument);
 
             // Act
-            var edits = await formattingService.FormatAsync(uri, codeDocument, range, options);
+            var edits = await formattingService.FormatAsync(uri, documentSnapshot.Object, range, options);
 
             // Assert
             var edited = ApplyEdits(source, edits);
@@ -568,9 +569,12 @@ tabSize: 12);
             var client = new FormattingLanguageServerClient();
             client.AddCodeDocument(codeDocument);
             var languageServer = Mock.Of<ILanguageServer>(ls => ls.Client == client);
+            var passes = new List<IFormattingPass>()
+            {
+                new CodeBlockDirectiveFormattingPass(mappingService, filePathNormalizer, languageServer, LoggerFactory)
+            };
 
-
-            return new DefaultRazorFormattingService(mappingService, filePathNormalizer, languageServer, LoggerFactory);
+            return new DefaultRazorFormattingService(passes, LoggerFactory);
         }
 
         private SourceText ApplyEdits(SourceText source, TextEdit[] edits)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -135,12 +135,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             public bool Called { get; private set; }
 
-            public override Task<TextEdit[]> ApplyFormattedEditsAsync(Uri uri, RazorCodeDocument codeDocument, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options)
+            public override Task<TextEdit[]> ApplyFormattedEditsAsync(Uri uri, DocumentSnapshot documentSnapshot, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options)
             {
                 throw new NotImplementedException();
             }
 
-            public override Task<TextEdit[]> FormatAsync(Uri uri, RazorCodeDocument codeDocument, OmniSharp.Extensions.LanguageServer.Protocol.Models.Range range, FormattingOptions options)
+            public override Task<TextEdit[]> FormatAsync(Uri uri, DocumentSnapshot documentSnapshot, OmniSharp.Extensions.LanguageServer.Protocol.Models.Range range, FormattingOptions options)
             {
                 Called = true;
                 return Task.FromResult(Array.Empty<TextEdit>());


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/23419

![ontypeformatting2](https://user-images.githubusercontent.com/1579269/88237131-6b129600-cc33-11ea-880e-f1ef36919a45.gif)


- Implemented a new pass based design for regular and ontype formatting
- Added the ability to re-parse the document in FormattingContext
- Updated FormattingVisitor and IndentationContext to have more information about each line
- Added the core logic for C# onTypeFormatting
- Added a `FormattingContentValidatorPass` to ensure the integrity of the document before returning formatting edits

Working on:
- Adding another pass that rejects formatting edits if we format C# blocks with mixed HTML
- Tests for everything
