### PR TITLE
Taparik/vs codeactions 3

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public const string RazorCodeActionRunnerCommand = "razor/runCodeAction";
 
-        public const string RazorCodeActionResolutionEndpoint = "razor/resolveCodeAction";
+        public const string RazorCodeActionResolutionCommand = "razor/resolveCodeAction";
 
         public static class CodeActions
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
@@ -32,14 +32,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         public override string Action => LanguageServerConstants.CodeActions.AddUsing;
 
-        public override async Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
+        public override async Task<WorkspaceEdit> ResolveAsync(object data, CancellationToken cancellationToken)
         {
             if (data is null)
             {
                 return null;
             }
 
-            var actionParams = data.ToObject<AddUsingsCodeActionParams>();
+            if (!(data is AddUsingsCodeActionParams actionParams))
+            {
+                actionParams = (data as JObject)?.ToObject<AddUsingsCodeActionParams>();
+            }
             var path = actionParams.Uri.GetAbsoluteOrUNCPath();
 
             var document = await Task.Factory.StartNew(() =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
@@ -82,7 +82,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             return request;
         }
 
-        private async Task<WorkspaceEdit> GetWorkspaceEditAsync(RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
+        // Internal for testing
+        internal async Task<WorkspaceEdit> GetWorkspaceEditAsync(RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
         {
             _logger.LogDebug($"Resolving workspace edit for action `{resolutionParams.Action}` with data `{resolutionParams.Data}`.");
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
@@ -8,11 +8,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
-    internal class CodeActionResolutionEndpoint : ICodeActionResolutionHandler
+    internal class CodeActionResolutionEndpoint : IRazorCodeActionResolutionHandler, ILSPCodeActionResolverHandler
     {
+        private static readonly string AssociatedServerCapability = "codeActionsResolveProvider";
+
         private readonly IReadOnlyDictionary<string, RazorCodeActionResolver> _resolvers;
         private readonly ILogger _logger;
 
@@ -44,6 +47,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             _resolvers = resolverMap;
         }
 
+        // Register VS LSP code action resolution server capability
+        public RegistrationExtensionResult GetRegistration() => new RegistrationExtensionResult(AssociatedServerCapability, true);
+
+        // Handle the Razor VSCode `razor/resolveCodeAction` command
         public async Task<RazorCodeActionResolutionResponse> Handle(RazorCodeActionResolutionParams request, CancellationToken cancellationToken)
         {
             if (request is null)
@@ -61,6 +68,33 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             var edit = await resolver.ResolveAsync(request.Data, cancellationToken).ConfigureAwait(false);
             return new RazorCodeActionResolutionResponse() { Edit = edit };
+        }
+
+        // Handle the VS LSP `textDocument/codeActionResolve` endpoint
+        public async Task<RazorCodeAction> Handle(RazorCodeAction request, CancellationToken cancellationToken)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (!(request.Data is JObject paramsObj))
+            {
+                Debug.Fail($"Invalid CodeAction Received {request.Title}.");
+                return request;
+            }
+
+            var resolutionParams = paramsObj.ToObject<RazorCodeActionResolutionParams>();
+            _logger.LogDebug($"Resolving action {resolutionParams.Action} with data {resolutionParams.Data}.");
+
+            if (!_resolvers.TryGetValue(resolutionParams.Action, out var resolver))
+            {
+                Debug.Fail($"No resolver registered for {resolutionParams.Action}.");
+                return request;
+            }
+
+            request.Edit = await resolver.ResolveAsync(resolutionParams.Data, cancellationToken).ConfigureAwait(false);
+            return request;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ComponentAccessibilityCodeActionProvider.cs
@@ -15,13 +15,14 @@ using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.Editor.Razor;
-using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal class ComponentAccessibilityCodeActionProvider : RazorCodeActionProvider
     {
+        private static readonly string CreateComponentFromTagTitle = "Create component from tag";
+
         private readonly TagHelperFactsService _tagHelperFactsService;
         private readonly FilePathNormalizer _filePathNormalizer;
 
@@ -33,41 +34,43 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             _filePathNormalizer = filePathNormalizer ?? throw new ArgumentNullException(nameof(filePathNormalizer));
         }
 
-        public override Task<CommandOrCodeActionContainer> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
+        private static Task<RazorCodeAction[]> EmptyResult => Task.FromResult<RazorCodeAction[]>(null);
+
+        public override Task<RazorCodeAction[]> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
         {
-            var commandOrCodeActions = new List<CommandOrCodeAction>();
+            var codeActions = new List<RazorCodeAction>();
 
             // Locate cursor
             var change = new SourceChange(context.Location.AbsoluteIndex, length: 0, newText: string.Empty);
             var node = context.CodeDocument.GetSyntaxTree().Root.LocateOwner(change);
             if (node is null)
             {
-                return Task.FromResult<CommandOrCodeActionContainer>(null);
+                return EmptyResult;
             }
 
             // Find start tag
             var startTag = (MarkupStartTagSyntax)node.Ancestors().FirstOrDefault(n => n is MarkupStartTagSyntax);
             if (startTag is null)
             {
-                return Task.FromResult<CommandOrCodeActionContainer>(null);
+                return EmptyResult;
             }
 
             // Ignore if start tag has dots, as we only handle short tags
             if (startTag.Name.Content.Contains("."))
             {
-                return Task.FromResult<CommandOrCodeActionContainer>(null);
+                return EmptyResult;
             }
 
             if (IsTagUnknown(startTag, context))
             {
-                AddComponentAccessFromTag(context, startTag, commandOrCodeActions);
-                AddCreateComponentFromTag(context, startTag, commandOrCodeActions);
+                AddComponentAccessFromTag(context, startTag, codeActions);
+                AddCreateComponentFromTag(context, startTag, codeActions);
             }
 
-            return Task.FromResult(new CommandOrCodeActionContainer(commandOrCodeActions));
+            return Task.FromResult(codeActions.ToArray());
         }
 
-        private void AddCreateComponentFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<CommandOrCodeAction> container)
+        private void AddCreateComponentFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<RazorCodeAction> container)
         {
             var path = context.Request.TextDocument.Uri.GetAbsoluteOrUNCPath();
             path = _filePathNormalizer.Normalize(path);
@@ -82,25 +85,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 Uri = context.Request.TextDocument.Uri,
                 Path = newComponentPath,
             };
-            var data = JObject.FromObject(actionParams);
 
             var resolutionParams = new RazorCodeActionResolutionParams
             {
                 Action = LanguageServerConstants.CodeActions.CreateComponentFromTag,
-                Data = data,
+                Data = actionParams,
             };
-            var serializedParams = JToken.FromObject(resolutionParams);
-            var arguments = new JArray(serializedParams);
 
-            container.Add(new CommandOrCodeAction(new Command
+            container.Add(new RazorCodeAction()
             {
-                Title = "Create component from tag",
-                Name = LanguageServerConstants.RazorCodeActionRunnerCommand,
-                Arguments = arguments,
-            }));
+                Title = CreateComponentFromTagTitle,
+                Data = resolutionParams
+            });
         }
 
