### PR TITLE
Resolve flaky tests with memory cache

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/MemoryCache.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/MemoryCache.cs
@@ -48,16 +48,11 @@ namespace Microsoft.CodeAnalysis.Razor
                 Compact();
             }
 
-            if (_dict.ContainsKey(key))
-            {
-                _dict.Remove(key);
-            }
-
-            _dict.Add(key, new CacheEntry
+            _dict[key] = new CacheEntry
             {
                 LastAccess = DateTime.UtcNow,
                 Value = value,
-            });
+            };
         }
 
         protected virtual void Compact()


### PR DESCRIPTION
This is an attempt to resolve some intermittent failures with the memory cache, likely caused by a concurrency issue between remove and add.

https://dev.azure.com/dnceng/public/_build/results?buildId=763979&view=ms.vss-test-web.build-test-results-tab&runId=23736232&resultId=100008&paneView=debug

Thanks @ryanbrandenburg!

