### PR TITLE
Enable onTypeFormatting for pure C# @{...} statement blocks

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CodeBlockDirectiveFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CodeBlockDirectiveFormattingPass.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var allEdits = new List<TextEdit>();
 
             // Iterate in reverse so that the newline changes don't affect the next code block directive.
-            for (var i = nodes.Length - 1; i >= 0; i--)
+            for (var i = nodes.Count - 1; i >= 0; i--)
             {
                 var directive = nodes[i];
                 if (!(directive.Body is RazorDirectiveBodySyntax directiveBody))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorSyntaxTreeExtensions.cs
@@ -41,5 +41,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             return codeBlockDirectives;
         }
+
+        public static CSharpStatementSyntax[] GetCSharpStatements(this RazorSyntaxTree syntaxTree)
+        {
+            if (syntaxTree is null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            // We want all nodes that represent Razor C# statements, @{ ... }.
+            var statements = syntaxTree.Root.DescendantNodes().OfType<CSharpStatementSyntax>().ToArray();
+            return statements;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorSyntaxTreeExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             return visitor.FormattingSpans;
         }
 
-        public static RazorDirectiveSyntax[] GetCodeBlockDirectives(this RazorSyntaxTree syntaxTree)
+        public static IReadOnlyList<RazorDirectiveSyntax> GetCodeBlockDirectives(this RazorSyntaxTree syntaxTree)
         {
             if (syntaxTree == null)
             {
@@ -37,12 +37,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 .DescendantNodes(node => node is RazorDocumentSyntax || node is MarkupBlockSyntax || node is CSharpCodeBlockSyntax)
                 .OfType<RazorDirectiveSyntax>()
                 .Where(directive => directive.DirectiveDescriptor?.Kind == DirectiveKind.CodeBlock)
-                .ToArray();
+                .ToList();
 
             return codeBlockDirectives;
         }
 
-        public static CSharpStatementSyntax[] GetCSharpStatements(this RazorSyntaxTree syntaxTree)
+        public static IReadOnlyList<CSharpStatementSyntax> GetCSharpStatements(this RazorSyntaxTree syntaxTree)
         {
             if (syntaxTree is null)
             {
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             // We want all nodes that represent Razor C# statements, @{ ... }.
-            var statements = syntaxTree.Root.DescendantNodes().OfType<CSharpStatementSyntax>().ToArray();
+            var statements = syntaxTree.Root.DescendantNodes().OfType<CSharpStatementSyntax>().ToList();
             return statements;
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    public class CSharpStatementBlockOnTypeFormattingTest : FormattingTestBase
+    {
+        [Fact]
+        public async Task CloseCurly_IfBlock_SingleLine()
+        {
+            await RunOnTypeFormattingTestAsync(
+input: @"
+@{
+ if(true){|}|
+}
+",
+expected: @"
+@{
+    if (true) { }
+}
+",
+triggerCharacter: "}");
+        }
+
+        [Fact]
+        public async Task CloseCurly_IfBlock_MultiLine()
+        {
+            await RunOnTypeFormattingTestAsync(
+input: @"
+@{
+ if(true)
+{
+ |}|
+}
+",
+expected: @"
+@{
+    if (true)
+    {
+    }
+}
+",
+triggerCharacter: "}");
+        }
+
+        [Fact]
+        public async Task Semicolon_Variable_SingleLine()
+        {
+            await RunOnTypeFormattingTestAsync(
+input: @"
+@{
+ var x = 'foo'|;|
+}
+",
+expected: @"
+@{
+    var x = 'foo';
+}
+",
+triggerCharacter: ";");
+        }
+
+        [Fact]
+        public async Task Semicolon_Variable_MultiLine()
+        {
+            await RunOnTypeFormattingTestAsync(
+input: @"
+@{
+ var x = @""
+foo""|;|
+}
+",
+expected: @"
+@{
+    var x = @""
+foo"";
+}
+",
+triggerCharacter: ";");
+        }
+    }
+}


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/23530

![ontypeformatting](https://user-images.githubusercontent.com/1579269/89825209-16af5780-db09-11ea-880f-a443a82d8330.gif)

Opening the floodgates for more pure C# ontypeformatting