### PR TITLE
Upgrade O# and remove workaround for hang.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,7 +122,7 @@
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <!-- STOP!!! We need to reference the version of JSON that our HOSTS supprt. -->
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
-    <OmniSharpExtensionsLanguageServerPackageVersion>0.18.0-beta0083</OmniSharpExtensionsLanguageServerPackageVersion>
+    <OmniSharpExtensionsLanguageServerPackageVersion>0.18.0-beta0084</OmniSharpExtensionsLanguageServerPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.33.0</OmniSharpMSBuildPackageVersion>
     <SystemPrivateUriPackageVersion>4.3.2</SystemPrivateUriPackageVersion>
     <SystemCompositionPackageVersion>1.0.31.0</SystemCompositionPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -125,10 +125,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var traceLevel = GetVerbosity();
             _server = await RazorLanguageServer.CreateAsync(serverStream, serverStream, traceLevel, ConfigureLanguageServer).ConfigureAwait(false);
 
-            // Fire and forget for Initialized. Need to allow the LSP infrastructure to run in order to actually Initialize. We do a Task.Run to emulate initializing
-            // the language server on a separate thread; otherwise we'll initialize our language server on VS' main thread which will have many unintended consequences
-            // such as O# booting their input read loop on VS' main thread.
-            Task.Run(() => _server.InitializedAsync(token)).FileAndForget("RazorLanguageServerClient_ActivateAsync");
+            // Fire and forget for Initialized. Need to allow the LSP infrastructure to run in order to actually Initialize.
+            _server.InitializedAsync(token).FileAndForget("RazorLanguageServerClient_ActivateAsync");
 
             var connection = new Connection(clientStream, clientStream);
             return connection;


### PR DESCRIPTION
- OmniSharp updated their package to include a fix for a VS infinite hang for peek definition & light bulb invocation. This PR just consumes the new package and removes our workaround.