### PR TITLE
Disable File Operation Based CodeActions in Liveshare/Codespaces

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
             var location = new SourceLocation(hostDocumentIndex, (int)request.Range.Start.Line, (int)request.Range.Start.Character);
 
-            var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, _languageServerFeatureOptions.SupportsFileCreation);
+            var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, _languageServerFeatureOptions.SupportsFileManipulation);
             var tasks = new List<Task<RazorCodeAction[]>>();
 
             if (cancellationToken.IsCancellationRequested)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentResolver _documentResolver;
         private readonly ILanguageServer _languageServer;
-        private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
         private CodeActionCapability _capability;
 
@@ -37,19 +37,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             ForegroundDispatcher foregroundDispatcher,
             DocumentResolver documentResolver,
             ILanguageServer languageServer,
-            LSPEditorFeatureDetector lspEditorFeatureDetector)
+            LanguageServerFeatureOptions languageServerFeatureOptions)
         {
             _providers = providers ?? throw new ArgumentNullException(nameof(providers));
             _foregroundDispatcher = foregroundDispatcher ?? throw new ArgumentNullException(nameof(foregroundDispatcher));
             _documentResolver = documentResolver ?? throw new ArgumentNullException(nameof(documentResolver));
             _languageServer = languageServer ?? throw new ArgumentNullException(nameof(languageServer));
-            _lspEditorFeatureDetector = lspEditorFeatureDetector ?? throw new ArgumentNullException(nameof(lspEditorFeatureDetector));
+            _languageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentNullException(nameof(languageServerFeatureOptions));
         }
-
-        // We don't current support file creation operations on Codespaces or Liveshare
-        internal bool IsVS => _supportsCodeActionResolve;
-        internal bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
-        internal bool SupportsFileCreation => !IsVS || !IsCodespacesOrLiveshare;
 
         public CodeActionRegistrationOptions GetRegistrationOptions()
         {
@@ -124,7 +119,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
             var location = new SourceLocation(hostDocumentIndex, (int)request.Range.Start.Line, (int)request.Range.Start.Character);
 
-            var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, SupportsFileCreation);
+            var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, _languageServerFeatureOptions.SupportsFileCreation);
             var tasks = new List<Task<RazorCodeAction[]>>();
 
             if (cancellationToken.IsCancellationRequested)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ComponentAccessibilityCodeActionProvider.cs
@@ -71,6 +71,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         private void AddCreateComponentFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<RazorCodeAction> container)
         {
+            if (context is null)
+            {
+                return;
+            }
+
+            if (!context.SupportsFileCreation)
+            {
+                return;
+            }
+
             var path = context.Request.TextDocument.Uri.GetAbsoluteOrUNCPath();
             path = _filePathNormalizer.Normalize(path);
             var newComponentPath = Path.Combine(Path.GetDirectoryName(path), $"{startTag.Name.Content}.razor");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ExtractToCodeBehindCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/ExtractToCodeBehindCodeActionProvider.cs
@@ -29,6 +29,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return EmptyResult;
             }
 
