### PR TITLE
Add Microsoft.Extensions.Primitives to extension

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyCodeBases.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyCodeBases.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\MediatR.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\MediatR.Extensions.Microsoft.DependencyInjection.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Options.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Primitives.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.DependencyInjection.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.DependencyInjection.Abstractions.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Configuration.Json.dll")]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -98,6 +98,7 @@
     <VSIXSourceItem Include="$(OutputPath)MediatR.dll" />
     <VSIXSourceItem Include="$(OutputPath)MediatR.Extensions.Microsoft.DependencyInjection.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Options.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Primitives.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.DependencyInjection.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.Json.dll" />

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -37,6 +37,7 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="MediatR.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="MediatR.Extensions.Microsoft.DependencyInjection.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Options.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Primitives.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.DependencyInjection.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Configuration.Json.dll" />


### PR DESCRIPTION
- This is required at ngen time and now that WTE has removed their Microsoft.Extensions.Primtivies codebase entry VS can't load this dependency at ngen time and I assume runtime?