### PR TITLE
Release/vscode16.8 preview3 v2

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/LanguageQueryResponse.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/LanguageQueryResponse.ts
@@ -10,5 +10,5 @@ export interface LanguageQueryResponse {
     kind: LanguageKind;
     position: vscode.Position;
     positionIndex: number;
-    hostDocumentVersion: number;
+    hostDocumentVersion: number | undefined;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorDocumentManager.ts
@@ -95,13 +95,10 @@ export class RazorDocumentManager implements IRazorDocumentManager {
 
             this.closeDocument(document.uri);
         });
-
-        // tslint:disable-next-line: no-floating-promises
         this.serverClient.onRequest(
             'razor/updateCSharpBuffer',
             async updateBufferRequest => this.updateCSharpBuffer(updateBufferRequest));
 
-        // tslint:disable-next-line: no-floating-promises
         this.serverClient.onRequest(
             'razor/updateHtmlBuffer',
             async updateBufferRequest => this.updateHtmlBuffer(updateBufferRequest));

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageFeatureBase.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageFeatureBase.ts
@@ -13,8 +13,6 @@ import { LanguageKind } from './RPC/LanguageKind';
 import { getUriPath } from './UriPaths';
 
 export class RazorLanguageFeatureBase {
-    private readonly undefinedDocumentVersion = -1;
-
     constructor(
         private readonly documentSynchronizer: RazorDocumentSynchronizer,
         protected readonly documentManager: RazorDocumentManager,
@@ -36,7 +34,7 @@ export class RazorLanguageFeatureBase {
                     ? razorDocument.csharpDocument
                     : razorDocument.htmlDocument;
 
-                if (languageResponse.hostDocumentVersion === this.undefinedDocumentVersion) {
+                if (languageResponse.hostDocumentVersion === undefined) {
                     // There should always be a document version attached to an open document.
                     // Log it and move on as if it was synchronized.
                     if (this.logger.verboseEnabled) {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
@@ -154,7 +154,7 @@ export class RazorLanguageServerClient implements vscode.Disposable {
         return this.client.sendRequest<TResponseType>(method, param);
     }
 
-    public async onRequest<TResponse, TError>(method: string, handler: GenericRequestHandler<TResponse, TError>) {
+    public onRequest<TResponse, TError>(method: string, handler: GenericRequestHandler<TResponse, TError>) {
         if (!this.isStarted) {
             throw new Error('Tried to bind on request logic while server is not started.');
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -75,6 +75,7 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
 
         const onStartRegistration = languageServerClient.onStart(async () => {
             vscodeType.commands.executeCommand<void>('omnisharp.registerLanguageMiddleware', razorLanguageMiddleware);
+            localRegistrations.push(documentManager.register());
             const documentSynchronizer = new RazorDocumentSynchronizer(documentManager, logger);
             const provisionalCompletionOrchestrator = new ProvisionalCompletionOrchestrator(
                 documentManager,
@@ -171,7 +172,6 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
                 vscodeType.languages.registerRenameProvider(
                     RazorLanguage.id,
                     renameProvider),
-                documentManager.register(),
                 csharpFeature.register(),
                 htmlFeature.register(),
                 documentSynchronizer.register(),


### PR DESCRIPTION
Getting the semanticTokenLegend causes the serverClient to be started prematurely, before `razor/updateCSharpBuffer` is registered. This causes the initial request to fail, but subsequent requests succeed which causes mangled __virtual.cs on local VSCode and bad errors in the Problems dialog.