### PR TITLE
 Set noDebug flag on launch url for Blazor WASM apps

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
@@ -103,12 +103,13 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
     }
 
     private async launchBrowser(folder: vscode.WorkspaceFolder | undefined, configuration: vscode.DebugConfiguration) {
+        const setNoDebugFlag = (url: string) => configuration.noDebug ? `${url}?_blazor_debug=false` : url;
         const browser = {
             name: JS_DEBUG_NAME,
             type: configuration.browser === 'edge' ? 'pwa-msedge' : 'pwa-chrome',
             request: 'launch',
             timeout: configuration.timeout || 30000,
-            url: configuration.url || 'https://localhost:5001',
+            url: setNoDebugFlag(configuration.url || 'https://localhost:5001'),
             webRoot: configuration.webRoot || '${workspaceFolder}',
             inspectUri: '{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}',
             trace: configuration.trace || false,


### PR DESCRIPTION
We're adding a query parameter that will be set/unset if the Blazor WASM application is under debug.

This flag will determine whether or not the Mono runtime optimizes execution for debugging or performance.

The flag defaults to true for backwards-compatibility but we'll need to set it to false to disable debugging overhead and improve app performance. This change only affects apps built in Development mode.

This PR should be merged after https://github.com/dotnet/aspnetcore/pull/24972.

Addresses https://github.com/dotnet/aspnetcore/issues/24623
