### PR TITLE
Fix FormatOnType corner case: Don't let C# formatter clean up non-C# …

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
@@ -47,6 +47,39 @@ triggerCharacter: "}");
         }
 
         [Fact]
+        public async Task CloseCurly_MultipleStatementBlocks()
+        {
+            await RunOnTypeFormattingTestAsync(
+input: @"
+<div>
+    @{
+      if(true) { }
+    }
+</div>
+
+@{
+ if(true)
+{
+ |}|
+}
+",
+expected: @"
+<div>
+    @{
+      if(true) { }
+    }
+</div>
+
+@{
+    if (true)
+    {
+    }
+}
+",
+triggerCharacter: "}");
+        }
+
+        [Fact]
         public async Task Semicolon_Variable_SingleLine()
         {
             await RunOnTypeFormattingTestAsync(


### PR DESCRIPTION
…lines

Part of https://github.com/dotnet/aspnetcore/issues/23530

Before:
```razor
<div>
  @{
    var x = "foo";
}  <-- see this
</div>
...[Invoke FormatOnType somewhere below]
```

After:
```razor
<div>
  @{
    var x = "foo";
  }    <-- see this
</div>
...[Invoke FormatOnType somewhere below]
```