+            if (!context.SupportsFileCreation)
+            {
+                return EmptyResult;
+            }
+
             if (!FileKinds.IsComponent(context.CodeDocument.GetFileKind()))
             {
                 return EmptyResult;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
@@ -10,17 +10,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal sealed class RazorCodeActionContext
     {
-        public RazorCodeActionContext(CodeActionParams request, DocumentSnapshot documentSnapshot, RazorCodeDocument codeDocument, SourceLocation location)
+        public RazorCodeActionContext(
+            CodeActionParams request,
+            DocumentSnapshot documentSnapshot,
+            RazorCodeDocument codeDocument,
+            SourceLocation location,
+            bool supportsFileCreation)
         {
             Request = request ?? throw new ArgumentNullException(nameof(request));
             DocumentSnapshot = documentSnapshot ?? throw new ArgumentNullException(nameof(documentSnapshot));
             CodeDocument = codeDocument ?? throw new ArgumentNullException(nameof(codeDocument));
             Location = location;
+            SupportsFileCreation = supportsFileCreation;
         }
 
         public CodeActionParams Request { get; }
         public DocumentSnapshot DocumentSnapshot { get; }
         public RazorCodeDocument CodeDocument { get; }
-        public SourceLocation Location { get;  }
+        public SourceLocation Location { get; }
+        public bool SupportsFileCreation { get; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOptions
+    {
+        public override bool SupportsFileCreation { get; } = true;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOptions
     {
-        public override bool SupportsFileCreation { get; } = true;
+        public override bool SupportsFileManipulation { get; } = true;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -32,6 +32,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Refactoring;
 using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -112,6 +113,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<RazorDefinitionEndpoint>()
                     .WithServices(services =>
                     {
+                        if (configure != null)
+                        {
+                            var builder = new RazorLanguageServerBuilder(services);
+                            configure(builder);
+                        }
+
                         var filePathNormalizer = new FilePathNormalizer();
                         services.AddSingleton<FilePathNormalizer>(filePathNormalizer);
 
@@ -202,13 +209,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<HtmlFactsService, DefaultHtmlFactsService>();
                         services.AddSingleton<WorkspaceDirectoryPathResolver, DefaultWorkspaceDirectoryPathResolver>();
                         services.AddSingleton<RazorComponentSearchEngine, DefaultRazorComponentSearchEngine>();
-                        services.AddSingleton<LanguageServerFeatureOptions, DefaultLanguageServerFeatureOptions>();
 
-                        if (configure != null)
-                        {
-                            var builder = new RazorLanguageServerBuilder(services);
-                            configure(builder);
-                        }
+                        // Defaults: For when the caller hasn't provided them through the `configure` action.
+                        services.TryAddSingleton<LanguageServerFeatureOptions, DefaultLanguageServerFeatureOptions>();
                     }));
 
             try

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -31,6 +31,7 @@ using System.Threading;
 using Microsoft.AspNetCore.Razor.LanguageServer.Refactoring;
 using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -111,12 +112,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<RazorDefinitionEndpoint>()
                     .WithServices(services =>
                     {
-                        if (configure != null)
-                        {
-                            var builder = new RazorLanguageServerBuilder(services);
-                            configure(builder);
-                        }
-
                         var filePathNormalizer = new FilePathNormalizer();
                         services.AddSingleton<FilePathNormalizer>(filePathNormalizer);
 
@@ -207,6 +202,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<HtmlFactsService, DefaultHtmlFactsService>();
                         services.AddSingleton<WorkspaceDirectoryPathResolver, DefaultWorkspaceDirectoryPathResolver>();
                         services.AddSingleton<RazorComponentSearchEngine, DefaultRazorComponentSearchEngine>();
+                        services.AddSingleton<LanguageServerFeatureOptions, DefaultLanguageServerFeatureOptions>();
+
+                        if (configure != null)
+                        {
+                            var builder = new RazorLanguageServerBuilder(services);
+                            configure(builder);
+                        }
                     }));
 
             try

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LSPEditorFeatureDetector.cs
@@ -7,7 +7,12 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
     {
         public abstract bool IsLSPEditorAvailable(string documentMoniker, object hierarchy);
 
+        /// <summary>
+        /// A remote client is a LiveShare guest or a "VS Cloud Connected Client"
+        /// </summary>
         public abstract bool IsRemoteClient();
+
+        public abstract bool IsLiveShareHost();
 
         public abstract bool IsLSPEditorFeatureEnabled();
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LSPEditorFeatureDetector.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
         public abstract bool IsLSPEditorAvailable(string documentMoniker, object hierarchy);
 
         /// <summary>
-        /// A remote client is a LiveShare guest or a "VS Cloud Connected Client"
+        /// A remote client is a LiveShare guest or a Codespaces instance
         /// </summary>
         public abstract bool IsRemoteClient();
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -5,6 +5,6 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
     internal abstract class LanguageServerFeatureOptions
     {
-        public abstract bool SupportsFileCreation { get; }
+        public abstract bool SupportsFileManipulation { get; }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
+{
+    internal abstract class LanguageServerFeatureOptions
+    {
+        public abstract bool SupportsFileCreation { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
@@ -81,14 +81,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return true;
         }
 
-        public override bool IsRemoteClient()
-        {
-            if (IsVSRemoteClient() || IsLiveShareGuest())
-            {
-                return true;
-            }
+        public override bool IsRemoteClient() => IsVSRemoteClient() || IsLiveShareGuest();
 
-            return false;
+        public override bool IsLiveShareHost()
+        {
+            var context = UIContext.FromUIContextGuid(LiveShareHostUIContextGuid);
+            return context.IsActive;
         }
 
         public override bool IsLSPEditorFeatureEnabled()
@@ -221,13 +219,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private protected virtual bool IsLiveShareGuest()
         {
             var context = UIContext.FromUIContextGuid(LiveShareGuestUIContextGuid);
-            return context.IsActive;
-        }
-
-        // Private protected virtual for testing
-        private protected virtual bool IsLiveShareHost()
-        {
-            var context = UIContext.FromUIContextGuid(LiveShareHostUIContextGuid);
             return context.IsActive;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
         private readonly FeedbackFileLoggerProviderFactory _feedbackFileLoggerProviderFactory;
-        private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
+        private readonly VSLanguageServerFeatureOptions _vsLanguageServerFeatureOptions;
 
         private object _shutdownLock;
         private RazorLanguageServer _server;
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             LSPRequestInvoker requestInvoker,
             ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
             FeedbackFileLoggerProviderFactory feedbackFileLoggerProviderFactory,
-            LSPEditorFeatureDetector lspEditorFeatureDetector)
+            VSLanguageServerFeatureOptions vsLanguageServerFeatureOptions)
         {
             if (customTarget is null)
             {
@@ -77,9 +77,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(feedbackFileLoggerProviderFactory));
             }
 
-            if (lspEditorFeatureDetector is null)
+            if (vsLanguageServerFeatureOptions is null)
             {
-                throw new ArgumentNullException(nameof(lspEditorFeatureDetector));
+                throw new ArgumentNullException(nameof(vsLanguageServerFeatureOptions));
             }
 
             _customMessageTarget = customTarget;
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             _requestInvoker = requestInvoker;
             _projectConfigurationFilePathStore = projectConfigurationFilePathStore;
             _feedbackFileLoggerProviderFactory = feedbackFileLoggerProviderFactory;
-            _lspEditorFeatureDetector = lspEditorFeatureDetector;
+            _vsLanguageServerFeatureOptions = vsLanguageServerFeatureOptions;
 
             _shutdownLock = new object();
         }
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var services = builder.Services;
             var loggerProvider = (FeedbackFileLoggerProvider)_feedbackFileLoggerProviderFactory.GetOrCreate();
             services.AddSingleton<ILoggerProvider>(loggerProvider);
-            services.AddSingleton(_lspEditorFeatureDetector);
+            services.AddSingleton<LanguageServerFeatureOptions, VSLanguageServerFeatureOptions>(s => _vsLanguageServerFeatureOptions);
         }
 
         private Trace GetVerbosity()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var services = builder.Services;
             var loggerProvider = (FeedbackFileLoggerProvider)_feedbackFileLoggerProviderFactory.GetOrCreate();
             services.AddSingleton<ILoggerProvider>(loggerProvider);
-            services.AddSingleton<LanguageServerFeatureOptions, VSLanguageServerFeatureOptions>(s => _vsLanguageServerFeatureOptions);
+            services.AddSingleton<LanguageServerFeatureOptions>(_vsLanguageServerFeatureOptions);
         }
 
         private Trace GetVerbosity()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Client;
@@ -34,6 +35,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
         private readonly FeedbackFileLoggerProviderFactory _feedbackFileLoggerProviderFactory;
+        private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
+
         private object _shutdownLock;
         private RazorLanguageServer _server;
         private IDisposable _serverShutdownDisposable;
@@ -46,7 +49,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             RazorLanguageClientMiddleLayer middleLayer,
             LSPRequestInvoker requestInvoker,
             ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
-            FeedbackFileLoggerProviderFactory feedbackFileLoggerProviderFactory)
+            FeedbackFileLoggerProviderFactory feedbackFileLoggerProviderFactory,
+            LSPEditorFeatureDetector lspEditorFeatureDetector)
         {
             if (customTarget is null)
             {
@@ -73,11 +77,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(feedbackFileLoggerProviderFactory));
             }
 
+            if (lspEditorFeatureDetector is null)
+            {
+                throw new ArgumentNullException(nameof(lspEditorFeatureDetector));
+            }
+
             _customMessageTarget = customTarget;
             _middleLayer = middleLayer;
             _requestInvoker = requestInvoker;
             _projectConfigurationFilePathStore = projectConfigurationFilePathStore;
             _feedbackFileLoggerProviderFactory = feedbackFileLoggerProviderFactory;
+            _lspEditorFeatureDetector = lspEditorFeatureDetector;
+
             _shutdownLock = new object();
         }
 
@@ -134,6 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var services = builder.Services;
             var loggerProvider = (FeedbackFileLoggerProvider)_feedbackFileLoggerProviderFactory.GetOrCreate();
             services.AddSingleton<ILoggerProvider>(loggerProvider);
+            services.AddSingleton(_lspEditorFeatureDetector);
         }
 
         private Trace GetVerbosity()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VSLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VSLanguageServerFeatureOptions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Export(typeof(VSLanguageServerFeatureOptions))]
