### PR TITLE
Fix CTRL+. Not Invoking Code Actions

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -135,6 +135,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
 
+            // VS Provides `CodeActionParams.Context.SelectionRange` in addition to
+            // `CodeActionParams.Range`. The `SelectionRange` is relative to where the
+            // code action was invoked (ex. line 14, char 3) whereas the `Range` is
+            // always at the start of the line (ex. line 14, char 0). We want to utilize
+            // the relative positioning to ensure we provide code actions for the appropriate
+            // context.
+            //
+            // Note: VS Code doesn't provide a `SelectionRange`.
             if (request.Context.SelectionRange != null)
             {
                 request.Range = request.Context.SelectionRange;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -148,6 +148,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 request.Range = request.Context.SelectionRange;
             }
 
+            // We hide `CodeActionParams.CodeActionContext` in order to capture
+            // `RazorCodeActionParams.ExtendedCodeActionContext`, we must
+            // restore this context to access diagnostics.
+            (request as CodeActionParams).Context = request.Context;
+
             var linePosition = new LinePosition(
                 request.Range.Start.Line,
                 request.Range.Start.Character);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
@@ -13,7 +13,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
-    internal class CodeActionResolutionEndpoint : ICodeActionResolveHandler
+    internal class CodeActionResolutionEndpoint : IRazorCodeActionResolveHandler
     {
         private static readonly string CodeActionsResolveProviderCapability = "codeActionsResolveProvider";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IRazorCodeActionHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IRazorCodeActionHandler.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
+{
+    [Parallel, Method("textDocument/codeAction", Direction.ClientToServer)]
+    internal interface IRazorCodeActionHandler :
+        IJsonRpcRequestHandler<RazorCodeActionParams, CommandOrCodeActionContainer>,
+        IRegistration<CodeActionRegistrationOptions>,
+        ICapability<CodeActionCapability>
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IRazorCodeActionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IRazorCodeActionResolveHandler.cs
@@ -8,7 +8,7 @@ using OmniSharp.Extensions.JsonRpc;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     [Serial, Method(LanguageServerConstants.RazorCodeActionResolveEndpoint)]
-    internal interface ICodeActionResolveHandler :
+    internal interface IRazorCodeActionResolveHandler :
         IJsonRpcRequestHandler<RazorCodeAction, RazorCodeAction>,
         IRegistrationExtension
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IRazorCodeActionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IRazorCodeActionResolveHandler.cs
@@ -7,7 +7,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
-    [Serial, Method(LanguageServerConstants.RazorCodeActionResolveEndpoint)]
+    [Parallel, Method(LanguageServerConstants.RazorCodeActionResolveEndpoint)]
     internal interface IRazorCodeActionResolveHandler :
         IJsonRpcRequestHandler<RazorCodeAction, RazorCodeAction>,
         IRegistrationExtension

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/ExtendedCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/ExtendedCodeActionContext.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
+{
+    class ExtendedCodeActionContext : CodeActionContext
+    {
+        [Optional]
+        public Range SelectionRange { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/ExtendedCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/ExtendedCodeActionContext.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
 {
-    class ExtendedCodeActionContext : CodeActionContext
+    internal class ExtendedCodeActionContext : CodeActionContext
     {
         [Optional]
         public Range SelectionRange { get; set; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionParams.cs
@@ -5,7 +5,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
 {
-    class RazorCodeActionParams : CodeActionParams
+    internal class RazorCodeActionParams : CodeActionParams
     {
         public new ExtendedCodeActionContext Context { get; set; }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionParams.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
+{
+    class RazorCodeActionParams : CodeActionParams
+    {
+        public new ExtendedCodeActionContext Context { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
@@ -3,16 +3,16 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal sealed class RazorCodeActionContext
     {
         public RazorCodeActionContext(
-            RazorCodeActionParams request,
+            CodeActionParams request,
             DocumentSnapshot documentSnapshot,
             RazorCodeDocument codeDocument,
             SourceLocation location,
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             SupportsFileCreation = supportsFileCreation;
         }
 
-        public RazorCodeActionParams Request { get; }
+        public CodeActionParams Request { get; }
         public DocumentSnapshot DocumentSnapshot { get; }
         public RazorCodeDocument CodeDocument { get; }
         public SourceLocation Location { get; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
@@ -3,16 +3,16 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal sealed class RazorCodeActionContext
     {
         public RazorCodeActionContext(
-            CodeActionParams request,
+            RazorCodeActionParams request,
             DocumentSnapshot documentSnapshot,
             RazorCodeDocument codeDocument,
             SourceLocation location,
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             SupportsFileCreation = supportsFileCreation;
         }
 
-        public CodeActionParams Request { get; }
+        public RazorCodeActionParams Request { get; }
         public DocumentSnapshot DocumentSnapshot { get; }
         public RazorCodeDocument CodeDocument { get; }
         public SourceLocation Location { get; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -46,10 +46,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             {
                 _supportsCodeActionResolve = false
             };
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -78,10 +79,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             {
                 _supportsCodeActionResolve = false
             };
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -109,10 +111,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             {
                 _supportsCodeActionResolve = false
             };
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -143,10 +146,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -155,7 +159,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Assert
             Assert.Single(commandOrCodeActionContainer);
         }
-
 
         [Fact]
         public async Task Handle_MultipleProviders()
@@ -180,10 +183,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -214,10 +218,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -251,10 +256,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -287,10 +293,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 _supportsCodeActionResolve = true
             };
 
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -333,10 +340,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 1), new Position(0, 1)),
+                Context = new ExtendedCodeActionContext()
             };
 
             // Act
@@ -350,6 +358,87 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                     Assert.True(c.CodeAction is RazorCodeAction);
                 },
                 c => Assert.True(c.IsCommand));
+        }
+
+        [Fact]
+        public async Task GenerateRazorCodeActionContextAsync_WithSelectionRange()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/Page.razor";
+            var codeDocument = CreateCodeDocument("@code {}");
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var codeActionEndpoint = new CodeActionEndpoint(
+                DocumentMappingService,
+                new RazorCodeActionProvider[] {
+                    new MockCodeActionProvider()
+                },
+                Array.Empty<CSharpCodeActionProvider>(),
+                Dispatcher,
+                documentResolver,
+                LanguageServer,
+                LanguageServerFeatureOptions)
+            {
+                _supportsCodeActionResolve = false
+            };
+
+            var initialRange = new Range(new Position(0, 1), new Position(0, 1));
+            var selectionRange = new Range(new Position(0, 5), new Position(0, 5));
+            var request = new RazorCodeActionParams()
+            {
+                TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
+                Range = initialRange,
+                Context = new ExtendedCodeActionContext()
+                {
+                    SelectionRange = selectionRange,
+                }
+            };
+
+            // Act
+            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, default);
+
+            // Assert
+            Assert.NotNull(razorCodeActionContext);
+            Assert.Equal(selectionRange, razorCodeActionContext.Request.Range);
+        }
+
+        [Fact]
+        public async Task GenerateRazorCodeActionContextAsync_WithoutSelectionRange()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/Page.razor";
+            var codeDocument = CreateCodeDocument("@code {}");
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var codeActionEndpoint = new CodeActionEndpoint(
+                DocumentMappingService,
+                new RazorCodeActionProvider[] {
+                    new MockCodeActionProvider()
+                },
+                Array.Empty<CSharpCodeActionProvider>(),
+                Dispatcher,
+                documentResolver,
+                LanguageServer,
+                LanguageServerFeatureOptions)
+            {
+                _supportsCodeActionResolve = false
+            };
+
+            var initialRange = new Range(new Position(0, 1), new Position(0, 1));
+            var request = new RazorCodeActionParams()
+            {
+                TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
+                Range = initialRange,
+                Context = new ExtendedCodeActionContext()
+                {
+                    SelectionRange = null
+                }
+            };
+
+            // Act
+            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, default);
+
+            // Assert
+            Assert.NotNull(razorCodeActionContext);
+            Assert.Equal(initialRange, razorCodeActionContext.Request.Range);
         }
 
         private class MockCodeActionProvider : RazorCodeActionProvider

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ComponentAccessibilityCodeActionProviderTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
@@ -26,7 +27,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -51,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = " <Component></Component>";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 0), new Position(0, 0)),
@@ -75,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "<Component></Component>";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 0), new Position(0, 0)),
@@ -118,7 +119,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "<NewComponent></NewComponent>";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 0), new Position(0, 0)),
@@ -144,7 +145,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "<NewComponent></NewComponent>";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 0), new Position(0, 0)),
@@ -169,7 +170,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "<Component></Component>";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(new Position(0, 0), new Position(0, 0)),
@@ -200,7 +201,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
                 });
         }
 
