### PR TITLE
Fix IntializeTestFile Test Flakyness

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
-    // Sets the FormattingTestBase.FileName static variable.
+    // Sets the FileName static variable.
     // Finds the test method name using reflection, and uses
     // that to find the expected input/output test files in the file system.
     [IntializeTestFile]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
@@ -18,7 +17,13 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
+    // Sets the FormattingTestBase.FileName static variable.
+    // Finds the test method name using reflection, and uses
+    // that to find the expected input/output test files in the file system.
     [IntializeTestFile]
+
+    // These tests must be run serially due to the test specific FileName static var.
+    [Collection("FormattingTestSerialRuns")]
     public class FormattingTestBase : LanguageServerTestBase
     {
         private static readonly AsyncLocal<string> _fileName = new AsyncLocal<string>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntegrationTestBase.cs
@@ -20,7 +20,13 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 {
+    // Sets the FileName static variable.
+    // Finds the test method name using reflection, and uses
+    // that to find the expected input/output test files in the file system.
     [IntializeTestFile]
+
+    // These tests must be run serially due to the test specific FileName static var.
+    [Collection("IntegrationTestSerialRuns")]
     public abstract class IntegrationTestBase
     {
         private static readonly AsyncLocal<string> _fileName = new AsyncLocal<string>();
@@ -85,13 +91,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         protected virtual bool DesignTime { get; } = false;
 
         /// <summary>
-        /// Gets the 
+        /// Gets the
         /// </summary>
         internal VirtualRazorProjectFileSystem FileSystem { get; } = new VirtualRazorProjectFileSystem();
 
         /// <summary>
-        /// Used to force a specific style of line-endings for testing. This matters for the baseline tests that exercise line mappings. 
-        /// Even though we normalize newlines for testing, the difference between platforms affects the data through the *count* of 
+        /// Used to force a specific style of line-endings for testing. This matters for the baseline tests that exercise line mappings.
+        /// Even though we normalize newlines for testing, the difference between platforms affects the data through the *count* of
         /// characters written.
         /// </summary>
         protected virtual string LineEnding { get; } = "\r\n";
@@ -160,7 +166,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             {
                 Content = text,
             };
-            
+
             return projectItem;
         }
 
@@ -206,7 +212,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             {
                 Content = fileContent,
             };
-            
+
             return projectItem;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorBaselineIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorBaselineIntegrationTestBase.cs
@@ -11,7 +11,13 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 {
+    // Sets the FileName static variable.
+    // Finds the test method name using reflection, and uses
+    // that to find the expected input/output test files in the file system.
     [IntializeTestFile]
+
+    // These tests must be run serially due to the test specific FileName static var.
+    [Collection("RazorBaselineIntegrationTestSerialRuns")]
     public abstract class RazorBaselineIntegrationTestBase : RazorIntegrationTestBase
     {
         private static readonly AsyncLocal<string> _directoryPath = new AsyncLocal<string>();
@@ -38,9 +44,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 #else
         protected bool GenerateBaselines { get; } = false;
 #endif
-        
+
         protected string TestProjectRoot { get; }
-        
+
         // For consistent line endings because the character counts are going to be recorded in files.
         internal override string LineEnding => "\r\n";
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/ParserTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/ParserTestBase.cs
@@ -13,7 +13,13 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
+    // Sets the FileName static variable.
+    // Finds the test method name using reflection, and uses
+    // that to find the expected input/output test files in the file system.
     [IntializeTestFile]
+
+    // These tests must be run serially due to the test specific FileName static var.
+    [Collection("ParserTestSerialRuns")]
     public abstract class ParserTestBase
     {
         private static readonly AsyncLocal<string> _fileName = new AsyncLocal<string>();
@@ -249,8 +255,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         internal static RazorParserOptions CreateParserOptions(
-            RazorLanguageVersion version, 
-            IEnumerable<DirectiveDescriptor> directives, 
+            RazorLanguageVersion version,
+            IEnumerable<DirectiveDescriptor> directives,
             bool designTime,
             RazorParserFeatureFlags featureFlags = null,
             string fileKind = null)


### PR DESCRIPTION
### Summary of the changes
 - Fixes the randomized test flakyness from formatting, when all tests are run together (does not repro on individual / debug)

ex.
```
 CloseCurly_Method_MultiLine
   Source: CodeDirectiveOnTypeFormattingTest.cs line 66
   Duration: 27 ms

  Message: 
    Assert.Equal() Failure
                             ↓ (pos 13)
    Expected: @code {\r\n    public void Foo\r\n    {\r\n    }\r\n}\r\n
    Actual:   @code {\r\n            public void Foo\r\n            {\r\n ···
                             ↑ (pos 13)
  Stack Trace: 
    FormattingTestBase.RunOnTypeFormattingTestAsync(String input, String expected, String triggerCharacter, Int32 tabSize, Boolean insertSpaces, String fileKind) line 115
    CodeDirectiveOnTypeFormattingTest.CloseCurly_Method_MultiLine() line 68
    --- End of stack trace from previous location ---
	
	
	 CodeBlockDirective_WithTabSize8
   Source: CodeDirectiveFormattingTest.cs line 499
   Duration: 36 ms

  Message: 
    Assert.Equal() Failure
                                       ↓ (pos 47)
    Expected: ···ss Foo { }\r\n        void Method()\r\n        {\r\n        }\r\n}\r\n
    Actual:   ···ss Foo { }\r\n                void Method()\r\n                {\r···
                                       ↑ (pos 47)
  Stack Trace: 
    FormattingTestBase.RunFormattingTestAsync(String input, String expected, Int32 tabSize, Boolean insertSpaces, String fileKind) line 76
    CodeDirectiveFormattingTest.CodeBlockDirective_WithTabSize8() line 501
    --- End of stack trace from previous location ---
```

Fixes: https://github.com/dotnet/aspnetcore/issues/26648