### PR TITLE
Log language server output to files (also)

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public Task InitializedAsync(CancellationToken token) => _innerServer.InitializedAsync(token);
 
-        public static Task<RazorLanguageServer> CreateAsync(Stream input, Stream output, Trace trace)
+        public static Task<RazorLanguageServer> CreateAsync(Stream input, Stream output, Trace trace, Action<IServiceCollection> configure = null)
         {
             Serializer.Instance.Settings.Converters.Add(SemanticTokensOrSemanticTokensEditsConverter.Instance);
             Serializer.Instance.JsonSerializer.Converters.RegisterRazorConverters();
@@ -67,8 +67,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithInput(input)
                     .WithOutput(output)
                     .ConfigureLogging(builder => builder
-                        .AddLanguageServer()
-                        .SetMinimumLevel(RazorLSPOptions.GetLogLevelForTrace(trace)))
+                        .AddLanguageServer(RazorLSPOptions.GetLogLevelForTrace(trace))
+                        .SetMinimumLevel(LogLevel.Trace)) // We set the minimum level here to "Trace" to ensure that other providers still get the opportunity to act on logs if they prefer.
                     .OnInitialized(async (s, request, response) =>
                     {
                         var jsonRpcHandlers = s.Services.GetServices<IJsonRpcHandler>();
@@ -107,6 +107,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<RazorDefinitionEndpoint>()
                     .WithServices(services =>
                     {
+                        configure?.Invoke(services);
+
                         var filePathNormalizer = new FilePathNormalizer();
                         services.AddSingleton<FilePathNormalizer>(filePathNormalizer);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLogWriter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLogWriter.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    internal class DefaultFeedbackFileLogWriter : FeedbackFileLogWriter, IDisposable
+    {
+        private readonly ConcurrentQueue<string> _logs;
+        private readonly SemaphoreSlim _logSemaphore;
+        private readonly Task _logWriterTask;
+        private readonly object _writeToLock;
+        private readonly FeedbackLogDirectoryProvider _feedbackLogDirectoryProvider;
+        private TextWriter _logWriter;
+        private string _logFile;
+        private bool _disposed;
+
+        public DefaultFeedbackFileLogWriter(FeedbackLogDirectoryProvider feedbackLogDirectoryProvider)
+        {
+            if (feedbackLogDirectoryProvider is null)
+            {
+                throw new ArgumentNullException(nameof(feedbackLogDirectoryProvider));
+            }
+
+            _logs = new ConcurrentQueue<string>();
+            _logSemaphore = new SemaphoreSlim(0);
+            _writeToLock = new object();
+            _feedbackLogDirectoryProvider = feedbackLogDirectoryProvider;
+
+            InitializeLogFile();
+
+            _logWriterTask = Task.Run(WriteToLogAsync);
+        }
+
+        public override void Write(string message)
+        {
+            lock (_writeToLock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                var timeStampString = DateTimeOffset.UtcNow.ToString("mm:ss.fff", CultureInfo.InvariantCulture);
+                var log = $"{timeStampString} | {message}";
+                _logs.Enqueue(log);
+                _logSemaphore.Release();
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_writeToLock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+            }
+
+            // Releasing the semaphore here causes our WriteToLogAsync loop to exit.
+            _logSemaphore.Release();
+            _logSemaphore.Dispose();
+
+            _logWriterTask.Wait();
+
+            _logWriter.Close();
+            _logWriter.Dispose();
+        }
+
+        private async Task WriteToLogAsync()
+        {
+            while (true)
+            {
+                await _logSemaphore.WaitAsync();
+                if (!_logs.TryDequeue(out var line))
+                {
+                    // An empty queue is a stop signal.
+                    break;
+                }
+                await _logWriter.WriteLineAsync(line);
+                await _logWriter.FlushAsync();
+            }
+        }
+
+        private void InitializeLogFile()
+        {
+            var logDirectory = _feedbackLogDirectoryProvider.GetDirectory();
+
+            // Ensure a unique file name, in case another log session started around the same time.
+            for (var index = 0; ; index++)
+            {
+                var fileName = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0:yyyyMMdd_HHmmss}{1}.log",
+                    DateTime.UtcNow,
+                    index == 0 ? string.Empty : "." + index);
+
+                var filePath = Path.Combine(logDirectory, fileName);
+                try
+                {
+                    var fileStream = File.Open(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+
+                    _logWriter = new StreamWriter(fileStream);
+                    _logFile = filePath;
+                    return;
+                }
+                catch (IOException)
+                {
+                    // The file probably already exists. Try again with the next index,
+                    // unless there were already too many failures.
+                    if (index == 9) throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLoggerProviderFactory.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    [Shared]
+    [Export(typeof(FeedbackFileLoggerProviderFactory))]
+    internal class DefaultFeedbackFileLoggerProviderFactory : FeedbackFileLoggerProviderFactory
+    {
+        private readonly object _creationLock;
+        private readonly FeedbackLogDirectoryProvider _feedbackLogDirectoryProvider;
+        private DefaultFeedbackFileLogWriter _currentFileLogWriter;
+
+        [ImportingConstructor]
+        public DefaultFeedbackFileLoggerProviderFactory(FeedbackLogDirectoryProvider feedbackLogDirectoryProvider)
+        {
+            if (feedbackLogDirectoryProvider is null)
+            {
+                throw new ArgumentNullException(nameof(feedbackLogDirectoryProvider));
+            }
+
+            _feedbackLogDirectoryProvider = feedbackLogDirectoryProvider;
+            _creationLock = new object();
+        }
+
+        public override FeedbackFileLoggerProvider GetOrCreate()
+        {
+            lock (_creationLock)
+            {
+                if (_currentFileLogWriter != null)
+                {
+                    // Dispose last log writer so we can start a new session. Technically only one should only ever be active at a time.
+                    _currentFileLogWriter.Dispose();
+                }
+
+                _currentFileLogWriter = new DefaultFeedbackFileLogWriter(_feedbackLogDirectoryProvider);
+                var provider = new FeedbackFileLoggerProvider(_currentFileLogWriter);
+
+                return provider;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackLogDirectoryProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackLogDirectoryProvider.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    [Shared]
+    [Export(typeof(FeedbackLogDirectoryProvider))]
+    internal class DefaultFeedbackLogDirectoryProvider : FeedbackLogDirectoryProvider
+    {
+        private const string FeedbackDirectoryName = "RazorVSFeedbackLogs";
+        private readonly object _accessLock = new object();
+        private string _baseLogDirectory;
+        private string _logDirectory;
+
+        public override string GetDirectory()
+        {
+            // Start cleaning up old directories in the background. Fire and forget
+            _ = Task.Run(() => CleanupOldDirectories());
+
+            lock (_accessLock)
+            {
+                if (_logDirectory == null)
+                {
+                    EnsureBaseLogDirectory();
+
+                    var processId = Process.GetCurrentProcess().Id;
+
+                    // There could be multiple versions of VS running, lets ensure that we get our own directory.
+                    var logDirectory = Path.Combine(_baseLogDirectory, processId.ToString(CultureInfo.InvariantCulture));
+                    Directory.CreateDirectory(logDirectory);
+
+                    // In the end the log directory looks something like C:\Users\nimullen\AppData\Local\Temp\RazorVSFeedbackLogs\12345
+
+                    // Assign after creation so it's attempted again if the directory creation fails.
+                    _logDirectory = logDirectory;
+                }
+            }
+
+            return _logDirectory;
+        }
+
+        private void EnsureBaseLogDirectory()
+        {
+            lock (_accessLock)
+            {
+                if (_baseLogDirectory == null)
+                {
+                    var tempDirectory = Path.GetTempPath();
+                    var baseLogDirectory = Path.Combine(tempDirectory, FeedbackDirectoryName);
+                    if (!Directory.Exists(_baseLogDirectory))
+                    {
+                        Directory.CreateDirectory(baseLogDirectory);
+                    }
+
+                    // In the end the base directory looks something like C:\Users\nimullen\AppData\Local\Temp\RazorVSFeedbackLogs
+
+                    // Assign after creation so it's attempted again if the directory creation fails.
+                    _baseLogDirectory = baseLogDirectory;
+                }
+            }
+        }
+
+        private void CleanupOldDirectories()
+        {
+            try
+            {
+                EnsureBaseLogDirectory();
+
+                var directories = Directory.GetDirectories(_baseLogDirectory);
+                for (var i = 0; i < directories.Length; i++)
+                {
+                    var directory = directories[i];
+                    var processIdString = Path.GetFileName(directory);
+
+                    // Logs are grouped by process ID as the folder name.
+                    if (!int.TryParse(processIdString, out var logProcessId))
+                    {
+                        continue;
+                    }
+
+                    var devenvProcesses = Process.GetProcessesByName("devenv");
+
+                    // Given we're runnin in VS there will always be at least 1 devenv process.
+
+                    var logsAssociatedProcess = devenvProcesses.FirstOrDefault(process => process.Id == logProcessId);
+                    if (logsAssociatedProcess != null)
+                    {
+                        // Devenv for that log is still running, don't touch it
+                        continue;
+                    }
+
+                    // Stale log, no associated devenv. Delete it.
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+            catch (Exception)
+            {
+                // Swallow all exceptions when cleaning up. We're doing our best to not leave big disk footprints in the users temp folder; however, if this time we fail
+                // we'll try again next time.
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLogWriter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLogWriter.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    internal abstract class FeedbackFileLogWriter
+    {
+        public abstract void Write(string message);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLogger.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    internal class FeedbackFileLogger : ILogger
+    {
+        private readonly string _categoryName;
+        private readonly FeedbackFileLogWriter _feedbackFileLogWriter;
+
+        public FeedbackFileLogger(string categoryName, FeedbackFileLogWriter feedbackFileLogWriter)
+        {
+            if (categoryName is null)
+            {
+                throw new ArgumentNullException(nameof(categoryName));
+            }
+
+            if (feedbackFileLogWriter is null)
+            {
+                throw new ArgumentNullException(nameof(feedbackFileLogWriter));
+            }
+
+            _categoryName = categoryName;
+            _feedbackFileLogWriter = feedbackFileLogWriter;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => Scope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var formattedResult = formatter(state, exception);
+            var logContent = $"[{_categoryName}] {formattedResult}";
+            _feedbackFileLogWriter.Write(logContent);
+        }
+
+        private class Scope : IDisposable
+        {
+            public static readonly Scope Instance = new Scope();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProvider.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    internal class FeedbackFileLoggerProvider : ILoggerProvider
+    {
+        // Internal for testing
+        internal const string OmniSharpFrameworkCategoryPrefix = "OmniSharp.Extensions.LanguageServer.Server";
+        private const string RazorLanguageServerPrefix = "Microsoft.AspNetCore.Razor.LanguageServer";
+        private readonly FeedbackFileLogWriter _feedbackFileLogWriter;
+
+        public FeedbackFileLoggerProvider(FeedbackFileLogWriter feedbackFileLogWriter)
+        {
+            if (feedbackFileLogWriter is null)
+            {
+                throw new ArgumentNullException(nameof(feedbackFileLogWriter));
+            }
+
+            _feedbackFileLogWriter = feedbackFileLogWriter;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            if (categoryName is null)
+            {
+                throw new ArgumentNullException(nameof(categoryName));
+            }
+
+            if (categoryName.StartsWith(OmniSharpFrameworkCategoryPrefix, StringComparison.Ordinal))
+            {
+                // Loggers created for O# framework pieces should be ignored for feedback. They emit too much noise.
+                return NoopLogger.Instance;
+            }
+
+            if (categoryName.StartsWith(RazorLanguageServerPrefix, StringComparison.Ordinal))
+            {
+                // Reduce the size of the Razor language server categories. We assume nearly all logs here are going to be from the server and thus limiting
+                // the amount of noise they emit will be valuable for readability and will ultimately reduce the size of the log on the users box.
+                categoryName = categoryName.Substring(RazorLanguageServerPrefix.Length + 1 /* . */);
+            }
+
+            return new FeedbackFileLogger(categoryName, _feedbackFileLogWriter);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private class NoopLogger : ILogger
+        {
+            public static readonly ILogger Instance = new NoopLogger();
+
+            private NoopLogger()
+            {
+            }
+
+            public IDisposable BeginScope<TState>(TState state) => Scope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => false;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+            }
+
+            private class Scope : IDisposable
+            {
+                public static readonly Scope Instance = new Scope();
+
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    internal abstract class FeedbackFileLoggerProviderFactory
+    {
+        public abstract FeedbackFileLoggerProvider GetOrCreate();
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackLogDirectoryProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackLogDirectoryProvider.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    internal abstract class FeedbackLogDirectoryProvider
+    {
+        public abstract string GetDirectory();
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Feedback/FeedbackFileLoggerProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Feedback/FeedbackFileLoggerProviderTest.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    public class FeedbackFileLoggerProviderTest
+    {
+        [Fact]
+        public void CreateLogger_OmniSharpFrameworkCategory_DisabledByDefault()
+        {
+            // Arrange
+            var fileLogWriter = Mock.Of<FeedbackFileLogWriter>();
+            var provider = new FeedbackFileLoggerProvider(fileLogWriter);
+            var categoryName = FeedbackFileLoggerProvider.OmniSharpFrameworkCategoryPrefix + ".Test";
+
+            // Act
+            var logger = provider.CreateLogger(categoryName);
+
+            // Assert
+            Assert.False(logger.IsEnabled(LogLevel.Trace));
+            provider.Dispose();
+        }
+
+        [Fact]
+        public void CreateLogger_Category_EnabledByDefault()
+        {
+            // Arrange
+            var fileLogWriter = Mock.Of<FeedbackFileLogWriter>();
+            var provider = new FeedbackFileLoggerProvider(fileLogWriter);
+            var categoryName = "Test";
+
+            // Act
+            var logger = provider.CreateLogger(categoryName);
+
+            // Assert
+            Assert.True(logger.IsEnabled(LogLevel.Trace));
+            provider.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
- Expanded our RazorLanguageServer implementation to allow hosts to configure services.
- In VS hosted scenarios we now register a new `ILoggerProvider` that logs out to the users `%temp%/RazorVSFeedbackLogs/pid` directory. Each VS instance has its own folder but on VS boot we cross-check all pre-existing folders and cleanup any folders that no longer correspond to an active VS process. We accomplish this by querying for all `devenv` processes and then cross-checking their pid's against the folder names we've created.
- Underlying VS' `ILoggerProvider` is a FileLogWriter that accepts writes synchronously for N number of providers. Behind the scenes it synchronously writes all of its contents to disk.
- This is a pre-requisite PR for actually providing feedback information as part of a users VSFeedback flow. The APIs required there require files to be uploaded so I needed to build out a good amount of infrastructure to support those requirements.
- Found that the amount of log output O# emits resulted in extremely large logs (hit a mb worth in under a minute) therefore took some countermeasures to mute a lot of O#'s specific loggging.
- Could not add significant tests for these pieces because the majority of it is either highly integration based or file based.

For instance, one VS instance navigating across three different solutions would result in three log files. two "complete" and one active:
![image](https://user-images.githubusercontent.com/2008729/89838808-03a88180-db21-11ea-8522-1d48e80a7112.png)


Part of dotnet/aspnetcore#24129