-        private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, SourceSpan componentSourceSpan, bool supportsFileCreation = true)
+        private static RazorCodeActionContext CreateRazorCodeActionContext(RazorCodeActionParams request, SourceLocation location, string filePath, string text, SourceSpan componentSourceSpan, bool supportsFileCreation = true)
         {
             var shortComponent = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "Fully.Qualified.Component", "TestAssembly");
             shortComponent.TagMatchingRule(rule => rule.TagName = "Component");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "@page \"/test\"\n@code {}";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "@page \"/test\"\n@code {}";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "@page \"/test\"\n@code {}";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "@page \"/test\"\n@code";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "@page \"/test\"\n@code { void Test() { <h1>Hello, world!</h1> } }";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "@page \"/test\"\n@code { private var x = 1; }";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "@page \"/test\"\n@code { private var x = 1; }";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             // Arrange
             var documentPath = "c:/Test.razor";
             var contents = "@page \"/test\"\n@functions { private var x = 1; }";
-            var request = new CodeActionParams()
+            var request = new RazorCodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = new Range(),
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             Assert.Equal(47, actionParams.RemoveEnd);
         }
 
-        private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, bool supportsFileCreation = true)
+        private static RazorCodeActionContext CreateRazorCodeActionContext(RazorCodeActionParams request, SourceLocation location, string filePath, string text, bool supportsFileCreation = true)
         {
             var codeDocument = TestRazorCodeDocument.CreateEmpty();
             codeDocument.SetFileKind(FileKinds.Component);


### PR DESCRIPTION
### Summary of the changes
Issue was due to some recent changes in LSP platform where they now give a `CodeActionParams.Range` which reflects the start of the line, instead of at the start of the area we want to act on. They still provide the "old"  selection range in `CodeActionParams.Context.SelectionRange`. Updated our logic to consume that instead if it's available.

Confirmed functionality in VS + VSCode & added tests.

Thanks @NTaylorMullen!

Fixes: https://github.com/dotnet/aspnetcore/issues/25964
