### PR TITLE
Fix component rename for fully qualified components.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -311,9 +311,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                 return null;
             }
 
-            var originTagHelpers = new List<TagHelperDescriptor>();
-            originTagHelpers.Add(primaryTagHelper);
-
+            var originTagHelpers = new List<TagHelperDescriptor>() { primaryTagHelper };
             var associatedTagHelper = FindAssociatedTagHelper(primaryTagHelper, documentSnapshot.Project.TagHelpers);
             if (associatedTagHelper == null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -20,6 +20,8 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
 {
@@ -91,19 +93,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                 return null;
             }
 
-            var originTagHelperBinding = await GetOriginTagHelperBindingAsync(requestDocumentSnapshot, codeDocument, request.Position).ConfigureAwait(false);
-            if (originTagHelperBinding is null)
+            var originTagHelpers = await GetOriginTagHelpersAsync(requestDocumentSnapshot, codeDocument, request.Position).ConfigureAwait(false);
+            if (originTagHelpers is null)
             {
                 return null;
             }
 
-            var originTagDescriptor = originTagHelperBinding.Descriptors.FirstOrDefault();
-            if (originTagDescriptor is null)
+            if (originTagHelpers is null)
             {
                 return null;
             }
 
-            var originComponentDocumentSnapshot = await _componentSearchEngine.TryLocateComponentAsync(originTagDescriptor).ConfigureAwait(false);
+            var originComponentDocumentSnapshot = await _componentSearchEngine.TryLocateComponentAsync(originTagHelpers.First()).ConfigureAwait(false);
             if (originComponentDocumentSnapshot is null)
             {
                 return null;
@@ -117,12 +118,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
 
             var documentChanges = new List<WorkspaceEditDocumentChange>();
             AddFileRenameForComponent(documentChanges, originComponentDocumentSnapshot, newPath);
-            AddEditsForCodeDocument(documentChanges, originTagHelperBinding, request.NewName, request.TextDocument.Uri, codeDocument);
+            AddEditsForCodeDocument(documentChanges, originTagHelpers, request.NewName, request.TextDocument.Uri, codeDocument);
 
             var documentSnapshots = await GetAllDocumentSnapshots(requestDocumentSnapshot, cancellationToken).ConfigureAwait(false);
             foreach (var documentSnapshot in documentSnapshots)
             {
-                await AddEditsForCodeDocument(documentChanges, originTagHelperBinding, request.NewName, documentSnapshot, cancellationToken);
+                await AddEditsForCodeDocumentAsync(documentChanges, originTagHelpers, request.NewName, documentSnapshot, cancellationToken);
             }
 
             return new WorkspaceEdit
@@ -192,7 +193,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             return newPath;
         }
 
-        public async Task AddEditsForCodeDocument(List<WorkspaceEditDocumentChange> documentChanges, TagHelperBinding originTagHelperBinding, string newName, DocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
+        public async Task AddEditsForCodeDocumentAsync(List<WorkspaceEditDocumentChange> documentChanges, IReadOnlyList<TagHelperDescriptor> originTagHelpers, string newName, DocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
         {
             if (documentSnapshot is null)
             {
@@ -216,25 +217,45 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                 Host = string.Empty,
                 Scheme = Uri.UriSchemeFile,
             }.Uri;
-            AddEditsForCodeDocument(documentChanges, originTagHelperBinding, newName, uri, codeDocument);
+            AddEditsForCodeDocument(documentChanges, originTagHelpers, newName, uri, codeDocument);
         }
 
-        public void AddEditsForCodeDocument(List<WorkspaceEditDocumentChange> documentChanges, TagHelperBinding originTagHelperBinding, string newName, DocumentUri uri, RazorCodeDocument codeDocument)
+        public void AddEditsForCodeDocument(List<WorkspaceEditDocumentChange> documentChanges, IReadOnlyList<TagHelperDescriptor> originTagHelpers, string newName, DocumentUri uri, RazorCodeDocument codeDocument)
         {
             var documentIdentifier = new VersionedTextDocumentIdentifier { Uri = uri };
             var tagHelperElements = codeDocument.GetSyntaxTree().Root
                 .DescendantNodes()
                 .Where(n => n.Kind == SyntaxKind.MarkupTagHelperElement)
                 .OfType<MarkupTagHelperElementSyntax>();
-            foreach (var node in tagHelperElements)
+
+            for (var i = 0; i < originTagHelpers.Count; i++)
             {
-                if (node is MarkupTagHelperElementSyntax tagHelperElement && BindingsMatch(originTagHelperBinding, tagHelperElement.TagHelperInfo.BindingResult))
+                var editedName = newName;
+                var originTagHelper = originTagHelpers[i];
+                if (originTagHelper?.IsComponentFullyQualifiedNameMatch() == true)
                 {
-                    documentChanges.Add(new WorkspaceEditDocumentChange(new TextDocumentEdit
+                    // Fully qualified binding, our "new name" needs to be fully qualified.
+                    if (!DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(originTagHelper.Name, out var namespaceSpan, out _))
                     {
-                        TextDocument = documentIdentifier,
-                        Edits = CreateEditsForMarkupTagHelperElement(tagHelperElement, codeDocument, newName)
-                    }));
+                        return;
+                    }
+
+                    var namespaceString = originTagHelper.Name.Substring(namespaceSpan.Start, namespaceSpan.Length);
+
+                    // The origin TagHelper was fully qualified so any fully qualified rename locations we find will need a fully qualified renamed edit.
+                    editedName = $"{namespaceString}.{newName}";
+                }
+
+                foreach (var node in tagHelperElements)
+                {
+                    if (node is MarkupTagHelperElementSyntax tagHelperElement && BindingContainsTagHelper(originTagHelper, tagHelperElement.TagHelperInfo.BindingResult))
+                    {
+                        documentChanges.Add(new WorkspaceEditDocumentChange(new TextDocumentEdit
+                        {
+                            TextDocument = documentIdentifier,
+                            Edits = CreateEditsForMarkupTagHelperElement(tagHelperElement, codeDocument, editedName)
+                        }));
+                    }
                 }
             }
         }
@@ -260,22 +281,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             return edits;
         }
 
-        private static bool BindingsMatch(TagHelperBinding left, TagHelperBinding right)
+        private static bool BindingContainsTagHelper(TagHelperDescriptor primaryTagHelper, TagHelperBinding potentialBinding)
         {
-            foreach (var leftDescriptor in left.Descriptors)
+            foreach (var descriptor in potentialBinding.Descriptors)
             {
-                foreach (var rightDescriptor in right.Descriptors)
+                if (descriptor.Equals(primaryTagHelper))
                 {
-                    if (leftDescriptor.Equals(rightDescriptor))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
+
             return false;
         }
 
-        private async Task<TagHelperBinding> GetOriginTagHelperBindingAsync(DocumentSnapshot documentSnapshot, RazorCodeDocument codeDocument, Position position)
+        private async Task<IReadOnlyList<TagHelperDescriptor>> GetOriginTagHelpersAsync(DocumentSnapshot documentSnapshot, RazorCodeDocument codeDocument, Position position)
         {
             var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
             var linePosition = new LinePosition((int)position.Line, (int)position.Character);
@@ -301,7 +320,58 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                 return null;
             }
 
-            return tagHelperElement.TagHelperInfo.BindingResult;
+            // Can only have 1 component TagHelper belonging to an element at a time
+            var primaryTagHelper = tagHelperElement.TagHelperInfo.BindingResult.Descriptors.FirstOrDefault(descriptor => descriptor.IsComponentTagHelper());
+            if (primaryTagHelper == null)
+            {
+                return null;
+            }
+
+            var originTagHelpers = new List<TagHelperDescriptor>();
+            originTagHelpers.Add(primaryTagHelper);
+
+            var associatedTagHelper = FindAssociatedTagHelper(primaryTagHelper, documentSnapshot.Project.TagHelpers);
+            if (associatedTagHelper == null)
+            {
+                Debug.Fail("Components should always have an associated TagHelper.");
+                return null;
+            }
+
+            originTagHelpers.Add(associatedTagHelper);
+
+            return originTagHelpers;
+        }
+
+        private static TagHelperDescriptor FindAssociatedTagHelper(TagHelperDescriptor tagHelper, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            var typeName = tagHelper.GetTypeName();
+            var assemblyName = tagHelper.AssemblyName;
+            for (var i = 0; i < tagHelpers.Count; i++)
+            {
+                var currentTagHelper = tagHelpers[i];
+
+                if (tagHelper == currentTagHelper)
+                {
+                    // Same as the primary, we're looking for our other pair.
+                    continue;
+                }
+
+                var currentTypeName = currentTagHelper.GetTypeName();
+                if (!string.Equals(typeName, currentTypeName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!string.Equals(assemblyName, currentTagHelper.AssemblyName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // Found our associated TagHelper, there should only ever be 1 other associated TagHelper (fully qualified and non-fully qualified).
+                return currentTagHelper;
+            }
+
+            return null;
         }
 
         public void SetCapability(RenameCapability capability)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -94,12 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             }
 
             var originTagHelpers = await GetOriginTagHelpersAsync(requestDocumentSnapshot, codeDocument, request.Position).ConfigureAwait(false);
-            if (originTagHelpers is null)
-            {
-                return null;
-            }
-
-            if (originTagHelpers is null)
+            if (originTagHelpers is null || originTagHelpers.Count == 0)
             {
                 return null;
             }
@@ -281,18 +276,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             return edits;
         }
 
-        private static bool BindingContainsTagHelper(TagHelperDescriptor primaryTagHelper, TagHelperBinding potentialBinding)
-        {
-            foreach (var descriptor in potentialBinding.Descriptors)
-            {
-                if (descriptor.Equals(primaryTagHelper))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+        private static bool BindingContainsTagHelper(TagHelperDescriptor tagHelper, TagHelperBinding potentialBinding) => potentialBinding.Descriptors.Any(descriptor => descriptor.Equals(tagHelper));
 
         private async Task<IReadOnlyList<TagHelperDescriptor>> GetOriginTagHelpersAsync(DocumentSnapshot documentSnapshot, RazorCodeDocument codeDocument, Position position)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -81,19 +81,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             var editChange = result.DocumentChanges.ElementAt(1);
             Assert.True(editChange.IsTextDocumentEdit);
             Assert.Equal("file:///c:/First/Component1.razor", editChange.TextDocumentEdit.TextDocument.Uri.ToString());
-            Assert.Equal(2, editChange.TextDocumentEdit.Edits.Count());
-            var editChangeEdit1 = editChange.TextDocumentEdit.Edits.ElementAt(0);
-            Assert.Equal("Component5", editChangeEdit1.NewText);
-            Assert.Equal(2, editChangeEdit1.Range.Start.Line);
-            Assert.Equal(1, editChangeEdit1.Range.Start.Character);
-            Assert.Equal(2, editChangeEdit1.Range.End.Line);
-            Assert.Equal(11, editChangeEdit1.Range.End.Character);
-            var editChangeEdit2 = editChange.TextDocumentEdit.Edits.ElementAt(1);
-            Assert.Equal("Component5", editChangeEdit2.NewText);
-            Assert.Equal(2, editChangeEdit2.Range.Start.Line);
-            Assert.Equal(14, editChangeEdit2.Range.Start.Character);
-            Assert.Equal(2, editChangeEdit2.Range.End.Line);
-            Assert.Equal(24, editChangeEdit2.Range.End.Character);
+            Assert.Collection(
+                editChange.TextDocumentEdit.Edits,
+                edit =>
+                {
+                    Assert.Equal("Component5", edit.NewText);
+                    Assert.Equal(2, edit.Range.Start.Line);
+                    Assert.Equal(1, edit.Range.Start.Character);
+                    Assert.Equal(2, edit.Range.End.Line);
+                    Assert.Equal(11, edit.Range.End.Character);
+                },
+                edit =>
+                {
+                    Assert.Equal("Component5", edit.NewText);
+                    Assert.Equal(2, edit.Range.Start.Line);
+                    Assert.Equal(14, edit.Range.Start.Character);
+                    Assert.Equal(2, edit.Range.End.Line);
+                    Assert.Equal(24, edit.Range.End.Character);
+                });
         }
 
         [Fact]
@@ -123,36 +128,46 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             var editChange1 = result.DocumentChanges.ElementAt(1);
             Assert.True(editChange1.IsTextDocumentEdit);
             Assert.Equal("file:///c:/First/Index.razor", editChange1.TextDocumentEdit.TextDocument.Uri.ToString());
-            Assert.Equal(2, editChange1.TextDocumentEdit.Edits.Count());
-            var editChange1Edit1 = editChange1.TextDocumentEdit.Edits.ElementAt(0);
-            Assert.Equal("Component5", editChange1Edit1.NewText);
-            Assert.Equal(2, editChange1Edit1.Range.Start.Line);
-            Assert.Equal(1, editChange1Edit1.Range.Start.Character);
-            Assert.Equal(2, editChange1Edit1.Range.End.Line);
-            Assert.Equal(14, editChange1Edit1.Range.End.Character);
-            var editChange1Edit2 = editChange1.TextDocumentEdit.Edits.ElementAt(1);
-            Assert.Equal("Component5", editChange1Edit2.NewText);
-            Assert.Equal(2, editChange1Edit2.Range.Start.Line);
-            Assert.Equal(17, editChange1Edit2.Range.Start.Character);
-            Assert.Equal(2, editChange1Edit2.Range.End.Line);
-            Assert.Equal(30, editChange1Edit2.Range.End.Character);
+            Assert.Collection(
+                editChange1.TextDocumentEdit.Edits,
+                edit =>
+                {
+                    Assert.Equal("Component5", edit.NewText);
+                    Assert.Equal(2, edit.Range.Start.Line);
+                    Assert.Equal(1, edit.Range.Start.Character);
+                    Assert.Equal(2, edit.Range.End.Line);
+                    Assert.Equal(14, edit.Range.End.Character);
+                },
+                edit =>
+                {
+                    Assert.Equal("Component5", edit.NewText);
+                    Assert.Equal(2, edit.Range.Start.Line);
+                    Assert.Equal(17, edit.Range.Start.Character);
+                    Assert.Equal(2, edit.Range.End.Line);
+                    Assert.Equal(30, edit.Range.End.Character);
+                });
 
             var editChange2 = result.DocumentChanges.ElementAt(2);
             Assert.True(editChange2.IsTextDocumentEdit);
             Assert.Equal("file:///c:/First/Index.razor", editChange2.TextDocumentEdit.TextDocument.Uri.ToString());
-            Assert.Equal(2, editChange2.TextDocumentEdit.Edits.Count());
-            var editChange2Edit1 = editChange2.TextDocumentEdit.Edits.ElementAt(0);
-            Assert.Equal("Test.Component5", editChange2Edit1.NewText);
-            Assert.Equal(3, editChange2Edit1.Range.Start.Line);
-            Assert.Equal(1, editChange2Edit1.Range.Start.Character);
-            Assert.Equal(3, editChange2Edit1.Range.End.Line);
-            Assert.Equal(19, editChange2Edit1.Range.End.Character);
-            var editChange2Edit2 = editChange2.TextDocumentEdit.Edits.ElementAt(1);
-            Assert.Equal("Test.Component5", editChange2Edit2.NewText);
-            Assert.Equal(3, editChange2Edit2.Range.Start.Line);
-            Assert.Equal(22, editChange2Edit2.Range.Start.Character);
-            Assert.Equal(3, editChange2Edit2.Range.End.Line);
-            Assert.Equal(40, editChange2Edit2.Range.End.Character);
+            Assert.Collection(
+                editChange2.TextDocumentEdit.Edits,
+                edit =>
+                {
+                    Assert.Equal("Test.Component5", edit.NewText);
+                    Assert.Equal(3, edit.Range.Start.Line);
+                    Assert.Equal(1, edit.Range.Start.Character);
+                    Assert.Equal(3, edit.Range.End.Line);
+                    Assert.Equal(19, edit.Range.End.Character);
+                },
+                edit =>
+                {
+                    Assert.Equal("Test.Component5", edit.NewText);
+                    Assert.Equal(3, edit.Range.Start.Line);
+                    Assert.Equal(22, edit.Range.Start.Character);
+                    Assert.Equal(3, edit.Range.End.Line);
+                    Assert.Equal(40, edit.Range.End.Character);
+                });
         }
 
         [Fact]
@@ -182,19 +197,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             var editChange1 = result.DocumentChanges.ElementAt(1);
             Assert.True(editChange1.IsTextDocumentEdit);
             Assert.Equal("file:///c:/Second/Component3.razor", editChange1.TextDocumentEdit.TextDocument.Uri.ToString());
-            Assert.Equal(2, editChange1.TextDocumentEdit.Edits.Count());
-            var editChange1Edit1 = editChange1.TextDocumentEdit.Edits.ElementAt(0);
-            Assert.Equal("Component5", editChange1Edit1.NewText);
-            Assert.Equal(1, editChange1Edit1.Range.Start.Line);
-            Assert.Equal(1, editChange1Edit1.Range.Start.Character);
-            Assert.Equal(1, editChange1Edit1.Range.End.Line);
-            Assert.Equal(11, editChange1Edit1.Range.End.Character);
-            var editChange1Edit2 = editChange1.TextDocumentEdit.Edits.ElementAt(1);
-            Assert.Equal("Component5", editChange1Edit2.NewText);
-            Assert.Equal(1, editChange1Edit2.Range.Start.Line);
-            Assert.Equal(14, editChange1Edit2.Range.Start.Character);
-            Assert.Equal(1, editChange1Edit2.Range.End.Line);
-            Assert.Equal(24, editChange1Edit2.Range.End.Character);
+            Assert.Collection(
+                editChange1.TextDocumentEdit.Edits,
+                edit =>
+                {
+                    Assert.Equal("Component5", edit.NewText);
+                    Assert.Equal(1, edit.Range.Start.Line);
+                    Assert.Equal(1, edit.Range.Start.Character);
+                    Assert.Equal(1, edit.Range.End.Line);
+                    Assert.Equal(11, edit.Range.End.Character);
+                },
+                edit =>
+                {
+                    Assert.Equal("Component5", edit.NewText);
+                    Assert.Equal(1, edit.Range.Start.Line);
+                    Assert.Equal(14, edit.Range.Start.Character);
+                    Assert.Equal(1, edit.Range.End.Line);
+                    Assert.Equal(24, edit.Range.End.Character);
+                });
             var editChange2 = result.DocumentChanges.ElementAt(2);
             Assert.True(editChange2.IsTextDocumentEdit);
             Assert.Equal("file:///c:/Second/Component4.razor", editChange2.TextDocumentEdit.TextDocument.Uri.ToString());
@@ -228,19 +248,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             var editChange = result.DocumentChanges.ElementAt(1);
             Assert.True(editChange.IsTextDocumentEdit);
             Assert.Equal("file:///c:/Dir1/Directory1.razor", editChange.TextDocumentEdit.TextDocument.Uri.ToString());
-            Assert.Equal(2, editChange.TextDocumentEdit.Edits.Count());
-            var editChangeEdit1 = editChange.TextDocumentEdit.Edits.ElementAt(0);
-            Assert.Equal("TestComponent", editChangeEdit1.NewText);
-            Assert.Equal(1, editChangeEdit1.Range.Start.Line);
-            Assert.Equal(1, editChangeEdit1.Range.Start.Character);
-            Assert.Equal(1, editChangeEdit1.Range.End.Line);
-            Assert.Equal(11, editChangeEdit1.Range.End.Character);
-            var editChangeEdit2 = editChange.TextDocumentEdit.Edits.ElementAt(1);
-            Assert.Equal("TestComponent", editChangeEdit2.NewText);
-            Assert.Equal(1, editChangeEdit2.Range.Start.Line);
-            Assert.Equal(14, editChangeEdit2.Range.Start.Character);
-            Assert.Equal(1, editChangeEdit2.Range.End.Line);
-            Assert.Equal(24, editChangeEdit2.Range.End.Character);
+            Assert.Collection(
+                editChange.TextDocumentEdit.Edits,
+                edit =>
+                {
+                    Assert.Equal("TestComponent", edit.NewText);
+                    Assert.Equal(1, edit.Range.Start.Line);
+                    Assert.Equal(1, edit.Range.Start.Character);
+                    Assert.Equal(1, edit.Range.End.Line);
+                    Assert.Equal(11, edit.Range.End.Character);
+                },
+                edit =>
+                {
+                    Assert.Equal("TestComponent", edit.NewText);
+                    Assert.Equal(1, edit.Range.Start.Line);
+                    Assert.Equal(14, edit.Range.Start.Character);
+                    Assert.Equal(1, edit.Range.End.Line);
+                    Assert.Equal(24, edit.Range.End.Character);
+                });
         }
 
         private static IEnumerable<TagHelperDescriptor> CreateRazorComponentTagHelperDescriptors(string assemblyName, string namespaceName, string tagName)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
@@ -92,6 +94,65 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             Assert.Equal(14, editChangeEdit2.Range.Start.Character);
             Assert.Equal(2, editChangeEdit2.Range.End.Line);
             Assert.Equal(24, editChangeEdit2.Range.End.Character);
+        }
+
+        [Fact]
+        public async Task Handle_Rename_FullyQualifiedAndNot()
+        {
+            // Arrange
+            var request = new RenameParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri("file:///c:/First/Index.razor")
+                },
+                Position = new Position(2, 1),
+                NewName = "Component5"
+            };
+
+            // Act
+            var result = await _endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(3, result.DocumentChanges.Count());
+            var renameChange = result.DocumentChanges.ElementAt(0);
+            Assert.True(renameChange.IsRenameFile);
+            Assert.Equal("file:///c:/First/Component1337.razor", renameChange.RenameFile.OldUri);
+            Assert.Equal("file:///c:/First/Component5.razor", renameChange.RenameFile.NewUri);
+            var editChange1 = result.DocumentChanges.ElementAt(1);
+            Assert.True(editChange1.IsTextDocumentEdit);
+            Assert.Equal("file:///c:/First/Index.razor", editChange1.TextDocumentEdit.TextDocument.Uri.ToString());
+            Assert.Equal(2, editChange1.TextDocumentEdit.Edits.Count());
+            var editChange1Edit1 = editChange1.TextDocumentEdit.Edits.ElementAt(0);
+            Assert.Equal("Component5", editChange1Edit1.NewText);
+            Assert.Equal(2, editChange1Edit1.Range.Start.Line);
+            Assert.Equal(1, editChange1Edit1.Range.Start.Character);
+            Assert.Equal(2, editChange1Edit1.Range.End.Line);
+            Assert.Equal(14, editChange1Edit1.Range.End.Character);
+            var editChange1Edit2 = editChange1.TextDocumentEdit.Edits.ElementAt(1);
+            Assert.Equal("Component5", editChange1Edit2.NewText);
+            Assert.Equal(2, editChange1Edit2.Range.Start.Line);
+            Assert.Equal(17, editChange1Edit2.Range.Start.Character);
+            Assert.Equal(2, editChange1Edit2.Range.End.Line);
+            Assert.Equal(30, editChange1Edit2.Range.End.Character);
+
+            var editChange2 = result.DocumentChanges.ElementAt(2);
+            Assert.True(editChange2.IsTextDocumentEdit);
+            Assert.Equal("file:///c:/First/Index.razor", editChange2.TextDocumentEdit.TextDocument.Uri.ToString());
+            Assert.Equal(2, editChange2.TextDocumentEdit.Edits.Count());
+            var editChange2Edit1 = editChange2.TextDocumentEdit.Edits.ElementAt(0);
+            Assert.Equal("Test.Component5", editChange2Edit1.NewText);
+            Assert.Equal(3, editChange2Edit1.Range.Start.Line);
+            Assert.Equal(1, editChange2Edit1.Range.Start.Character);
+            Assert.Equal(3, editChange2Edit1.Range.End.Line);
+            Assert.Equal(19, editChange2Edit1.Range.End.Character);
+            var editChange2Edit2 = editChange2.TextDocumentEdit.Edits.ElementAt(1);
+            Assert.Equal("Test.Component5", editChange2Edit2.NewText);
+            Assert.Equal(3, editChange2Edit2.Range.Start.Line);
+            Assert.Equal(22, editChange2Edit2.Range.Start.Character);
+            Assert.Equal(3, editChange2Edit2.Range.End.Line);
+            Assert.Equal(40, editChange2Edit2.Range.End.Character);
         }
 
         [Fact]