-        private void AddComponentAccessFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<CommandOrCodeAction> container)
+        private void AddComponentAccessFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<RazorCodeAction> container)
         {
             var matching = FindMatchingTagHelpers(context, startTag);
 
@@ -115,35 +114,32 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 var fullyQualifiedComponentName = tagHelperPair.Short.Name;  // We assume .Name is the fully qualified component name
                 DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(fullyQualifiedComponentName, out var namespaceSpan, out var _);
                 var namespaceName = tagHelperPair.Short.Name.Substring(namespaceSpan.Start, namespaceSpan.Length);
+
                 var actionParams = new AddUsingsCodeActionParams
                 {
                     Uri = context.Request.TextDocument.Uri,
                     Namespace = namespaceName,
                 };
-                var data = JObject.FromObject(actionParams);
 
                 var resolutionParams = new RazorCodeActionResolutionParams
                 {
                     Action = LanguageServerConstants.CodeActions.AddUsing,
-                    Data = data,
+                    Data = actionParams,
                 };
-                var serializedParams = JToken.FromObject(resolutionParams);
-                var arguments = new JArray(serializedParams);
 
                 // Insert @using
-                container.Add(new CommandOrCodeAction(new Command
+                container.Add(new RazorCodeAction()
                 {
                     Title = $"@using {namespaceName}",
-                    Name = LanguageServerConstants.RazorCodeActionRunnerCommand,
-                    Arguments = arguments,
-                }));
+                    Data = resolutionParams
+                });
 
                 // Fully qualify
