### PR TITLE
Remove Reflection from Default LSP Request Invoker

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/TestLanguageServiceBroker.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/TestLanguageServiceBroker.cs
@@ -77,22 +77,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             throw new NotImplementedException();
         }
 
-#pragma warning disable CA1801 // Parameter is never used
-        public Task<(ILanguageClient, JToken)> SynchronizedRequestAsync(
-            string[] contentTypes,
-            Func<JToken, bool> capabilitiesFilter,
-            string method,
-            JToken parameters,
-            CancellationToken cancellationToken)
-        {
-            // We except it to be called with only one content type.
-            var contentType = Assert.Single(contentTypes);
-
-            _callback?.Invoke(contentType, method);
-
-            return Task.FromResult<(ILanguageClient, JToken)>((null, null));
-        }
-
         public Task<(ILanguageClient, JToken)> RequestAsync(
             string[] contentTypes,
             Func<JToken, bool> capabilitiesFilter,
@@ -197,6 +181,5 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             throw new NotImplementedException();
         }
-#pragma warning restore CA1801 // Parameter is never used
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/23191

This got unblocked by the fact that we no longer use the [`SynchronizedRequestAsync`](https://github.com/dotnet/aspnetcore-tooling/blob/4ddccd8e65312f3520f4c109c4a94ce81db37c66/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPRequestInvoker.cs#L49-L58)  method. 
