### PR TITLE
Zip and provide Razor logs during VS feedback flow.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,6 +94,7 @@
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>15.8.166</MicrosoftBuildPackageVersion>
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
+    <MicrosoftInternalVisualStudioShellEmbeddable>16.4.29305.180</MicrosoftInternalVisualStudioShellEmbeddable>
     <MicrosoftNETCoreApp50PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp50PackageVersion>
     <MicrosoftNetRoslynDiagnosticsPackageVersion>2.6.3</MicrosoftNetRoslynDiagnosticsPackageVersion>
     <MicrosoftVisualStudioCoreUtilityPackageVersion>16.7.66</MicrosoftVisualStudioCoreUtilityPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,9 +94,10 @@
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>15.8.166</MicrosoftBuildPackageVersion>
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
-    <MicrosoftInternalVisualStudioShellEmbeddable>16.4.29305.180</MicrosoftInternalVisualStudioShellEmbeddable>
+    <MicrosoftInternalVisualStudioShellEmbeddablePackageVersion>16.4.29305.180</MicrosoftInternalVisualStudioShellEmbeddablePackageVersion>
     <MicrosoftNETCoreApp50PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp50PackageVersion>
     <MicrosoftNetRoslynDiagnosticsPackageVersion>2.6.3</MicrosoftNetRoslynDiagnosticsPackageVersion>
+    <MicrosoftServiceHubFrameworkPackageVersion>2.6.44</MicrosoftServiceHubFrameworkPackageVersion>
     <MicrosoftVisualStudioCoreUtilityPackageVersion>16.7.66</MicrosoftVisualStudioCoreUtilityPackageVersion>
     <MicrosoftVisualStudioComponentModelHostPackageVersion>16.0.467</MicrosoftVisualStudioComponentModelHostPackageVersion>
     <MicrosoftVisualStudioImageCatalogPackageVersion>16.6.30107.105</MicrosoftVisualStudioImageCatalogPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackLogDirectoryProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackLogDirectoryProvider.cs
@@ -20,6 +20,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
         private string _baseLogDirectory;
         private string _logDirectory;
 
+        public override bool DirectoryCreated => _logDirectory != null;
+
         public override string GetDirectory()
         {
             // Start cleaning up old directories in the background. Fire and forget

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackLogDirectoryProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackLogDirectoryProvider.cs
@@ -5,6 +5,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
 {
     internal abstract class FeedbackLogDirectoryProvider
     {
+        public abstract bool DirectoryCreated { get; }
+
         public abstract string GetDirectory();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/RazorFeedbackDiagnosticFileProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/RazorFeedbackDiagnosticFileProvider.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using Microsoft.Internal.VisualStudio.Shell.Embeddable.Feedback;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    [Shared]
+    [Export(typeof(IFeedbackDiagnosticFileProvider))]
+    internal class RazorFeedbackDiagnosticFileProvider : IFeedbackDiagnosticFileProvider
+    {
+        private readonly FeedbackLogDirectoryProvider _feedbackLogDirectoryProvider;
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+
+        [ImportingConstructor]
+        public RazorFeedbackDiagnosticFileProvider(
+            JoinableTaskContext joinableTaskContext,
+            FeedbackLogDirectoryProvider feedbackLogDirectoryProvider)
+        {
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            if (feedbackLogDirectoryProvider is null)
+            {
+                throw new ArgumentNullException(nameof(feedbackLogDirectoryProvider));
+            }
+
+            _feedbackLogDirectoryProvider = feedbackLogDirectoryProvider;
+            _joinableTaskFactory = joinableTaskContext.Factory;
+        }
+
+        public IReadOnlyCollection<string> GetFiles()
+        {
+            if (!_feedbackLogDirectoryProvider.DirectoryCreated)
+            {
+                // No one requested to create any feedback logs, no reason for us to provide any logs.
+                return Array.Empty<string>();
+            }
+
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
+            var zipFileName = $"RazorLogs_{timestamp}.zip";
+            var zipFilePath = Path.Combine(Path.GetTempPath(), zipFileName);
+            var logDirectory = _feedbackLogDirectoryProvider.GetDirectory();
+            if (!Directory.Exists(logDirectory))
+            {
+                // This should never be the case, just being extra defensive.
+                return Array.Empty<string>();
+            }
+
+            _joinableTaskFactory.RunAsync(() => ZipLogsAsync(logDirectory, zipFilePath));
+
+            return new[] { zipFilePath };
+        }
+
+        private static async Task ZipLogsAsync(string logs, string zipFilePath)
+        {
+            // Because we still have a handle to the log files, we can't zip them. So copy them and then zip the copy
+            var copiedLogs = CopyLogsToDirectory(logs);
+
+            // Start another task to zip this in the background.
+            await Task.Run(() => ZipFile.CreateFromDirectory(copiedLogs, zipFilePath));
+
+            try
+            {
+                if (Directory.Exists(copiedLogs))
+                {
+                    Directory.Delete(copiedLogs, true);
+                }
+            }
+            catch (Exception)
+            {
+                // Swallow any cleanup exceptions, we did our best.
+            }
+        }
+
+        private static string CopyLogsToDirectory(string logs)
+        {
+            var copyLocation = logs + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
+            if (!Directory.Exists(copyLocation))
+            {
+                Directory.CreateDirectory(copyLocation);
+                var dirInfo = new DirectoryInfo(logs);
+                foreach (var file in dirInfo.GetFiles())
+                {
+                    try
+                    {
+                        var toFilepath = Path.Combine(copyLocation, file.Name);
+                        file.CopyTo(toFilepath);
+                    }
+                    catch (Exception)
+                    {
+                        // If we can't copy a log file, indicate that there was one that failed to copy
+                        var failedFilePath = Path.Combine(copyLocation, "FAILED_" + file.Name);
+                        using var failedFile = File.Create(failedFilePath);
+                    }
+                }
+            }
+
+            return copyLocation;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="System.Composition" Version="$(SystemCompositionPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="$(MicrosoftInternalVisualStudioShellEmbeddable)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.16.3.DesignTime" Version="$(MicrosoftVisualStudioShellInterop163DesignTimePackageVersion)" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -19,7 +19,8 @@
   <ItemGroup>
     <PackageReference Include="System.Composition" Version="$(SystemCompositionPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="$(MicrosoftInternalVisualStudioShellEmbeddable)" />
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="$(MicrosoftInternalVisualStudioShellEmbeddablePackageVersion)" />
+    <PackageReference Include="Microsoft.ServiceHub.Framework" Version="$(MicrosoftServiceHubFrameworkPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.16.3.DesignTime" Version="$(MicrosoftVisualStudioShellInterop163DesignTimePackageVersion)" />


### PR DESCRIPTION
- Added a new `RazorFeedbackDiagnosticFileProvider` that serves as the entry point for the VS "report feedback" tool. This is called whenever a user attempts to report feedback and it does the work in order to zip up all of our appropriate logs and feed them to the underlying VS feedback system.
- This isn't enough on its own we need to separately go through an approval process with the feedback team in order to get our log uploads "approved".
- Untestable given it's all file/integration driven.

Fixes dotnet/aspnetcore#24129.2