@@ -182,13 +243,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             Assert.Equal(24, editChangeEdit2.Range.End.Character);
         }
 
-        private static TagHelperDescriptor CreateRazorComponentTagHelperDescriptor(string assemblyName, string namespaceName, string tagName)
+        private static IEnumerable<TagHelperDescriptor> CreateRazorComponentTagHelperDescriptors(string assemblyName, string namespaceName, string tagName)
         {
             var fullyQualifiedName = $"{namespaceName}.{tagName}";
             var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
             builder.TagMatchingRule(rule => rule.TagName = tagName);
             builder.SetTypeName(fullyQualifiedName);
-            return builder.Build();
+            yield return builder.Build();
+
+            var fullyQualifiedBuilder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
+            fullyQualifiedBuilder.TagMatchingRule(rule => rule.TagName = fullyQualifiedName);
+            fullyQualifiedBuilder.SetTypeName(fullyQualifiedName);
+            fullyQualifiedBuilder.AddMetadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch);
+            yield return fullyQualifiedBuilder.Build();
         }
 
         private static TestRazorProjectItem CreateProjectItem(string text, string filePath)
@@ -199,10 +266,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             };
         }
 
-        private DocumentSnapshot CreateRazorDocumentSnapshot(RazorProjectEngine projectEngine, TestRazorProjectItem item, string rootNamespaceName)
+        private DocumentSnapshot CreateRazorDocumentSnapshot(RazorProjectEngine projectEngine, TestRazorProjectItem item, string rootNamespaceName, IReadOnlyList<TagHelperDescriptor> tagHelpers)
         {
             var codeDocument = projectEngine.ProcessDesignTime(item);
-
+            
             var namespaceNode = (NamespaceDeclarationIntermediateNode)codeDocument
                 .GetDocumentIntermediateNode()
                 .FindDescendantNodes<IntermediateNode>()
@@ -210,59 +277,69 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             namespaceNode.Content = rootNamespaceName;
 
             var sourceText = SourceText.From(new string(item.Content));
+            var projectWorkspaceState = new ProjectWorkspaceState(tagHelpers, LanguageVersion.Default);
+            var projectSnapshot = TestProjectSnapshot.Create("C:/project.csproj", projectWorkspaceState);
             var documentSnapshot = Mock.Of<DocumentSnapshot>(d =>
                 d.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
                 d.FilePath == item.FilePath &&
                 d.FileKind == FileKinds.Component &&
-                d.GetTextAsync() == Task.FromResult(sourceText));
+                d.GetTextAsync() == Task.FromResult(sourceText) &&
+                d.Project == projectSnapshot);
             return documentSnapshot;
         }
 
         private RazorComponentRenameEndpoint CreateEndpoint(LanguageServerFeatureOptions languageServerFeatureOptions = null)
         {
-            var tag1 = CreateRazorComponentTagHelperDescriptor("First", "First.Components", "Component1");
-            var tag2 = CreateRazorComponentTagHelperDescriptor("First", "Test", "Component2");
-            var tag3 = CreateRazorComponentTagHelperDescriptor("Second", "Second.Components", "Component3");
-            var tag4 = CreateRazorComponentTagHelperDescriptor("Second", "Second.Components", "Component4");
-            var directory1 = CreateRazorComponentTagHelperDescriptor("First", "Test.Components", "Directory1");
-            var directory2 = CreateRazorComponentTagHelperDescriptor("First", "Test.Components", "Directory2");
-            var tagHelperDescriptors = new[] { tag1, tag2, tag3, tag4, directory1, directory2 };
+            var tagHelperDescriptors = new List<TagHelperDescriptor>();
+            tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("First", "First.Components", "Component1"));
+            tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("First", "Test", "Component2"));
+            tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("Second", "Second.Components", "Component3"));
+            tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("Second", "Second.Components", "Component4"));
+            tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("First", "Test", "Component1337"));
+            tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("First", "Test.Components", "Directory1"));
+            tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("First", "Test.Components", "Directory2"));
                 
             var item1 = CreateProjectItem("@namespace First.Components\n@using Test\n<Component2></Component2>", "c:/First/Component1.razor");
             var item2 = CreateProjectItem("@namespace Test", "c:/First/Component2.razor");
             var item3 = CreateProjectItem("@namespace Second.Components\n<Component3></Component3>", "c:/Second/Component3.razor");
             var item4 = CreateProjectItem("@namespace Second.Components\n<Component3></Component3>\n<Component3></Component3>", "c:/Second/Component4.razor");
