### PR TITLE
Include DisableUserExperience attribute when pre-activating LSP servers

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LSPRazorProjectHost.cs
@@ -104,25 +104,34 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     clientName = clientNameValue.ToString();
                 }
 
+                var disableUserExperience = false;
+                if (client.Metadata.TryGetValue("DisableUserExperience", out var disableUserExperienceValue))
+                {
+                    disableUserExperience = (bool)disableUserExperienceValue;
+                }
+
                 applicableClients.Add(new Lazy<ILanguageClient, ILanguageClientMetadata>(
                     () => { return client.Value; },
-                    new LanguageClientMetadata(clientName, contentTypes)));
+                    new LanguageClientMetadata(clientName, contentTypes, disableUserExperience)));
             }
 
             return applicableClients;
         }
 
-        private class LanguageClientMetadata : ILanguageClientMetadata
+        private class LanguageClientMetadata : ILanguageClientMetadata, IIsUserExperienceDisabledMetadata
         {
-            public LanguageClientMetadata(string clientName, IEnumerable<string> contentTypes)
+            public LanguageClientMetadata(string clientName, IEnumerable<string> contentTypes, bool isUserExperienceDisabled)
             {
                 ClientName = clientName;
                 ContentTypes = contentTypes;
+                IsUserExperienceDisabled = isUserExperienceDisabled;
             }
 
             public string ClientName { get; }
 
             public IEnumerable<string> ContentTypes { get; }
+
+            public bool IsUserExperienceDisabled { get; }
         }
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
This takes a change from https://github.com/dotnet/aspnetcore-tooling/pull/2291 separately from the C#_LSP removal to include the DisableUserExperience attribute during pre-activation.  

Without this, the liveshare LSP server in roslyn will start providing diagnostics locally, see https://github.com/dotnet/roslyn/issues/45966

I am taking this change separately as I'm not exactly sure when C#_LSP will go in - some issues with roslyn insertions + triple insertion may delay.

Addresses https://github.com/dotnet/roslyn/issues/45966
