### PR TITLE
Add a Razor LSP language service for our buffers.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public static readonly Guid RazorActiveUIContextGuid = new Guid("3c5ded8f-72c7-4b1f-af2d-099ceeb935b8");
 
-        public const string LanguageServiceString = "4513FA64-5B72-4B58-9D4C-1D3C81996C2C";
+        public const string RazorLanguageServiceString = "4513FA64-5B72-4B58-9D4C-1D3C81996C2C";
 
         public static readonly Guid RazorLanguageServiceGuid = new Guid(RazorLanguageServiceString);
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -27,6 +27,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public const string LanguageServiceString = "4513FA64-5B72-4B58-9D4C-1D3C81996C2C";
 
-        public static readonly Guid LanguageServiceGuid = new Guid(LanguageServiceString);
+        public static readonly Guid RazorLanguageServiceGuid = new Guid(RazorLanguageServiceString);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -24,5 +24,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public const string VSProjectItemsIdentifier = "CF_VSSTGPROJECTITEMS";
 
         public static readonly Guid RazorActiveUIContextGuid = new Guid("3c5ded8f-72c7-4b1f-af2d-099ceeb935b8");
+
+        public const string LanguageServiceString = "4513FA64-5B72-4B58-9D4C-1D3C81996C2C";
+
+        public static readonly Guid LanguageServiceGuid = new Guid(LanguageServiceString);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Text;
@@ -23,16 +24,25 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
     {
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactory;
+        private readonly LSPEditorFeatureDetector _editorFeatureDetector;
 
         [ImportingConstructor]
-        public RazorLSPTextViewConnectionListener(IVsEditorAdaptersFactoryService editorAdaptersFactory)
+        public RazorLSPTextViewConnectionListener(
+            IVsEditorAdaptersFactoryService editorAdaptersFactory,
+            LSPEditorFeatureDetector editorFeatureDetector)
         {
             if (editorAdaptersFactory is null)
             {
                 throw new ArgumentNullException(nameof(editorAdaptersFactory));
             }
 
+            if (editorFeatureDetector is null)
+            {
+                throw new ArgumentNullException(nameof(editorFeatureDetector));
+            }
+
             _editorAdaptersFactory = editorAdaptersFactory;
+            _editorFeatureDetector = editorFeatureDetector;
         }
 
         public void SubjectBuffersConnected(ITextView textView, ConnectionReason reason, IReadOnlyCollection<ITextBuffer> subjectBuffers)
@@ -43,6 +53,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             var vsTextView = _editorAdaptersFactory.GetViewAdapter(textView);
+
+            // In remote client scenarios there's a custom language service applied to buffers in order to enable delegation of interactions.
+            // Because of this we don't want to break that experience so we ensure not to "set" a langauge service for remote clients.
+            if (!_editorFeatureDetector.IsRemoteClient())
+            {
+                vsTextView.GetBuffer(out var vsBuffer);
+                vsBuffer.SetLanguageServiceID(RazorLSPConstants.LanguageServiceGuid);
+            }
 
             RazorLSPTextViewFilter.CreateAndRegister(vsTextView);
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             if (!_editorFeatureDetector.IsRemoteClient())
             {
                 vsTextView.GetBuffer(out var vsBuffer);
-                vsBuffer.SetLanguageServiceID(RazorLSPConstants.LanguageServiceGuid);
+                vsBuffer.SetLanguageServiceID(RazorLSPConstants.RazorLanguageServiceGuid);
             }
 
             RazorLSPTextViewFilter.CreateAndRegister(vsTextView);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLangaugeInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLangaugeInfo.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    [Guid(RazorLSPConstants.LanguageServiceString)]
+    [Guid(RazorLSPConstants.RazorLanguageServiceString)]
     internal partial class RazorLanguageService : IVsLanguageInfo
     {
         public int GetLanguageName(out string bstrName)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLangaugeInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLangaugeInfo.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Guid(RazorLSPConstants.LanguageServiceString)]
+    internal partial class RazorLanguageService : IVsLanguageInfo
+    {
+        public int GetLanguageName(out string bstrName)
+        {
+            bstrName = "RazorLSP";
+            return VSConstants.S_OK;
+        }
+
+        public int GetFileExtensions(out string pbstrExtensions)
+        {
+            pbstrExtensions = default;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int GetColorizer(IVsTextLines pBuffer, out IVsColorizer ppColorizer)
+        {
+            ppColorizer = default;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int GetCodeWindowManager(IVsCodeWindow pCodeWin, out IVsCodeWindowManager ppCodeWinMgr)
+        {
+            ppCodeWinMgr = default;
+            return VSConstants.E_NOTIMPL;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -2,21 +2,24 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.VisualStudio.LanguageServerClient.Razor;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.RazorExtension
 {
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [AboutDialogInfo(PackageGuidString, "ASP.NET Core Razor Language Services", "#110", "#112", IconResourceID = "#400")]
+    [ProvideService(typeof(RazorLanguageService))]
+    [ProvideLanguageService(typeof(RazorLanguageService), RazorLSPConstants.RazorLSPContentTypeName, 110)]
     [Guid(PackageGuidString)]
     public sealed class RazorPackage : AsyncPackage
     {
         public const string PackageGuidString = "13b72f58-279e-49e0-a56d-296be02f0805";
-        public const string CSharpPackageGuidString = "13c3bbb4-f18f-4111-9f54-a0fb010d9194";
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
@@ -24,9 +27,8 @@ namespace Microsoft.VisualStudio.RazorExtension
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Explicitly trigger the load of the CSharp package. This ensures that UI-bound services are appropriately prefetched. Ideally, we shouldn't need this but until Roslyn fixes it on their side, we have to live with it.
-            var shellService = (IVsShell7)AsyncPackage.GetGlobalService(typeof(SVsShell));
-            await shellService.LoadPackageAsync(new Guid(CSharpPackageGuidString));
+            var container = this as IServiceContainer;
+            container.AddService(typeof(RazorLanguageService), new RazorLanguageService(), promote: true);
         }
     }
 }


### PR DESCRIPTION
- A language service in Visual Studio enables a language to fully control the end-to-end experience. This serves as a pre-requisite to the debugging work we're doing to enable Blazor WebAssembly breakpoints to properly bind in the new LSP editor. That functionality is hooked up via a language service hook.
- Setup the initial language service to be "simple" meaning it notifies everyone listening that things are not implemented so the editor falls back to default implementations. This means this language service as it exists in this changeset effectively does nothing. However, because we're going to be adding to this I've made the language service a partial class because expansions of VS language services are done via additional interfaces on the same type; making it a partial class will somewhat reduce the complexity of our language service being a "god class".
- Purposefully do not setup our language service in remote client scenarios because LiveShare owns that language service to enable delegation.

Part of dotnet/aspnetcore#26643