### PR TITLE
Properly track/untrack doc state when files get renamed while open.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultFileUriProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultFileUriProvider.cs
@@ -82,5 +82,15 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
             return false;
         }
+
+        public override void Remove(ITextBuffer textBuffer)
+        {
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            textBuffer.Properties.RemoveProperty(TextBufferUri);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentManager.cs
@@ -92,6 +92,9 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                 return;
             }
 
+            // Given we're no longer tracking the document we don't want to pin the Uri to the current state of the buffer (could have been renamed to another Uri).
+            _fileUriProvider.Remove(buffer);
+
             if (_documents.TryRemove(uri, out _))
             {
                 var args = new LSPDocumentChangeEventArgs(lspDocument.CurrentSnapshot, @new: null, LSPDocumentChangeKind.Removed);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/FileUriProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/FileUriProvider.cs
@@ -35,5 +35,11 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         /// <param name="textBuffer">A text buffer</param>
         /// <param name="uri">A <see cref="Uri"/> that can be used to locate the provided <paramref name="textBuffer"/>.</param>
         public abstract void AddOrUpdate(ITextBuffer textBuffer, Uri uri);
+
+        /// <summary>
+        /// Clears all <see cref="Uri"/> related state on the provided <paramref name="buffer"/>.
+        /// </summary>
+        /// <param name="buffer">A text buffer</param>
+        public abstract void Remove(ITextBuffer buffer);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorContentTypeChangeListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorContentTypeChangeListenerTest.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
@@ -74,6 +76,93 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             // Act
             listener.RazorBufferDisposed(DisposedRazorBuffer);
+
+            // Assert
+            lspDocumentManager.VerifyAll();
+        }
+
+        [Theory]
+        [InlineData(FileActionTypes.ContentSavedToDisk)]
+        [InlineData(FileActionTypes.ContentLoadedFromDisk)]
+        public void TextDocument_FileActionOccurred_NonRenameEvent_Noops(FileActionTypes fileActionType)
+        {
+            // Arrange
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
+            lspDocumentManager.Setup(manager => manager.TrackDocument(It.IsAny<ITextBuffer>()))
+                .Throws<XunitException>();
+            lspDocumentManager.Setup(manager => manager.UntrackDocument(It.IsAny<ITextBuffer>()))
+                .Throws<XunitException>();
+            var listener = CreateListener(lspDocumentManager.Object);
+            var args = new TextDocumentFileActionEventArgs("C:/path/to/file.razor", DateTime.UtcNow, fileActionType);
+            var textDocument = Mock.Of<ITextDocument>(td => td.TextBuffer == RazorBuffer);
+
+            // Act & Assert
+            listener.TextDocument_FileActionOccurred(textDocument, args);
+        }
+
+        [Fact]
+        public void TextDocument_FileActionOccurred_NonTextDocument_Noops()
+        {
+            // Arrange
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
+            lspDocumentManager.Setup(manager => manager.TrackDocument(It.IsAny<ITextBuffer>()))
+                .Throws<XunitException>();
+            lspDocumentManager.Setup(manager => manager.UntrackDocument(It.IsAny<ITextBuffer>()))
+                .Throws<XunitException>();
+            var listener = CreateListener(lspDocumentManager.Object);
+            var args = new TextDocumentFileActionEventArgs("C:/path/to/file.razor", DateTime.UtcNow, FileActionTypes.DocumentRenamed);
+
+            // Act & Assert
+            listener.TextDocument_FileActionOccurred(RazorBuffer, args);
+        }
+
+        [Fact]
+        public void TextDocument_FileActionOccurred_NoAssociatedBuffer_Noops()
+        {
+            // Arrange
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
+            lspDocumentManager.Setup(manager => manager.TrackDocument(It.IsAny<ITextBuffer>()))
+                .Throws<XunitException>();
+            lspDocumentManager.Setup(manager => manager.UntrackDocument(It.IsAny<ITextBuffer>()))
+                .Throws<XunitException>();
+            var listener = CreateListener(lspDocumentManager.Object);
+            var args = new TextDocumentFileActionEventArgs("C:/path/to/file.razor", DateTime.UtcNow, FileActionTypes.DocumentRenamed);
+            var textDocument = Mock.Of<ITextDocument>();
+
+            // Act & Assert
+            listener.TextDocument_FileActionOccurred(textDocument, args);
+        }
+
+        [Fact]
+        public void TextDocument_FileActionOccurred_Rename_UntracksAndThenTracks()
+        {
+            // Arrange
+            var lspDocumentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
+            var tracked = false;
+            var untracked = false;
+            lspDocumentManager.Setup(manager => manager.TrackDocument(It.IsAny<ITextBuffer>()))
+                .Callback(() =>
+                {
+                    Assert.False(tracked);
+                    Assert.True(untracked);
+
+                    tracked = true;
+                })
+                .Verifiable();
+            lspDocumentManager.Setup(manager => manager.UntrackDocument(It.IsAny<ITextBuffer>()))
+                .Callback(() =>
+                {
+                    Assert.False(tracked);
+                    Assert.False(untracked);
+                    untracked = true;
+                })
+                .Verifiable();
+            var listener = CreateListener(lspDocumentManager.Object);
+            var args = new TextDocumentFileActionEventArgs("C:/path/to/file.razor", DateTime.UtcNow, FileActionTypes.DocumentRenamed);
+            var textDocument = Mock.Of<ITextDocument>(td => td.TextBuffer == RazorBuffer);
+
+            // Act
+            listener.TextDocument_FileActionOccurred(textDocument, args);
 
             // Assert
             lspDocumentManager.VerifyAll();


### PR DESCRIPTION
- Our current way of initializing the Razor world was powered by TextBuffer content type changes. For most cases this was an accurate way to detect when documents were created/torn down; however, in the case that a user renames a document that happens to be opened to a file name that has the same content type we we weren't notified. Meaning we'd try and lookup C#/HTML documents and we'd fail to find them because we'd still think the buffer was associated with the old name.
- Updated our `RazorContentTypeChangeListener` to attach to `ITextDocument` `FileActionOccurred` events to properly track/untrack our documents.
- Found that our current way of "untracking" a buffer would result in the buffers Uri state bleeding into future renames. To address this I expanded the FileUriProvider to have a "Remove" method which clears state.
- Updated tests to validate the new renaming mechanism.

Part of dotnet/aspnetcore#25045

FYI @ToddGrun in case you area also relying on `IContentTypeChangeListener`s