### PR TITLE
Edge Handling Test Cases

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -363,6 +363,76 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
+        public void GetLanguageKindCore_RazorEdgeWithCSharpMarker()
+        {
+            // Arrange
+            var text = "@{var x = 1;}";
+            var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
+
+            // Act
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 12);
+
+            // Assert
+            Assert.Equal(RazorLanguageKind.CSharp, languageKind);
+        }
+
+        [Fact]
+        public void GetLanguageKindCore_ExplicitExpressionStartCSharp()
+        {
+            // Arrange
+            var text = "@()";
+            var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
+
+            // Act
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 2);
+
+            // Assert
+            Assert.Equal(RazorLanguageKind.CSharp, languageKind);
+        }
+
+        [Fact]
+        public void GetLanguageKindCore_ExplicitExpressionInProgressCSharp()
+        {
+            // Arrange
+            var text = "@(Da)";
+            var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
+
+            // Act
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 4);
+
+            // Assert
+            Assert.Equal(RazorLanguageKind.CSharp, languageKind);
+        }
+
+        [Fact]
+        public void GetLanguageKindCore_ImplicitExpressionStartCSharp()
+        {
+            // Arrange
+            var text = "@";
+            var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
+
+            // Act
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 1);
+
+            // Assert
+            Assert.Equal(RazorLanguageKind.CSharp, languageKind);
+        }
+
+        [Fact]
+        public void GetLanguageKindCore_ImplicitExpressionInProgressCSharp()
+        {
+            // Arrange
+            var text = "@Da";
+            var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
+
+            // Act
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 3);
+
+            // Assert
+            Assert.Equal(RazorLanguageKind.CSharp, languageKind);
+        }
+
+        [Fact]
         public void GetLanguageKindCore_RazorEdgeWithHtml()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -349,7 +349,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
-        public void GetLanguageKindCore_RazorEdgeWithCSharp()
+        public void GetLanguageKindCore_CSharpEdgeWithCSharp()
         {
             // Arrange
             var text = "@{}";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -349,7 +349,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
-        public void GetLanguageKindCore_CSharpEdgeWithCSharp()
+        public void GetLanguageKindCore_RazorEdgeWithCSharp()
         {
             // Arrange
             var text = "@{}";
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
-        public void GetLanguageKindCore_RazorEdgeWithCSharpMarker()
+        public void GetLanguageKindCore_CSharpEdgeWithCSharpMarker()
         {
             // Arrange
             var text = "@{var x = 1;}";


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/24296

Investigated, discussed offline and closing out.

Essentially this stricter handling seems to be primarily needed for the `OnTypeFormatting` case, and there are some additional nuances with a stricter interpretation (ex. breaks down for `@(Da|)` case as it thinks we're in Razor instead of C#). 

Just adding in some additional tests which validate these situations.
