### PR TITLE
Add set/hit breakpoint support for some Razor C#.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/CSharpBreakpointResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/CSharpBreakpointResolver.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    // This type is temporary and will be replaced by an ExternalAccess.Razor type once available.
+
+    internal abstract class CSharpBreakpointResolver
+    {
+        public abstract bool TryGetBreakpointSpan(SyntaxTree tree, int position, CancellationToken cancellationToken, out TextSpan breakpointSpan);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultCSharpBreakpointResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultCSharpBreakpointResolver.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Reflection;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    // This type is temporary and will be replaced by an ExternalAccess.Razor type once available.
+
+    [Export(typeof(CSharpBreakpointResolver))]
+    internal class DefaultCSharpBreakpointResolver : CSharpBreakpointResolver
+    {
+        private readonly MethodInfo _tryGetBreakpointSpan;
+
+        public DefaultCSharpBreakpointResolver()
+        {
+            try
+            {
+                var assemblyName = typeof(SyntaxTree).Assembly.GetName();
+                assemblyName.Name = "Microsoft.CodeAnalysis.CSharp.Features";
+                var assembly = Assembly.Load(assemblyName);
+                var type = assembly.GetType("Microsoft.CodeAnalysis.CSharp.EditAndContinue.BreakpointSpans");
+                _tryGetBreakpointSpan = type.GetMethod("TryGetBreakpointSpan");
+
+                if (_tryGetBreakpointSpan == null)
+                {
+                    throw new InvalidOperationException(
+                        "Error occured when acessing the TryGetBreakpointSpan method on Roslyn's BreakpointSpan's type. Roslyn may have changed in an unexpected way.");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    "Error occured when creating an instance of Roslyn's BreakpointSpan's type. Roslyn may have changed in an unexpected way.",
+                    ex);
+            }
+        }
+
+        public override bool TryGetBreakpointSpan(SyntaxTree tree, int position, CancellationToken cancellationToken, out TextSpan breakpointSpan)
+        {
+            var parameters = new object[] { tree, position, cancellationToken, new TextSpan() };
+            var result = _tryGetBreakpointSpan.Invoke(obj: null, parameters);
+            var boolResult = (bool)result;
+
+            if (boolResult)
+            {
+                breakpointSpan = (TextSpan)parameters[3];
+                return true;
+            }
+
+            breakpointSpan = default;
+            return false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorBreakpointResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorBreakpointResolver.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    [Export(typeof(RazorBreakpointResolver))]
+    internal class DefaultRazorBreakpointResolver : RazorBreakpointResolver
+    {
+        private readonly FileUriProvider _fileUriProvider;
+        private readonly LSPDocumentManager _documentManager;
+        private readonly LSPProjectionProvider _projectionProvider;
+        private readonly LSPDocumentMappingProvider _documentMappingProvider;
+        private readonly CSharpBreakpointResolver _csharpBreakpointResolver;
+
+        [ImportingConstructor]
+        public DefaultRazorBreakpointResolver(
+            FileUriProvider fileUriProvider,
+            LSPDocumentManager documentManager,
+            LSPProjectionProvider projectionProvider,
+            LSPDocumentMappingProvider documentMappingProvider,
+            CSharpBreakpointResolver csharpBreakpointResolver)
+        {
+            if (fileUriProvider is null)
+            {
+                throw new ArgumentNullException(nameof(fileUriProvider));
+            }
+
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (projectionProvider is null)
+            {
+                throw new ArgumentNullException(nameof(projectionProvider));
+            }
+
+            if (documentMappingProvider is null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingProvider));
+            }
+
+            if (csharpBreakpointResolver is null)
+            {
+                throw new ArgumentNullException(nameof(csharpBreakpointResolver));
+            }
+
+            _fileUriProvider = fileUriProvider;
+            _documentManager = documentManager;
+            _projectionProvider = projectionProvider;
+            _documentMappingProvider = documentMappingProvider;
+            _csharpBreakpointResolver = csharpBreakpointResolver;
+        }
+
+        public override async Task<Range> TryResolveBreakpointRangeAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
+        {
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            if (!_fileUriProvider.TryGet(textBuffer, out var documentUri))
+            {
+                // Not an addressable Razor document. Do not allow a breakpoint here.
+                return null;
+            }
+
+            if (!_documentManager.TryGetDocument(documentUri, out var documentSnapshot))
+            {
+                // No associated Razor document. Do not allow a breakpoint here.
+                return null;
+            }
+
+            var lspPosition = new Position(lineIndex, characterIndex);
+            var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, lspPosition, cancellationToken).ConfigureAwait(false);
+            if (projectionResult == null)
+            {
+                // Can't map the position, invalid breakpoitn location.
+                return null;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (projectionResult.LanguageKind != RazorLanguageKind.CSharp)
+            {
+                // We only allow breakpoints in C#
+                return null;
+            }
+
+            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var virtualDocument))
+            {
+                Debug.Fail("Some how there's no C# document associated with the host Razor document when validating breakpoint locations.");
+                return null;
+            }
+
+            var sourceText = virtualDocument.Snapshot.AsText();
+            var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, isGeneratedCode: true, cancellationToken: cancellationToken);
+            if (!_csharpBreakpointResolver.TryGetBreakpointSpan(syntaxTree, projectionResult.PositionIndex, cancellationToken, out var csharpBreakpointSpan))
+            {
+                return null;
+            }
+
+            virtualDocument.Snapshot.GetLineAndCharacter(csharpBreakpointSpan.Start, out var startLineIndex, out var startCharacterIndex);
+            virtualDocument.Snapshot.GetLineAndCharacter(csharpBreakpointSpan.End, out var endLineIndex, out var endCharacterIndex);
+
+            var projectedRange = new[]
+            {
+                new Range()
+                {
+                    Start = new Position(startLineIndex, startCharacterIndex),
+                    End = new Position(endLineIndex, endCharacterIndex),
+                },
+            };
+            var hostDocumentMapping = await _documentMappingProvider.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, documentUri, projectedRange, cancellationToken);
+            if (hostDocumentMapping == null)
+            {
+                return null;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var hostDocumentRange = hostDocumentMapping.Ranges.FirstOrDefault();
+            if (hostDocumentRange == null)
+            {
+                return null;
+            }
+
+            return hostDocumentRange;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorBreakpointResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorBreakpointResolver.cs
@@ -74,13 +74,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
 
             if (!_fileUriProvider.TryGet(textBuffer, out var documentUri))
             {
-                // Not an addressable Razor document. Do not allow a breakpoint here.
+                // Not an addressable Razor document. Do not allow a breakpoint here. In practice this shouldn't happen, just being defensive.
                 return null;
             }
 
             if (!_documentManager.TryGetDocument(documentUri, out var documentSnapshot))
             {
-                // No associated Razor document. Do not allow a breakpoint here.
+                // No associated Razor document. Do not allow a breakpoint here. In practice this shouldn't happen, just being defensive.
                 return null;
             }
 
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, lspPosition, cancellationToken).ConfigureAwait(false);
             if (projectionResult == null)
             {
-                // Can't map the position, invalid breakpoitn location.
+                // Can't map the position, invalid breakpoint location.
                 return null;
             }
 
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
 
             if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var virtualDocument))
             {
-                Debug.Fail("Some how there's no C# document associated with the host Razor document when validating breakpoint locations.");
+                Debug.Fail($"Some how there's no C# document associated with the host Razor document {documentUri.OriginalString} when validating breakpoint locations.");
                 return null;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
                     End = new Position(endLineIndex, endCharacterIndex),
                 },
             };