-                container.Add(new CommandOrCodeAction(new CodeAction
+                container.Add(new RazorCodeAction()
                 {
                     Title = $"{tagHelperPair.Short.Name}",
                     Edit = CreateRenameTagEdit(context, startTag, tagHelperPair.Short.Name),
-                }));
+                });
             }
         }
 
@@ -160,6 +156,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             {
                 parentTagName = parentTagHelperElement.StartTag.Name.Content;
             }
+
             var attributes = _tagHelperFactsService.StringifyAttributes(startTag.Attributes);
 
             // Find all matching tag helpers
@@ -197,6 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     NewText = newTagName,
                 },
             };
+
             var endTag = (startTag.Parent as MarkupElementSyntax).EndTag;
             if (endTag != null)
             {
@@ -206,18 +204,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     NewText = newTagName,
                 });
             }
+
             return new WorkspaceEdit
             {
                 Changes = new Dictionary<Uri, IEnumerable<TextEdit>> {
                     [context.Request.TextDocument.Uri] = changes,
                 }
             };
-        }
-
-        private sealed class TagHelperPair
-        {
-            public TagHelperDescriptor Short = null;
-            public TagHelperDescriptor FullyQualified = null;
         }
 
         private bool IsTagUnknown(MarkupStartTagSyntax startTag, RazorCodeActionContext context)
@@ -235,6 +228,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 }
             }
             return false;
