### PR TITLE
Initialize O# on a threadpool thread to prevent deadlocks

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -125,8 +125,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var traceLevel = GetVerbosity();
             _server = await RazorLanguageServer.CreateAsync(serverStream, serverStream, traceLevel, ConfigureLanguageServer).ConfigureAwait(false);
 
-            // Fire and forget for Initialized. Need to allow the LSP infrastructure to run in order to actually Initialize.
-            _server.InitializedAsync(token).FileAndForget("RazorLanguageServerClient_ActivateAsync");
+            // Fire and forget for Initialized. Need to allow the LSP infrastructure to run in order to actually Initialize. We do a Task.Run to emulate initializing
+            // the language server on a separate thread; otherwise we'll initialize our language server on VS' main thread which will have many unintended consequences
+            // such as O# booting their input read loop on VS' main thread.
+            Task.Run(() => _server.InitializedAsync(token)).FileAndForget("RazorLanguageServerClient_ActivateAsync");
 
             var connection = new Connection(clientStream, clientStream);
             return connection;


### PR DESCRIPTION
- Prior to this change we would unintentionally initialize O# on the main thread  which would pin its input handler reading loop to the main thread. Meaning it'd "while true" but only ever read data on the main thread. To workaround this we now initialize O# on a random threadpool thread. Separately I've commited a fix to O# to fix their input handling logic (configure await false).

O# fix: https://github.com/OmniSharp/csharp-language-server-protocol/pull/354/files

Fixes dotnet/aspnetcore#25738