### PR TITLE
No-op Component Parameter Renames

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -293,8 +293,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             }
 
             var owner = syntaxTree.Root.LocateOwner(change);
+            if (owner == null)
+            {
+                Debug.Fail("Owner should never be null.");
+                return null;
+            }
+
             var node = owner.Ancestors().FirstOrDefault(n => n.Kind == SyntaxKind.MarkupTagHelperStartTag);
             if (node == null || !(node is MarkupTagHelperStartTagSyntax tagHelperStartTag))
+            {
+                return null;
+            }
+
+            // Ensure the rename action was invoked on the component name
+            // instead of a component parameter. This serves as an issue 
+            // mitigation till `textDocument/prepareRename` is supported 
+            // and we can ensure renames aren't triggered in unsupported
+            // contexts. (https://github.com/dotnet/aspnetcore/issues/26407)
+            if (owner.SpanStart != tagHelperStartTag.SpanStart)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -310,7 +310,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             // mitigation till `textDocument/prepareRename` is supported 
             // and we can ensure renames aren't triggered in unsupported
             // contexts. (https://github.com/dotnet/aspnetcore/issues/26407)
-            if (owner.SpanStart != tagHelperStartTag.SpanStart)
+            if (!tagHelperStartTag.Name.FullSpan.IntersectsWith(hostDocumentIndex))
             {
                 return null;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -102,6 +102,27 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
         }
 
         [Fact]
+        public async Task Handle_Rename_OnComponentParameter_ReturnsNull()
+        {
+            // Arrange
+            var request = new RenameParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri("file:///c:/Second/ComponentWithParam.razor")
+                },
+                Position = new Position(1, 14),
+                NewName = "Test2"
+            };
+
+            // Act
+            var result = await _endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
         public async Task Handle_Rename_FullyQualifiedAndNot()
         {
             // Arrange
@@ -323,18 +344,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("First", "Test", "Component1337"));
             tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("First", "Test.Components", "Directory1"));
             tagHelperDescriptors.AddRange(CreateRazorComponentTagHelperDescriptors("First", "Test.Components", "Directory2"));
-                
+
             var item1 = CreateProjectItem("@namespace First.Components\n@using Test\n<Component2></Component2>", "c:/First/Component1.razor");
             var item2 = CreateProjectItem("@namespace Test", "c:/First/Component2.razor");
             var item3 = CreateProjectItem("@namespace Second.Components\n<Component3></Component3>", "c:/Second/Component3.razor");
             var item4 = CreateProjectItem("@namespace Second.Components\n<Component3></Component3>\n<Component3></Component3>", "c:/Second/Component4.razor");
+            var itemComponentParam = CreateProjectItem("@namespace Second.Components\n<Component3 Title=\"Something\"></Component3>", "c:/Second/Component5.razor");
             var item1337 = CreateProjectItem(string.Empty, "c:/First/Component1337.razor");
             var indexItem = CreateProjectItem("@namespace First.Components\n@using Test\n<Component1337></Component1337>\n<Test.Component1337></Test.Component1337>", "c:/First/Index.razor");
 
             var itemDirectory1 = CreateProjectItem("@namespace Test.Components\n<Directory2></Directory2>", "c:/Dir1/Directory1.razor");
             var itemDirectory2 = CreateProjectItem("@namespace Test.Components\n<Directory1></Directory1>", "c:/Dir2/Directory2.razor");
 
