### PR TITLE
Enable script and style block support

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public const string CSharpContentTypeName = "CSharp";
 
-        public const string HtmlLSPContentTypeName = "htmlyLSP";
+        public const string HtmlLSPContentTypeName = "html-delegation";
 
         public const string VirtualCSharpFileNameSuffix = ".g.cs";
 


### PR DESCRIPTION
This switches Razor to html-delegation language server which supports CSS and JavaScript in HTML. I did a quick sanity test, and I'm not seeing any major blockers.