-            var hostDocumentMapping = await _documentMappingProvider.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, documentUri, projectedRange, cancellationToken);
+            var hostDocumentMapping = await _documentMappingProvider.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, documentUri, projectedRange, cancellationToken).ConfigureAwait(false);
             if (hostDocumentMapping == null)
             {
                 return null;
@@ -133,11 +133,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
             cancellationToken.ThrowIfCancellationRequested();
 
             var hostDocumentRange = hostDocumentMapping.Ranges.FirstOrDefault();
-            if (hostDocumentRange == null)
-            {
-                return null;
-            }
-
             return hostDocumentRange;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/RazorBreakpointResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/RazorBreakpointResolver.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    internal abstract class RazorBreakpointResolver
+    {
+        public abstract Task<Range> TryResolveBreakpointRangeAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/DefaultWaitDialogFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/DefaultWaitDialogFactory.cs
@@ -38,7 +38,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
             JoinableTaskContext joinableTaskContext,
             IVsThreadedWaitDialogFactory waitDialogFactory)
         {
-
             _waitDialogFactory = waitDialogFactory;
             _joinableTaskFactory = joinableTaskContext.Factory;
         }
@@ -48,7 +47,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
             Debug.Assert(_joinableTaskFactory.Context.IsOnMainThread);
 
             var result = _waitDialogFactory.CreateInstance(out var dialog2);
-
             if (result != VSConstants.S_OK)
             {
                 return null;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/WaitDialogResult.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Dialogs/WaitDialogResult.cs
@@ -11,8 +11,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs
             Cancelled = cancelled;
         }
 
-        public bool Cancelled { get; }
-
         public TResult Result { get; }
+
+        public bool Cancelled { get; }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ITextSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ITextSnapshotExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal static class ITextSnapshotExtensions
+    {
+        public static void GetLineAndCharacter(this ITextSnapshot snapshot, int index, out int lineNumber, out int characterIndex)
+        {
+            if (snapshot is null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            var line = snapshot.GetLineFromPosition(index);
+
+            lineNumber = line.LineNumber;
+            characterIndex = index - line.Start.Position;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -6,7 +6,9 @@ using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServerClient.Razor;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -33,8 +35,10 @@ namespace Microsoft.VisualStudio.RazorExtension
             container.AddService(typeof(RazorLanguageService), (container, type) =>
             {
                 var componentModel = (IComponentModel)GetGlobalService(typeof(SComponentModel));
+                var breakpointResolver = componentModel.GetService<RazorBreakpointResolver>();
                 var waitDialogFactory = componentModel.GetService<WaitDialogFactory>();
-                return new RazorLanguageService(waitDialogFactory);
+                var editorAdaptersFactory = componentModel.GetService<IVsEditorAdaptersFactoryService>();
+                return new RazorLanguageService(breakpointResolver, waitDialogFactory, editorAdaptersFactory);
             }, promote: true);
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -1,0 +1,327 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+using Microsoft.VisualStudio.Test;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    public class DefaultRazorBreakpointResolverTest
+    {
+        public DefaultRazorBreakpointResolverTest()
+        {
+            DocumentUri = new Uri("file://C:/path/to/file.razor", UriKind.Absolute);
+
+            ValidBreakpointCSharp = "private int foo = 123;";
+            InvalidBreakpointCSharp = "private int bar;";
+            var mappedCSharpText =
+$@"
+    {ValidBreakpointCSharp}
+    {InvalidBreakpointCSharp}
+";
+            var csharpTextSnapshot = new StringTextSnapshot(
+$@"public class SomeRazorFile
+{{{mappedCSharpText}}}");
+            CSharpTextBuffer = new TestTextBuffer(csharpTextSnapshot);
+
+            var textBufferSnapshot = new StringTextSnapshot($"@code {{{mappedCSharpText}}}");
+            HostTextbuffer = new TestTextBuffer(textBufferSnapshot);
+        }
+
+        private string ValidBreakpointCSharp { get; }
+
+        private string InvalidBreakpointCSharp { get; }
+
+        private ITextBuffer CSharpTextBuffer { get; }
+
+        private Uri DocumentUri { get; }
+
+        private ITextBuffer HostTextbuffer { get; }
+
+        [Fact]
+        public async Task TryResolveBreakpointRangeAsync_UnaddressableTextBuffer_ReturnsNull()
+        {
+            // Arrange
+            var differentTextBuffer = Mock.Of<ITextBuffer>();
+            var resolver = CreateResolverWith();
+
+            // Act
+            var breakpointRange = await resolver.TryResolveBreakpointRangeAsync(differentTextBuffer, lineIndex: 0, characterIndex: 1, CancellationToken.None);
+
+            // Assert
+            Assert.Null(breakpointRange);
+        }
+
+        [Fact]
+        public async Task TryResolveBreakpointRangeAsync_UnknownRazorDocument_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = Mock.Of<LSPDocumentManager>();
+            var resolver = CreateResolverWith(documentManager: documentManager);
+
+            // Act
+            var result = await resolver.TryResolveBreakpointRangeAsync(HostTextbuffer, lineIndex: 0, characterIndex: 1, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task TryResolveBreakpointRangeAsync_UnprojectedLocation_ReturnsNull()
+        {
+            // Arrange
+            var resolver = CreateResolverWith();
+
+            // Act
+            var breakpointRange = await resolver.TryResolveBreakpointRangeAsync(HostTextbuffer, lineIndex: 0, characterIndex: 1, CancellationToken.None);
+
+            // Assert
+            Assert.Null(breakpointRange);
+        }
+
+        [Fact]
+        public async Task TryResolveBreakpointRangeAsync_RazorProjectedLocation_ReturnsNull()
+        {
+            // Arrange
+            var position = new Position(line: 0, character: 2);
+            var projectionProvider = new TestLSPProjectionProvider(
+                DocumentUri,
+                new Dictionary<Position, ProjectionResult>()
+                {
+                    [position] = new ProjectionResult()
+                    {
+                        LanguageKind = RazorLanguageKind.Razor,
+                        HostDocumentVersion = 0,
+                        Position = position,
+                    }
+                });
+            var resolver = CreateResolverWith(projectionProvider: projectionProvider);
+
+            // Act
+            var breakpointRange = await resolver.TryResolveBreakpointRangeAsync(HostTextbuffer, position.Line, position.Character, CancellationToken.None);
+
+            // Assert
+            Assert.Null(breakpointRange);
+        }
+
+        [Fact]
+        public async Task TryResolveBreakpointRangeAsync_NotValidBreakpointLocation_ReturnsNull()
+        {
+            // Arrange
+            var hostDocumentPosition = GetPosition(InvalidBreakpointCSharp, HostTextbuffer);
+            var csharpDocumentPosition = GetPosition(InvalidBreakpointCSharp, CSharpTextBuffer);
+            var csharpDocumentIndex = CSharpTextBuffer.CurrentSnapshot.GetText().IndexOf(ValidBreakpointCSharp, StringComparison.Ordinal);
+            var projectionProvider = new TestLSPProjectionProvider(
+                DocumentUri,
+                new Dictionary<Position, ProjectionResult>()
+                {
+                    [hostDocumentPosition] = new ProjectionResult()
+                    {
+                        LanguageKind = RazorLanguageKind.CSharp,
+                        HostDocumentVersion = 0,
+                        Position = csharpDocumentPosition,
+                        PositionIndex = csharpDocumentIndex,
+                    }
+                });
+            var resolver = CreateResolverWith(projectionProvider: projectionProvider);
+
+            // Act
+            var breakpointRange = await resolver.TryResolveBreakpointRangeAsync(HostTextbuffer, hostDocumentPosition.Line, hostDocumentPosition.Character, CancellationToken.None);
+
+            // Assert
+            Assert.Null(breakpointRange);
+        }
+
+        [Fact]
+        public async Task TryResolveBreakpointRangeAsync_UnmappableCSharpBreakpointLocation_ReturnsNull()
+        {
+            // Arrange
+            var hostDocumentPosition = GetPosition(ValidBreakpointCSharp, HostTextbuffer);
+            var csharpDocumentPosition = GetPosition(ValidBreakpointCSharp, CSharpTextBuffer);
+            var csharpDocumentIndex = CSharpTextBuffer.CurrentSnapshot.GetText().IndexOf(ValidBreakpointCSharp, StringComparison.Ordinal);
+            var projectionProvider = new TestLSPProjectionProvider(
+                DocumentUri,
+                new Dictionary<Position, ProjectionResult>()
+                {
+                    [hostDocumentPosition] = new ProjectionResult()
+                    {
+                        LanguageKind = RazorLanguageKind.CSharp,
+                        HostDocumentVersion = 0,
+                        Position = csharpDocumentPosition,
+                        PositionIndex = csharpDocumentIndex,
+                    }
+                });
+            var resolver = CreateResolverWith(projectionProvider: projectionProvider);
+
+            // Act
+            var breakpointRange = await resolver.TryResolveBreakpointRangeAsync(HostTextbuffer, hostDocumentPosition.Line, hostDocumentPosition.Character, CancellationToken.None);
+
+            // Assert
+            Assert.Null(breakpointRange);
+        }
+
+        [Fact]
+        public async Task TryResolveBreakpointRangeAsync_MappableCSharpBreakpointLocation_ReturnsHostBreakpointLocation()
+        {
+            // Arrange
+            var hostDocumentPosition = GetPosition(ValidBreakpointCSharp, HostTextbuffer);
+            var csharpDocumentPosition = GetPosition(ValidBreakpointCSharp, CSharpTextBuffer);
+            var csharpDocumentIndex = CSharpTextBuffer.CurrentSnapshot.GetText().IndexOf(ValidBreakpointCSharp, StringComparison.Ordinal);
+            var projectionProvider = new TestLSPProjectionProvider(
+                DocumentUri,
+                new Dictionary<Position, ProjectionResult>()
+                {
+                    [hostDocumentPosition] = new ProjectionResult()
+                    {
+                        LanguageKind = RazorLanguageKind.CSharp,
+                        HostDocumentVersion = 0,
+                        Position = csharpDocumentPosition,
+                        PositionIndex = csharpDocumentIndex,
+                    }
+                });
+            var expectedCSharpBreakpointRange = new Range()
+            {
+                Start = csharpDocumentPosition,
+                End = new Position(csharpDocumentPosition.Line, csharpDocumentPosition.Character + ValidBreakpointCSharp.Length),
+            };
+            var hostBreakpointRange = new Range()
+            {
+                Start = hostDocumentPosition,
+                End = new Position(hostDocumentPosition.Line, hostDocumentPosition.Character + ValidBreakpointCSharp.Length),
+            };
+            var mappingProvider = new TestLSPDocumentMappingProvider(
+                new Dictionary<Range, RazorMapToDocumentRangesResponse>()
+                {
+                    [expectedCSharpBreakpointRange] = new RazorMapToDocumentRangesResponse()
+                    {
+                        HostDocumentVersion = 0,
+                        Ranges = new[]
+                        {
+                            hostBreakpointRange,
+                        },
+                    }
+                });
+            var resolver = CreateResolverWith(projectionProvider: projectionProvider, documentMappingProvider: mappingProvider);
+
+            // Act
+            var breakpointRange = await resolver.TryResolveBreakpointRangeAsync(HostTextbuffer, hostDocumentPosition.Line, hostDocumentPosition.Character, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(hostBreakpointRange, breakpointRange);
+        }
+
+        private RazorBreakpointResolver CreateResolverWith(
+            FileUriProvider uriProvider = null,
+            LSPDocumentManager documentManager = null,
+            LSPProjectionProvider projectionProvider = null,
+            LSPDocumentMappingProvider documentMappingProvider = null)
+        {
+            var documentUri = DocumentUri;
+            uriProvider ??= Mock.Of<FileUriProvider>(provider => provider.TryGet(HostTextbuffer, out documentUri) == true);
+            var csharpDocumentUri = new Uri(DocumentUri.OriginalString + ".g.cs", UriKind.Absolute);
+            var csharpVirtualDocumentSnapshot = new CSharpVirtualDocumentSnapshot(csharpDocumentUri, CSharpTextBuffer.CurrentSnapshot, hostDocumentSyncVersion: 0);
+            LSPDocumentSnapshot documentSnapshot = new TestLSPDocumentSnapshot(DocumentUri, 0, csharpVirtualDocumentSnapshot);
+            documentManager ??= Mock.Of<LSPDocumentManager>(manager => manager.TryGetDocument(DocumentUri, out documentSnapshot) == true);
+            projectionProvider ??= Mock.Of<LSPProjectionProvider>();
+            documentMappingProvider ??= Mock.Of<LSPDocumentMappingProvider>();
+            var csharpBreakpointResolver = new DefaultCSharpBreakpointResolver();
+            var razorBreakpointResolver = new DefaultRazorBreakpointResolver(
+                uriProvider,
+                documentManager,
+                projectionProvider,
+                documentMappingProvider,
+                csharpBreakpointResolver);
+
+            return razorBreakpointResolver;
+        }
+
+        private Position GetPosition(string content, ITextBuffer textBuffer)
+        {
+            var index = textBuffer.CurrentSnapshot.GetText().IndexOf(content, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(content));
+            }
+
+            textBuffer.CurrentSnapshot.GetLineAndCharacter(index, out var lineIndex, out var characterIndex);
+            return new Position(lineIndex, characterIndex);
+        }
+
+        private class TestLSPDocumentMappingProvider : LSPDocumentMappingProvider
+        {
+            private readonly IReadOnlyDictionary<Range, RazorMapToDocumentRangesResponse> _mappings;
+
+            public TestLSPDocumentMappingProvider(IReadOnlyDictionary<Range, RazorMapToDocumentRangesResponse> mappings)
+            {
+                if (mappings is null)
+                {
+                    throw new ArgumentNullException(nameof(mappings));
+                }
+
+                _mappings = mappings;
+            }
+
+            public override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(
+                RazorLanguageKind languageKind,
+                Uri razorDocumentUri,
+                Range[] projectedRanges,
+                CancellationToken cancellationToken)
+            {
+                _mappings.TryGetValue(projectedRanges[0], out var response);
+                return Task.FromResult(response);
+            }
+
+            public override Task<TextEdit[]> RemapFormattedTextEditsAsync(Uri uri, TextEdit[] edits, FormattingOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public override Task<Location[]> RemapLocationsAsync(Location[] locations, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public override Task<TextEdit[]> RemapTextEditsAsync(Uri uri, TextEdit[] edits, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public override Task<WorkspaceEdit> RemapWorkspaceEditAsync(WorkspaceEdit workspaceEdit, CancellationToken cancellationToken) => throw new NotImplementedException();
+        }
+
+        private class TestLSPProjectionProvider : LSPProjectionProvider
+        {
+            private readonly Uri _documentUri;
+            private readonly IReadOnlyDictionary<Position, ProjectionResult> _mappings;
+
+            public TestLSPProjectionProvider(Uri documentUri, IReadOnlyDictionary<Position, ProjectionResult> mappings)
+            {
+                if (documentUri is null)
+                {
+                    throw new ArgumentNullException(nameof(documentUri));
+                }
+
+                if (mappings is null)
+                {
+                    throw new ArgumentNullException(nameof(mappings));
+                }
+
+                _documentUri = documentUri;
+                _mappings = mappings;
+            }
+
+            public override Task<ProjectionResult> GetProjectionAsync(LSPDocumentSnapshot documentSnapshot, Position position, CancellationToken cancellationToken)
+            {
+                if (documentSnapshot.Uri != _documentUri)
+                {
+                    return Task.FromResult((ProjectionResult)null);
+                }
+
+                _mappings.TryGetValue(position, out var projectionResult);
+
+                return Task.FromResult(projectionResult);
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLanguageService`IVsLanguageDebugInfoTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLanguageService`IVsLanguageDebugInfoTest.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Dialogs;
+using Microsoft.VisualStudio.Test;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Moq;
+using Xunit;
+using Position = Microsoft.VisualStudio.LanguageServer.Protocol.Position;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class RazorLanguageService_IVsLanguageDebugInfoTest
+    {
+        private TextSpan[] TextSpans { get; } = new[]
+        {
+            new TextSpan()
+        };
+
+        [Fact]
+        public void ValidateBreakpointLocation_CanNotGetBackingTextBuffer_ReturnsNotImpl()
+        {
+            // Arrange
+            var languageService = CreateLanguageServiceWith(editorAdaptersFactory: Mock.Of<IVsEditorAdaptersFactoryService>());
+
+            // Act
+            var result = languageService.ValidateBreakpointLocation(Mock.Of<IVsTextBuffer>(), 0, 0, TextSpans);
+
+            // Assert
+            Assert.Equal(VSConstants.E_NOTIMPL, result);
+        }
+
+        [Fact]
+        public void ValidateBreakpointLocation_InvalidLocation_ReturnsEFail()
+        {
+            // Arrange
+            var languageService = CreateLanguageServiceWith();
+
+            // Act
+            var result = languageService.ValidateBreakpointLocation(Mock.Of<IVsTextBuffer>(), int.MaxValue, 0, TextSpans);
+
+            // Assert
+            Assert.Equal(VSConstants.E_FAIL, result);
+        }
+
+        [Fact]
+        public void ValidateBreakpointLocation_NullBreakpointRange_ReturnsEFail()
+        {
+            // Arrange
+            var languageService = CreateLanguageServiceWith();
+
+            // Act
+            var result = languageService.ValidateBreakpointLocation(Mock.Of<IVsTextBuffer>(), 0, 0, TextSpans);
+
+            // Assert
+            Assert.Equal(VSConstants.E_FAIL, result);
+        }
+
+        [Fact]
+        public void ValidateBreakpointLocation_ValidBreakpointRange_ReturnsSOK()
+        {
+            // Arrange
+            var breakpointRange = new Range()
+            {
+                Start = new Position(2, 4),
+                End = new Position(3, 5),
+            };
+            var breakpointResolver = Mock.Of<RazorBreakpointResolver>(resolver => resolver.TryResolveBreakpointRangeAsync(It.IsAny<ITextBuffer>(), 0, 0, It.IsAny<CancellationToken>()) == Task.FromResult(breakpointRange));
+            var languageService = CreateLanguageServiceWith(breakpointResolver);
+
+            // Act
+            var result = languageService.ValidateBreakpointLocation(Mock.Of<IVsTextBuffer>(), 0, 0, TextSpans);
+
+            // Assert
+            Assert.Equal(VSConstants.S_OK, result);
+            var span = Assert.Single(TextSpans);
+            Assert.Equal(2, span.iStartLine);
+            Assert.Equal(4, span.iStartIndex);
+            Assert.Equal(3, span.iEndLine);
+            Assert.Equal(5, span.iEndIndex);
+        }
+
+        [Fact]
+        public void ValidateBreakpointLocation_CanNotCreateDialog_ReturnsEFail()
+        {
+            // Arrange
+            var languageService = CreateLanguageServiceWith(waitDialogFactory: Mock.Of<WaitDialogFactory>());
+
+            // Act
+            var result = languageService.ValidateBreakpointLocation(Mock.Of<IVsTextBuffer>(), 0, 0, TextSpans);
+
+            // Assert
+            Assert.Equal(VSConstants.E_FAIL, result);
+        }
+
+        private RazorLanguageService CreateLanguageServiceWith(
+            RazorBreakpointResolver breakpointResolver = null,
+            WaitDialogFactory waitDialogFactory = null,
+            IVsEditorAdaptersFactoryService editorAdaptersFactory = null)
+        {
+            breakpointResolver ??= Mock.Of<RazorBreakpointResolver>();
+            waitDialogFactory ??= new TestWaitDialogFactory();
+            editorAdaptersFactory ??= Mock.Of<IVsEditorAdaptersFactoryService>(service => service.GetDataBuffer(It.IsAny<IVsTextBuffer>()) == new TestTextBuffer(new StringTextSnapshot(Environment.NewLine)));
+
+            var languageService = new RazorLanguageService(breakpointResolver, waitDialogFactory, editorAdaptersFactory);
+            return languageService;
+        }
+
+        private class TestWaitDialogFactory : WaitDialogFactory
+        {
+            public override WaitDialogResult<TResult> TryCreateWaitDialog<TResult>(string title, string message, Func<WaitDialogContext, Task<TResult>> onWaitAsync)
+            {
+                var context = new DefaultWaitDialogContext();
+                var result = onWaitAsync(context).Result;
+
+                var dialogResult = new WaitDialogResult<TResult>(result, context.CancellationToken.IsCancellationRequested);
+                return dialogResult;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- This changeset enables breakpoints to be set on C# code that's not obfuscated by other Razor paradigms. For instance, implicit expressions cannot have breakpoints set on them with this changeset because `__o = DateTime.Now` is the entirety of the breakpoint but the user can only see `@DateTime.Now`.
- Had to add a C# breakpoint resolver because the breakpoint APIs provided by C# are internal only. I will do a follow up PR to Roslyn in order to properly expose the breakpoint information APIs via ExternalAccess.Razor
- Added some cleanup to the existing wait dialog factory types from the previous changeset.
- Added tests for both the Razor breakpoint resolver and the language service extension usage.

![U81XnxADuf](https://user-images.githubusercontent.com/2008729/96907692-70f55e80-1450-11eb-90bd-9644f0ef67ea.gif)

Part of dotnet/aspnetcore#26643