+    internal class VSLanguageServerFeatureOptions : LanguageServerFeatureOptions
+    {
+        private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
+
+        [ImportingConstructor]
+        public VSLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
+        {
+            if (lspEditorFeatureDetector is null)
+            {
+                throw new ArgumentNullException(nameof(lspEditorFeatureDetector));
+            }
+
+            _lspEditorFeatureDetector = lspEditorFeatureDetector;
+        }
+
+        // We don't currently support file creation operations on VS Codespaces or VS Liveshare
+        public override bool SupportsFileCreation => !IsCodespacesOrLiveshare;
+
+        private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VSLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VSLanguageServerFeatureOptions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         // We don't currently support file creation operations on VS Codespaces or VS Liveshare
-        public override bool SupportsFileCreation => !IsCodespacesOrLiveshare;
+        public override bool SupportsFileManipulation => !IsCodespacesOrLiveshare;
 
         private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
     }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/MacLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/MacLSPEditorFeatureDetector.cs
@@ -14,6 +14,8 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
 
         public override bool IsLSPEditorFeatureEnabled() => false;
 
+        public override bool IsLiveShareHost() => false;
+
         public override bool IsRemoteClient() => false;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Moq;
 using Xunit;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -25,13 +26,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
     {
         private readonly DocumentResolver EmptyDocumentResolver = Mock.Of<DocumentResolver>();
         private readonly ILanguageServer LanguageServer = Mock.Of<ILanguageServer>();
+        private readonly LSPEditorFeatureDetector LSPEditorFeatureDetector = Mock.Of<LSPEditorFeatureDetector>();
 
         [Fact]
         public async Task Handle_NoDocument()
         {
             // Arrange
             var documentPath = "C:/path/to/Page.razor";
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, EmptyDocumentResolver, LanguageServer)
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, EmptyDocumentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = false
             };
