### PR TITLE
Updating LanguageServer.Protocol assemblies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -98,13 +98,13 @@
     <MicrosoftNetCompilersToolsetPackageVersion>3.8.0-3.20454.4</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftNetRoslynDiagnosticsPackageVersion>2.6.3</MicrosoftNetRoslynDiagnosticsPackageVersion>
     <MicrosoftServiceHubFrameworkPackageVersion>2.6.44</MicrosoftServiceHubFrameworkPackageVersion>
-    <MicrosoftVisualStudioCoreUtilityPackageVersion>16.7.66</MicrosoftVisualStudioCoreUtilityPackageVersion>
+    <MicrosoftVisualStudioCoreUtilityPackageVersion>16.8.80</MicrosoftVisualStudioCoreUtilityPackageVersion>
     <MicrosoftVisualStudioComponentModelHostPackageVersion>16.0.467</MicrosoftVisualStudioComponentModelHostPackageVersion>
     <MicrosoftVisualStudioImageCatalogPackageVersion>16.7.30204.194-pre</MicrosoftVisualStudioImageCatalogPackageVersion>
     <MicrosoftVisualStudioEditorPackageVersion>16.4.280</MicrosoftVisualStudioEditorPackageVersion>
     <MicrosoftVisualStudioLanguagePackageVersion>16.6.255</MicrosoftVisualStudioLanguagePackageVersion>
     <MicrosoftVisualStudioLanguageIntellisensePackageVersion>16.6.255</MicrosoftVisualStudioLanguageIntellisensePackageVersion>
-    <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>16.7.65</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
+    <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>16.8.103</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
     <MicrosoftVisualStudioPackageLanguageService150PackageVersion>16.7.30204.53-pre</MicrosoftVisualStudioPackageLanguageService150PackageVersion>
     <MicrosoftVisualStudioLiveSharePackageVersion>0.3.1074</MicrosoftVisualStudioLiveSharePackageVersion>
     <MicrosoftVisualStudioOLEInteropPackageVersion>7.10.6071</MicrosoftVisualStudioOLEInteropPackageVersion>
@@ -114,8 +114,8 @@
     <MicrosoftVisualStudioShellInterop163DesignTimePackageVersion>16.3.29316.127</MicrosoftVisualStudioShellInterop163DesignTimePackageVersion>
     <MicrosoftVisualStudioShell150PackageVersion>16.7.30204.53-pre</MicrosoftVisualStudioShell150PackageVersion>
     <MicrosoftVisualStudioShellInteropPackageVersion>7.10.6073</MicrosoftVisualStudioShellInteropPackageVersion>
-    <MicrosoftVisualStudioTextDataPackageVersion>16.6.255</MicrosoftVisualStudioTextDataPackageVersion>
-    <MicrosoftVisualStudioTextUIPackageVersion>16.6.255</MicrosoftVisualStudioTextUIPackageVersion>
+    <MicrosoftVisualStudioTextDataPackageVersion>16.8.80</MicrosoftVisualStudioTextDataPackageVersion>
+    <MicrosoftVisualStudioTextUIPackageVersion>16.8.80</MicrosoftVisualStudioTextUIPackageVersion>
     <MicrosoftVisualStudioThreadingPackageVersion>16.7.29-alpha</MicrosoftVisualStudioThreadingPackageVersion>
     <MonoAddinsPackageVersion>1.3.8</MonoAddinsPackageVersion>
     <MonoDevelopSdkPackageVersion>1.0.15</MonoDevelopSdkPackageVersion>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var result = await mappingProvider.RemapWorkspaceEditAsync(workspaceEdit, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            var documentEdit = Assert.Single(result.DocumentChanges);
+            var documentEdit = Assert.Single(result.DocumentChanges?.Value as TextDocumentEdit[]);
             Assert.Equal(RazorFile, documentEdit.TextDocument.Uri);
             Assert.Equal(expectedVersion, documentEdit.TextDocument.Version);
 
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var result = await mappingProvider.RemapWorkspaceEditAsync(workspaceEdit, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            var documentEdit = Assert.Single(result.DocumentChanges);
+            var documentEdit = Assert.Single(result.DocumentChanges?.Value as TextDocumentEdit[]);
             Assert.Equal(CSharpFile, documentEdit.TextDocument.Uri);
             Assert.Equal(expectedVersion, documentEdit.TextDocument.Version);
 
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var result = await mappingProvider.RemapWorkspaceEditAsync(workspaceEdit, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            Assert.Collection(result.DocumentChanges,
+            Assert.Collection(result.DocumentChanges?.Value as TextDocumentEdit[],
                 d =>
                 {
                     Assert.Equal(RazorFile, d.TextDocument.Uri);
@@ -268,7 +268,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 Changes[uri.AbsoluteUri] = edits;
 
-                DocumentChanges = DocumentChanges?.Append(new TextDocumentEdit()
+                DocumentChanges = (DocumentChanges?.Value as TextDocumentEdit[])?.Append(new TextDocumentEdit()
                 {
                     Edits = edits,
                     TextDocument = new VersionedTextDocumentIdentifier()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/TestLanguageServiceBroker.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/TestLanguageServiceBroker.cs
@@ -71,7 +71,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public IRequestBroker<CodeAction, CodeAction> CodeActionsResolveBroker => throw new NotImplementedException();
 
-        public IStreamingRequestBroker<SemanticTokensParams, SumType<ResolvedSemanticToken[], ResolvedSemanticTokenEdits>> SemanticTokensBroker => throw new NotImplementedException();
+        public IStreamingRequestBroker<DocumentDiagnosticsParams, DiagnosticReport[]> DocumentDiagnosticsBroker => throw new NotImplementedException();
+
+        public IStreamingRequestBroker<WorkspaceDocumentDiagnosticsParams, WorkspaceDiagnosticReport[]> WorkspaceDiagnosticsBroker => throw new NotImplementedException();
+
+        IStreamingRequestBroker<SemanticTokensParams, SumType<ResolvableSemanticTokens, ResolvableSemanticTokensEdits>> ILanguageServiceBroker.SemanticTokensBroker => throw new NotImplementedException();
+
+        public IRequestBroker<KindAndModifier, IconMapping> KindDescriptionResolveBroker => throw new NotImplementedException();
 
         public TestLanguageServiceBroker(Action<string, string> callback)
         {


### PR DESCRIPTION
Need to update those to get them in sync with what other language server (e.g. TypeScript and Web Tools) are using. Without that, JSON deserialization doesn't work correctly. E.g. VSHover doesn't get deserialized as VSHover but as just Hover instead.

