### PR TITLE
Fix VSFeedback logger writing logs.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -84,9 +84,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     // I think that would mean either having 0 Serial Handlers in the whole LS, or making VSLanguageServerClient handle this more gracefully.
                     .WithContentModifiedSupport(false)
                     .WithSerializer(Serializer.Instance)
-                    .ConfigureLogging(builder => builder
-                        .SetMinimumLevel(logLevel)
-                        .AddLanguageProtocolLogging(logLevel))
                     .OnInitialized(async (s, request, response, cancellationToken) =>
                     {
                         var handlersManager = s.GetRequiredService<IHandlersManager>();
@@ -132,6 +129,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                             var builder = new RazorLanguageServerBuilder(services);
                             configure(builder);
                         }
+
+                        services.AddLogging(builder => builder
+                            .SetMinimumLevel(logLevel)
+                            .AddLanguageProtocolLogging(logLevel));
 
                         var filePathNormalizer = new FilePathNormalizer();
                         services.AddSingleton<FilePathNormalizer>(filePathNormalizer);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -140,8 +140,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             var services = builder.Services;
-            var loggerProvider = (FeedbackFileLoggerProvider)_feedbackFileLoggerProviderFactory.GetOrCreate();
-            services.AddSingleton<ILoggerProvider>(loggerProvider);
+            services.AddLogging(logging =>
+            {
+                logging.AddFilter<FeedbackFileLoggerProvider>(level => true);
+                var loggerProvider = (FeedbackFileLoggerProvider)_feedbackFileLoggerProviderFactory.GetOrCreate();
+                logging.AddProvider(loggerProvider);
+            });
             services.AddSingleton<LanguageServerFeatureOptions>(_vsLanguageServerFeatureOptions);
         }
 


### PR DESCRIPTION
- When we updated O# the way logging was wired up changed. Because of this if the user didn't have verbose logging enabled they would not publish information when "Report a problem..." in Visual Studio was clicked.
- Changed how we setup logging in our language server. Instead of relying on the "ConfigureLogging" extensions that O# exposes we add the logging directly to the services collection. This way we can expand on the default logging registrations mechanisms.

Fixes dotnet/aspnetcore#26699