@@ -56,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var codeDocument = CreateCodeDocument("@code {}");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             codeDocument.SetUnsupported();
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer)
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = false
             };
@@ -80,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentPath = "C:/path/to/Page.razor";
             var codeDocument = CreateCodeDocument("@code {}");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer)
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = false
             };
@@ -106,7 +108,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             var codeActionEndpoint = new CodeActionEndpoint(new RazorCodeActionProvider[] {
                 new MockCodeActionProvider()
-            }, Dispatcher, documentResolver, LanguageServer)
+            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = false
             };
@@ -136,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockCodeActionProvider(),
                 new MockCodeActionProvider(),
                 new MockCodeActionProvider(),
-            }, Dispatcher, documentResolver, LanguageServer)
+            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = false
             };
@@ -163,7 +165,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             var codeActionEndpoint = new CodeActionEndpoint(new RazorCodeActionProvider[] {
                 new MockNullCodeActionProvider()
-            }, Dispatcher, documentResolver, LanguageServer)
+            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = false
             };
@@ -193,7 +195,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockNullCodeActionProvider(),
                 new MockCodeActionProvider(),
                 new MockNullCodeActionProvider(),
-            }, Dispatcher, documentResolver, LanguageServer)
+            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = false
             };
@@ -222,7 +224,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockCodeActionProvider(),
                 new MockCommandProvider(),
                 new MockNullCodeActionProvider()
-            }, Dispatcher, documentResolver, LanguageServer)
+            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = true
             };