+        }
+
+        private sealed class TagHelperPair
+        {
+            public TagHelperDescriptor Short = null;
+            public TagHelperDescriptor FullyQualified = null;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CreateComponentCodeActionResolver.cs
@@ -32,14 +32,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         public override string Action => LanguageServerConstants.CodeActions.CreateComponentFromTag;
 
-        public override async Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
+        public override async Task<WorkspaceEdit> ResolveAsync(object data, CancellationToken cancellationToken)
         {
             if (data is null)
             {
                 return null;
             }
 
-            var actionParams = data.ToObject<CreateComponentCodeActionParams>();
+            if (!(data is CreateComponentCodeActionParams actionParams))
+            {
+                actionParams = (data as JObject)?.ToObject<CreateComponentCodeActionParams>();
+            }
+
             var path = actionParams.Uri.GetAbsoluteOrUNCPath();
 
             var document = await Task.Factory.StartNew(() =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ExtractToCodeBehindCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ExtractToCodeBehindCodeActionProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -14,16 +13,16 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Newtonsoft.Json.Linq;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal class ExtractToCodeBehindCodeActionProvider : RazorCodeActionProvider
     {
-        private static readonly Task<CommandOrCodeActionContainer> EmptyResult = Task.FromResult<CommandOrCodeActionContainer>(null);
+        private static readonly string Title = "Extract block to code behind";
 
-        override public Task<CommandOrCodeActionContainer> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
+        private static Task<RazorCodeAction[]> EmptyResult => Task.FromResult<RazorCodeAction[]>(null);
+
+        public override Task<RazorCodeAction[]> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
         {
             if (context is null)
             {
@@ -56,7 +55,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             }
 
             // Make sure we've found a @code or @functions
-            if (directiveNode.DirectiveDescriptor != ComponentCodeDirective.Directive && directiveNode.DirectiveDescriptor != FunctionsDirective.Directive)
+            if (directiveNode.DirectiveDescriptor != ComponentCodeDirective.Directive &&
+                directiveNode.DirectiveDescriptor != FunctionsDirective.Directive)
             {
                 return EmptyResult;
             }
@@ -67,19 +67,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return EmptyResult;
             }
 
-            var cSharpCodeBlockNode = directiveNode.Body.DescendantNodes().FirstOrDefault(n => n is CSharpCodeBlockSyntax);
-            if (cSharpCodeBlockNode is null)
+            var csharpCodeBlockNode = directiveNode.Body.DescendantNodes().FirstOrDefault(n => n is CSharpCodeBlockSyntax);
+            if (csharpCodeBlockNode is null)
             {
                 return EmptyResult;
             }
 
-            if (HasUnsupportedChildren(cSharpCodeBlockNode))
+            if (HasUnsupportedChildren(csharpCodeBlockNode))
             {
                 return EmptyResult;
             }
 
             // Do not provide code action if the cursor is inside the code block
-            if (context.Location.AbsoluteIndex > cSharpCodeBlockNode.SpanStart)
+            if (context.Location.AbsoluteIndex > csharpCodeBlockNode.SpanStart)
             {
                 return EmptyResult;
             }
@@ -87,37 +87,33 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var actionParams = new ExtractToCodeBehindCodeActionParams()
             {
                 Uri = context.Request.TextDocument.Uri,
-                ExtractStart = cSharpCodeBlockNode.Span.Start,
-                ExtractEnd = cSharpCodeBlockNode.Span.End,
+                ExtractStart = csharpCodeBlockNode.Span.Start,
+                ExtractEnd = csharpCodeBlockNode.Span.End,
                 RemoveStart = directiveNode.Span.Start,
                 RemoveEnd = directiveNode.Span.End
             };
-            var data = JObject.FromObject(actionParams);
 
             var resolutionParams = new RazorCodeActionResolutionParams()
             {
                 Action = LanguageServerConstants.CodeActions.ExtractToCodeBehindAction,
-                Data = data,
+                Data = actionParams,
             };
-            var serializedParams = JToken.FromObject(resolutionParams);
-            var arguments = new JArray(serializedParams);
 
-            var container = new List<CommandOrCodeAction>
+            var codeAction = new RazorCodeAction()
             {
-                new Command()
-                {
-                    Title = "Extract block to code behind",
-                    Name = LanguageServerConstants.RazorCodeActionRunnerCommand,
-                    Arguments = arguments,
-                }
+                Title = Title,
+                Data = resolutionParams
             };
 
-            return Task.FromResult((CommandOrCodeActionContainer)container);
+            return Task.FromResult(new[] { codeAction });
         }
 
         private static bool HasUnsupportedChildren(Language.Syntax.SyntaxNode node)
         {
-            return node.DescendantNodes().Any(n => n is MarkupBlockSyntax || n is CSharpTransitionSyntax || n is RazorCommentBlockSyntax);
+            return node.DescendantNodes().Any(n =>
+                n is MarkupBlockSyntax ||
+                n is CSharpTransitionSyntax ||
+                n is RazorCommentBlockSyntax);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ExtractToCodeBehindCodeActionResolver.cs
@@ -43,14 +43,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         public override string Action => LanguageServerConstants.CodeActions.ExtractToCodeBehindAction;
 
-        public override async Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
+        public override async Task<WorkspaceEdit> ResolveAsync(object data, CancellationToken cancellationToken)
         {
             if (data is null)
             {
                 return null;
             }
 
-            var actionParams = data.ToObject<ExtractToCodeBehindCodeActionParams>();
+            if (!(data is ExtractToCodeBehindCodeActionParams actionParams))
+            {
+                actionParams = (data as JObject)?.ToObject<ExtractToCodeBehindCodeActionParams>();
+            }
+
             var path = _filePathNormalizer.Normalize(actionParams.Uri.GetAbsoluteOrUNCPath());
 
             var document = await Task.Factory.StartNew(() =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ICodeActionResolutionHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ICodeActionResolutionHandler.cs
@@ -7,7 +7,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
-    [Serial, Method(LanguageServerConstants.RazorCodeActionResolutionEndpoint)]
+    [Serial, Method(LanguageServerConstants.RazorCodeActionResolutionCommand)]
     internal interface ICodeActionResolutionHandler : IJsonRpcRequestHandler<RazorCodeActionResolutionParams, RazorCodeActionResolutionResponse>
     {
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ILSPCodeActionResolverHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ILSPCodeActionResolverHandler.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
+{
+    [Serial, Method("textDocument/codeActionResolve")]
+    internal interface ILSPCodeActionResolverHandler :
+        IJsonRpcRequestHandler<RazorCodeAction, RazorCodeAction>,
+        IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IRazorCodeActionResolutionHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IRazorCodeActionResolutionHandler.cs
@@ -8,7 +8,8 @@ using OmniSharp.Extensions.JsonRpc;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     [Serial, Method(LanguageServerConstants.RazorCodeActionResolutionCommand)]
-    internal interface ICodeActionResolutionHandler : IJsonRpcRequestHandler<RazorCodeActionResolutionParams, RazorCodeActionResolutionResponse>
+    internal interface IRazorCodeActionResolutionHandler :
+        IJsonRpcRequestHandler<RazorCodeActionResolutionParams, RazorCodeActionResolutionResponse>
     {
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeAction.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeAction.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using MediatR;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
+{
+    [JsonObject]
+    public class RazorCodeAction : CodeAction, IRequest<RazorCodeAction>, IBaseRequest
+    {
+        public RazorCodeAction()
+        {
+        }
+
+        [JsonProperty(PropertyName = "title", Required = Required.Always)]
+        public new string Title { get; set; }
+
+        [JsonProperty(PropertyName = "kind", NullValueHandling = NullValueHandling.Ignore)]
+        public new CodeActionKind Kind { get; set; }
+
+        [JsonProperty(PropertyName = "diagnostics", NullValueHandling = NullValueHandling.Ignore)]
+        public new Container<Diagnostic> Diagnostics { get; set; }
+
+        [JsonProperty(PropertyName = "edit", NullValueHandling = NullValueHandling.Ignore)]
+        public new WorkspaceEdit Edit { get; set; }
+
+        [JsonProperty(PropertyName = "command", NullValueHandling = NullValueHandling.Ignore)]
+        public new Command Command { get; set; }
+
+        [JsonProperty(PropertyName = "data", NullValueHandling = NullValueHandling.Ignore)]
+        public object Data { get; set; }
+
+        [JsonProperty(PropertyName = "children")]
+        public RazorCodeAction[] Children { get; set; } = Array.Empty<RazorCodeAction>();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
+{
+    internal static class RazorCodeActionExtensions
+    {
+        public static CommandOrCodeAction AsOmnisharpCommandOrCodeAction(this RazorCodeAction razorCodeAction)
+        {
+            if (razorCodeAction.Data is null)
+            {
+                // No command data
+                return new CommandOrCodeAction(new CodeAction()
+                {
+                    Title = razorCodeAction.Title ?? string.Empty,
+                    Edit = razorCodeAction.Edit,
+                    Diagnostics = razorCodeAction.Diagnostics,
+                    Kind = razorCodeAction.Kind,
+                    Command = razorCodeAction.Command
+                });
+            }
+
+            var serializedParams = JToken.FromObject(razorCodeAction.Data);
+            var arguments = new JArray(serializedParams);
+
+            return new CommandOrCodeAction(new Command
+            {
+                Title = razorCodeAction.Title ?? string.Empty,
+                Name = LanguageServerConstants.RazorCodeActionRunnerCommand,
+                Arguments = arguments
+            });
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionResolutionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionResolutionParams.cs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using MediatR;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
 {
     internal class RazorCodeActionResolutionParams : IRequest<RazorCodeActionResolutionResponse>
     {
         public string Action { get; set; }
-        public JObject Data { get; set; }
+        public object Data { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionProvider.cs
@@ -3,12 +3,12 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal abstract class RazorCodeActionProvider
     {
-        public abstract Task<CommandOrCodeActionContainer> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken);
+        public abstract Task<RazorCodeAction[]> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionResolver.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
@@ -12,6 +11,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
     {
         public abstract string Action { get; }
 
-        public abstract Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken);
+        public abstract Task<WorkspaceEdit> ResolveAsync(object data, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
@@ -148,8 +148,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentChanges = workspaceEdit.DocumentChanges.ToArray();
             var addUsingsChange = documentChanges[0];
             Assert.True(addUsingsChange.IsTextDocumentEdit);
-            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
-            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            var firstEdit = Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
             Assert.Equal(1, firstEdit.Range.Start.Line);
             Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
         }
@@ -182,8 +181,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentChanges = workspaceEdit.DocumentChanges.ToArray();
             var addUsingsChange = documentChanges[0];
             Assert.True(addUsingsChange.IsTextDocumentEdit);
-            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
-            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            var firstEdit = Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
             Assert.Equal(0, firstEdit.Range.Start.Line);
             Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
         }
@@ -216,8 +214,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentChanges = workspaceEdit.DocumentChanges.ToArray();
             var addUsingsChange = documentChanges[0];
             Assert.True(addUsingsChange.IsTextDocumentEdit);
-            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
-            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            var firstEdit = Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
             Assert.Equal(1, firstEdit.Range.Start.Line);
             Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
         }
@@ -250,8 +247,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentChanges = workspaceEdit.DocumentChanges.ToArray();
             var addUsingsChange = documentChanges[0];
             Assert.True(addUsingsChange.IsTextDocumentEdit);
-            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
-            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            var firstEdit = Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
             Assert.Equal(2, firstEdit.Range.Start.Line);
             Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
         }
@@ -284,8 +280,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentChanges = workspaceEdit.DocumentChanges.ToArray();
             var addUsingsChange = documentChanges[0];
             Assert.True(addUsingsChange.IsTextDocumentEdit);
-            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
-            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            var firstEdit = Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
             Assert.Equal(1, firstEdit.Range.Start.Line);
             Assert.Equal($"@using System.Linq{Environment.NewLine}", firstEdit.NewText);
         }
@@ -317,9 +312,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
 
             var documentChanges = workspaceEdit.DocumentChanges.ToArray();
             var addUsingsChange = documentChanges[0];
-            Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
             Assert.True(addUsingsChange.IsTextDocumentEdit);
-            var firstEdit = addUsingsChange.TextDocumentEdit.Edits.First();
+            var firstEdit = Assert.Single(addUsingsChange.TextDocumentEdit.Edits);
             Assert.Equal(2, firstEdit.Range.Start.Line);
             Assert.Equal($"@using Microsoft.AspNetCore.Razor.Language{Environment.NewLine}", firstEdit.NewText);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Threading;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -17,19 +16,22 @@ using Moq;
 using Xunit;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using OmniSharp.Extensions.LanguageServer.Server;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
 {
     public class CodeActionEndpointTest : LanguageServerTestBase
     {
         private readonly DocumentResolver EmptyDocumentResolver = Mock.Of<DocumentResolver>();
+        private readonly ILanguageServer LanguageServer = Mock.Of<ILanguageServer>();
 
         [Fact]
         public async Task Handle_NoDocument()
         {
             // Arrange
             var documentPath = "C:/path/to/Page.razor";
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, EmptyDocumentResolver, LoggerFactory);
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, EmptyDocumentResolver, LanguageServer);
             var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -51,7 +53,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var codeDocument = CreateCodeDocument("@code {}");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             codeDocument.SetUnsupported();
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LoggerFactory);
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer);
             var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -72,7 +74,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentPath = "C:/path/to/Page.razor";
             var codeDocument = CreateCodeDocument("@code {}");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LoggerFactory);
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer);
             var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -95,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             var codeActionEndpoint = new CodeActionEndpoint(new RazorCodeActionProvider[] {
                 new MockCodeActionProvider()
-            }, Dispatcher, documentResolver, LoggerFactory);
+            }, Dispatcher, documentResolver, LanguageServer);
 
             var request = new CodeActionParams()
             {
@@ -122,7 +124,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockCodeActionProvider(),
                 new MockCodeActionProvider(),
                 new MockCodeActionProvider(),
-            }, Dispatcher, documentResolver, LoggerFactory);
+            }, Dispatcher, documentResolver, LanguageServer);
 
             var request = new CodeActionParams()
             {
@@ -146,7 +148,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             var codeActionEndpoint = new CodeActionEndpoint(new RazorCodeActionProvider[] {
                 new NullMockCodeActionProvider()
-            }, Dispatcher, documentResolver, LoggerFactory);
+            }, Dispatcher, documentResolver, LanguageServer);
 
             var request = new CodeActionParams()
             {
@@ -173,7 +175,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new NullMockCodeActionProvider(),
                 new MockCodeActionProvider(),
                 new NullMockCodeActionProvider(),
-            }, Dispatcher, documentResolver, LoggerFactory);
+            }, Dispatcher, documentResolver, LanguageServer);
 
             var request = new CodeActionParams()
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
@@ -86,7 +85,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 Action = action;
             }
 
