### PR TITLE
Switch from 'C#_LSP' to 'CSharp' content type for C# lsp server

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             { LanguageClientConstants.ClientNamePropertyKey, "RazorCSharp" }
         };
 
-        private static IContentType _csharpLSPContentType;
+        private static IContentType _csharpContentType;
 
         [ImportingConstructor]
         public CSharpVirtualDocumentFactory(
@@ -37,13 +37,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             get
             {
-                if (_csharpLSPContentType == null)
+                if (_csharpContentType == null)
                 {
-                    var contentType = ContentTypeRegistry.GetContentType(RazorLSPConstants.CSharpLSPContentTypeName);
-                    _csharpLSPContentType = new RemoteContentDefinitionType(contentType);
+                    var contentType = ContentTypeRegistry.GetContentType(RazorLSPConstants.CSharpContentTypeName);
+                    _csharpContentType = new RemoteContentDefinitionType(contentType);
                 }
 
-                return _csharpLSPContentType;
+                return _csharpContentType;
             }
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var contentType = RazorLSPConstants.RazorLSPContentTypeName;
             if (serverKind == LanguageServerKind.CSharp)
             {
-                contentType = RazorLSPConstants.CSharpLSPContentTypeName;
+                contentType = RazorLSPConstants.CSharpContentTypeName;
             }
             else if (serverKind == LanguageServerKind.Html)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private static readonly string[] _applicableContentTypes = new string[]
         {
             RazorLSPConstants.RazorLSPContentTypeName,
-            RazorLSPConstants.CSharpLSPContentTypeName,
+            RazorLSPConstants.CSharpContentTypeName,
             RazorLSPConstants.HtmlLSPContentTypeName,
         };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
@@ -89,6 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private static List<Lazy<ILanguageClient, ILanguageClientMetadata>> GetApplicableClients(IEnumerable<Lazy<ILanguageClient, IDictionary<string, object>>> languageClients)
         {
             var applicableClients = new List<Lazy<ILanguageClient, ILanguageClientMetadata>>();
+
             foreach (var client in languageClients)
             {
                 if (!client.Metadata.TryGetValue(nameof(ILanguageClientMetadata.ContentTypes), out var contentTypeValue) ||
@@ -104,25 +105,34 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     clientName = clientNameValue.ToString();
                 }
 
+                var disableUserExperience = false;
+                if (client.Metadata.TryGetValue("DisableUserExperience", out var disableUserExperienceValue))
+                {
+                    disableUserExperience = (bool)disableUserExperienceValue;
+                }
+
                 applicableClients.Add(new Lazy<ILanguageClient, ILanguageClientMetadata>(
                     () => { return client.Value; },
-                    new LanguageClientMetadata(clientName, contentTypes)));
+                    new LanguageClientMetadata(clientName, contentTypes, disableUserExperience)));
             }
 
             return applicableClients;
         }
 
-        private class LanguageClientMetadata : ILanguageClientMetadata
+        private class LanguageClientMetadata : ILanguageClientMetadata, IIsUserExperienceDisabledMetadata
         {
-            public LanguageClientMetadata(string clientName, IEnumerable<string> contentTypes)
+            public LanguageClientMetadata(string clientName, IEnumerable<string> contentTypes, bool isUserExperienceDisabled)
             {
                 ClientName = clientName;
                 ContentTypes = contentTypes;
+                IsUserExperienceDisabled = isUserExperienceDisabled;
             }
 
             public string ClientName { get; }
 
             public IEnumerable<string> ContentTypes { get; }
+
+            public bool IsUserExperienceDisabled { get; }
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public const string RazorFileExtension = ".razor";
 
-        public const string CSharpLSPContentTypeName = "C#_LSP";
+        public const string CSharpContentTypeName = "CSharp";
 
         public const string HtmlLSPContentTypeName = "htmlyLSP";
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             var csharpContentType = Mock.Of<IContentType>();
             ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
-                registry => registry.GetContentType(RazorLSPConstants.CSharpLSPContentTypeName) == csharpContentType);
+                registry => registry.GetContentType(RazorLSPConstants.CSharpContentTypeName) == csharpContentType);
             var textBufferFactory = new Mock<ITextBufferFactoryService>();
             textBufferFactory
                 .Setup(factory => factory.CreateTextBuffer())

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPRequestInvokerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPRequestInvokerTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageServiceBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPConstants.CSharpLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConstants.CSharpContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var broker = new TestLanguageServiceBroker((contentType, method) =>
             {
                 called = true;
-                Assert.Equal(RazorLSPConstants.CSharpLSPContentTypeName, contentType);
+                Assert.Equal(RazorLSPConstants.CSharpContentTypeName, contentType);
                 Assert.Equal(expectedMethod, method);
             });
             var requestInvoker = new DefaultLSPRequestInvoker(broker);


### PR DESCRIPTION
We're getting ready to remove the 'C#_LSP' content type in https://github.com/dotnet/roslyn/pull/46370
This PR switches the razor LSP to look for the c# lsp server on the 'CSharp' content type instead of the 'C#_LSP' content type.
This change requires #46370 plus another liveshare PR and *should not be merged* until we are ready to do a triple insertion, but I wanted to get all PRs created and approved first.

Addresses https://github.com/dotnet/aspnetcore/issues/19184

cc @NTaylorMullen 
