### PR TITLE
Fix VS4Mac component discovery issues through upgrade.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/DefaultLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/DefaultLSPEditorFeatureDetector.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
+{
+    [Shared]
+    [Export(typeof(LSPEditorFeatureDetector))]
+    internal class DefaultLSPEditorFeatureDetector : LSPEditorFeatureDetector
+    {
+        public override bool IsLSPEditorAvailable(string documentMoniker, object hierarchy) => false;
+
+        public override bool IsLSPEditorFeatureEnabled() => false;
+
+        public override bool IsRemoteClient() => false;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/MacLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/MacLSPEditorFeatureDetector.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
 {
     [Shared]
     [Export(typeof(LSPEditorFeatureDetector))]
-    internal class DefaultLSPEditorFeatureDetector : LSPEditorFeatureDetector
+    internal class MacLSPEditorFeatureDetector : LSPEditorFeatureDetector
     {
         public override bool IsLSPEditorAvailable(string documentMoniker, object hierarchy) => false;
 


### PR DESCRIPTION
- Turns out the two VS4Mac issues which we had reported were already fixed in the latest master.
- Attempting to upgrade to the latest Razor tooling bits resulted in a MEF failure for our LSP editor feature detector dependency that was introduced at the CodeAnalysis.Razor.Workspaces layer. To resolve this I went ahead and added a VS4Mac specific LSP feature detector that always returns false.
- Could not add tests for this because it's more at the integration layer.

Fixes dotnet/aspnetcore#23745
Fixes dotnet/aspnetcore#23746
