### PR TITLE
Fix VSCode config parsing in Razor language server

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,7 +122,7 @@
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <!-- STOP!!! We need to reference the version of JSON that our HOSTS supprt. -->
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
-    <OmniSharpExtensionsLanguageServerPackageVersion>0.18.0-beta0084</OmniSharpExtensionsLanguageServerPackageVersion>
+    <OmniSharpExtensionsLanguageServerPackageVersion>0.18.1</OmniSharpExtensionsLanguageServerPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.33.0</OmniSharpMSBuildPackageVersion>
     <SystemPrivateUriPackageVersion>4.3.2</SystemPrivateUriPackageVersion>
     <SystemCompositionPackageVersion>1.0.31.0</SystemCompositionPackageVersion>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/ImplementInterfaceAbstractClassCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/ImplementInterfaceAbstractClassCodeActionProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             if (diagnostics is null)
             {
-                return null;
+                return EmptyResult;
             }
 
             var results = new List<RazorCodeAction>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
@@ -70,12 +70,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             switch (resolutionParams.Language)
             {
                 case LanguageServerConstants.CodeActions.Languages.Razor:
-                    return await ResolveRazorCodeAction(
+                    return await ResolveRazorCodeActionAsync(
                         request,
                         resolutionParams,
                         cancellationToken).ConfigureAwait(false);
                 case LanguageServerConstants.CodeActions.Languages.CSharp:
-                    return await ResolveCSharpCodeAction(
+                    return await ResolveCSharpCodeActionAsync(
                         request,
                         resolutionParams,
                         cancellationToken);
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         }
 
         // Internal for testing
-        internal async Task<RazorCodeAction> ResolveRazorCodeAction(
+        internal async Task<RazorCodeAction> ResolveRazorCodeActionAsync(
             RazorCodeAction codeAction,
             RazorCodeActionResolutionParams resolutionParams,
             CancellationToken cancellationToken)
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         }
 
         // Internal for testing
-        internal async Task<RazorCodeAction> ResolveCSharpCodeAction(
+        internal async Task<RazorCodeAction> ResolveCSharpCodeActionAsync(
             RazorCodeAction codeAction,
             RazorCodeActionResolutionParams resolutionParams,
             CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeAction.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeAction.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
         public new Command Command { get; set; }
 
         [JsonProperty(PropertyName = "data", NullValueHandling = NullValueHandling.Ignore)]
-        public object Data { get; set; }
+        public new object Data { get; set; }
 
         [JsonProperty(PropertyName = "children")]
         public RazorCodeAction[] Children { get; set; } = Array.Empty<RazorCodeAction>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentContainerStore.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentContainerStore.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                 var latestDocument = generatedDocumentContainer.LatestDocument;
 
-                Task.Factory.StartNew(() =>
+                _ = Task.Factory.StartNew(() =>
                 {
                     if (!_projectSnapshotManager.IsDocumentOpen(filePath))
                     {
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                 var latestDocument = generatedDocumentContainer.LatestDocument;
 
-                Task.Factory.StartNew(() =>
+                _ = Task.Factory.StartNew(() =>
                 {
                     if (!_projectSnapshotManager.IsDocumentOpen(filePath))
                     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             var result = _server.Value.Client.SendRequest(LanguageServerConstants.RazorUpdateCSharpBufferEndpoint, request);
             // This is the call that actually makes the request, any SendRequest without a .Returning* after it will do nothing.
-            result.ReturningVoid(CancellationToken.None);
+            _ = result.ReturningVoid(CancellationToken.None);
         }
 
         public override void PublishHtml(string filePath, SourceText sourceText, int hostDocumentVersion)
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             };
 
             var result = _server.Value.Client.SendRequest(LanguageServerConstants.RazorUpdateHtmlBufferEndpoint, request);
-            result.ReturningVoid(CancellationToken.None);
+            _ = result.ReturningVoid(CancellationToken.None);
         }
 
         private void ProjectSnapshotManager_Changed(object sender, ProjectChangeEventArgs args)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultHostDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultHostDocumentFactory.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 var sharedContainer = _generatedDocumentContainerStore.Get(filePath);
                 var container = (GeneratedDocumentContainer)sender;
                 var latestDocument = (DefaultDocumentSnapshot)container.LatestDocument;
-                Task.Factory.StartNew(async () =>
+                _ = Task.Factory.StartNew(async () =>
                 {
                     var codeDocument = await latestDocument.GetGeneratedOutputAsync();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
@@ -54,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 };
 
                 var response = _server.SendRequest("workspace/configuration", request);
-                var result = await response.Returning<object[]>(cancellationToken);
+                var result = await response.Returning<JObject[]>(CancellationToken.None);
                 if (result == null || result.Length < 2 || result[0] == null)
                 {
                     _logger.LogWarning("Client failed to provide the expected configuration.");
@@ -63,13 +64,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                 var builder = new ConfigurationBuilder();
 
-                var razorJsonString = result[0].ToString();
-                using var razorStream = new MemoryStream(Encoding.UTF8.GetBytes(razorJsonString));
-                builder.AddJsonStream(razorStream);
-
-                var htmlJsonString = result[1].ToString();
-                using var htmlStream = new MemoryStream(Encoding.UTF8.GetBytes(htmlJsonString));
-                builder.AddJsonStream(htmlStream);
+                var configObject = new JObject
+                {
+                    { "razor", result[0] },
+                    { "html", result[1] }
+                };
+                var configJsonString = configObject.ToString();
+                using var configStream = new MemoryStream(Encoding.UTF8.GetBytes(configJsonString));
+                builder.AddJsonStream(configStream);
 
                 var config = builder.Build();
 
@@ -87,16 +89,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             var instance = RazorLSPOptions.Default;
 
-            Enum.TryParse(config["trace"], out Trace trace);
+            Enum.TryParse(config["razor:trace"], out Trace trace);
 
             var enableFormatting = instance.EnableFormatting;
-            if (bool.TryParse(config["format:enable"], out var parsedEnableFormatting))
+            if (bool.TryParse(config["razor:format:enable"], out var parsedEnableFormatting))
             {
                 enableFormatting = parsedEnableFormatting;
             }
 
             var autoClosingTags = instance.AutoClosingTags;
-            if (bool.TryParse(config["autoClosingTags"], out var parsedAutoClosingTags))
+            if (bool.TryParse(config["html:autoClosingTags"], out var parsedAutoClosingTags))
             {
                 autoClosingTags = parsedAutoClosingTags;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 };
 
                 var response = _server.SendRequest("workspace/configuration", request);
-                var result = await response.Returning<JObject[]>(CancellationToken.None);
+                var result = await response.Returning<JObject[]>(cancellationToken);
                 if (result == null || result.Length < 2 || result[0] == null)
                 {
                     _logger.LogWarning("Client failed to provide the expected configuration.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         private void FileSystemWatcher_ProjectConfigurationFileEvent_Background(string physicalFilePath, RazorFileChangeKind kind)
         {
-            Task.Factory.StartNew(
+            _ = Task.Factory.StartNew(
                 () => FileSystemWatcher_ProjectConfigurationFileEvent(physicalFilePath, kind),
                 CancellationToken.None, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         private void FileSystemWatcher_ProjectFileEvent_Background(string physicalFilePath, RazorFileChangeKind kind)
         {
-            Task.Factory.StartNew(
+            _ = Task.Factory.StartNew(
                 () => FileSystemWatcher_ProjectFileEvent(physicalFilePath, kind),
                 CancellationToken.None, TaskCreationOptions.None, _foregroundDispatcher.ForegroundScheduler);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -160,7 +160,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             if (_documentResolver.TryResolveDocument(textDocumentPath, out var documentSnapshot))
             {
                 // Start generating the C# for the document so it can immediately be ready for incoming requests.
-                documentSnapshot.GetGeneratedOutputAsync();
+                _ = documentSnapshot.GetGeneratedOutputAsync();
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
@@ -110,7 +110,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
         }
 
+#pragma warning disable VSTHRD100 // Avoid async void methods
         private async void DocumentClosedTimer_Tick(object state)
+#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             await Task.Factory.StartNew(
                 ClearClosedDocuments,
@@ -190,7 +192,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
         }
 
+#pragma warning disable VSTHRD100 // Avoid async void methods
         private async void WorkTimer_Tick(object state)
+#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             DocumentSnapshot[] documents;
             lock (_work)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptionsMonitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptionsMonitor.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return disposable;
         }
 
-        public virtual async Task UpdateAsync(CancellationToken cancellationToken)
+        public virtual async Task UpdateAsync(CancellationToken cancellationToken = default)
         {
             var latestOptions = await _configurationService.GetLatestOptionsAsync(cancellationToken);
             if (latestOptions != null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -103,7 +103,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         {
                             // Initialize our options for the first time.
                             var optionsMonitor = languageServer.Services.GetRequiredService<RazorLSPOptionsMonitor>();
-                            _ = Task.Delay(TimeSpan.FromSeconds(3)).ContinueWith(async (_) => await optionsMonitor.UpdateAsync(cancellationToken), TaskScheduler.Default);
+
+                            // Explicitly not passing in the same CancellationToken as that might get cancelled before the update happens.
+                            _ = Task.Delay(TimeSpan.FromSeconds(3))
+                                .ContinueWith(async (_) => await optionsMonitor.UpdateAsync(), TaskScheduler.Default);
                         }
                     })
                     .WithHandler<RazorDocumentSynchronizationEndpoint>()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         {
                             // Initialize our options for the first time.
                             var optionsMonitor = languageServer.Services.GetRequiredService<RazorLSPOptionsMonitor>();
-                            _ = Task.Delay(TimeSpan.FromSeconds(3)).ContinueWith(async (_) => await optionsMonitor.UpdateAsync(cancellationToken));
+                            _ = Task.Delay(TimeSpan.FromSeconds(3)).ContinueWith(async (_) => await optionsMonitor.UpdateAsync(cancellationToken), TaskScheduler.Default);
                         }
                     })
                     .WithHandler<RazorDocumentSynchronizationEndpoint>()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorServerReadyPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorServerReadyPublisher.cs
@@ -47,7 +47,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _projectManager.Changed += ProjectSnapshotManager_Changed;
         }
 
+#pragma warning disable VSTHRD100 // Avoid async void methods
         private async void ProjectSnapshotManager_Changed(object sender, ProjectChangeEventArgs args)
+#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             _foregroundDispatcher.AssertForegroundThread();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             AddFileRenameForComponent(documentChanges, originComponentDocumentSnapshot, newPath);
             AddEditsForCodeDocument(documentChanges, originTagHelpers, request.NewName, request.TextDocument.Uri, codeDocument);
 
-            var documentSnapshots = await GetAllDocumentSnapshots(requestDocumentSnapshot, cancellationToken).ConfigureAwait(false);
+            var documentSnapshots = await GetAllDocumentSnapshotsAsync(requestDocumentSnapshot, cancellationToken).ConfigureAwait(false);
             foreach (var documentSnapshot in documentSnapshots)
             {
                 await AddEditsForCodeDocumentAsync(documentChanges, originTagHelpers, request.NewName, documentSnapshot, cancellationToken);
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             };
         }
 
-        private async Task<List<DocumentSnapshot>> GetAllDocumentSnapshots(DocumentSnapshot skipDocumentSnapshot, CancellationToken cancellationToken)
+        private async Task<List<DocumentSnapshot>> GetAllDocumentSnapshotsAsync(DocumentSnapshot skipDocumentSnapshot, CancellationToken cancellationToken)
         {
             return await Task.Factory.StartNew(() =>
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return await Handle(request.TextDocument.Uri.GetAbsolutePath(), cancellationToken, range: null);
+            return await HandleAsync(request.TextDocument.Uri.GetAbsolutePath(), cancellationToken, range: null);
         }
 
         public async Task<SemanticTokens> Handle(SemanticTokensRangeParams request, CancellationToken cancellationToken)
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return await Handle(request.TextDocument, cancellationToken, request.Range);
+            return await HandleAsync(request.TextDocument, cancellationToken, request.Range);
         }
 
         public async Task<SemanticTokensFullOrDelta?> Handle(SemanticTokensDeltaParams request, CancellationToken cancellationToken)
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             });
         }
 
-        private async Task<SemanticTokens> Handle(TextDocumentIdentifier textDocument, CancellationToken cancellationToken, Range range = null)
+        private async Task<SemanticTokens> HandleAsync(TextDocumentIdentifier textDocument, CancellationToken cancellationToken, Range range = null)
         {
             var absolutePath = textDocument.Uri.GetAbsolutePath();
             var documentSnapshot = await TryGetCodeDocumentAsync(absolutePath, cancellationToken);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             Range range,
             CancellationToken cancellationToken)
         {
-            var codeDocument = await GetRazorCodeDocument(documentSnapshot);
+            var codeDocument = await GetRazorCodeDocumentAsync(documentSnapshot);
             if (codeDocument is null)
             {
                 throw new ArgumentNullException(nameof(codeDocument));
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             string previousResultId,
             CancellationToken cancellationToken)
         {
-            var codeDocument = await GetRazorCodeDocument(documentSnapshot);
+            var codeDocument = await GetRazorCodeDocumentAsync(documentSnapshot);
             if (codeDocument is null)
             {
                 throw new ArgumentNullException(nameof(codeDocument));
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             }
         }
 
-        private async Task<RazorCodeDocument> GetRazorCodeDocument(DocumentSnapshot documentSnapshot)
+        private async Task<RazorCodeDocument> GetRazorCodeDocumentAsync(DocumentSnapshot documentSnapshot)
         {
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
             if (codeDocument.IsUnsupported())

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticTokensEditsDiffer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticTokensEditsDiffer.cs
@@ -76,7 +76,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Services
                         break;
                     case DiffEdit.Type.Insert:
                         if (current != null &&
-                            current.Data.Any() &&
+                            current.Data.HasValue &&
+                            current.Data.Value.Any() &&
                             current.Start == diff.Position)
                         {
                             current.Data = current.Data.Append(NewArray[diff.NewTextPosition.Value]).ToImmutableArray();

--- a/src/Razor/src/rzls/Program.cs
+++ b/src/Razor/src/rzls/Program.cs
@@ -12,7 +12,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         public static void Main(string[] args)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             MainAsync(args).Wait();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         public static async Task MainAsync(string[] args)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -737,7 +737,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
         {
             public override Task<IReadOnlyList<RazorCodeAction>> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
             {
-                return null;
+                return Task.FromResult<IReadOnlyList<RazorCodeAction>>(null);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
@@ -398,7 +398,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
 
             public override Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
             {
-                return null;
+                return Task.FromResult<WorkspaceEdit>(null);
             }
         }
 
@@ -431,7 +431,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
 
             public override Task<RazorCodeAction> ResolveAsync(CSharpCodeActionParams csharpParams, RazorCodeAction codeAction, CancellationToken cancellationToken)
             {
-                return null;
+                return Task.FromResult<RazorCodeAction>(null);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
@@ -259,7 +259,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             };
 
             // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveRazorCodeAction(codeAction, request, default);
+            var resolvedCodeAction = await codeActionEndpoint.ResolveRazorCodeActionAsync(codeAction, request, default);
 
             // Assert
             Assert.NotNull(resolvedCodeAction.Edit);
@@ -285,7 +285,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             };
 
             // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveRazorCodeAction(codeAction, request, default);
+            var resolvedCodeAction = await codeActionEndpoint.ResolveRazorCodeActionAsync(codeAction, request, default);
 
             // Assert
             Assert.NotNull(resolvedCodeAction.Edit);
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             };
 
             // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeAction(codeAction, request, default);
+            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
 
             // Assert
             Assert.NotNull(resolvedCodeAction.Edit);
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             };
 
             // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeAction(codeAction, request, default);
+            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
 
             // Assert
             Assert.NotNull(resolvedCodeAction.Edit);
@@ -366,7 +366,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.CodeActions
             };
 
             // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeAction(codeAction, request, default);
+            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
 
             // Assert
             Assert.NotNull(resolvedCodeAction.Edit);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         private static ProjectSnapshotManagerAccessor _projectSnapshotManager = CreateProjectSnapshotManagerAccessor();
 
         [Fact]
-        public async void Handle_SearchFound()
+        public async Task Handle_SearchFound()
         {
             // Arrange
             var tagHelperDescriptor1 = CreateRazorComponentTagHelperDescriptor("First", "First.Components", "Component1");
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         }
 
         [Fact]
-        public async void Handle_SearchFound_SetNamespace()
+        public async Task Handle_SearchFound_SetNamespace()
         {
             // Arrange
             var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", "Test", "Component2");
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         }
 
         [Fact]
-        public async void Handle_SearchMissing_IncorrectAssembly()
+        public async Task Handle_SearchMissing_IncorrectAssembly()
         {
             // Arrange
             var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("Third", "First.Components", "Component3");
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         }
 
         [Fact]
-        public async void Handle_SearchMissing_IncorrectNamespace()
+        public async Task Handle_SearchMissing_IncorrectNamespace()
         {
             // Arrange
             var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", "First.Components", "Component2");
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
         }
 
         [Fact]
-        public async void Handle_SearchMissing_IncorrectComponent()
+        public async Task Handle_SearchMissing_IncorrectComponent()
         {
             // Arrange
             var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", "First.Components", "Component3");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Moq;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -30,10 +31,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 ".Trim();
             var htmlJsonString = @"
 {
+  ""format"": ""true"",
   ""autoClosingTags"": ""false""
 }
 ".Trim();
-            var result = new object[] { razorJsonString, htmlJsonString };
+            var result = new JObject[] { JObject.Parse(razorJsonString), JObject.Parse(htmlJsonString) };
             var languageServer = GetLanguageServer(new ResponseRouterReturns(result));
             var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <NoWarn>$(NoWarn);VSTHRD200</NoWarn>
     
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -18,6 +19,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
+    [SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "Requires execution on the foreground thread.")]
     public class ProjectConfigurationStateSynchronizerTest : LanguageServerTestBase
     {
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -1157,7 +1157,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
 
                 Assert.Equal(x.DeleteCount, y.DeleteCount);
                 Assert.Equal(x.Start, y.Start);
-                Assert.Equal(x.Data, y.Data, ImmutableArrayIntComparer.Instance);
+                Assert.Equal(x.Data.Value, y.Data.Value, ImmutableArrayIntComparer.Instance);
 
                 return x.DeleteCount == y.DeleteCount &&
                     x.Start == y.Start;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/26476

- The fix here is to make our config parsing logic handle cases when the same option name is used in multiple sections. See test for example.
- Upgraded O# version to address the didChangeHandler not getting called issue
- All other changes here are to fix analyzer warnings in the language server
~Will send a separate PR to fully fix https://github.com/dotnet/aspnetcore/issues/26476 which will essentially be a O# version upgrade~
