### PR TITLE
Handle `null` project handles appropriately in our LS proxy.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Host/DefaultProjectSnapshotManagerProxy.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Host/DefaultProjectSnapshotManagerProxy.cs
@@ -117,6 +117,11 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Host
 
         private ProjectSnapshotHandleProxy ConvertToProxy(ProjectSnapshot project)
         {
+            if (project == null)
+            {
+                return null;
+            }
+
             var projectWorkspaceState = new ProjectWorkspaceState(project.TagHelpers, project.CSharpLanguageVersion);
             var projectFilePath = _session.ConvertLocalPathToSharedUri(project.FilePath);
             var projectHandleProxy = new ProjectSnapshotHandleProxy(projectFilePath, project.Configuration, project.RootNamespace, projectWorkspaceState);


### PR DESCRIPTION
- The reason we explode is that we try to convert certain types which may be null and don't properly handle the null case. In practice this typically presents itself in Codespaces scenarios when moving from an open folder LiveShare scenario to a project loaded scenario. LiveShare launches all host/guest services at which point we notify those services that projects are being added (since we're in the midst of opening a solution) at which point the "old" project is null because it didn't exist in the open folder scenario.

Fixes dotnet/aspnetcore#26702