### PR TITLE
Fix nested html indentation and other bugs

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -191,13 +191,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 }
                 else
                 {
-                    // Couldn't find a corresponding FormattingSpan.
+                    // Couldn't find a corresponding FormattingSpan. Happens if it is a 0 length line.
+                    // Let's create a 0 length span to represent this and default it to HTML.
+                    var placeholderSpan = new FormattingSpan(
+                        new Language.Syntax.TextSpan(total + nonWsChar, 0),
+                        new Language.Syntax.TextSpan(total + nonWsChar, 0),
+                        FormattingSpanKind.Markup,
+                        FormattingBlockKind.Markup,
+                        indentationLevel: 0,
+                        isInClassBody: false);
+
                     result.Indentations[i] = new IndentationContext
                     {
                         Line = i,
-                        IndentationLevel = -1,
+                        IndentationLevel = 0,
                         RelativeIndentationLevel = previousIndentationLevel,
                         ExistingIndentation = nonWsChar,
+                        FirstSpan = placeholderSpan,
                     };
                 }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
@@ -164,6 +164,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             for (var i = startLine; i <= endLine; i++)
             {
+                if (!context.Indentations[i].StartsInCSharpContext)
+                {
+                    // Not a CSharp line. Don't touch it.
+                    continue;
+                }
+
                 var line = sourceText.Lines[i];
                 if (line.Span.Length == 0)
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal class FormattingVisitor : SyntaxWalker
     {
+        private const string HtmlTagName = "html";
+
         private RazorSourceDocument _source;
         private List<FormattingSpan> _spans;
         private FormattingBlockKind _currentBlockKind;
@@ -132,12 +134,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public override void VisitMarkupElement(MarkupElementSyntax node)
         {
             Visit(node.StartTag);
-            _currentIndentationLevel++;
+
+            // Temporary fix to not break the default Html formatting behavior
+            if (!string.Equals(node.StartTag?.Name?.Content, HtmlTagName, StringComparison.OrdinalIgnoreCase))
+            {
+                _currentIndentationLevel++;
+            }
+
             foreach (var child in node.Body)
             {
                 Visit(child);
             }
-            _currentIndentationLevel--;
+
+            // Temporary fix to not break the default Html formatting behavior
+            if (!string.Equals(node.StartTag?.Name?.Content, HtmlTagName, StringComparison.OrdinalIgnoreCase))
+            {
+                _currentIndentationLevel--;
+            }
+
             Visit(node.EndTag);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             Visit(node.StartTag);
 
-            // Temporary fix to not break the default Html formatting behavior
+            // Temporary fix to not break the default Html formatting behavior. Remove after https://github.com/dotnet/aspnetcore/issues/25475.
             if (!string.Equals(node.StartTag?.Name?.Content, HtmlTagName, StringComparison.OrdinalIgnoreCase))
             {
                 _currentIndentationLevel++;
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 Visit(child);
             }
 
-            // Temporary fix to not break the default Html formatting behavior
+            // Temporary fix to not break the default Html formatting behavior. Remove after https://github.com/dotnet/aspnetcore/issues/25475.
             if (!string.Equals(node.StartTag?.Name?.Content, HtmlTagName, StringComparison.OrdinalIgnoreCase))
             {
                 _currentIndentationLevel--;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 #endif
         }
 
-    protected async Task RunOnTypeFormattingTestAsync(string input, string expected, string triggerCharacter, int tabSize = 4, bool insertSpaces = true, string fileKind = null)
+        protected async Task RunOnTypeFormattingTestAsync(string input, string expected, string triggerCharacter, int tabSize = 4, bool insertSpaces = true, string fileKind = null)
         {
             // Arrange
             fileKind ??= FileKinds.Component;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -14,12 +14,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Formatting
         {
             await RunFormattingTestAsync(
 input: @"
-|   <div>
-</div>|
+|   <html>
+<head>
+   <title>Hello</title></head>
+<body><div>
+</div>
+        </body>
+ </html>|
 ",
 expected: @"
-<div>
-</div>
+<html>
+<head>
+    <title>Hello</title>
+</head>
+<body>
+    <div>
+    </div>
+</body>
+</html>
 ");
         }
 
@@ -39,6 +51,15 @@ input: @"|@page ""/error""
 <p>
     <strong>The Development environment shouldn't be enabled for deployed applications.
 </strong>
+            <div>
+ <div>
+    <div>
+<div>
+        This is heavily nested
+</div>
+ </div>
+    </div>
+        </div>
 </p>
 |",
 expected: @"@page ""/error""
@@ -56,6 +77,15 @@ expected: @"@page ""/error""
     <strong>
         The Development environment shouldn't be enabled for deployed applications.
     </strong>
+    <div>
+        <div>
+            <div>
+                <div>
+                    This is heavily nested
+                </div>
+            </div>
+        </div>
+    </div>
 </p>
 ");
         }
@@ -75,6 +105,15 @@ if (true)
             }
         }
         </p>
+<div>
+ @{
+    <div>
+<div>
+        This is heavily nested
+</div>
+ </div>
+    }
+        </div>
 }
 |",
 expected: @"@page ""/test""
@@ -88,6 +127,15 @@ expected: @"@page ""/test""
             }
         }
     </p>
