### PR TITLE
Update Scripts from ASP.NET Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ASP.NET Core Tooling
 ====================
 
 ASP.NET Core is an open-source and cross-platform framework for building modern cloud based internet connected applications, such as web apps, IoT apps and mobile backends.
-This repo contains tools for working on ASP.NET Core apps using the [.NET Core Command Line](https://github.com/dotnet/cli) and [Visual Studio](https://visualstudio.com).
+This repo contains tools for working on ASP.NET Core apps using the [.NET Core Command Line](https://github.com/dotnet/cli), [Visual Studio](https://visualstudio.com) & [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Status   [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/aspnetcore-tooling/aspnetcore-tooling-ci?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=264&branchName=master)
 

--- a/activate.ps1
+++ b/activate.ps1
@@ -1,8 +1,15 @@
 #
 # This file must be used by invoking ". .\activate.ps1" from the command line.
-# You cannot run it directly.
+# You cannot run it directly. See https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scripts#script-scope-and-dot-sourcing
+#
 # To exit from the environment this creates, execute the 'deactivate' function.
 #
+
+if ($MyInvocation.CommandOrigin -eq 'runspace') {
+    Write-Host -f Red "This script cannot be invoked directly."
+    Write-Host -f Red "To function correctly, this script file must be 'dot sourced' by calling `". $PSCommandPath`" (notice the dot at the beginning)."
+    exit 1
+}
 
 function deactivate ([switch]$init) {
 
@@ -31,6 +38,7 @@ deactivate -init
 $_OLD_PATH = $env:PATH
 # Tell dotnet where to find itself
 $env:DOTNET_ROOT = "$PSScriptRoot\.dotnet"
+${env:DOTNET_ROOT(x86)} = "$PSScriptRoot\.dotnet\x86"
 # Tell dotnet not to look beyond the DOTNET_ROOT folder for more dotnet things
 $env:DOTNET_MULTILEVEL_LOOKUP = 0
 # Put dotnet first on PATH

--- a/docs/contributing/BuildFromSource.md
+++ b/docs/contributing/BuildFromSource.md
@@ -77,7 +77,9 @@ Use these command to launch VS Code with the right settings.
 On Windows (requires PowerShell):
 
 ```ps1
-.\activate.ps1
+# The extra dot at the beginning is required to 'dot source' this file into the right scope.
+
+. .\activate.ps1
 code .
 ```
 

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -1,9 +1,11 @@
 @ECHO OFF
+SETLOCAL
 
 :: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET Core SDK.
 
-:: This tells .NET Core to use .dotnet\dotnet.exe
-SET DOTNET_ROOT=%~dp0.dotnet\
+:: This tells .NET Core to use the same dotnet.exe that build scripts use
+SET DOTNET_ROOT=%~dp0.dotnet
+SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
 
 :: This tells .NET Core not to go looking for .NET Core in other places
 SET DOTNET_MULTILEVEL_LOOKUP=0
@@ -11,13 +13,7 @@ SET DOTNET_MULTILEVEL_LOOKUP=0
 :: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
 SET PATH=%DOTNET_ROOT%;%PATH%
 
-SET sln=%1
-
-IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
-    restore.cmd
-)
-
-echo ProTip^: You can drag and drop a solution file onto startvs.cmd
+SET sln=%~1
 
 IF "%sln%"=="" (
     echo Error^: Expected argument ^<SLN_FILE^>
@@ -26,4 +22,9 @@ IF "%sln%"=="" (
     exit /b 1
 )
 
-start %sln%
+IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
+    echo .NET Core has not yet been installed. Run `%~dp0restore.cmd` to install tools
+    exit /b 1
+)
+
+start "" "%sln%"


### PR DESCRIPTION
@ryanbrandenburg pointed out my change from `. .\activate.ps1` to `.\activate.ps1` in the build from source PR README. I've been using `.\activate.ps1` and haven't run into any particular issues, however, it's not the recommended way to source due to [scoping](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scripts#script-scope-and-dot-sourcing). dotnet/aspnetcore enforces this dot sourcing, so I copied over the script changes here.

Also noticed startvs.cmd had changed so brought that over as well.

Thanks @ryanbrandenburg!