### PR TITLE
Increase TagHelperDescriptorCache size.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperDescriptorCache.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperDescriptorCache.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Razor
     internal static class TagHelperDescriptorCache
     {
         private static readonly MemoryCache<int, TagHelperDescriptor> CachedTagHelperDescriptors =
-            new MemoryCache<int, TagHelperDescriptor>(1500);
+            new MemoryCache<int, TagHelperDescriptor>(4500);
 
         internal static bool TryGetDescriptor(int hashCode, out TagHelperDescriptor descriptor) =>
             CachedTagHelperDescriptors.TryGetValue(hashCode, out descriptor);


### PR DESCRIPTION
- Given the sheer amount of TagHelperDescriptor compact crashes we've seen it looks like users are fully utilizing the cache we had in place. Given the current 1500 entries results in ~3MB of overhead I think it's fair to expand that to ~9MB to ease in larger project development. People love their TagHelpers!
- This is being done with the assumption the users hitting these cache compaction cases are in fact using larger projects; however, there is another case where they just leave VS open for significant periods of time and are navigating among loads of different solutions (less likely but possible).