### PR TITLE
Fix NullReferenceException race in existing editor.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -383,7 +383,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             _dispatcher.AssertForegroundThread();
 
-            _latestChangeReference = _parser.QueueChange(change, snapshot);
+            _latestChangeReference = _parser?.QueueChange(change, snapshot);
         }
 
         private void OnNotifyForegroundIdle()

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -383,6 +383,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             _dispatcher.AssertForegroundThread();
 
+            // _parser can be null if we're in the midst of rebuilding the internal parser (TagHelper refresh/solution teardown)
             _latestChangeReference = _parser?.QueueChange(change, snapshot);
         }
 


### PR DESCRIPTION
- Things are faster now, when we tear down the parser whether it be due to a TagHelper refresh or the solution is tearing down it's possible that our internal parser is `null`. To protect against this I just allowed for it to be `null` and to essentially no-op in these scenarios.

Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1153369

/cc @ToddGrun 
