### PR TITLE
Add cross-plat tests to Razor.slim.sln

### DIFF
--- a/src/Razor/Razor.Slim.sln
+++ b/src/Razor/Razor.Slim.sln
@@ -60,6 +60,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Lang
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common", "test\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common.csproj", "{262C3178-4564-4224-80DD-C72FA0E06432}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.LanguageServer", "src\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj", "{DA90AF6B-A593-46AD-9597-A43C9FAE532E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.LanguageServer.Common", "src\Microsoft.AspNetCore.Razor.LanguageServer.Common\Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj", "{A8D7938C-B635-40B0-92EB-CB4C2D06EF6F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.LanguageServer.Common.Test", "test\Microsoft.AspNetCore.Razor.LanguageServer.Common.Test\Microsoft.AspNetCore.Razor.LanguageServer.Common.Test.csproj", "{8F60F0C5-55C8-467D-B109-6708ECCAF4AF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.LanguageServer.Test", "test\Microsoft.AspNetCore.Razor.LanguageServer.Test\Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj", "{D6D23DCC-0185-464E-90D5-833A97E8F631}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.LanguageServer.Test.Common", "test\Microsoft.AspNetCore.Razor.LanguageServer.Test.Common\Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.csproj", "{7122A9E2-271D-4E62-92A8-7025E0840048}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -162,6 +172,26 @@ Global
 		{262C3178-4564-4224-80DD-C72FA0E06432}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{262C3178-4564-4224-80DD-C72FA0E06432}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{262C3178-4564-4224-80DD-C72FA0E06432}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA90AF6B-A593-46AD-9597-A43C9FAE532E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA90AF6B-A593-46AD-9597-A43C9FAE532E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA90AF6B-A593-46AD-9597-A43C9FAE532E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA90AF6B-A593-46AD-9597-A43C9FAE532E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8D7938C-B635-40B0-92EB-CB4C2D06EF6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8D7938C-B635-40B0-92EB-CB4C2D06EF6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8D7938C-B635-40B0-92EB-CB4C2D06EF6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8D7938C-B635-40B0-92EB-CB4C2D06EF6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F60F0C5-55C8-467D-B109-6708ECCAF4AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F60F0C5-55C8-467D-B109-6708ECCAF4AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F60F0C5-55C8-467D-B109-6708ECCAF4AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F60F0C5-55C8-467D-B109-6708ECCAF4AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6D23DCC-0185-464E-90D5-833A97E8F631}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6D23DCC-0185-464E-90D5-833A97E8F631}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6D23DCC-0185-464E-90D5-833A97E8F631}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6D23DCC-0185-464E-90D5-833A97E8F631}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7122A9E2-271D-4E62-92A8-7025E0840048}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7122A9E2-271D-4E62-92A8-7025E0840048}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7122A9E2-271D-4E62-92A8-7025E0840048}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7122A9E2-271D-4E62-92A8-7025E0840048}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -191,6 +221,11 @@ Global
 		{C1BDA061-68C1-4BF3-9D4C-19C7EA110B2E} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 		{64BBC407-4B89-48D2-A08A-BAAB129EFE2E} = {92463391-81BE-462B-AC3C-78C6C760741F}
 		{262C3178-4564-4224-80DD-C72FA0E06432} = {92463391-81BE-462B-AC3C-78C6C760741F}
+		{DA90AF6B-A593-46AD-9597-A43C9FAE532E} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
+		{A8D7938C-B635-40B0-92EB-CB4C2D06EF6F} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
+		{8F60F0C5-55C8-467D-B109-6708ECCAF4AF} = {92463391-81BE-462B-AC3C-78C6C760741F}
+		{D6D23DCC-0185-464E-90D5-833A97E8F631} = {92463391-81BE-462B-AC3C-78C6C760741F}
+		{7122A9E2-271D-4E62-92A8-7025E0840048} = {92463391-81BE-462B-AC3C-78C6C760741F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0035341D-175A-4D05-95E6-F1C2785A1E26}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -149,21 +149,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             Assert.Equal("/", normalized);
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Test only valid on non-Windows boxes")]
-        public void Normalize_NonWindows_AddsLeadingForwardSlash()
-        {
-            // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
-            var filePath = "path/to/document.cshtml";
-
-            // Act
-            var normalized = filePathNormalizer.Normalize(filePath);
-
-            // Assert
-            Assert.Equal("/path/to/document.cshtml", normalized);
-        }
-
         [Fact]
         public void Normalize_UrlDecodesFilePath()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.CodeAnalysis.Razor;
 using Moq;
 using Xunit;
@@ -150,7 +151,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Equal(0, detector.StopCount);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Handle_ChangedConfigurationOutputPath_StartsWithNewPath()
         {
             // Arrange
@@ -181,7 +184,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Equal(1, detector.StopCount);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Handle_ChangedConfigurationExternalToInternal_StopsWithoutRestarting()
         {
             // Arrange
@@ -212,7 +217,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Equal(1, detector.StopCount);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Handle_MultipleProjects_StartedAndStopped()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
@@ -49,8 +49,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void GetItem_RootedFilePath_DoesNotBelongToProject()
         {
             // Arrange
-            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to", FilePathNormalizer);
-            var documentFilePath = "C:/otherpath/to/file.cshtml";
+            var fileSystem = new RemoteRazorProjectFileSystem("/C:/path/to", FilePathNormalizer);
+            var documentFilePath = "/C:/otherpath/to/file.cshtml";
 
             // Act
             var item = fileSystem.GetItem(documentFilePath, fileKind: null);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
@@ -45,7 +46,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Equal(documentFilePath, item.PhysicalPath);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux)]
         public void GetItem_RootedFilePath_DoesNotBelongToProject()
         {
             // Arrange


### PR DESCRIPTION
- This ensures that these language server tests are running cross-plat.
- Initially I expect this test to fail with several cross-plat related test breaks. We'll update the PR to get them all building