### PR TITLE
Fix Malformed FQN Component Code Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ src/Razor/test/OutOfWorkspaceFile.razor
 # Benchmark generated
 src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/BenchmarkDotNet.Artifacts/results/*
 src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/BenchmarkDotNet.Artifacts/*Benchmark.log
+
+# Yarn Logs
+yarn-*.log

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         private static WorkspaceEdit CreateRenameTagEdit(RazorCodeActionContext context, MarkupStartTagSyntax startTag, string newTagName)
         {
-            var documentChanges = new List<WorkspaceEditDocumentChange>();
+            var textEdits = new List<TextEdit>();
             var codeDocumentIdentifier = new VersionedTextDocumentIdentifier() { Uri = context.Request.TextDocument.Uri };
 
             var startTagTextEdit = new TextEdit
@@ -190,14 +190,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 NewText = newTagName,
             };
 
-            var startTagWorkspaceEdit = new WorkspaceEditDocumentChange(new TextDocumentEdit()
-            {
-                TextDocument = codeDocumentIdentifier,
-                Edits = new[] { startTagTextEdit },
-            });
-
-            documentChanges.Add(startTagWorkspaceEdit);
-
+            textEdits.Add(startTagTextEdit);
 
             var endTag = (startTag.Parent as MarkupElementSyntax).EndTag;
             if (endTag != null)
@@ -208,18 +201,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     NewText = newTagName,
                 };
 
-                var endTagWorkspaceEdit = new WorkspaceEditDocumentChange(new TextDocumentEdit()
-                {
-                    TextDocument = codeDocumentIdentifier,
-                    Edits = new[] { endTagTextEdit },
-                });
-
-                documentChanges.Add(endTagWorkspaceEdit);
+                textEdits.Add(endTagTextEdit);
             }
 
             return new WorkspaceEdit
             {
-                DocumentChanges = documentChanges
+                DocumentChanges = new List<WorkspaceEditDocumentChange>()
+                {
+                    new WorkspaceEditDocumentChange(
+                        new TextDocumentEdit()
+                        {
+                            TextDocument = codeDocumentIdentifier,
+                            Edits = textEdits,
+                        }
+                    )
+                }
             };
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -177,12 +177,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (!_documentManager.TryGetDocument(codeActionParams.TextDocument.Uri, out var documentSnapshot))
             {
-                return default;
+                return null;
             }
 
             if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
             {
-                return default;
+                return null;
             }
 
             codeActionParams.TextDocument.Uri = csharpDoc.Uri;


### PR DESCRIPTION
### Summary of the changes
 - Malformed FQN component was due to two separate workspace edits overwriting values. Updated to use a single workspace edit, with multiple text edits. Not sure why this issue wasn't materializing in earlier testing 🤔.
- Unit tests: Wouldn't have caught this issue as the difference occurs in how LSP platform interprets the order of edits.

Fixes: https://github.com/dotnet/aspnetcore/issues/25969