### PR TITLE
Fix trailing edge hover queries for minimized attributes.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
@@ -125,7 +125,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                     Debug.Assert(binding.Descriptors.Any());
                     var tagHelperAttributes = _tagHelperFactsService.GetBoundTagHelperAttributes(tagHelperDocumentContext, selectedAttributeName, binding);
 
-                    var attribute = attributes.Single(a => a.Span.IntersectsWith(location.AbsoluteIndex));
+                    // Grab the first attribute that we find that intersects with this location. That way if there are multiple attributes side-by-side aka hovering over:
+                    //      <input checked| minimized />
+                    // Then we take the left most attribute (attributes are returned in source order).
+                    var attribute = attributes.First(a => a.Span.IntersectsWith(location.AbsoluteIndex));
                     if (attribute is MarkupTagHelperAttributeSyntax thAttributeSyntax)
                     {
                         attribute = thAttributeSyntax.Name;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -84,6 +84,26 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
         }
 
         [Fact]
+        public void GetHoverInfo_TagHelper_AttributeTrailingEdge()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 bool-val minimized></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var service = GetDefaultRazorHoverInfoService();
+            var edgeLocation = txt.IndexOf("bool-val", StringComparison.Ordinal) + "bool-val".Length;
+            var location = new SourceLocation(edgeLocation, 0, edgeLocation);
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location);
+
+            // Assert
+            Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
+            Assert.DoesNotContain("**IntVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
+            var expectedRange = new RangeModel(new Position(1, 7), new Position(1, 15));
+            Assert.Equal(expectedRange, hover.Range);
+        }
+
+        [Fact]
         public void GetHoverInfo_TagHelper_AttributeValue_ReturnsNull()
         {
             // Arrange


### PR DESCRIPTION
- When hovering over a trailing edge of a minimized attribute there was no value right hand side to pad each attribute. Because of this our hover logic would always expect there to be only one valid attribute at the hover location; however, at edges this wasn't true.
- Added a test to account for the new scenario.

Fixes dotnet/aspnetcore#26747