+    <div>
+        @{
+            <div>
+                <div>
+                    This is heavily nested
+                </div>
+            </div>
+        }
+    </div>
 }
 ");
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsMixedHtmlBlock.input.html
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsMixedHtmlBlock.input.html
@@ -9,4 +9,13 @@
             ~
         ~
         </p>
+<div>
+ ~~
+    <div>
+<div>
+        This is heavily nested
+</div>
+ </div>
+    ~
+        </div>
 ~

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsMixedHtmlBlock.output.html
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsMixedHtmlBlock.output.html
@@ -9,4 +9,13 @@
     ~
     ~
 </p>
+<div>
+    ~~
+    <div>
+        <div>
+            This is heavily nested
+        </div>
+    </div>
+    ~
+</div>
 ~

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsRazorHtmlBlock.input.html
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsRazorHtmlBlock.input.html
@@ -10,4 +10,13 @@
 <p>
     <strong>The Development environment shouldn't be enabled for deployed applications.
 </strong>
+            <div>
+ <div>
+    <div>
+<div>
+        This is heavily nested
+</div>
+ </div>
+    </div>
+        </div>
 </p>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsRazorHtmlBlock.output.html
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsRazorHtmlBlock.output.html
@@ -13,4 +13,13 @@
     <strong>
         The Development environment shouldn't be enabled for deployed applications.
     </strong>
+    <div>
+        <div>
+            <div>
+                <div>
+                    This is heavily nested
+                </div>
+            </div>
+        </div>
+    </div>
 </p>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsSimpleHtmlTag.input.html
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsSimpleHtmlTag.input.html
@@ -1,2 +1,7 @@
-   <div>
+   <html>
+<head>
+   <title>Hello</title></head>
+<body><div>
 </div>
+        </body>
+ </html>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsSimpleHtmlTag.output.html
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsSimpleHtmlTag.output.html
@@ -1,2 +1,9 @@
-<div>
-</div>
+<html>
+<head>
+    <title>Hello</title>
+</head>
+<body>
+    <div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This change fixes a few bugs,

1. More than 3 levels of nesting causes extra indentation.
    - This was because `AdjustCSharpIndentation` method touched non-csharp lines
2. Our understanding of HTML structure of the document overrides what the real HTML formatter does. This is visible with `<html>` tag formatting.
    - The temporary fix for this is to special case `<html>` tag formatting on our side
3. Accessing some properties on `FormattingContext` null-refs if there is a 0 length line in the document (We just happened to not use these properties in places where this would've thrown. We go lucky so far. The fix for bug 1 exposed this)

Added tests

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198948/
