### PR TITLE
Update document synchronizer context version differently in the zero …

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/TextBufferExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/TextBufferExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 
 namespace Microsoft.VisualStudio.Text
 {
@@ -30,18 +29,6 @@ namespace Microsoft.VisualStudio.Text
             var result = textBuffer.Properties.TryGetProperty(HostDocumentVersionMarked, out hostDocumentVersion);
 
             return result;
-        }
-
-        public static void MakeEmptyEdit(this ITextBuffer textBuffer)
-        {
-            var bufferLength = textBuffer.CurrentSnapshot.Length;
-            using var edit = textBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
-            edit.Insert(bufferLength, " ");
-            edit.Apply();
-
-            using var revertEdit = textBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
-            revertEdit.Delete(bufferLength, 1);
-            revertEdit.Apply();
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VirtualDocumentBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VirtualDocumentBase.cs
@@ -56,16 +56,6 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             _hostDocumentSyncVersion = hostDocumentVersion;
             TextBuffer.SetHostDocumentSyncVersion(_hostDocumentSyncVersion);
 
-            if (changes.Count == 0)
-            {
-                // Even though nothing changed here, we want the synchronizer to be aware of the host document version change.
-                // So, let's make an empty edit to invoke the text buffer Changed events.
-                TextBuffer.MakeEmptyEdit();
-
-                _currentSnapshot = GetUpdatedSnapshot();
-                return _currentSnapshot;
-            }
-
             using var edit = TextBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, InviolableEditTag.Instance);
             for (var i = 0; i < changes.Count; i++)
             {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Infrastructure/TestTextBuffer.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Infrastructure/TestTextBuffer.cs
@@ -39,6 +39,11 @@ namespace Microsoft.VisualStudio.Test
 
         public void ApplyEdits(params TestEdit[] edits)
         {
+            if (edits.Length == 0)
+            {
+                return;
+            }
+
             var args = new TextContentChangedEventArgs(edits[0].OldSnapshot, edits[edits.Length - 1].NewSnapshot, new EditOptions(), null);
             foreach (var edit in edits)
             {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/VirtualDocumentBaseTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/VirtualDocumentBaseTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         }
 
         [Fact]
-        public void Update_NoChanges_InvokesPostChangedEventTwice_NoEffectiveChanges()
+        public void Update_NoChanges_InvokesPostChangedEventZeroTimes_NoEffectiveChanges()
         {
             // Arrange
             var textBuffer = new TestTextBuffer(new StringTextSnapshot("Hello World"));
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             document.Update(Array.Empty<ITextChange>(), hostDocumentVersion: 1);
 
             // Assert
-            Assert.Equal(2, called);
+            Assert.Equal(0, called);
             var text = textBuffer.CurrentSnapshot.GetText();
             Assert.Equal("Hello World", text);
         }


### PR DESCRIPTION
…edit case

This empty edit is actually two edits that get messaged over as didChange notifications to the language server(s). In the WTE hosting CSS case, there are two language servers, thus four notifications sent out. Additionally, this causes one of the css language servers to send back publishDiagnostics also. All this happens for CSS when just typing a char in markup.
