### PR TITLE
Prevent @ from being inserted when closing a self-closing tag.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             }
 
             var attribute = owner.Parent;
-            if (attribute is MarkupMiscAttributeContentSyntax)
+            if (attribute is MarkupMiscAttributeContentSyntax && attribute.ContainsOnlyWhitespace())
             {
                 // This represents a tag when there's no attribute content <InputText | />.
                 return Completions;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -263,7 +263,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                         {
                             directiveCompletionItem.Command = RetriggerCompletionCommand;
                             directiveCompletionItem.Kind = CompletionItemKind.TypeParameter;
-                            directiveCompletionItem.Preselect = true;
                         }
 
                         directiveCompletionItem.SetRazorCompletionKind(razorCompletionItem.Kind);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxNodeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxNodeExtensions.cs
@@ -13,6 +13,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal static class SyntaxNodeExtensions
     {
+        public static bool ContainsOnlyWhitespace(this SyntaxNode node)
+        {
+            if (node is null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            var tokens = node.GetTokens();
+
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                var tokenKind = tokens[i].Kind;
+                if (tokenKind != SyntaxKind.Whitespace && tokenKind != SyntaxKind.NewLine)
+                {
+                    return false;
+                }
+            }
+
+            // All tokens were either whitespace or newlines.
+            return true;
+        }
+
         public static LinePositionSpan GetLinePositionSpan(this SyntaxNode node, RazorSourceDocument source)
         {
             if (node is null)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -183,6 +183,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        public void GetCompletionItems_InbetweenSelfClosingEnd_ReturnsEmptyList()
+        {
+            // Arrange
+
+            var syntaxTree = GetSyntaxTree("<input /" + Environment.NewLine);
+            var location = new SourceSpan(8, 0);
+
+            // Act
+            var result = Provider.GetCompletionItems(syntaxTree, TagHelperDocumentContext, location);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
         public void GetCompletionItems_AttributeAreaInComponentFile_ReturnsTransitionCompletionItem()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             // Assert
             Assert.True(result);
-            Assert.True(converted.Preselect);
+            Assert.False(converted.Preselect);
             Assert.Equal(completionItem.DisplayText, converted.Label);
             Assert.Equal(completionItem.InsertText, converted.InsertText);
             Assert.Equal(completionItem.DisplayText, converted.FilterText);


### PR DESCRIPTION
- Disabled pre-select for the `@...` completion item to ensure that when a user types `/` that completion is dismissed (if it's pre-selected it doesn't dismiss).
- Given that `/` is another completion character completion is re-invoked upon typing `/` allowing us to recompute valid completion items. Updated the logic that provided the `@...` completion item to not allow providing completions at `<input /|`. To do this I added a general extension method that will probably be used more frequently to detect if a node contains only whitespace.
- Updated existing tests to reflect the new "pre-select" option being false.
- Added a new test to validate the scenario when a user is typing out the closing tag of an HTML element.

**Before:**
![npecv1nFEI](https://user-images.githubusercontent.com/1874516/90197950-2044f380-dd85-11ea-87fd-cb600cc40174.gif)

**After:**
![KfCydFy3qd](https://user-images.githubusercontent.com/2008729/92971317-19b5a480-f435-11ea-8778-596a081bc87d.gif)


Fixes dotnet/aspnetcore#24895