@@ -261,7 +263,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockCodeActionProvider(),
                 new MockCommandProvider(),
                 new MockNullCodeActionProvider()
-            }, Dispatcher, documentResolver, LanguageServer)
+            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
             {
                 _supportsCodeActionResolve = false
             };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
     {
         private readonly DocumentResolver EmptyDocumentResolver = Mock.Of<DocumentResolver>();
         private readonly ILanguageServer LanguageServer = Mock.Of<ILanguageServer>();
-        private readonly LanguageServerFeatureOptions LanguageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(l => l.SupportsFileCreation == true);
+        private readonly LanguageServerFeatureOptions LanguageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(l => l.SupportsFileManipulation == true);
 
         [Fact]
         public async Task Handle_NoDocument()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -26,14 +26,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
     {
         private readonly DocumentResolver EmptyDocumentResolver = Mock.Of<DocumentResolver>();
         private readonly ILanguageServer LanguageServer = Mock.Of<ILanguageServer>();
-        private readonly LSPEditorFeatureDetector LSPEditorFeatureDetector = Mock.Of<LSPEditorFeatureDetector>();
+        private readonly LanguageServerFeatureOptions LanguageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(l => l.SupportsFileCreation == true);
 
         [Fact]
         public async Task Handle_NoDocument()
         {
             // Arrange
             var documentPath = "C:/path/to/Page.razor";
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, EmptyDocumentResolver, LanguageServer, LSPEditorFeatureDetector)
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, EmptyDocumentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = false
             };
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var codeDocument = CreateCodeDocument("@code {}");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             codeDocument.SetUnsupported();
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = false
             };
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentPath = "C:/path/to/Page.razor";
             var codeDocument = CreateCodeDocument("@code {}");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
+            var codeActionEndpoint = new CodeActionEndpoint(Array.Empty<RazorCodeActionProvider>(), Dispatcher, documentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = false
             };
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             var codeActionEndpoint = new CodeActionEndpoint(new RazorCodeActionProvider[] {
                 new MockCodeActionProvider()
-            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
+            }, Dispatcher, documentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = false
             };
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockCodeActionProvider(),
                 new MockCodeActionProvider(),
                 new MockCodeActionProvider(),
-            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
+            }, Dispatcher, documentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = false
             };
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
             var codeActionEndpoint = new CodeActionEndpoint(new RazorCodeActionProvider[] {
                 new MockNullCodeActionProvider()
-            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
+            }, Dispatcher, documentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = false
             };
@@ -195,7 +195,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockNullCodeActionProvider(),
                 new MockCodeActionProvider(),
                 new MockNullCodeActionProvider(),
-            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
+            }, Dispatcher, documentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = false
             };
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockCodeActionProvider(),
                 new MockCommandProvider(),
                 new MockNullCodeActionProvider()
-            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
+            }, Dispatcher, documentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = true
             };
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 new MockCodeActionProvider(),
                 new MockCommandProvider(),
                 new MockNullCodeActionProvider()
-            }, Dispatcher, documentResolver, LanguageServer, LSPEditorFeatureDetector)
+            }, Dispatcher, documentResolver, LanguageServer, LanguageServerFeatureOptions)
             {
                 _supportsCodeActionResolve = false
             };

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorFeatureDetectorTest.cs
@@ -234,13 +234,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             public bool ProjectSupportsRazorLSPEditorValue { get; set; }
 
+            public override bool IsLiveShareHost() => IsLiveShareHostValue;
+
             private protected override bool EnvironmentFeatureEnabled() => EnvironmentFeatureEnabledValue;
 
             private protected override bool IsFeatureFlagEnabledCached() => IsFeatureFlagEnabledValue;
 
             private protected override bool IsLiveShareGuest() => IsLiveShareGuestValue;
-
-            private protected override bool IsLiveShareHost() => IsLiveShareHostValue;
 
             private protected override bool IsVSRemoteClient() => IsVSRemoteClientValue;
 


### PR DESCRIPTION
### Summary of the changes
 - Disables `Create Component` & `Extract to CodeBehind` for liveshare host/guest + codespaces.

Fixes: https://github.com/dotnet/aspnetcore/issues/25128

Created https://github.com/dotnet/aspnetcore/issues/25333 to track revert.


