### PR TITLE
Swallow exceptions caused from resetting manual reset events.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
@@ -194,7 +194,14 @@ namespace Microsoft.VisualStudio.Editor.Razor
                         return WorkParcel.Empty;
                     }
 
-                    _hasParcel.Reset();
+                    try
+                    {
+                        _hasParcel.Reset();
+                    }
+                    catch (Exception)
+                    {
+                        // Swallow any exceptions caused by resetting the parcel switch to avoid crashing VS.
+                    }
 
                     lock (_stateLock)
                     {


### PR DESCRIPTION
- Somehow calling `.Reset` still gets triggered after disposal. To prevent VS from crashing swallow any exception caused by resetting.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1177023