-            public override Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
+            public override Task<WorkspaceEdit> ResolveAsync(object data, CancellationToken cancellationToken)
             {
                 return Task.FromResult(new WorkspaceEdit());
             }
@@ -101,7 +100,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 Action = action;
             }
 
-            public override Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
+            public override Task<WorkspaceEdit> ResolveAsync(object data, CancellationToken cancellationToken)
             {
                 return null;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ComponentAccessibilityCodeActionProviderTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Language;
@@ -90,10 +89,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
             // Assert
-            Assert.Equal(3, commandOrCodeActionContainer.Count());
-            Assert.Equal("@using Fully.Qualified", commandOrCodeActionContainer.ElementAt(0).Command.Title);
-            Assert.Equal("Fully.Qualified.Component", commandOrCodeActionContainer.ElementAt(1).CodeAction.Title);
-            Assert.Equal("Create component from tag", commandOrCodeActionContainer.ElementAt(2).Command.Title) ;
+            Assert.Collection(commandOrCodeActionContainer,
+                e =>
+                {
+                    Assert.Equal("@using Fully.Qualified", e.Title);
+                    Assert.NotNull(e.Data);
+                    Assert.Null(e.Edit);
+                },
+                e =>
+                {
+                    Assert.Equal("Fully.Qualified.Component", e.Title);
+                    Assert.NotNull(e.Edit);
+                    Assert.Null(e.Data);
+                },
+                e =>
+                {
+                    Assert.Equal("Create component from tag", e.Title);
+                    Assert.NotNull(e.Data);
+                    Assert.Null(e.Edit);
+                });
         }
 
         [Fact]
