### PR TITLE
Add initial VS debugging shims / integrations.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/DefaultWaitDialogContext.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/DefaultWaitDialogContext.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
+{
+    internal class DefaultWaitDialogContext : WaitDialogContext
+    {
+        private readonly CancellationTokenSource _cts;
+
+        public DefaultWaitDialogContext()
+        {
+            _cts = new CancellationTokenSource();
+        }
+
+        public override CancellationToken CancellationToken => _cts.Token;
+
+        public void OnCanceled() => _cts.Cancel();
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/DefaultWaitDialogFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/DefaultWaitDialogFactory.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
+{
+    [Export(typeof(WaitDialogFactory))]
+    internal class DefaultWaitDialogFactory : WaitDialogFactory
+    {
+        private readonly IVsThreadedWaitDialogFactory _waitDialogFactory;
+        private readonly JoinableTaskFactory _joinableTaskFactory;
+
+        [ImportingConstructor]
+        public DefaultWaitDialogFactory(JoinableTaskContext joinableTaskContext)
+        {
+            if (joinableTaskContext is null)
+            {
+                throw new ArgumentNullException(nameof(joinableTaskContext));
+            }
+
+            _waitDialogFactory = (IVsThreadedWaitDialogFactory)Shell.Package.GetGlobalService(typeof(SVsThreadedWaitDialogFactory));
+            if (_waitDialogFactory == null)
+            {
+                throw new ArgumentNullException(nameof(_waitDialogFactory));
+            }
+
+            _joinableTaskFactory = joinableTaskContext.Factory;
+        }
+
+        // Test constructor
+        internal DefaultWaitDialogFactory(
+            JoinableTaskContext joinableTaskContext,
+            IVsThreadedWaitDialogFactory waitDialogFactory)
+        {
+
+            _waitDialogFactory = waitDialogFactory;
+            _joinableTaskFactory = joinableTaskContext.Factory;
+        }
+
+        public override WaitDialogResult<TResult> TryCreateWaitDialog<TResult>(string title, string message, Func<WaitDialogContext, Task<TResult>> onWaitAsync)
+        {
+            Debug.Assert(_joinableTaskFactory.Context.IsOnMainThread);
+
+            var result = _waitDialogFactory.CreateInstance(out var dialog2);
+
+            if (result != VSConstants.S_OK)
+            {
+                return null;
+            }
+
+            if (!(dialog2 is IVsThreadedWaitDialog4 dialog4))
+            {
+                Debug.Fail("This is unexpected, the dialog should always be an IVsThreadedWaitDialog4");
+                return null;
+            }
+
+            var context = new DefaultWaitDialogContext();
+            var callback = new Callback(context);
+
+            dialog4.StartWaitDialogWithCallback(title, message, szProgressText: null, varStatusBmpAnim: null, szStatusBarText: null, fIsCancelable: true, iDelayToShowDialog: 2, fShowProgress: false, iTotalSteps: 0, iCurrentStep: 0, pCallback: callback);
+
+            TResult waitResult = default;
+            _joinableTaskFactory.Run(async () =>
+            {
+                try
+                {
+                    waitResult = await onWaitAsync(context).ConfigureAwait(false);
+                }
+                catch (TaskCanceledException)
+                {
+                    // Swallow task cancelled exceptions, they represent the user cancelling the wait dialog.
+                }
+            });
+
+            dialog4.EndWaitDialog(out var cancelledResult);
+
+            var cancelled = cancelledResult != 0;
+            var dialogResult = new WaitDialogResult<TResult>(waitResult, cancelled);
+            return dialogResult;
+        }
+
+        private class Callback : IVsThreadedWaitDialogCallback
+        {
+            private readonly DefaultWaitDialogContext _waitContext;
+
+            public Callback(DefaultWaitDialogContext waitContext) => _waitContext = waitContext;
+
+            public void OnCanceled() => _waitContext.OnCanceled();
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/WaitDialogContext.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/WaitDialogContext.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
+{
+    internal abstract class WaitDialogContext
+    {
+        public abstract CancellationToken CancellationToken { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/WaitDialogFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/WaitDialogFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
+{
+    internal abstract class WaitDialogFactory
+    {
+        public abstract WaitDialogResult<TResult> TryCreateWaitDialog<TResult>(string title, string message, Func<WaitDialogContext, Task<TResult>> onWaitAsync);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/WaitDialogResult.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/WaitDialogResult.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
+{
+    internal class WaitDialogResult<TResult>
+    {
+        public WaitDialogResult(TResult result, bool cancelled)
+        {
+            Result = result;
+            Cancelled = cancelled;
+        }
+
+        public bool Cancelled { get; }
+
+        public TResult Result { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.ruleset
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.ruleset
@@ -70,9 +70,15 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0060" Action="None" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
+    <Rule Id="CA2208" Action="None" />
+  </Rules>
   <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
     <Rule Id="CA1063" Action="None" />
     <Rule Id="CA1707" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA2208" Action="None" />
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.CSharp.Analyzers">
     <Rule Id="CA1303" Action="None" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLanguageDebugInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLanguageDebugInfo.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs;
+using Microsoft.VisualStudio.TextManager.Interop;
+using TextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal partial class RazorLanguageService : IVsLanguageDebugInfo
+    {
+        private readonly WaitDialogFactory _waitDialogFactory;
+
+        [ImportingConstructor]
+        public RazorLanguageService(WaitDialogFactory waitDialogFactory)
+        {
+            if (waitDialogFactory is null)
+            {
+                throw new ArgumentNullException(nameof(waitDialogFactory));
+            }
+
+            _waitDialogFactory = waitDialogFactory;
+        }
+
+        public int GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR ppEnum)
+        {
+            ppEnum = default;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int ValidateBreakpointLocation(IVsTextBuffer pBuffer, int iLine, int iCol, TextSpan[] pCodeSpan)
+        {
+            var dialogResult = _waitDialogFactory.TryCreateWaitDialog(
+                title: "Determining breakpoint location...",
+                message: "Razor Debugger",
+                (context) =>
+                {
+                    return Task.FromResult(VSConstants.E_NOTIMPL);
+                });
+
+            if (dialogResult == null)
+            {
+                // Failed to create the dialog at all.
+                return VSConstants.E_FAIL;
+            }
+
+            if (dialogResult.Cancelled)
+            {
+                return VSConstants.E_FAIL;
+            }
+
+            return dialogResult.Result;
+        }
+
+        public int GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, out string pbstrName, out int piLineOffset)
+        {
+            pbstrName = default;
+            piLineOffset = default;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int GetLocationOfName(string pszName, out string pbstrMkDoc, TextSpan[] pspanLocation)
+        {
+            pbstrMkDoc = default;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int ResolveName(string pszName, uint dwFlags, out IVsEnumDebugName ppNames)
+        {
+            ppNames = default;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int GetLanguageID(IVsTextBuffer pBuffer, int iLine, int iCol, out Guid pguidLanguageID)
+        {
+            pguidLanguageID = default;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int IsMappedLocation(IVsTextBuffer pBuffer, int iLine, int iCol)
+        {
+            return VSConstants.E_NOTIMPL;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -5,7 +5,9 @@ using System;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServerClient.Razor;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
@@ -28,7 +30,12 @@ namespace Microsoft.VisualStudio.RazorExtension
             cancellationToken.ThrowIfCancellationRequested();
 
             var container = this as IServiceContainer;
-            container.AddService(typeof(RazorLanguageService), new RazorLanguageService(), promote: true);
+            container.AddService(typeof(RazorLanguageService), (container, type) =>
+            {
+                var componentModel = (IComponentModel)GetGlobalService(typeof(SComponentModel));
+                var waitDialogFactory = componentModel.GetService<WaitDialogFactory>();
+                return new RazorLanguageService(waitDialogFactory);
+            }, promote: true);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Dialogs/DefaultWaitDialogFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Dialogs/DefaultWaitDialogFactoryTest.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
+{
+    public class DefaultWaitDialogFactoryTest : IDisposable
+    {
+        public DefaultWaitDialogFactoryTest()
+        {
+            JoinableTaskContext = new JoinableTaskContext();
+        }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        private JoinableTaskFactory JoinableTaskFactory => JoinableTaskContext.Factory;
+
+        [Fact]
+        public void TryCreateWaitDialog_Cancelled()
+        {
+            // Arrange
+            var dialog = new TestThreadedWaitDialog();
+            var vsWaitDialogFactory = CreateVSWaitDialogFactory(dialog);
+            var waitDialogFactory = new DefaultWaitDialogFactory(JoinableTaskContext, vsWaitDialogFactory);
+
+            // Act
+            var result = waitDialogFactory.TryCreateWaitDialog(title: null, message: null, async (context) =>
+            {
+                await Task.Delay(10, context.CancellationToken);
+
+                dialog.Cancel();
+
+                await Task.Delay(10000, context.CancellationToken);
+                return true;
+            });
+
+            // Assert
+            Assert.True(result.Cancelled);
+            Assert.False(result.Result);
+        }
+
+        [Fact]
+        public void TryCreateWaitDialog_Success()
+        {
+            // Arrange
+            var vsWaitDialogFactory = CreateVSWaitDialogFactory();
+            var waitDialogFactory = new DefaultWaitDialogFactory(JoinableTaskContext, vsWaitDialogFactory);
+
+            // Act
+            var result = waitDialogFactory.TryCreateWaitDialog(title: null, message: null, async (context) =>
+            {
+                await Task.Delay(10, context.CancellationToken);
+                return 1234;
+            });
+
+            // Assert
+            Assert.False(result.Cancelled);
+            Assert.Equal(1234, result.Result);
+        }
+
+        [Fact]
+        public void TryCreateWaitDialog_FailureToCreateDialog_ReturnsNull()
+        {
+            // Arrange
+            IVsThreadedWaitDialog2 waitDialog2 = null;
+            var vsWaitDialogFactory = Mock.Of<IVsThreadedWaitDialogFactory>(factory => factory.CreateInstance(out waitDialog2) == VSConstants.E_FAIL);
+            var waitDialogFactory = new DefaultWaitDialogFactory(JoinableTaskContext, vsWaitDialogFactory);
+
+            // Act
+            var result = waitDialogFactory.TryCreateWaitDialog(title: null, message: null, (context) => Task.FromResult(true));
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        public void Dispose()
+        {
+            JoinableTaskContext.Dispose();
+        }
+
+        private IVsThreadedWaitDialogFactory CreateVSWaitDialogFactory(IVsThreadedWaitDialog2 waitDialog = null)
+        {
+            waitDialog ??= new TestThreadedWaitDialog();
+            var vsWaitDialogFactory = Mock.Of<IVsThreadedWaitDialogFactory>(factory => factory.CreateInstance(out waitDialog) == VSConstants.S_OK);
+            return vsWaitDialogFactory;
+        }
+
+        private class TestThreadedWaitDialog : IVsThreadedWaitDialog2, IVsThreadedWaitDialog4
+        {
+            private IVsThreadedWaitDialogCallback _callback;
+            private bool _cancelled;
+
+            public void Cancel()
+            {
+                _cancelled = true;
+                _callback?.OnCanceled();
+            }
+
+            public void StartWaitDialogWithCallback(string szWaitCaption, string szWaitMessage, string szProgressText, object varStatusBmpAnim, string szStatusBarText, bool fIsCancelable, int iDelayToShowDialog, bool fShowProgress, int iTotalSteps, int iCurrentStep, IVsThreadedWaitDialogCallback pCallback)
+            {
+                _callback = pCallback;
+            }
+
+            public void EndWaitDialog(out int pfCanceled)
+            {
+                pfCanceled = _cancelled ? 1 : 0;
+            }
+
+            public void StartWaitDialog(string szWaitCaption, string szWaitMessage, string szProgressText, object varStatusBmpAnim, string szStatusBarText, int iDelayToShowDialog, bool fIsCancelable, bool fShowMarqueeProgress) => throw new NotImplementedException();
+
+            public void StartWaitDialogWithPercentageProgress(string szWaitCaption, string szWaitMessage, string szProgressText, object varStatusBmpAnim, string szStatusBarText, bool fIsCancelable, int iDelayToShowDialog, int iTotalSteps, int iCurrentStep) => throw new NotImplementedException();
+
+            public void UpdateProgress(string szUpdatedWaitMessage, string szProgressText, string szStatusBarText, int iCurrentStep, int iTotalSteps, bool fDisableCancel, out bool pfCanceled) => throw new NotImplementedException();
+
+            public void HasCanceled(out bool pfCanceled) => throw new NotImplementedException();
+
+            public bool StartWaitDialogEx(string szWaitCaption, string szWaitMessage, string szProgressText, object varStatusBmpAnim, string szStatusBarText, int iDelayToShowDialog, bool fIsCancelable, bool fShowMarqueeProgress) => throw new NotImplementedException();
+
+            int IVsThreadedWaitDialog2.StartWaitDialog(string szWaitCaption, string szWaitMessage, string szProgressText, object varStatusBmpAnim, string szStatusBarText, int iDelayToShowDialog, bool fIsCancelable, bool fShowMarqueeProgress) => throw new NotImplementedException();
+
+            int IVsThreadedWaitDialog2.StartWaitDialogWithPercentageProgress(string szWaitCaption, string szWaitMessage, string szProgressText, object varStatusBmpAnim, string szStatusBarText, bool fIsCancelable, int iDelayToShowDialog, int iTotalSteps, int iCurrentStep) => throw new NotImplementedException();
+
+            int IVsThreadedWaitDialog2.EndWaitDialog(out int pfCanceled) => throw new NotImplementedException();
+
+            int IVsThreadedWaitDialog2.UpdateProgress(string szUpdatedWaitMessage, string szProgressText, string szStatusBarText, int iCurrentStep, int iTotalSteps, bool fDisableCancel, out bool pfCanceled) => throw new NotImplementedException();
+
+            int IVsThreadedWaitDialog2.HasCanceled(out bool pfCanceled) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
- Added a `IVsLanguageDebugInfo` extension to our language service. This interface will be used when attempting to set breakpoints for any file that has our language service. In our case, that's only RazorLSP files.
- Added a generic wait dialog utility for us to use when we can't possibly go async due to call paths being enforced as synchronous.
- Implemented the skeleton of `ValidateBreakpointLocation` to show how the wait dialog factory will be used. Because the API is synchronous the wait dialog is essential to ensure we can run asynchronous work but also simultaneously allow users to "stop" that async work.
- Added tests for our wait dialog wrapper.

Part of dotnet/aspnetcore#26643