### PR TITLE
Don't create document in VSCode if it already exists (#2282)

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -156,7 +156,14 @@ export class RazorDocumentManager implements IRazorDocumentManager {
     }
 
     private addDocument(uri: vscode.Uri) {
-        const document = createDocument(uri);
+        const path = getUriPath(uri);
+        let document = this.razorDocuments[path];
+        if (document) {
+            this.logger.logMessage(`Skipping document creation for '${path}' because it already exists.`);
+            return document;
+        }
+
+        document = createDocument(uri);
         this.razorDocuments[document.path] = document;
 
         this.notifyDocumentChange(document, RazorDocumentChangeKind.added);


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspnetcore-tooling/pull/2282

Need to insert into the release branch which has the previously inserted head.