### PR TITLE
Add support for FAR, def, impl, rename and signature help for HTML.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
-            if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.CSharp)
+            if (projectionResult == null)
             {
                 return null;
             }
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var result = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(
                 Methods.TextDocumentDefinitionName,
-                RazorLSPConstants.CSharpContentTypeName,
+                projectionResult.LanguageKind.ToContainedLanguageContentType(),
                 textDocumentPositionParams,
                 cancellationToken).ConfigureAwait(false);
 
@@ -96,6 +96,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 return result;
             }
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             var remappedLocations = await _documentMappingProvider.RemapLocationsAsync(result, cancellationToken).ConfigureAwait(false);
             return remappedLocations;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToImplementationHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToImplementationHandler.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
-            if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.CSharp)
+            if (projectionResult == null)
             {
                 return null;
             }
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var result = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(
                 Methods.TextDocumentImplementationName,
-                RazorLSPConstants.CSharpContentTypeName,
+                projectionResult.LanguageKind.ToContainedLanguageContentType(),
                 textDocumentPositionParams,
                 cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RenameHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RenameHandler.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
-            if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.CSharp)
+            if (projectionResult == null)
             {
                 // We only support C# renames for now.
                 return null;
@@ -90,9 +90,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var result = await _requestInvoker.ReinvokeRequestOnServerAsync<RenameParams, WorkspaceEdit>(
                 Methods.TextDocumentRenameName,
-                RazorLSPConstants.CSharpContentTypeName,
+                projectionResult.LanguageKind.ToContainedLanguageContentType(),
                 renameParams,
                 cancellationToken).ConfigureAwait(false);
+
+            if (result == null)
+            {
+                return null;
+            }
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/SignatureHelpHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/SignatureHelpHandler.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
-            if (projectionResult == null || projectionResult.LanguageKind != RazorLanguageKind.CSharp)
+            if (projectionResult == null)
             {
                 return null;
             }
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var signatureHelp = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, SignatureHelp>(
                 Methods.TextDocumentSignatureHelpName,
-                RazorLSPConstants.CSharpContentTypeName,
+                projectionResult.LanguageKind.ToContainedLanguageContentType(),
                 textDocumentPositionParams,
                 cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToDefinitionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToDefinitionHandlerTest.cs
@@ -68,33 +68,60 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         }
 
         [Fact]
-        public async Task HandleRequestAsync_HtmlProjection_ReturnsNull()
+        public async Task HandleRequestAsync_HtmlProjection_InvokesHtmlLanguageServer()
         {
             // Arrange
+            var invokedLSPRequest = false;
+            var invokedRemapRequest = false;
+            var expectedLocation = GetLocation(5, 5, 5, 5, Uri);
             var documentManager = new TestDocumentManager();
             documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
-            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+
+            var virtualHtmlUri = new Uri("C:/path/to/file.razor__virtual.html");
+            var htmlLocation = GetLocation(100, 100, 100, 100, virtualHtmlUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, string, TextDocumentPositionParams, CancellationToken>((method, serverContentType, definitionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentDefinitionName, method);
+                    Assert.Equal(RazorLSPConstants.HtmlLSPContentTypeName, serverContentType);
+                    invokedLSPRequest = true;
+                })
+                .Returns(Task.FromResult(new[] { htmlLocation }));
 
             var projectionResult = new ProjectionResult()
             {
                 LanguageKind = RazorLanguageKind.Html,
             };
-            var projectionProvider = new Mock<LSPProjectionProvider>();
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var definitionHandler = new GoToDefinitionHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+            documentMappingProvider
+                .Setup(d => d.RemapLocationsAsync(It.IsAny<Location[]>(), It.IsAny<CancellationToken>()))
+                .Callback<Location[], CancellationToken>((locations, token) =>
+                {
+                    Assert.Equal(htmlLocation, locations[0]);
+                    invokedRemapRequest = true;
+                })
+                .Returns(Task.FromResult(Array.Empty<Location>()));
+
+            var definitionHandler = new GoToDefinitionHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var definitionRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
-                Position = new Position(0, 1)
+                Position = new Position(10, 5)
             };
 
             // Act
             var result = await definitionHandler.HandleRequestAsync(definitionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            Assert.Null(result);
+            Assert.True(invokedLSPRequest);
+            Assert.True(invokedRemapRequest);
+
+            // Actual remapping behavior is tested elsewhere.
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToImplementationHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToImplementationHandlerTest.cs
@@ -68,33 +68,60 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         }
 
         [Fact]
-        public async Task HandleRequestAsync_HtmlProjection_ReturnsNull()
+        public async Task HandleRequestAsync_HtmlProjection_InvokesHtmlLanguageServer()
         {
             // Arrange
+            var invokedLSPRequest = false;
+            var invokedRemapRequest = false;
+            var expectedLocation = GetLocation(5, 5, 5, 5, Uri);
             var documentManager = new TestDocumentManager();
             documentManager.AddDocument(Uri, Mock.Of<LSPDocumentSnapshot>());
-            var requestInvoker = Mock.Of<LSPRequestInvoker>();
+
+            var virtualHtmlUri = new Uri("C:/path/to/file.razor__virtual.html");
+            var htmlLocation = GetLocation(100, 100, 100, 100, virtualHtmlUri);
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TextDocumentPositionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, string, TextDocumentPositionParams, CancellationToken>((method, serverContentType, implementationParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentImplementationName, method);
+                    Assert.Equal(RazorLSPConstants.HtmlLSPContentTypeName, serverContentType);
+                    invokedLSPRequest = true;
+                })
+                .Returns(Task.FromResult(new[] { htmlLocation }));
 
             var projectionResult = new ProjectionResult()
             {
                 LanguageKind = RazorLanguageKind.Html,
             };
-            var projectionProvider = new Mock<LSPProjectionProvider>();
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>();
-            var implementationHandler = new GoToImplementationHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider);
+            var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
+            documentMappingProvider
+                .Setup(d => d.RemapLocationsAsync(It.IsAny<Location[]>(), It.IsAny<CancellationToken>()))
+                .Callback<Location[], CancellationToken>((locations, token) =>
+                {
+                    Assert.Equal(htmlLocation, locations[0]);
+                    invokedRemapRequest = true;
+                })
+                .Returns(Task.FromResult(Array.Empty<Location>()));
+
+            var implementationHandler = new GoToImplementationHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object);
             var implementationRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
-                Position = new Position(0, 1)
+                Position = new Position(10, 5)
             };
 
             // Act
             var result = await implementationHandler.HandleRequestAsync(implementationRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            Assert.Null(result);
+            Assert.True(invokedLSPRequest);
+            Assert.True(invokedRemapRequest);
+
+            // Actual remapping behavior is tested elsewhere.
         }
 
         [Fact]


### PR DESCRIPTION
- This sounds more impressive then it really is. Basically we no longer restrict our handlers to only delegate for C#.
- Expanded some of the pre-existing handler logic to better handle "null" cases where sub-language servers can't handle requests and consequently return `null`.
- Sprinkled some more cancellation token throw if cancellation requested.
- Updated pre-existing tests for the handlers to properly expect delegation for HTML projections.

**Note:** In practice this looks to only light up go-to-def/signature help for JS/CSS. Once things are implemented on the web tools side I imagine things will just "light up"

Fixes dotnet/aspnetcore#26950

/cc @alexgav 