@@ -117,8 +131,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
             // Assert
-            Assert.Single(commandOrCodeActionContainer);
-            Assert.Equal("Create component from tag", commandOrCodeActionContainer.ElementAt(0).Command.Title);
+            var command = Assert.Single(commandOrCodeActionContainer);
+            Assert.Equal("Create component from tag", command.Title);
+            Assert.NotNull(command.Data);
         }
 
         private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, SourceSpan componentSourceSpan)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Language;
@@ -163,11 +162,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
             // Assert
-            Assert.Single(commandOrCodeActionContainer);
-            var actionParams = commandOrCodeActionContainer
-                .First().Command.Arguments[0]
-                .ToObject<RazorCodeActionResolutionParams>().Data
-                .ToObject<ExtractToCodeBehindCodeActionParams>();
+            var codeAction = Assert.Single(commandOrCodeActionContainer);
+            var razorCodeActionResolutionParams = codeAction.Data as RazorCodeActionResolutionParams;
+            var actionParams = razorCodeActionResolutionParams.Data as ExtractToCodeBehindCodeActionParams;
             Assert.Equal(14, actionParams.RemoveStart);
             Assert.Equal(19, actionParams.ExtractStart);
             Assert.Equal(42, actionParams.ExtractEnd);
@@ -195,11 +192,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
             // Assert
