### PR TITLE
Tweak component search and implement component rename

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -4,11 +4,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -16,11 +15,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class DefaultRazorComponentSearchEngine : RazorComponentSearchEngine
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly ProjectSnapshotManager _projectSnapshotManager;
 
-        public DefaultRazorComponentSearchEngine(ProjectSnapshotManager projectSnapshotManager)
+        public DefaultRazorComponentSearchEngine(ProjectSnapshotManagerAccessor projectSnapshotManagerAccessor)
         {
-            _projectSnapshotManager = projectSnapshotManager ?? throw new ArgumentNullException(nameof(projectSnapshotManager));
+            _projectSnapshotManager = projectSnapshotManagerAccessor?.Instance ?? throw new ArgumentNullException(nameof(projectSnapshotManagerAccessor));
         }
 
         /// <summary>Search for a component in a project based on its tag name and fully qualified name.</summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -29,6 +29,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Server;
 using ILanguageServer = OmniSharp.Extensions.LanguageServer.Server.ILanguageServer;
 using System.Threading;
+using Microsoft.AspNetCore.Razor.LanguageServer.Refactoring;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -102,6 +103,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<CodeActionEndpoint>()
                     .WithHandler<CodeActionResolutionEndpoint>()
                     .WithHandler<MonitorProjectConfigurationFilePathEndpoint>()