-            var fileSystem = new TestRazorProjectFileSystem(new[] { item1, item2, item3, item4, indexItem, itemDirectory1, itemDirectory2 });
+            var fileSystem = new TestRazorProjectFileSystem(new[] { item1, item2, item3, item4, itemComponentParam, indexItem, itemDirectory1, itemDirectory2 });
 
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, builder => {
                 builder.AddDirective(NamespaceDirective.Directive);
@@ -345,6 +367,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             var component2 = CreateRazorDocumentSnapshot(projectEngine, item2, "Test", tagHelperDescriptors);
             var component3 = CreateRazorDocumentSnapshot(projectEngine, item3, "Second.Components", tagHelperDescriptors);
             var component4 = CreateRazorDocumentSnapshot(projectEngine, item4, "Second.Components", tagHelperDescriptors);
+            var componentWithParam = CreateRazorDocumentSnapshot(projectEngine, itemComponentParam, "Second.Components", tagHelperDescriptors);
             var component1337 = CreateRazorDocumentSnapshot(projectEngine, item1337, "Test", tagHelperDescriptors);
             var index = CreateRazorDocumentSnapshot(projectEngine, indexItem, "First.Components", tagHelperDescriptors);
             var directory1Component = CreateRazorDocumentSnapshot(projectEngine, itemDirectory1, "Test.Components", tagHelperDescriptors);
@@ -364,6 +387,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
                 p.DocumentFilePaths == new[] { "c:/Second/Component3.razor", "c:/Second/Component4.razor", index.FilePath } &&
                 p.GetDocument("c:/Second/Component3.razor") == component3 &&
                 p.GetDocument("c:/Second/Component4.razor") == component4 &&
+                p.GetDocument("c:/Second/ComponentWithParam.razor") == componentWithParam &&
                 p.GetDocument(index.FilePath) == index);
 
             var projectSnapshotManager = Mock.Of<ProjectSnapshotManagerBase>(p => p.Projects == new[] { firstProject, secondProject });
@@ -374,6 +398,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
                 d.TryResolveDocument("c:/First/Component2.razor", out component2) == true &&
                 d.TryResolveDocument("c:/Second/Component3.razor", out component3) == true &&
                 d.TryResolveDocument("c:/Second/Component4.razor", out component4) == true &&
+                d.TryResolveDocument("c:/Second/ComponentWithParam.razor", out componentWithParam) == true &&
                 d.TryResolveDocument(index.FilePath, out index) == true &&
                 d.TryResolveDocument(component1337.FilePath, out component1337) == true &&
                 d.TryResolveDocument(itemDirectory1.FilePath, out directory1Component) == true &&

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -123,6 +123,90 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
         }
 
         [Fact]
+        public async Task Handle_Rename_OnOpeningBrace_ReturnsNull()
+        {
+            // Arrange
+            var request = new RenameParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri("file:///c:/Second/ComponentWithParam.razor")
+                },
+                Position = new Position(1, 0),
+                NewName = "Test2"
+            };
+
+            // Act
+            var result = await _endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Handle_Rename_OnComponentNameLeadingEdge_ReturnsResult()
+        {
+            // Arrange
+            var request = new RenameParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri("file:///c:/Second/ComponentWithParam.razor")
+                },
+                Position = new Position(1, 1),
+                NewName = "Test2"
+            };
+
+            // Act
+            var result = await _endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task Handle_Rename_OnComponentName_ReturnsResult()
+        {
+            // Arrange
+            var request = new RenameParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri("file:///c:/Second/ComponentWithParam.razor")
+                },
+                Position = new Position(1, 3),
+                NewName = "Test2"
+            };
+
+            // Act
+            var result = await _endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task Handle_Rename_OnComponentNameTrailingEdge_ReturnsResult()
+        {
+            // Arrange
+            var request = new RenameParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri("file:///c:/Second/ComponentWithParam.razor")
+                },
+                Position = new Position(1, 10),
+                NewName = "Test2"
+            };
+
+            // Act
+            var result = await _endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        [Fact]
         public async Task Handle_Rename_FullyQualifiedAndNot()
         {
             // Arrange


### PR DESCRIPTION
Currently `F2` anywhere on a component start tag (ex. even component parameter) will trigger the rename window. We want to only show this window when a rename is triggered for the component name itself. This requires LSP platform to support [`textDocument/prepareRename`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareRename). I've created a [VSTS issue here](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1222641). In the meantime, these changes ensure a rename operation on anywhere but the start of the component tag no-op.

Fixes: https://github.com/dotnet/aspnetcore/issues/26165

Issue for `textDocument/prepareRename` tracking: https://github.com/dotnet/aspnetcore/issues/26407