### PR TITLE
Support Previews for Edit Based Code Actions

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ComponentAccessibilityCodeActionProviderTest.cs
@@ -100,6 +100,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 {
                     Assert.Equal("Fully.Qualified.Component", e.Title);
                     Assert.NotNull(e.Edit);
+                    Assert.NotNull(e.Edit.DocumentChanges);
                     Assert.Null(e.Data);
                 },
                 e =>
@@ -193,6 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 {
                     Assert.Equal("Fully.Qualified.Component", e.Title);
                     Assert.NotNull(e.Edit);
+                    Assert.NotNull(e.Edit.DocumentChanges);
                     Assert.Null(e.Data);
                 });
         }


### PR DESCRIPTION
### Summary of the changes
 - LSP Platform doesn't currently support previews for `WorkspaceEdit.Changes`. Transitioned to `WorkspaceEdit.DocumentChanges` to ensure we get code action previews.

![image](https://user-images.githubusercontent.com/14852843/93245974-eb8bd980-f740-11ea-867a-0045d255d40d.png)


Fixes: https://github.com/dotnet/aspnetcore/issues/25894
