### PR TITLE
Remove equals and hash from C# trigger character list.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     internal class CompletionHandler : IRequestHandler<CompletionParams, SumType<CompletionItem[], CompletionList>?>
     {
         private static readonly IReadOnlyList<string> RazorTriggerCharacters = new[] { "@" };
-        private static readonly IReadOnlyList<string> CSharpTriggerCharacters = new[] { " ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", ">", "~" };
+        private static readonly IReadOnlyList<string> CSharpTriggerCharacters = new[] { " ", "(", "#", ".", "<", "[", "{", "\"", "/", ">", "~" };
         private static readonly IReadOnlyList<string> HtmlTriggerCharacters = new[] { ":", "@", "#", ".", "!", "*", ",", "(", "[", "=", "_", "-", "<", "&", "\\", "/", "'", "\"", "=", ":", " " };
 
         public static readonly IReadOnlyList<string> AllTriggerCharacters = new HashSet<string>(


### PR DESCRIPTION
- Initially this C# trigger character list was pulled directly from Roslyn; however, after some testing this looks to cause some issues. For instance having equals as a trigger character results in:
![image](https://i.imgur.com/t1xCI5e.gif)

FYI @dibarbet @allisonchou 