### PR TITLE
Properly handle snapshot manager changes that get nested.

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -593,6 +593,39 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Equal(ProjectChangeKind.ProjectChanged, ProjectManager.ListenersNotifiedOf);
         }
 
+        [ForegroundFact]
+        public void NestedNotifications_NotifiesListenersInCorrectOrder()
+        {
+            // Arrange
+            var listenerNotifications = new List<ProjectChangeKind>();
+            ProjectManager.ProjectAdded(HostProject);
+            ProjectManager.Reset();
+            ProjectManager.Changed += (sender, args) =>
+            {
+                // These conditions will result in a triply nested change notification of Add -> Change -> Remove all within the .Change chain.
+
+                if (args.Kind == ProjectChangeKind.DocumentAdded)
+                {
+                    ProjectManager.DocumentOpened(HostProject.FilePath, Documents[0].FilePath, SourceText);
+                }
+                else if (args.Kind == ProjectChangeKind.DocumentChanged)
+                {
+                    ProjectManager.DocumentRemoved(HostProject, Documents[0]);
+                }
+            };
+            ProjectManager.Changed += (sender, args) =>
+            {
+                listenerNotifications.Add(args.Kind);
+            };
+            ProjectManager.NotifyChangedEvents = true;
+
+            // Act
+            ProjectManager.DocumentAdded(HostProject, Documents[0], null);
+
+            // Assert
+            Assert.Equal(new[] { ProjectChangeKind.DocumentAdded, ProjectChangeKind.DocumentChanged, ProjectChangeKind.DocumentRemoved }, listenerNotifications);
+        }
+
         private class TestProjectSnapshotManager : DefaultProjectSnapshotManager
         {
             public TestProjectSnapshotManager(ForegroundDispatcher dispatcher, IEnumerable<ProjectSnapshotChangeTrigger> triggers, Workspace workspace)
@@ -601,6 +634,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
 
             public ProjectChangeKind? ListenersNotifiedOf { get; private set; }
+
+            public bool NotifyChangedEvents { get; set; }
 
             public DefaultProjectSnapshot GetSnapshot(HostProject hostProject)
             {
@@ -620,6 +655,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             protected override void NotifyListeners(ProjectChangeEventArgs e)
             {
                 ListenersNotifiedOf = e.Kind;
+
+                if (NotifyChangedEvents)
+                {
+                    base.NotifyListeners(e);
+                }
             }
         }
 


### PR DESCRIPTION
- I found that in VisualStudio when you rename a document our system detects that a new file gets added and reacts by "opening" said document. Now the problem with this approach is that our project snapshot manager would notify consumers of a "DocumentChanged" event for a file that hadn't been notified as "added" yet. To account for this I added a notification work queue to the project snapshot manager and unwind all notifications after an initial notification has been notified.
- Added a test for this case.

Part of dotnet/aspnetcore#25045