### PR TITLE
Expose the language service brokers capabilitiesTokenFilter

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPRequestInvoker.cs
@@ -44,15 +44,25 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
         public override Task<TOut> ReinvokeRequestOnServerAsync<TIn, TOut>(string method, string contentType, TIn parameters, CancellationToken cancellationToken)
         {
-            return RequestServerCoreAsync<TIn, TOut>(method, contentType, parameters, cancellationToken);
+            return RequestServerCoreAsync<TIn, TOut>(method, contentType, token => true, parameters, cancellationToken);
+        }
+
+        public override Task<TOut> ReinvokeRequestOnServerAsync<TIn, TOut>(string method, string contentType, Func<JToken, bool> capabilitiesFilter, TIn parameters, CancellationToken cancellationToken)
+        {
+            return RequestServerCoreAsync<TIn, TOut>(method, contentType, capabilitiesFilter, parameters, cancellationToken);
         }
 
         public override Task<IEnumerable<TOut>> ReinvokeRequestOnMultipleServersAsync<TIn, TOut>(string method, string contentType, TIn parameters, CancellationToken cancellationToken)
         {
-            return RequestMultipleServerCoreAsync<TIn, TOut>(method, contentType, parameters, cancellationToken);
+            return RequestMultipleServerCoreAsync<TIn, TOut>(method, contentType, token => true, parameters, cancellationToken);
         }
 
-        private async Task<TOut> RequestServerCoreAsync<TIn, TOut>(string method, string contentType, TIn parameters, CancellationToken cancellationToken)
+        public override Task<IEnumerable<TOut>> ReinvokeRequestOnMultipleServersAsync<TIn, TOut>(string method, string contentType, Func<JToken, bool> capabilitiesFilter, TIn parameters, CancellationToken cancellationToken)
+        {
+            return RequestMultipleServerCoreAsync<TIn, TOut>(method, contentType, capabilitiesFilter, parameters, cancellationToken);
+        }
+
+        private async Task<TOut> RequestServerCoreAsync<TIn, TOut>(string method, string contentType, Func<JToken, bool> capabilitiesFilter, TIn parameters, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(method))
             {
@@ -63,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
             var (_, resultToken) = await _languageServiceBroker.RequestAsync(
                 new[] { contentType },
-                token => true,
+                capabilitiesFilter,
                 method,
                 serializedParams,
                 cancellationToken).ConfigureAwait(false);
@@ -72,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             return result;
         }
 
-        private async Task<IEnumerable<TOut>> RequestMultipleServerCoreAsync<TIn, TOut>(string method, string contentType, TIn parameters, CancellationToken cancellationToken)
+        private async Task<IEnumerable<TOut>> RequestMultipleServerCoreAsync<TIn, TOut>(string method, string contentType, Func<JToken, bool> capabilitiesFilter, TIn parameters, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(method))
             {
@@ -83,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
             var clientAndResultTokenPairs = await _languageServiceBroker.RequestMultipleAsync(
                 new[] { contentType },
-                token => true,
+                capabilitiesFilter,
                 method,
                 serializedParams,
                 cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/LSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/LSPRequestInvoker.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 {
@@ -15,9 +17,23 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             TIn parameters,
             CancellationToken cancellationToken);
 
+        public abstract Task<TOut> ReinvokeRequestOnServerAsync<TIn, TOut>(
+            string method,
+            string contentType,
+            Func<JToken, bool> capabilitiesFilter,
+            TIn parameters,
+            CancellationToken cancellationToken);
+
         public abstract Task<IEnumerable<TOut>> ReinvokeRequestOnMultipleServersAsync<TIn, TOut>(
             string method,
             string contentType,
+            TIn parameters,
+            CancellationToken cancellationToken);
+
+        public abstract Task<IEnumerable<TOut>> ReinvokeRequestOnMultipleServersAsync<TIn, TOut>(
+            string method,
+            string contentType,
+            Func<JToken, bool> capabilitiesFilter,
             TIn parameters,
             CancellationToken cancellationToken);
     }


### PR DESCRIPTION
This allows users of the DefaultLSPRequestInvoker to filter based on server capabilies
