### PR TITLE
Fix renaming a component that exists in a different directory.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                 return null;
             }
 
-            var newPath = MakeNewPath(requestDocumentSnapshot.FilePath, request.NewName);
+            var newPath = MakeNewPath(originComponentDocumentSnapshot.FilePath, request.NewName);
             if (File.Exists(newPath))
             {
                 return null;


### PR DESCRIPTION
- We were passing in the wrong document snapshot for generating the new path.
- Added a test that validates the correct behavior.

Fixes dotnet/aspnetcore#25018