### PR TITLE
Fix formatting test infrastructure

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -169,11 +169,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 Options = request.Options
             };
 
-            response.Edits = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentRangeFormattingParams, TextEdit[]>(
+            var edits = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentRangeFormattingParams, TextEdit[]>(
                 Methods.TextDocumentRangeFormattingName,
                 serverContentType,
                 formattingParams,
                 cancellationToken).ConfigureAwait(false);
+
+            response.Edits = edits ?? Array.Empty<TextEdit>();
 
             return response;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -182,6 +182,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var documentSnapshot = new Mock<DocumentSnapshot>();
             documentSnapshot.Setup(d => d.GetGeneratedOutputAsync()).Returns(Task.FromResult(codeDocument));
             documentSnapshot.Setup(d => d.Project.GetProjectEngine()).Returns(projectEngine);
+            documentSnapshot.Setup(d => d.FilePath).Returns(path);
             documentSnapshot.Setup(d => d.TargetPath).Returns(path);
             documentSnapshot.Setup(d => d.Project.TagHelpers).Returns(tagHelpers);
             documentSnapshot.Setup(d => d.FileKind).Returns(fileKind);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -178,5 +178,89 @@ expected: @"@page ""/test""
 }
 ");
         }
+
+        [Fact]
+        public async Task FormatsComplexBlock()
+        {
+            await RunFormattingTestAsync(
+input: @"|@page ""/""
+
+<h1>Hello, world!</h1>
+
+        Welcome to your new app.
+
+<SurveyPrompt Title=""How is Blazor working for you?"" />
+
+<div class=""FF""
+     id=""ERT"">
+     asdf
+    <div class=""3""
+         id=""3"">
+             @if(true){<p></p>}
+         </div>
+</div>
+
+@{
+<div class=""FF""
+    id=""ERT"">
+    asdf
+    <div class=""3""
+        id=""3"">
+            @if(true){<p></p>}
+        </div>
+</div>
+}
+
+@functions {
+        public class Foo
+    {
+        @* This is a Razor Comment *@
+        void Method() { }
+    }
+}
+|",
+expected: @"@page ""/""
+
+<h1>Hello, world!</h1>
+
+        Welcome to your new app.
+
+<SurveyPrompt Title=""How is Blazor working for you?"" />
+
+<div class=""FF""
+     id=""ERT"">
+    asdf
+    <div class=""3""
+         id=""3"">
+        @if (true)
+        {
+            <p></p>
+        }
+    </div>
+</div>
+
+@{
+    <div class=""FF""
+         id=""ERT"">
+        asdf
+        <div class=""3""
+             id=""3"">
+            @if (true)
+            {
+                <p></p>
+            }
+        </div>
+    </div>
+}
+
+@functions {
+    public class Foo
+    {
+        @* This is a Razor Comment *@
+        void Method() { }
+    }
+}
+");
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsComplexBlock.input.html
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsComplexBlock.input.html
@@ -1,0 +1,35 @@
+~~~~~ ~~~
+
+<h1>Hello, world!</h1>
+
+        Welcome to your new app.
+
+<SurveyPrompt Title="How is Blazor working for you?" />
+
+<div class="FF"
+     id="ERT">
+     asdf
+    <div class="3"
+         id="3">
+             ~~~~~~~~~~<p></p>~
+         </div>
+</div>
+
+~~
+<div class="FF"
+    id="ERT">
+    asdf
+    <div class="3"
+        id="3">
+            ~~~~~~~~~~<p></p>~
+        </div>
+</div>
+~
+
+~~~~~~~~~~ ~
+        ~~~~~~ ~~~~~ ~~~
+    ~
+        ~~ ~~~~ ~~ ~ ~~~~~ ~~~~~~~ ~~
+        ~~~~ ~~~~~~~~ ~ ~
+    ~
+~

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsComplexBlock.output.html
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestFiles/HtmlFormattingTest/FormatsComplexBlock.output.html
@@ -1,0 +1,35 @@
+~~~~~ ~~~
+
+<h1>Hello, world!</h1>
+
+        Welcome to your new app.
+
+<SurveyPrompt Title="How is Blazor working for you?" />
+
+<div class="FF"
+     id="ERT">
+    asdf
+    <div class="3"
+         id="3">
+        ~~~~~~~~~~<p></p>~
+    </div>
+</div>
+
+~~
+<div class="FF"
+     id="ERT">
+    asdf
+    <div class="3"
+         id="3">
+        ~~~~~~~~~~<p></p>~
+    </div>
+</div>
+~
+
+~~~~~~~~~~ ~
+        ~~~~~~ ~~~~~ ~~~
+    ~
+        ~~ ~~~~ ~~ ~ ~~~~~ ~~~~~~~ ~~
+        ~~~~ ~~~~~~~~ ~ ~
+    ~
+~


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/26527

Contains a bunch of cleanups and fixes the issue where formatting was behaving differently in VS vs tests. This was because we were not generating line pragmas in tests.