+            var item1337 = CreateProjectItem(string.Empty, "c:/First/Component1337.razor");
+            var indexItem = CreateProjectItem("@namespace First.Components\n@using Test\n<Component1337></Component1337>\n<Test.Component1337></Test.Component1337>", "c:/First/Index.razor");
 
             var itemDirectory1 = CreateProjectItem("@namespace Test.Components\n<Directory2></Directory2>", "c:/Dir1/Directory1.razor");
             var itemDirectory2 = CreateProjectItem("@namespace Test.Components\n<Directory1></Directory1>", "c:/Dir2/Directory2.razor");
 
-            var fileSystem = new TestRazorProjectFileSystem(new[] { item1, item2, item3, item4, itemDirectory1, itemDirectory2 });
+            var fileSystem = new TestRazorProjectFileSystem(new[] { item1, item2, item3, item4, indexItem, itemDirectory1, itemDirectory2 });
 
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, builder => {
                 builder.AddDirective(NamespaceDirective.Directive);
                 builder.AddTagHelpers(tagHelperDescriptors);
             });
             
-            var component1 = CreateRazorDocumentSnapshot(projectEngine, item1, "First.Components");
-            var component2 = CreateRazorDocumentSnapshot(projectEngine, item2, "Test");
-            var component3 = CreateRazorDocumentSnapshot(projectEngine, item3, "Second.Components");
-            var component4 = CreateRazorDocumentSnapshot(projectEngine, item4, "Second.Components");
-            var directory1Component = CreateRazorDocumentSnapshot(projectEngine, itemDirectory1, "Test.Components");
-            var directory2Component = CreateRazorDocumentSnapshot(projectEngine, itemDirectory2, "Test.Components");
+            var component1 = CreateRazorDocumentSnapshot(projectEngine, item1, "First.Components", tagHelperDescriptors);
+            var component2 = CreateRazorDocumentSnapshot(projectEngine, item2, "Test", tagHelperDescriptors);
+            var component3 = CreateRazorDocumentSnapshot(projectEngine, item3, "Second.Components", tagHelperDescriptors);
+            var component4 = CreateRazorDocumentSnapshot(projectEngine, item4, "Second.Components", tagHelperDescriptors);
+            var component1337 = CreateRazorDocumentSnapshot(projectEngine, item1337, "Test", tagHelperDescriptors);
+            var index = CreateRazorDocumentSnapshot(projectEngine, indexItem, "First.Components", tagHelperDescriptors);
+            var directory1Component = CreateRazorDocumentSnapshot(projectEngine, itemDirectory1, "Test.Components", tagHelperDescriptors);
+            var directory2Component = CreateRazorDocumentSnapshot(projectEngine, itemDirectory2, "Test.Components", tagHelperDescriptors);
 
             var firstProject = Mock.Of<ProjectSnapshot>(p =>
                 p.FilePath == "c:/First/First.csproj" &&
-                p.DocumentFilePaths == new[] { "c:/First/Component1.razor", "c:/First/Component2.razor", itemDirectory1.FilePath, itemDirectory2.FilePath } &&
+                p.DocumentFilePaths == new[] { "c:/First/Component1.razor", "c:/First/Component2.razor", itemDirectory1.FilePath, itemDirectory2.FilePath, component1337.FilePath } &&
                 p.GetDocument("c:/First/Component1.razor") == component1 &&
                 p.GetDocument("c:/First/Component2.razor") == component2 &&
                 p.GetDocument(itemDirectory1.FilePath) == directory1Component &&
-                p.GetDocument(itemDirectory2.FilePath) == directory2Component);
+                p.GetDocument(itemDirectory2.FilePath) == directory2Component &&
+                p.GetDocument(component1337.FilePath) == component1337);
 
             var secondProject = Mock.Of<ProjectSnapshot>(p =>
                 p.FilePath == "c:/Second/Second.csproj" &&
-                p.DocumentFilePaths == new[] { "c:/Second/Component3.razor", "c:/Second/Component4.razor" } &&
+                p.DocumentFilePaths == new[] { "c:/Second/Component3.razor", "c:/Second/Component4.razor", index.FilePath } &&
                 p.GetDocument("c:/Second/Component3.razor") == component3 &&
-                p.GetDocument("c:/Second/Component4.razor") == component4);
+                p.GetDocument("c:/Second/Component4.razor") == component4 &&
+                p.GetDocument(index.FilePath) == index);
 
             var projectSnapshotManager = Mock.Of<ProjectSnapshotManagerBase>(p => p.Projects == new[] { firstProject, secondProject });
             var projectSnapshotManagerAccessor = new TestProjectSnapshotManagerAccessor(projectSnapshotManager);
@@ -272,6 +349,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
                 d.TryResolveDocument("c:/First/Component2.razor", out component2) == true &&
                 d.TryResolveDocument("c:/Second/Component3.razor", out component3) == true &&
                 d.TryResolveDocument("c:/Second/Component4.razor", out component4) == true &&
+                d.TryResolveDocument(index.FilePath, out index) == true &&
+                d.TryResolveDocument(component1337.FilePath, out component1337) == true &&
                 d.TryResolveDocument(itemDirectory1.FilePath, out directory1Component) == true &&
                 d.TryResolveDocument(itemDirectory2.FilePath, out directory2Component) == true);
 


### PR DESCRIPTION
- Prior to this when renaming a component it would only ever successfully rename a non-fully qualified component. Now we understand that a rename operation can occur on a fully qualified component and translate the appropriate edits. Also, we used to never translate edits onto associated fully qualified components. Now we do the needful.
- Added a test to cover the fully qualified scenario.

![image](https://i.imgur.com/Zfp5v2i.gif)


Fixes dotnet/aspnetcore#25021
