### PR TITLE
Quick infrastructure fix-ups

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -80,9 +80,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f2b7fe854a0b1f78c04dfc065164d6d61040f5b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-3.20422.3" CoherentParentDependency="Microsoft.CodeAnalysis.Razor">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-2.20403.2" CoherentParentDependency="Microsoft.CodeAnalysis.Razor" Pinned="true">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>54793d1934c52506e498790841fbcd15a33c1b05</Sha>
+      <Sha>b6a07e61473ed8a804de465f7c1cb5c17f80732d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -66,7 +66,7 @@
     <SystemResourcesExtensionsPackageVersion>6.0.0-alpha.1.20428.2</SystemResourcesExtensionsPackageVersion>
     <SystemTextEncodingsWebPackageVersion>6.0.0-alpha.1.20428.2</SystemTextEncodingsWebPackageVersion>
     <!-- Packages from dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>3.8.0-3.20422.3</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>3.8.0-2.20403.2</MicrosoftNetCompilersToolsetPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--


### PR DESCRIPTION
- Pin Microsoft.Net.Compilers.Toolset version to isolate us from Arcade
  - The version now matches dotnet/runtime
  - Will move the pin to previous version if anything breaks

In conjunction with: https://github.com/dotnet/aspnetcore/pull/25545

cc/ @dougbu
