### PR TITLE
Remove loadpoints for Microsoft.Extensions.*

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public Task InitializedAsync(CancellationToken token) => _innerServer.InitializedAsync(token);
 
-        public static Task<RazorLanguageServer> CreateAsync(Stream input, Stream output, Trace trace, Action<IServiceCollection> configure = null)
+        public static Task<RazorLanguageServer> CreateAsync(Stream input, Stream output, Trace trace, Action<RazorLanguageServerBuilder> configure = null)
         {
             Serializer.Instance.Settings.Converters.Add(SemanticTokensOrSemanticTokensEditsConverter.Instance);
             Serializer.Instance.JsonSerializer.Converters.RegisterRazorConverters();
@@ -107,7 +107,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<RazorDefinitionEndpoint>()
                     .WithServices(services =>
                     {
-                        configure?.Invoke(services);
+                        if (configure != null)
+                        {
+                            var builder = new RazorLanguageServerBuilder(services);
+                            configure(builder);
+                        }
 
                         var filePathNormalizer = new FilePathNormalizer();
                         services.AddSingleton<FilePathNormalizer>(filePathNormalizer);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerBuilder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerBuilder.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class RazorLanguageServerBuilder
+    {
+        public RazorLanguageServerBuilder(IServiceCollection services)
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            Services = services;
+        }
+
+        public IServiceCollection Services { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLoggerProviderFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
             _creationLock = new object();
         }
 
-        public override FeedbackFileLoggerProvider GetOrCreate()
+        public override object GetOrCreate()
         {
             lock (_creationLock)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLogger.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
     {
         private readonly string _categoryName;
         private readonly FeedbackFileLogWriter _feedbackFileLogWriter;
+        private readonly Scope _noopScope;
 
         public FeedbackFileLogger(string categoryName, FeedbackFileLogWriter feedbackFileLogWriter)
         {
@@ -25,9 +26,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
 
             _categoryName = categoryName;
             _feedbackFileLogWriter = feedbackFileLogWriter;
+            _noopScope = new Scope();
         }
 
-        public IDisposable BeginScope<TState>(TState state) => Scope.Instance;
+        public IDisposable BeginScope<TState>(TState state) => _noopScope;
 
         public bool IsEnabled(LogLevel logLevel) => true;
 
@@ -40,8 +42,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
 
         private class Scope : IDisposable
         {
-            public static readonly Scope Instance = new Scope();
-
             public void Dispose()
             {
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProvider.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
         internal const string OmniSharpFrameworkCategoryPrefix = "OmniSharp.Extensions.LanguageServer.Server";
         private const string RazorLanguageServerPrefix = "Microsoft.AspNetCore.Razor.LanguageServer";
         private readonly FeedbackFileLogWriter _feedbackFileLogWriter;
+        private readonly ILogger _noopLogger;
 
         public FeedbackFileLoggerProvider(FeedbackFileLogWriter feedbackFileLogWriter)
         {
@@ -21,6 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
             }
 
             _feedbackFileLogWriter = feedbackFileLogWriter;
+            _noopLogger = new NoopLogger();
         }
 
         public ILogger CreateLogger(string categoryName)
@@ -33,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
             if (categoryName.StartsWith(OmniSharpFrameworkCategoryPrefix, StringComparison.Ordinal))
             {
                 // Loggers created for O# framework pieces should be ignored for feedback. They emit too much noise.
-                return NoopLogger.Instance;
+                return _noopLogger;
             }
 
             if (categoryName.StartsWith(RazorLanguageServerPrefix, StringComparison.Ordinal))
@@ -52,12 +54,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
 
         private class NoopLogger : ILogger
         {
-            public static readonly ILogger Instance = new NoopLogger();
-
-            private NoopLogger()
-            {
-            }
-
             public IDisposable BeginScope<TState>(TState state) => Scope.Instance;
 
             public bool IsEnabled(LogLevel logLevel) => false;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactory.cs
@@ -5,6 +5,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
 {
     internal abstract class FeedbackFileLoggerProviderFactory
     {
-        public abstract FeedbackFileLoggerProvider GetOrCreate();
+        /// <summary>
+        /// Returns a <see cref="FeedbackFileLoggerProvider"/>. This is an optimization to ensure we don't load an extra logging dll at MEF load time in Visual Studio.
+        /// </summary>
+        /// <returns>A created <see cref="FeedbackFileLoggerProvider"/>.</returns>
+        public abstract object GetOrCreate();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -124,14 +124,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return connection;
         }
 
-        private void ConfigureLanguageServer(IServiceCollection services)
+        private void ConfigureLanguageServer(RazorLanguageServerBuilder builder)
         {
-            if (services is null)
+            if (builder is null)
             {
-                throw new ArgumentNullException(nameof(services));
+                throw new ArgumentNullException(nameof(builder));
             }
 
-            var loggerProvider = _feedbackFileLoggerProviderFactory.GetOrCreate();
+            var services = builder.Services;
+            var loggerProvider = (FeedbackFileLoggerProvider)_feedbackFileLoggerProviderFactory.GetOrCreate();
             services.AddSingleton<ILoggerProvider>(loggerProvider);
         }
 


### PR DESCRIPTION
- MEF was auto-loading some additional dependencies because our FeedbackLoggerProviderFactory's signature had an ILogger impl. Changed the return type to `object` to workaround this
- Static's were resulting in some dependency injection/logging assemblies being loaded too eagerly.
- NOTE: This is a best bet at fixing a perf regression. May need to work more at it later. Couldn't reproduce easily sadly.