### PR TITLE
Start mapping TextSpans in our pre-existing RazorSpanMappingService.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSpanMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSpanMappingService.cs
@@ -54,9 +54,9 @@ namespace Microsoft.CodeAnalysis.Razor
             var results = ImmutableArray.CreateBuilder<RazorMappedSpanResult>();
             foreach (var span in spans)
             {
-                if (TryGetLinePositionSpan(span, source, output.GetCSharpDocument(), out var linePositionSpan))
+                if (TryGetMappedSpans(span, source, output.GetCSharpDocument(), out var linePositionSpan, out var mappedSpan))
                 {
-                    results.Add(new RazorMappedSpanResult(output.Source.FilePath, linePositionSpan, span));
+                    results.Add(new RazorMappedSpanResult(output.Source.FilePath, linePositionSpan, mappedSpan));
                 }
                 else
                 {
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Razor
         }
 
         // Internal for testing.
-        internal static bool TryGetLinePositionSpan(TextSpan span, SourceText source, RazorCSharpDocument output, out LinePositionSpan linePositionSpan)
+        internal static bool TryGetMappedSpans(TextSpan span, SourceText source, RazorCSharpDocument output, out LinePositionSpan linePositionSpan, out TextSpan mappedSpan)
         {
             var mappings = output.SourceMappings;
             for (var i = 0; i < mappings.Count; i++)
@@ -89,12 +89,13 @@ namespace Microsoft.CodeAnalysis.Razor
                 if (leftOffset >= 0 && rightOffset <= 0)
                 {
                     // This span mapping contains the span.
-                    var adjusted = new TextSpan(original.Start + leftOffset, (original.End + rightOffset) - (original.Start + leftOffset));
-                    linePositionSpan = source.Lines.GetLinePositionSpan(adjusted);
+                    mappedSpan = new TextSpan(original.Start + leftOffset, (original.End + rightOffset) - (original.Start + leftOffset));
+                    linePositionSpan = source.Lines.GetLinePositionSpan(mappedSpan);
                     return true;
                 }
             }
 
+            mappedSpan = default;
             linePositionSpan = default;
             return false;
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorSpanMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorSpanMappingServiceTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Razor
         }
 
         [Fact]
-        public async Task TryGetLinePositionSpan_SpanMatchesSourceMapping_ReturnsTrue()
+        public async Task TryGetMappedSpans_SpanMatchesSourceMapping_ReturnsTrue()
         {
             // Arrange
             var sourceText = SourceText.From(@"
@@ -53,15 +53,16 @@ namespace Microsoft.CodeAnalysis.Razor
             var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal), symbol.Length);
 
             // Act
-            var result = RazorSpanMappingService.TryGetLinePositionSpan(span, await document.GetTextAsync(), generated, out var mapped);
+            var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out var mappedLinePositionSpan, out var mappedSpan);
             
             // Assert
             Assert.True(result);
-            Assert.Equal(new LinePositionSpan(new LinePosition(1, 1), new LinePosition(1, 13)), mapped);
+            Assert.Equal(new LinePositionSpan(new LinePosition(1, 1), new LinePosition(1, 13)), mappedLinePositionSpan);
+            Assert.Equal(new TextSpan(Environment.NewLine.Length + 1, symbol.Length), mappedSpan);
         }
 
         [Fact]
-        public async Task TryGetLinePositionSpan_SpanMatchesSourceMappingAndPosition_ReturnsTrue()
+        public async Task TryGetMappedSpans_SpanMatchesSourceMappingAndPosition_ReturnsTrue()
         {
             // Arrange
             var sourceText = SourceText.From(@"
@@ -88,15 +89,16 @@ namespace Microsoft.CodeAnalysis.Razor
             var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal) + symbol.Length, StringComparison.Ordinal), symbol.Length);
 
             // Act
-            var result = RazorSpanMappingService.TryGetLinePositionSpan(span, await document.GetTextAsync(), generated, out var mapped);
+            var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out var mappedLinePositionSpan, out var mappedSpan);
 
             // Assert
             Assert.True(result);
-            Assert.Equal(new LinePositionSpan(new LinePosition(2, 1), new LinePosition(2, 13)), mapped);
+            Assert.Equal(new LinePositionSpan(new LinePosition(2, 1), new LinePosition(2, 13)), mappedLinePositionSpan);
+            Assert.Equal(new TextSpan(Environment.NewLine.Length + 1 + symbol.Length + Environment.NewLine.Length + 1, symbol.Length), mappedSpan);
         }
 
         [Fact]
-        public async Task TryGetLinePositionSpan_SpanWithinSourceMapping_ReturnsTrue()
+        public async Task TryGetMappedSpans_SpanWithinSourceMapping_ReturnsTrue()
         {
             // Arrange
             var sourceText = SourceText.From(@"
@@ -122,15 +124,16 @@ namespace Microsoft.CodeAnalysis.Razor
             var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal), symbol.Length);
 
             // Act
-            var result = RazorSpanMappingService.TryGetLinePositionSpan(span, await document.GetTextAsync(), generated, out var mapped);
+            var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out var mappedLinePositionSpan, out var mappedSpan);
 
             // Assert
             Assert.True(result);
-            Assert.Equal(new LinePositionSpan(new LinePosition(2, 22), new LinePosition(2, 34)), mapped);
+            Assert.Equal(new LinePositionSpan(new LinePosition(2, 22), new LinePosition(2, 34)), mappedLinePositionSpan);
+            Assert.Equal(new TextSpan(Environment.NewLine.Length + 2 + Environment.NewLine.Length + "    var x = SomeClass.".Length, symbol.Length), mappedSpan);
         }
 
         [Fact]
-        public async Task TryGetLinePositionSpan_SpanOutsideSourceMapping_ReturnsFalse()
+        public async Task TryGetMappedSpans_SpanOutsideSourceMapping_ReturnsFalse()
         {
             // Arrange
             var sourceText = SourceText.From(@"
@@ -156,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Razor
             var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal), symbol.Length);
 
             // Act
-            var result = RazorSpanMappingService.TryGetLinePositionSpan(span, await document.GetTextAsync(), generated, out var mapped);
+            var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out var mappedLinePositionSpan, out var mappedSpan);
 
             // Assert
             Assert.False(result);


### PR DESCRIPTION
- To enable Roslyn to allow C# rename for closed Razor files we need to be providing `TextSpans` with appropriate mappings
- Updated tests to account for new mapping information.

Fixes dotnet/aspnetcore#25113