-            Assert.Single(commandOrCodeActionContainer);
-            var actionParams = commandOrCodeActionContainer
-                .First().Command.Arguments[0]
-                .ToObject<RazorCodeActionResolutionParams>().Data
-                .ToObject<ExtractToCodeBehindCodeActionParams>();
+            var codeAction = Assert.Single(commandOrCodeActionContainer);
+            var razorCodeActionResolutionParams = codeAction.Data as RazorCodeActionResolutionParams;
+            var actionParams = razorCodeActionResolutionParams.Data as ExtractToCodeBehindCodeActionParams;
             Assert.Equal(14, actionParams.RemoveStart);
             Assert.Equal(24, actionParams.ExtractStart);
             Assert.Equal(47, actionParams.ExtractEnd);


### PR DESCRIPTION
### Summary of the changes
- Razor Code Actions support for Add Using + Fully Qualified Namespace for Tags
    - ![FullyQualifyAddUsing](https://user-images.githubusercontent.com/14852843/90831706-2abd3b00-e2f9-11ea-9ddb-9c8a87567b75.gif)
- Extract to Component & Create Component should just work, however haven't had a chance to test them out yet as the create document commands aren't currently available directly. 
- Support for both VS + VS Code Code Actions
- Added/updated tests
 - Note seeing this sometimes: https://github.com/dotnet/aspnetcore/issues/25105
    - Background document is "correct"
    - Investigating still

Fixes: https://github.com/dotnet/aspnetcore/issues/23985