+                    .WithHandler<RazorComponentRenameEndpoint>()
                     .WithServices(services =>
                     {
                         var filePathNormalizer = new FilePathNormalizer();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -1,0 +1,292 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using System.IO;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
+{
+    class RazorComponentRenameEndpoint : IRenameHandler
+    {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly DocumentResolver _documentResolver;
+        private readonly ProjectSnapshotManager _projectSnapshotManager;
+        private readonly RazorComponentSearchEngine _componentSearchEngine;
+        private readonly ILogger _logger;
+
+        private RenameCapability _capability;
+
+        public RazorComponentRenameEndpoint(
+            ForegroundDispatcher foregroundDispatcher,
+            DocumentResolver documentResolver,
+            RazorComponentSearchEngine componentSearchEngine,
+            ProjectSnapshotManagerAccessor projectSnapshotManagerAccessor,
+            ILoggerFactory loggerFactory)
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher ?? throw new ArgumentNullException(nameof(foregroundDispatcher));
+            _documentResolver = documentResolver ?? throw new ArgumentNullException(nameof(documentResolver));
+            _componentSearchEngine = componentSearchEngine ?? throw new ArgumentNullException(nameof(componentSearchEngine));
+            _projectSnapshotManager = projectSnapshotManagerAccessor?.Instance ?? throw new ArgumentNullException(nameof(projectSnapshotManagerAccessor));
+            _logger = loggerFactory.CreateLogger<RazorComponentRenameEndpoint>();
+        }
+
+        public RenameRegistrationOptions GetRegistrationOptions()
+        {
+            return new RenameRegistrationOptions
+            {
+                PrepareProvider = false,
+                DocumentSelector = RazorDefaults.Selector,
+            };
+        }
+
+        public async Task<WorkspaceEdit> Handle(RenameParams request, CancellationToken cancellationToken)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var documentSnapshot = await Task.Factory.StartNew(() =>
+            {
+                _documentResolver.TryResolveDocument(request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
+                return documentSnapshot;
+            }, cancellationToken, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler).ConfigureAwait(false);
+
+            if (documentSnapshot is null)
+            {
+                return null;
+            }
+
+            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+            if (codeDocument.IsUnsupported())
+            {
+                return null;
+            }
+
+            if (!FileKinds.IsComponent(codeDocument.GetFileKind()))
+            {
+                return null;
+            }
+
+            var originTagHelperBinding = await GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, request.Position).ConfigureAwait(false);
+            if (originTagHelperBinding is null)
+            {
+                return null;
+            }
+
+            var originTagDescriptor = originTagHelperBinding.Descriptors.First();
+            var originComponentDocumentSnapshot = await await Task.Factory.StartNew(() =>
+            {
+                return _componentSearchEngine.TryLocateComponentAsync(originTagDescriptor).ConfigureAwait(false);
+            }, cancellationToken, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler).ConfigureAwait(false);
+
+            if (originComponentDocumentSnapshot is null)
+            {
+                return null;
+            }
+
+            var newPath = MakeNewPath(documentSnapshot.FilePath, request.NewName);
+            if (File.Exists(newPath))
+            {
+                return null;
+            }
+
+            var documentChanges = new List<WorkspaceEditDocumentChange>();
+            AddFileRenameForComponent(documentChanges, originComponentDocumentSnapshot, newPath);
+            AddEditsForCodeDocument(documentChanges, originTagHelperBinding, request.NewName, request.TextDocument.Uri, codeDocument);
+
+            var projects = await Task.Factory.StartNew(() =>
+            {
+                return _projectSnapshotManager.Projects.ToArray();
+            }, cancellationToken, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler).ConfigureAwait(false);
+
+            var documentPaths = new HashSet<string>();
+            foreach (var project in projects)
+            {
+                foreach (var documentPath in project.DocumentFilePaths)
+                {
+                    if (string.Equals(documentPath, documentSnapshot.FilePath, FilePathComparison.Instance))
+                    {
+                        continue;
+                    }
+                    documentPaths.Add(documentPath);
+                }
+            }
+
+            foreach (var documentPath in documentPaths)
+            {
+                await AddEditsForCodeDocument(documentChanges, originTagHelperBinding, request.NewName, documentPath, cancellationToken);
+            }
+
+            return new WorkspaceEdit
+            {
+                DocumentChanges = documentChanges,
+            };
+        }
+
+        public void AddFileRenameForComponent(List<WorkspaceEditDocumentChange> documentChanges, DocumentSnapshot documentSnapshot, string newPath)
+        {
+            var oldUri = new UriBuilder
+            {
+                Path = documentSnapshot.FilePath,
+                Host = string.Empty,
+                Scheme = Uri.UriSchemeFile,
+            }.Uri;
+            var newUri = new UriBuilder
+            {
+                Path = newPath,
+                Host = string.Empty,
+                Scheme = Uri.UriSchemeFile,
+            }.Uri;
+
+            documentChanges.Add(new WorkspaceEditDocumentChange(new RenameFile
+            {
+                OldUri = oldUri.ToString(),
+                NewUri = newUri.ToString(),
+            }));
+        }
+
+        private static string MakeNewPath(string originalPath, string newName)
+        {
+            var newFileName = $"{newName}{Path.GetExtension(originalPath)}";
+            var newPath = Path.Combine(Path.GetDirectoryName(originalPath), newFileName);
+            return newPath;
+        }
+
+        public async Task AddEditsForCodeDocument(List<WorkspaceEditDocumentChange> documentChanges, TagHelperBinding originTagHelperBinding, string newName, string documentPath, CancellationToken cancellationToken)
+        {
+            var documentSnapshot = await Task.Factory.StartNew(() =>
+            {
+                _documentResolver.TryResolveDocument(documentPath, out var documentSnapshot);
+                return documentSnapshot;
+            }, cancellationToken, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler).ConfigureAwait(false);
+
+            if (documentSnapshot is null)
+            {
+                return;
+            }
+
+            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+            if (codeDocument.IsUnsupported())
+            {
+                return;
+            }
+
+            if (!FileKinds.IsComponent(codeDocument.GetFileKind()))
+            {
+                return;
+            }
+
+            var uri = new UriBuilder
+            {
+                Path = documentPath,
+                Host = string.Empty,
+                Scheme = Uri.UriSchemeFile,
+            }.Uri;
+            AddEditsForCodeDocument(documentChanges, originTagHelperBinding, newName, uri, codeDocument);
+        }
+
+        public void AddEditsForCodeDocument(List<WorkspaceEditDocumentChange> documentChanges, TagHelperBinding originTagHelperBinding, string newName, Uri uri, RazorCodeDocument codeDocument)
+        {
+            var documentIdentifier = new VersionedTextDocumentIdentifier { Uri = uri };
+            foreach (var node in codeDocument.GetSyntaxTree().Root.DescendantNodes().Where(n => n.Kind == SyntaxKind.MarkupTagHelperElement))
+            {
+                if (node is MarkupTagHelperElementSyntax tagHelperElement && BindingsMatch(originTagHelperBinding, tagHelperElement.TagHelperInfo.BindingResult))
+                {
+                    documentChanges.Add(new WorkspaceEditDocumentChange(new TextDocumentEdit
+                    {
+                        TextDocument = documentIdentifier,
+                        Edits = CreateEditsForMarkupTagHelperElement(tagHelperElement, codeDocument, newName)
+                    }));
+                }
+            }
+        }
+
+        public List<TextEdit> CreateEditsForMarkupTagHelperElement(MarkupTagHelperElementSyntax element, RazorCodeDocument codeDocument, string newName)
+        {
+            var edits = new List<TextEdit>
+            {
+                new TextEdit()
+                {
+                    Range = element.StartTag.Name.GetRange(codeDocument.Source),
+                    NewText = newName,
+                },
+            };
+            if (element.EndTag != null)
+            {
+                edits.Add(new TextEdit()
+                {
+                    Range = element.EndTag.Name.GetRange(codeDocument.Source),
+                    NewText = newName,
+                });
+            }
+            return edits;
+        }
+
+        private static bool BindingsMatch(TagHelperBinding left, TagHelperBinding right)
+        {
+            foreach (var leftDescriptor in left.Descriptors)
+            {
+                foreach (var rightDescriptor in right.Descriptors)
+                {
+                    if (leftDescriptor.Equals(rightDescriptor))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private async Task<TagHelperBinding> GetOriginTagHelperBindingAsync(DocumentSnapshot documentSnapshot, RazorCodeDocument codeDocument, Position position)
+        {
+            var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
+            var linePosition = new LinePosition((int)position.Line, (int)position.Character);
+            var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
+            var location = new SourceLocation(hostDocumentIndex, (int)position.Line, (int)position.Character);
+
+            var change = new SourceChange(location.AbsoluteIndex, length: 0, newText: string.Empty);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            if (syntaxTree?.Root is null)
+            {
+                return null;
+            }
+
+            var owner = syntaxTree.Root.LocateOwner(change);
+            var node = owner.Ancestors().FirstOrDefault(n => n.Kind == SyntaxKind.MarkupTagHelperElement);
+            if (node == null || !(node is MarkupTagHelperElementSyntax tagHelperElement))
+            {
+                return null;
+            }
+
+            return tagHelperElement.TagHelperInfo.BindingResult;
+        }
+
+        public void SetCapability(RenameCapability capability)
+        {
+            _capability = capability;
+        }
+    }
+}
+ 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorRenameProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorRenameProvider.ts
@@ -31,7 +31,7 @@ export class RazorRenameProvider
         const projection = await this.getProjection(document, position, token);
         if (!projection || projection.languageKind !== LanguageKind.CSharp) {
             // We only support C# renames for now. Reject the rename request.
-            return Promise.reject('Cannot rename this symbol.');
+            return null;  // Promise.reject('Cannot rename this symbol.');
         }
 
         // Let the rename go through. OmniSharp doesn't currently support "prepareRename" so we need to utilize document

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorRenameProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorRenameProvider.ts
@@ -31,6 +31,11 @@ export class RazorRenameProvider
         const projection = await this.getProjection(document, position, token);
         if (!projection || projection.languageKind !== LanguageKind.CSharp) {
             // We only support C# renames for now. Reject the rename request.
+            // Originally we rejected here. However due to how the language
+            // server client currently works, if we reject here it prevents
+            // other servers from being able to return a response instead.
+            // Null is the only return that allows us to handle renaming
+            // from the Razor language server.
             return null;  // Promise.reject('Cannot rename this symbol.');
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -105,7 +105,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
             var sourceDocument = TestRazorSourceDocument.Create(text, filePath: filePath, relativePath: filePath);
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, builder => {
                 builder.AddDirective(NamespaceDirective.Directive);
-                builder.SetRootNamespace(rootNamespaceName);
             });
             var codeDocument = projectEngine.Process(sourceDocument, FileKinds.Component, Array.Empty<RazorSourceDocument>(), Array.Empty<TagHelperDescriptor>());
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -17,8 +17,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
 {
     public class DefaultRazorComponentSearchEngineTest : LanguageServerTestBase
     {
-        private static ProjectSnapshotManager _projectSnapshotManager = CreateProjectSnapshotManager();
-        private static readonly DefaultRazorComponentSearchEngine _searchEngine = new DefaultRazorComponentSearchEngine(_projectSnapshotManager);
+        private static ProjectSnapshotManagerAccessor _projectSnapshotManager = CreateProjectSnapshotManagerAccessor();
 
         [Fact]
         public async void Handle_SearchFound()
@@ -26,10 +25,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
             // Arrange
             var tagHelperDescriptor1 = CreateRazorComponentTagHelperDescriptor("First", "First.Components", "Component1");
             var tagHelperDescriptor2 = CreateRazorComponentTagHelperDescriptor("Second", "Second.Components", "Component3");
+            var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, _projectSnapshotManager);
 
             // Act
-            var documentSnapshot1 = await _searchEngine.TryLocateComponentAsync(tagHelperDescriptor1).ConfigureAwait(false);
-            var documentSnapshot2 = await _searchEngine.TryLocateComponentAsync(tagHelperDescriptor2).ConfigureAwait(false);
+            var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor1).ConfigureAwait(false);
+            var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor2).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(documentSnapshot1);
@@ -41,9 +41,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         {
             // Arrange
             var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", "Test", "Component2");
+            var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, _projectSnapshotManager);
 
             // Act
-            var documentSnapshot = await _searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
+            var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(documentSnapshot);
@@ -54,9 +55,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         {
             // Arrange
             var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("Third", "First.Components", "Component3");
+            var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, _projectSnapshotManager);
 
             // Act
-            var documentSnapshot = await _searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
+            var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
 
             // Assert
             Assert.Null(documentSnapshot);
@@ -67,9 +69,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         {
             // Arrange
             var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", "First.Components", "Component2");
+            var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, _projectSnapshotManager);
 
             // Act
-            var documentSnapshot = await _searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
+            var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
 
             // Assert
             Assert.Null(documentSnapshot);
@@ -80,9 +83,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         {
             // Arrange
             var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", "First.Components", "Component3");
+            var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, _projectSnapshotManager);
 
             // Act
-            var documentSnapshot = await _searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
+            var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
 
             // Assert
             Assert.Null(documentSnapshot);
@@ -118,7 +122,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
             return documentSnapshot;
         }
     
-        internal static ProjectSnapshotManager CreateProjectSnapshotManager()
+        internal static ProjectSnapshotManagerAccessor CreateProjectSnapshotManagerAccessor()
         {
             var firstProject = Mock.Of<ProjectSnapshot>(p =>
                 p.FilePath == "c:/First/First.csproj" &&
@@ -131,7 +135,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
                 p.DocumentFilePaths == new[] { "c:/Second/Component3.razor" } &&
                 p.GetDocument("c:/Second/Component3.razor") == CreateRazorDocumentSnapshot("", "c:/Second/Component3.razor", "Second.Components"));
 
-            return Mock.Of<ProjectSnapshotManager>(p => p.Projects == new[] { firstProject, secondProject });
+            var projectSnapshotManager = Mock.Of<ProjectSnapshotManagerBase>(p => p.Projects == new[] { firstProject, secondProject });
+            return new TestProjectSnapshotManagerAccessor(projectSnapshotManager);
+        }
+
+        internal class TestProjectSnapshotManagerAccessor : ProjectSnapshotManagerAccessor
+        {
+            public TestProjectSnapshotManagerAccessor(ProjectSnapshotManagerBase instance)
+            {
+                Instance = instance;
+            }
+
+            public override ProjectSnapshotManagerBase Instance { get; }
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -1,12 +1,151 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Refactoring
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
 {
-    class RazorComponentRenameEndpointTest
+    public class RazorComponentRenameEndpointTest : LanguageServerTestBase
     {
+        private RazorProjectEngine _projectEngine;
+        private RazorComponentRenameEndpoint _endpoint;
+
+        public RazorComponentRenameEndpointTest()
+        {
+            CreateEndpoint();
+        }
+
+        [Fact]
+        public async Task Handle_SimpleRename()
+        {
+            // Arrange
+            var request = new RenameParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri("file:///c:/First/Component1.razor")
+                },
+                Position = new Position(1, 1),
+                NewName = "Component5"
+            };
+
+            // Act
+            var result = await _endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        private static TagHelperDescriptor CreateRazorComponentTagHelperDescriptor(string assemblyName, string namespaceName, string tagName)
+        {
+            var fullyQualifiedName = $"{namespaceName}.{tagName}";
+            var builder1 = TagHelperDescriptorBuilder.Create(fullyQualifiedName, assemblyName);
+            builder1.TagMatchingRule(rule => rule.TagName = tagName);
+            return builder1.Build();
+        }
+
+        private static TestRazorProjectItem CreateProjectItem(string text, string filePath)
+        {
+            var item = new TestRazorProjectItem(filePath, filePath, filePath, "/", FileKinds.Component)
+            {
+                Content = text
+            };
+            return item;
+        }
+
+        private DocumentSnapshot CreateRazorDocumentSnapshot(TestRazorProjectItem item, string rootNamespaceName)
+        {
+            var codeDocument = _projectEngine.ProcessDesignTime(item);
+
+            var namespaceNode = (NamespaceDeclarationIntermediateNode)codeDocument
+                .GetDocumentIntermediateNode()
+                .FindDescendantNodes<IntermediateNode>()
+                .FirstOrDefault(n => n is NamespaceDeclarationIntermediateNode);
+            namespaceNode.Content = rootNamespaceName;
+
+            var sourceText = SourceText.From(new string(item.Content));
+            var documentSnapshot = Mock.Of<DocumentSnapshot>(d =>
+                d.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
+                d.FilePath == item.FilePath &&
+                d.FileKind == FileKinds.Component &&
+                d.GetTextAsync() == Task.FromResult(sourceText));
+            return documentSnapshot;
+        }
+
+        private void CreateEndpoint()
+        {
+            var tag1 = CreateRazorComponentTagHelperDescriptor("First", "First.Components", "Component1");
+            var tag2 = CreateRazorComponentTagHelperDescriptor("First", "Test", "Component2");
+            var tag3 = CreateRazorComponentTagHelperDescriptor("Second", "Second.Components", "Component3");
+            var tag4 = CreateRazorComponentTagHelperDescriptor("Second", "Second.Components", "Component4");
+            var tagHelperDescriptors = new[] { tag1, tag2, tag3, tag4 };
+
+            var item1 = CreateProjectItem("@using Test\n<Component2></Component2>", "c:/First/Component1.razor");
+            var item2 = CreateProjectItem("@namespace Test", "c:/First/Component2.razor");
+            var item3 = CreateProjectItem("<Component3></Component3>", "c:/Second/Component3.razor");
+            var item4 = CreateProjectItem("<Component3></Component3>", "c:/Second/Component4.razor");
+            var fileSystem = new TestRazorProjectFileSystem(new[] { item1, item2, item3, item4 });
+
+            _projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, builder => {
+                builder.AddDirective(NamespaceDirective.Directive);
+                builder.AddTagHelpers(tagHelperDescriptors);
+            });
+            _projectEngine.ProcessDeclarationOnly(item1);
+            _projectEngine.ProcessDeclarationOnly(item2);
+            _projectEngine.ProcessDeclarationOnly(item3);
+            _projectEngine.ProcessDeclarationOnly(item4);
+
+            var component1 = CreateRazorDocumentSnapshot(item1, "First.Components");
+            var component2 = CreateRazorDocumentSnapshot(item2, "Test");
+            var component3 = CreateRazorDocumentSnapshot(item3, "Second.Components");
+            var component4 = CreateRazorDocumentSnapshot(item4, "Second.Components");
+
+            var firstProject = Mock.Of<ProjectSnapshot>(p =>
+                p.FilePath == "c:/First/First.csproj" &&
+                p.DocumentFilePaths == new[] { "c:/First/Component1.razor", "c:/First/Component2.razor" } &&
+                p.GetDocument("c:/First/Component1.razor") == component1 &&
+                p.GetDocument("c:/First/Component2.razor") == component2);
+
+            var secondProject = Mock.Of<ProjectSnapshot>(p =>
+                p.FilePath == "c:/Second/Second.csproj" &&
+                p.DocumentFilePaths == new[] { "c:/Second/Component3.razor" } &&
+                p.GetDocument("c:/Second/Component3.razor") == component3 &&
+                p.GetDocument("c:/Second/Component4.razor") == component4);
+
+            var projectSnapshotManager = Mock.Of<ProjectSnapshotManagerBase>(p => p.Projects == new[] { firstProject, secondProject });
+            var projectSnapshotManagerAccessor = new TestProjectSnapshotManagerAccessor(projectSnapshotManager);
+
+            var documentResolver = Mock.Of<DocumentResolver>(d =>
+                d.TryResolveDocument("c:/First/Component1.razor", out component1) == true &&
+                d.TryResolveDocument("c:/First/Component2.razor", out component2) == true &&
+                d.TryResolveDocument("c:/Second/Component3.razor", out component3) == true &&
+                d.TryResolveDocument("c:/Second/Component4.razor", out component4) == true);
+
+            var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, projectSnapshotManagerAccessor);
+            _endpoint = new RazorComponentRenameEndpoint(Dispatcher, documentResolver, searchEngine, projectSnapshotManagerAccessor);
+        }
+
+        internal class TestProjectSnapshotManagerAccessor : ProjectSnapshotManagerAccessor
+        {
+            public TestProjectSnapshotManagerAccessor(ProjectSnapshotManagerBase instance)
+            {
+                Instance = instance;
+            }
+
+            public override ProjectSnapshotManagerBase Instance { get; }
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Refactoring
+{
+    class RazorComponentRenameEndpointTest
+    {
+    }
+}


### PR DESCRIPTION
This pull request is ugly as hell but there are a couple cases where I'm just not sure how to make it better. Have a couple ideas that I'd appreciate feedback on in addition to general review:

- Should I add an overload to `TryLocateComponentAsync` that takes a list of projects to look through to reduce the number of times we need to be on the foreground (currently we get the project list twice, once to find the origin component and once to iterate through all document paths)
- I found duplicate files naively iterating through project -> documents. Is my `HashSet` approach reasonable?
- Should I be `await`ing multiple promises to be more efficient here? Does it matter?
- Does anyone have any ideas on how to reduce boilerplate to access the `RazorCodeDocument` of a `DocumentSnapshot` from a `Uri`?