### PR TITLE
Use V3 publishing infrastructure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -332,6 +332,6 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
-      # See https://github.com/dotnet/arcade/issues/2871
-      enableSymbolValidation: false
-      publishInstallersAndChecksums: true
+      publishingInfraVersion: 3
+      enableSigningValidation: false
+      enableNugetValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
-    <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
-
+    <PublishingVersion>3</PublishingVersion>
     <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishingBlobItems</PublishDependsOnTargets>
-
     <_UploadPathRoot>aspnetcore-tooling</_UploadPathRoot>
   </PropertyGroup>
 
-  <!-- $(InstallersOutputPath) and $(SymbolsOutputPath) are not defined. Root Directory.Build.props is not imported. -->
   <ItemGroup>
     <!-- Prepare for _PublishingBlobItems target. -->
-    <_ItemsToPublish Include="$(ArtifactsDir)\packages\**\*.tgz" />
-    <_ItemsToPublish Include="$(ArtifactsDir)\LanguageServer\**\*.zip" />
+    <_ItemsToPublish Include="$(ArtifactsPackagesDir)**\*.tgz" />
+    <_ItemsToPublish Include="$(ArtifactsDir)LanguageServer\**\*.zip" />
   </ItemGroup>
 
 <Target Name="_PublishingBlobItems">


### PR DESCRIPTION
- see https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Publishing.md#how-to-upgrade-from-v2-to-v3
- also remove post-build validations now done in the Validate-DotNet pipeline

nits:
- do not set post-build parameters to their defaults
- remove incorrect comments and ancient workarounds from Publishing.props