### PR TITLE
Make project state serialization lazy.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -80,7 +80,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             {
                 _foregroundDispatcher.AssertForegroundThread();
 
-
                 var i = 0;
                 var projects = new ProjectSnapshot[_projects.Count];
                 foreach (var entry in _projects)
@@ -89,6 +88,16 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 }
 
                 return projects;
+            }
+        }
+
+        public override IReadOnlyCollection<string> OpenDocuments
+        {
+            get
+            {
+                _foregroundDispatcher.AssertForegroundThread();
+
+                return _openDocuments;
             }
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManagerBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManagerBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
@@ -9,6 +10,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     internal abstract class ProjectSnapshotManagerBase : ProjectSnapshotManager
     {
         public abstract Workspace Workspace { get; }
+
+        public abstract IReadOnlyCollection<string> OpenDocuments { get; }
 
         public abstract void DocumentAdded(HostProject hostProject, HostDocument hostDocument, TextLoader textLoader);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -129,11 +129,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     // A Razor document was just opened, we should become "active" which means we'll constantly be monitoring project state.
                     _active = true;
 
-                    if (args.Kind == ProjectChangeKind.DocumentChanged &&
-                        args.Newer.ProjectWorkspaceState != null)
+                    if (args.Newer?.ProjectWorkspaceState != null)
                     {
                         // Typically document open events don't result in us re-processing project state; however, given this is the first time a user opened a Razor document we should.
-                        EnqueuePublish(args.Newer);
+                        // Don't enqueue, just publish to get the most immediate result.
+                        Publish(args.Newer);
                         return;
                     }
                 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -26,6 +26,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     internal class DefaultRazorProjectChangePublisher : ProjectSnapshotChangeTrigger
     {
         internal readonly Dictionary<string, Task> _deferredPublishTasks;
+
+        // Internal for testing
+        internal bool _active;
+
         private const string TempFileExt = ".temp";
         private readonly RazorLogger _logger;
         private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
@@ -35,7 +39,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly object _publishLock;
 
         private readonly JsonSerializer _serializer = new JsonSerializer();
-
         private ProjectSnapshotManagerBase _projectSnapshotManager;
 
         [ImportingConstructor]
@@ -111,6 +114,34 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             if (!_lspEditorFeatureDetector.IsLSPEditorAvailable(args.ProjectFilePath, hierarchy: null))
             {
                 return;
+            }
+
+            // Prior to doing any sort of project state serialization/publishing we avoid any excess work as long as there aren't any "open" Razor files.
+            // However, once a Razor file is opened we turn the firehose on and start doing work.
+            // By taking this lazy approach we ensure that we don't do any excess Razor work (serialization is expensive) in non-Razor scenarios.
+
+            if (!_active)
+            {
+                // Not currently active, we need to decide if we should become active or if we should no-op.
+
+                if (_projectSnapshotManager.OpenDocuments.Count > 0)
+                {
+                    // A Razor document was just opened, we should become "active" which means we'll constantly be monitoring project state.
+                    _active = true;
+
+                    if (args.Kind == ProjectChangeKind.DocumentChanged &&
+                        args.Newer.ProjectWorkspaceState != null)
+                    {
+                        // Typically document open events don't result in us re-processing project state; however, given this is the first time a user opened a Razor document we should.
+                        EnqueuePublish(args.Newer);
+                        return;
+                    }
+                }
+                else
+                {
+                    // No open documents and not active. No-op.
+                    return;
+                }
             }
 
             // All the below Publish's (except ProjectRemoved) wait until our project has been initialized (ProjectWorkspaceState != null)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
         }
 
         [Fact]
-        public async Task ProjectManager_Changed_DocumentOpened_InitializedProject_NotActive_Enqueues()
+        public void ProjectManager_Changed_DocumentOpened_InitializedProject_NotActive_Publishes()
         {
             // Arrange
             var serializationSuccessful = false;
@@ -142,8 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             ProjectSnapshotManager.DocumentOpened(hostProject.FilePath, hostDocument.FilePath, SourceText.From(string.Empty));
 
             // Assert
-            var kvp = Assert.Single(publisher._deferredPublishTasks);
-            await kvp.Value.ConfigureAwait(false);
+            Assert.Empty(publisher._deferredPublishTasks);
             Assert.True(serializationSuccessful);
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.OperationProgress;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
@@ -51,7 +52,100 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
     {
         private readonly RazorLogger RazorLogger = Mock.Of<RazorLogger>();
 
+        public DefaultRazorProjectChangePublisherTest()
+        {
+            ProjectSnapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
+        }
+
+        private ProjectSnapshotManagerBase ProjectSnapshotManager { get; }
+
         private ProjectConfigurationFilePathStore ProjectConfigurationFilePathStore { get; } = new DefaultProjectConfigurationFilePathStore();
+
+        [Fact]
+        public void ProjectManager_Changed_NotActive_Noops()
+        {
+            // Arrange
+            var attemptedToSerialize = false;
+            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, rootNamespace: "TestRootNamespace");
+            var hostDocument = new HostDocument("/path/to/file.razor", "file.razor");
+            ProjectSnapshotManager.ProjectAdded(hostProject);
+            var publisher = new TestDefaultRazorProjectChangePublisher(
+                ProjectConfigurationFilePathStore,
+                RazorLogger,
+                onSerializeToFile: (snapshot, configurationFilePath) => attemptedToSerialize = true)
+            {
+                EnqueueDelay = 10,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
+
+            // Act
+            ProjectSnapshotManager.DocumentAdded(hostProject, hostDocument, new EmptyTextLoader(hostDocument.FilePath));
+
+            // Assert
+            Assert.Empty(publisher._deferredPublishTasks);
+            Assert.False(attemptedToSerialize);
+        }
+
+        [Fact]
+        public void ProjectManager_Changed_DocumentOpened_UninitializedProject_NotActive_Noops()
+        {
+            // Arrange
+            var attemptedToSerialize = false;
+            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, rootNamespace: "TestRootNamespace");
+            var hostDocument = new HostDocument("/path/to/file.razor", "file.razor");
+            ProjectSnapshotManager.ProjectAdded(hostProject);
+            ProjectSnapshotManager.DocumentAdded(hostProject, hostDocument, new EmptyTextLoader(hostDocument.FilePath));
+            var publisher = new TestDefaultRazorProjectChangePublisher(
+                ProjectConfigurationFilePathStore,
+                RazorLogger,
+                onSerializeToFile: (snapshot, configurationFilePath) => attemptedToSerialize = true)
+            {
+                EnqueueDelay = 10,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
+
+            // Act
+            ProjectSnapshotManager.DocumentOpened(hostProject.FilePath, hostDocument.FilePath, SourceText.From(string.Empty));
+
+            // Assert
+            Assert.Empty(publisher._deferredPublishTasks);
+            Assert.False(attemptedToSerialize);
+        }
+
+        [Fact]
+        public async Task ProjectManager_Changed_DocumentOpened_InitializedProject_NotActive_Enqueues()
+        {
+            // Arrange
+            var serializationSuccessful = false;
+            var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, rootNamespace: "TestRootNamespace");
+            var hostDocument = new HostDocument("/path/to/file.razor", "file.razor");
+            ProjectSnapshotManager.ProjectAdded(hostProject);
+            ProjectSnapshotManager.ProjectWorkspaceStateChanged(hostProject.FilePath, ProjectWorkspaceState.Default);
+            ProjectSnapshotManager.DocumentAdded(hostProject, hostDocument, new EmptyTextLoader(hostDocument.FilePath));
+            var projectSnapshot = ProjectSnapshotManager.Projects[0];
+            var expectedConfigurationFilePath = "/path/to/obj/bin/Debug/project.razor.json";
+            ProjectConfigurationFilePathStore.Set(projectSnapshot.FilePath, expectedConfigurationFilePath);
+            var publisher = new TestDefaultRazorProjectChangePublisher(
+                ProjectConfigurationFilePathStore,
+                RazorLogger,
+                onSerializeToFile: (snapshot, configurationFilePath) =>
+                {
+                    Assert.Equal(expectedConfigurationFilePath, configurationFilePath);
+                    serializationSuccessful = true;
+                })
+            {
+                EnqueueDelay = 10,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
+
+            // Act
+            ProjectSnapshotManager.DocumentOpened(hostProject.FilePath, hostDocument.FilePath, SourceText.From(string.Empty));
+
+            // Assert
+            var kvp = Assert.Single(publisher._deferredPublishTasks);
+            await kvp.Value.ConfigureAwait(false);
+            Assert.True(serializationSuccessful);
+        }
 
         [Theory]
         [InlineData(ProjectChangeKind.DocumentAdded)]
@@ -73,8 +167,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
                     serializationSuccessful = true;
                 })
             {
-                EnqueueDelay = 10
+                EnqueueDelay = 10,
+                _active = true,
             };
+            publisher.Initialize(ProjectSnapshotManager);
             ProjectConfigurationFilePathStore.Set(projectSnapshot.FilePath, expectedConfigurationFilePath);
             var args = ProjectChangeEventArgs.CreateTestInstance(projectSnapshot, projectSnapshot, documentFilePath: null, changeKind);
 
@@ -99,8 +195,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
                 RazorLogger,
                 onSerializeToFile: (snapshot, configurationFilePath) => attemptedToSerialize = true)
             {
-                EnqueueDelay = 10
+                EnqueueDelay = 10,
+                _active = true,
             };
+            publisher.Initialize(ProjectSnapshotManager);
             ProjectConfigurationFilePathStore.Set(projectSnapshot.FilePath, expectedConfigurationFilePath);
             publisher.EnqueuePublish(projectSnapshot);
             var args = ProjectChangeEventArgs.CreateTestInstance(projectSnapshot, newer: null, documentFilePath: null, ProjectChangeKind.ProjectRemoved);
@@ -133,8 +231,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
                     serializationSuccessful = true;
                 })
             {
-                EnqueueDelay = 10
+                EnqueueDelay = 10,
+                _active = true,
             };
