### PR TITLE
Don't create document in VSCode if it already exists

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -156,7 +156,14 @@ export class RazorDocumentManager implements IRazorDocumentManager {
     }
 
     private addDocument(uri: vscode.Uri) {
-        const document = createDocument(uri);
+        const path = getUriPath(uri);
+        let document = this.razorDocuments[path];
+        if (document) {
+            this.logger.logMessage(`Skipping document creation for '${path}' because it already exists.`);
+            return document;
+        }
+
+        document = createDocument(uri);
         this.razorDocuments[document.path] = document;
 
         this.notifyDocumentChange(document, RazorDocumentChangeKind.added);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/24354

- The C# buffer content was being reset because we were creating the same Razor document twice. Once because of vscode's open document API and the second time due to the workspace file watcher.
- This caused a race between our first update and the second creation.
- The fix was to not create another document if we have already created it once. I am unsure what is causing this to happen only now because our code has always been this way. @NTaylorMullen's theory is because we recently made things faster on our side causing this race to be exposed. 
- Verified the fix manually. Couldn't add tests because it involves vscode APIs but the fix is fairly simple.
