### PR TITLE
Revert " Set noDebug flag on launch url for Blazor WASM apps"

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
@@ -103,13 +103,12 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
     }
 
     private async launchBrowser(folder: vscode.WorkspaceFolder | undefined, configuration: vscode.DebugConfiguration) {
-        const setNoDebugFlag = (url: string) => configuration.noDebug ? `${url}?_blazor_debug=false` : url;
         const browser = {
             name: JS_DEBUG_NAME,
             type: configuration.browser === 'edge' ? 'pwa-msedge' : 'pwa-chrome',
             request: 'launch',
             timeout: configuration.timeout || 30000,
-            url: setNoDebugFlag(configuration.url || 'https://localhost:5001'),
+            url: configuration.url || 'https://localhost:5001',
             webRoot: configuration.webRoot || '${workspaceFolder}',
             inspectUri: '{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}',
             trace: configuration.trace || false,


### PR DESCRIPTION
Reverts dotnet/aspnetcore-tooling#2393.

We're pausing on implementing this change because:
- we discovered that the perf impact of running an app in debugging is within the accepted range when in development
- we want to land something for all editors in .NET 6/VS 16.9