+            publisher.Initialize(ProjectSnapshotManager);
             ProjectConfigurationFilePathStore.Set(firstSnapshot.FilePath, expectedConfigurationFilePath);
 
             // Act
@@ -153,7 +253,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             // Arrange
             var publisher = new TestDefaultRazorProjectChangePublisher(
                 ProjectConfigurationFilePathStore,
-                RazorLogger);
+                RazorLogger)
+            {
+                _active = true,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
             var omniSharpProjectSnapshot = CreateProjectSnapshot("/path/to/project.csproj");
 
             // Act & Assert
@@ -175,7 +279,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
                     Assert.Same(omniSharpProjectSnapshot, snapshot);
                     Assert.Equal(expectedConfigurationFilePath, configurationFilePath);
                     serializationSuccessful = true;
-                });
+                })
+            {
+                _active = true,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
             ProjectConfigurationFilePathStore.Set(omniSharpProjectSnapshot.FilePath, expectedConfigurationFilePath);
 
             // Act
@@ -189,7 +297,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
         public async Task ProjectAdded_PublishesToCorrectFilePathAsync()
         {
             // Arrange
-            var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var serializationSuccessful = false;
             var expectedConfigurationFilePath = "/path/to/obj/bin/Debug/project.razor.json";
 
@@ -200,8 +307,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
                 {
                     Assert.Equal(expectedConfigurationFilePath, configurationFilePath);
                     serializationSuccessful = true;
-                });
-            publisher.Initialize(snapshotManager);
+                })
+            {
+                _active = true,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
             var projectFilePath = "/path/to/project.csproj";
             var hostProject = new HostProject(projectFilePath, RazorConfiguration.Default, "TestRootNamespace");
             ProjectConfigurationFilePathStore.Set(hostProject.FilePath, expectedConfigurationFilePath);
@@ -210,8 +320,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             // Act
             await RunOnForegroundAsync(() =>
             {
-                snapshotManager.ProjectAdded(hostProject);
-                snapshotManager.ProjectWorkspaceStateChanged(projectFilePath, projectWorkspaceState);
+                ProjectSnapshotManager.ProjectAdded(hostProject);
+                ProjectSnapshotManager.ProjectWorkspaceStateChanged(projectFilePath, projectWorkspaceState);
             }).ConfigureAwait(false);
 
             // Assert
@@ -224,7 +334,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
         public async Task ProjectAdded_DoesNotPublishWithoutProjectWorkspaceStateAsync()
         {
             // Arrange
-            var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var serializationSuccessful = false;
             var expectedConfigurationFilePath = "/path/to/obj/bin/Debug/project.razor.json";
 
@@ -235,13 +344,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
                 {
                     Assert.True(false, "Serialization should not have been atempted because there is no ProjectWorkspaceState.");
                     serializationSuccessful = true;
-                });
-            publisher.Initialize(snapshotManager);
+                })
+            {
+                _active = true,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
             var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
             ProjectConfigurationFilePathStore.Set(hostProject.FilePath, expectedConfigurationFilePath);
 
             // Act
-            await RunOnForegroundAsync(() => snapshotManager.ProjectAdded(hostProject)).ConfigureAwait(false);
+            await RunOnForegroundAsync(() => ProjectSnapshotManager.ProjectAdded(hostProject)).ConfigureAwait(false);
 
             Assert.Empty(publisher._deferredPublishTasks);
 
@@ -253,16 +365,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
         public async Task ProjectRemoved_UnSetPublishFilePath_NoopsAsync()
         {
             // Arrange
-            var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var publisher = new TestDefaultRazorProjectChangePublisher(
                 ProjectConfigurationFilePathStore,
-                RazorLogger);
-            publisher.Initialize(snapshotManager);
+                RazorLogger)
+            {
+                _active = true,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
             var hostProject = new HostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
-            await RunOnForegroundAsync(() => snapshotManager.ProjectAdded(hostProject)).ConfigureAwait(false);
+            await RunOnForegroundAsync(() => ProjectSnapshotManager.ProjectAdded(hostProject)).ConfigureAwait(false);
 
             // Act & Assert
-            await RunOnForegroundAsync(() => snapshotManager.ProjectRemoved(hostProject)).ConfigureAwait(false);
+            await RunOnForegroundAsync(() => ProjectSnapshotManager.ProjectRemoved(hostProject)).ConfigureAwait(false);
 
             Assert.Empty(publisher._deferredPublishTasks);
         }
@@ -271,7 +385,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
         public async Task ProjectAdded_DoesNotFireWhenNotReadyAsync()
         {
             // Arrange
-            var snapshotManager = CreateProjectSnapshotManager(allowNotifyListeners: true);
             var serializationSuccessful = false;
             var expectedConfigurationFilePath = "/path/to/obj/bin/Debug/project.razor.json";
 
@@ -283,8 +396,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
                     Assert.Equal(expectedConfigurationFilePath, configurationFilePath);
                     serializationSuccessful = true;
                 },
-                shouldSerialize: false);
-            publisher.Initialize(snapshotManager);
+                shouldSerialize: false)
+            {
+                _active = true,
+            };
+            publisher.Initialize(ProjectSnapshotManager);
             var projectFilePath = "/path/to/project.csproj";
             var hostProject = new HostProject(projectFilePath, RazorConfiguration.Default, "TestRootNamespace");
             ProjectConfigurationFilePathStore.Set(hostProject.FilePath, expectedConfigurationFilePath);
@@ -293,8 +409,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             // Act
             await RunOnForegroundAsync(() =>
             {
-                snapshotManager.ProjectAdded(hostProject);
-                snapshotManager.ProjectWorkspaceStateChanged(projectFilePath, projectWorkspaceState);
+                ProjectSnapshotManager.ProjectAdded(hostProject);
+                ProjectSnapshotManager.ProjectWorkspaceStateChanged(projectFilePath, projectWorkspaceState);
             }).ConfigureAwait(false);
 
             // Assert


### PR DESCRIPTION
- When a solution has been opened, delay any sort of project state serialization/understanding until a Razor file has been opened. This way we aren't doing extra work for solutions/project scenarios that don't care about Razor.
- Added tests to validate the active and non-active states of the project change publisher.

Fixes dotnet/aspnetcore#26164