### PR TITLE
Reconfigure HTML & C# completion triggers.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -18,9 +19,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 CompletionProvider = new CompletionOptions()
                 {
-                    AllCommitCharacters = new[] { " ", ".", ";", ">", "=", "(", ")", "[", "]", "{", "}", "!" },
+                    AllCommitCharacters = new[] { " ", "{", "}", "[", "]", "(", ")", ".", ",", ":", ";", "+", "-", "*", "/", "%", "&", "|", "^", "!", "~", "=", "<", ">", "?", "@", "#", "'", "\"", "\\" },
                     ResolveProvider = true,
-                    TriggerCharacters = new[] { ".", "@", "<", "&", "\\", "/", "'", "\"", "=", ":", " " }
+                    TriggerCharacters = CompletionHandler.AllTriggerCharacters.ToArray()
                 },
                 OnAutoInsertProvider = new DocumentOnAutoInsertOptions()
                 {


### PR DESCRIPTION
- Updated HTML & C# completion trigger characters to accurately represent C# & HTML trigger characters. This basically involved going to both the C# and HTML language servers and pulling their trigger characters.
- Updated completion handling to rewrite the completion context if we determine that we should be invoking completion but the corresponding trigger character shouldn't be passed along to the sub-language server. For instance, when we type `@` we should be asking the C# language server for completions but we don't want to be passing the `@` character as a trigger character to C#'s language server because they didn't register for that; instead we now rewrite those completion contexts to be "invoked" completions instead of "triggered" completions.
- Updated completion tests to include the new trigger characters along with the new "rewriting" of the completion context scenario for C#.

Fixes dotnet/aspnetcore#25648

/cc @dibarbet @allisonchou this stops passing `@` to Roslyn as a trigger character.