### PR TITLE
Add breakpoint set support for implicit expressions and TagHelper/Component attributes.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -287,10 +287,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var projectedRangeAsSpan = projectedRange.AsTextSpan(csharpSourceText);
             var range = projectedRange;
             var startIndex = projectedRangeAsSpan.Start;
-            var startMappedDirectly = TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out var _);
+            var startMappedDirectly = TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _);
 
             var endIndex = projectedRangeAsSpan.End;
-            var endMappedDirectly = TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out var _);
+            var endMappedDirectly = TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _);
 
             if (startMappedDirectly && endMappedDirectly)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             var endIndex = range.End.GetAbsoluteIndex(csharpSourceText);
-            if (!TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out var _))
+            if (!TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _))
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -15,7 +16,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class DefaultRazorDocumentMappingService : RazorDocumentMappingService
     {
-        public override bool TryMapFromProjectedDocumentRange(RazorCodeDocument codeDocument, Range projectedRange, out Range originalRange)
+        public override bool TryMapFromProjectedDocumentRange(RazorCodeDocument codeDocument, Range projectedRange, out Range originalRange) => TryMapFromProjectedDocumentRange(codeDocument, projectedRange, MappingBehavior.Strict, out originalRange);
+
+        public override bool TryMapFromProjectedDocumentRange(RazorCodeDocument codeDocument, Range projectedRange, MappingBehavior mappingBehavior, out Range originalRange)
         {
             if (codeDocument is null)
             {
@@ -27,27 +30,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(projectedRange));
             }
 
-            originalRange = default;
-
-            var csharpSourceText = SourceText.From(codeDocument.GetCSharpDocument().GeneratedCode);
-            var range = projectedRange;
-            var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText);
-            if (!TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out var _))
+            if (mappingBehavior == MappingBehavior.Strict)
             {
-                return false;
+                return TryMapFromProjectedDocumentRangeStrict(codeDocument, projectedRange, out originalRange);
             }
-
-            var endIndex = range.End.GetAbsoluteIndex(csharpSourceText);
-            if (!TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out var _))
+            else if (mappingBehavior == MappingBehavior.Inclusive)
             {
-                return false;
+                return TryMapFromProjectedDocumentRangeInclusive(codeDocument, projectedRange, out originalRange);
             }
-
-            originalRange = new Range(
-                hostDocumentStart,
-                hostDocumentEnd);
-
-            return true;
+            else
+            {
+                throw new InvalidOperationException("Unknown mapping behavior");
+            }
         }
 
         public override bool TryMapToProjectedDocumentRange(RazorCodeDocument codeDocument, Range originalRange, out Range projectedRange)
@@ -257,6 +251,107 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Default to Razor
             return RazorLanguageKind.Razor;
+        }
+
+        private bool TryMapFromProjectedDocumentRangeStrict(RazorCodeDocument codeDocument, Range projectedRange, out Range originalRange)
+        {
+            originalRange = default;
+
+            var csharpSourceText = SourceText.From(codeDocument.GetCSharpDocument().GeneratedCode);
+            var range = projectedRange;
+            var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText);
+            if (!TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out var _))
+            {
+                return false;
+            }
+
+            var endIndex = range.End.GetAbsoluteIndex(csharpSourceText);
+            if (!TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out var _))
+            {
+                return false;
+            }
+
+            originalRange = new Range(
+                hostDocumentStart,
+                hostDocumentEnd);
+
+            return true;
+        }
+
+        private bool TryMapFromProjectedDocumentRangeInclusive(RazorCodeDocument codeDocument, Range projectedRange, out Range originalRange)
+        {
+            originalRange = default;
+
+            var csharpDoc = codeDocument.GetCSharpDocument();
+            var csharpSourceText = SourceText.From(csharpDoc.GeneratedCode);
+            var projectedRangeAsSpan = projectedRange.AsTextSpan(csharpSourceText);
+            var range = projectedRange;
+            var startIndex = projectedRangeAsSpan.Start;
+            var startMappedDirectly = TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out var _);
+
+            var endIndex = projectedRangeAsSpan.End;
+            var endMappedDirectly = TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out var _);
+
+            if (startMappedDirectly && endMappedDirectly)
+            {
+                // We strictly mapped the start/end of the projected range.
+                originalRange = new Range(hostDocumentStart, hostDocumentEnd);
+                return true;
+            }
+
+            List<SourceMapping> candidateMappings;
+            if (startMappedDirectly)
+            {
+                // Start of projected range intersects with a mapping
+                candidateMappings = csharpDoc.SourceMappings.Where(mapping => IntersectsWith(startIndex, mapping.GeneratedSpan)).ToList();
+            }
+            else if (endMappedDirectly)
+            {
+                // End of projected range intersects with a mapping
+                candidateMappings = csharpDoc.SourceMappings.Where(mapping => IntersectsWith(endIndex, mapping.GeneratedSpan)).ToList();
+            }
+            else
+            {
+                // Our range does not intersect with any mapping; we should see if it overlaps generated locations
+                candidateMappings = csharpDoc.SourceMappings.Where(mapping => Overlaps(projectedRangeAsSpan, mapping.GeneratedSpan)).ToList();
+            }
+
+            if (candidateMappings.Count == 1)
+            {
+                // We're intersecting or overlapping a single mapping, lets choose that.
+
+                var mapping = candidateMappings[0];
+                originalRange = ConvertMapping(codeDocument.Source, mapping);
+                return true;
+            }
+            else
+            {
+                // More then 1 or exactly 0 intersecting/overlapping mappings
+                return false;
+            }
+
+            bool Overlaps(TextSpan projectedRangeAsSpan, SourceSpan span)
+            {
+                var overlapStart = Math.Max(projectedRangeAsSpan.Start, span.AbsoluteIndex);
+                var overlapEnd = Math.Min(projectedRangeAsSpan.End, span.AbsoluteIndex + span.Length);
+
+                return overlapStart < overlapEnd;
+            }
+
+            bool IntersectsWith(int position, SourceSpan span)
+            {
+                return unchecked((uint)(position - span.AbsoluteIndex) <= (uint)span.Length);
+            }
+
+            static Range ConvertMapping(RazorSourceDocument sourceDocument, SourceMapping mapping)
+            {
+                var startLocation = sourceDocument.Lines.GetLocation(mapping.OriginalSpan.AbsoluteIndex);
+                var endLocation = sourceDocument.Lines.GetLocation(mapping.OriginalSpan.AbsoluteIndex + mapping.OriginalSpan.Length);
+                var convertedRange = new Range(
+                    new Position(startLocation.LineIndex, startLocation.CharacterIndex),
+                    new Position(endLocation.LineIndex, endLocation.CharacterIndex));
+                return convertedRange;
+            }
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var csharpSourceText = SourceText.From(codeDocument.GetCSharpDocument().GeneratedCode);
             var range = projectedRange;
             var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText);
-            if (!TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out var _))
+            if (!TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _))
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MappingBehavior.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MappingBehavior.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         ///     - Overlaps > 1 generated range = No mapping
         ///     - Intersects > 1 generated range = No mapping
         ///     - Overlaps 1 generated range = Will reduce the provided range down to the generated range.
-        ///     - Intersects 1 generated range = Will use the generated ranges mapping
+        ///     - Intersects 1 generated range = Will use the generated range mappings
         /// </summary>
         Inclusive
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MappingBehavior.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MappingBehavior.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal enum MappingBehavior
+    {
+        Strict,
+
+        /// <summary>
+        /// Inclusive mapping behavior will attempt to map overlapping or intersecting generated ranges with a provided projection range.
+        ///
+        /// Behavior:
+        ///     - Overlaps > 1 generated range = No mapping
+        ///     - Intersects > 1 generated range = No mapping
+        ///     - Overlaps 1 generated range = Will reduce the provided range down to the generated range.
+        ///     - Intersects 1 generated range = Will use the generated ranges mapping
+        /// </summary>
+        Inclusive
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         public abstract bool TryMapFromProjectedDocumentRange(RazorCodeDocument codeDocument, Range projectedRange, out Range originalRange);
 
+        public abstract bool TryMapFromProjectedDocumentRange(RazorCodeDocument codeDocument, Range projectedRange, MappingBehavior mappingBehavior, out Range originalRange);
+
         public abstract bool TryMapToProjectedDocumentRange(RazorCodeDocument codeDocument, Range originalRange, out Range projectedRange);
 
         public abstract bool TryMapFromProjectedDocumentPosition(RazorCodeDocument codeDocument, int csharpAbsoluteIndex, out Position originalPosition, out int originalIndex);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 var projectedRange = request.ProjectedRanges[i];
                 if (codeDocument.IsUnsupported() ||
-                    !_documentMappingService.TryMapFromProjectedDocumentRange(codeDocument, projectedRange, out var originalRange))
+                    !_documentMappingService.TryMapFromProjectedDocumentRange(codeDocument, projectedRange, request.MappingBehavior, out var originalRange))
                 {
                     // All language queries on unsupported documents return Html. This is equivalent to what pre-VSCode Razor was capable of.
                     ranges[i] = UndefinedRange;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorMapToDocumentRangesParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorMapToDocumentRangesParams.cs
@@ -14,5 +14,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public Uri RazorDocumentUri { get; set; }
 
         public Range[] ProjectedRanges { get; set; }
+
+        public MappingBehavior MappingBehavior { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
@@ -46,7 +46,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         public override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range[] projectedRanges, CancellationToken cancellationToken)
             => MapToDocumentRangesAsync(languageKind, razorDocumentUri, projectedRanges, LanguageServerMappingBehavior.Strict, cancellationToken);
 
-        public async override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range[] projectedRanges, LanguageServerMappingBehavior mappingBehavior, CancellationToken cancellationToken)
+        public async override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(
+            RazorLanguageKind languageKind, 
+            Uri razorDocumentUri, 
+            Range[] projectedRanges, 
+            LanguageServerMappingBehavior mappingBehavior, 
+            CancellationToken cancellationToken)
         {
             if (razorDocumentUri is null)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
@@ -43,7 +43,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             _lazyDocumentManager = lazyDocumentManager;
         }
 
-        public async override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range[] projectedRanges, CancellationToken cancellationToken)
+        public override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range[] projectedRanges, CancellationToken cancellationToken)
+            => MapToDocumentRangesAsync(languageKind, razorDocumentUri, projectedRanges, LanguageServerMappingBehavior.Strict, cancellationToken);
+
+        public async override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range[] projectedRanges, LanguageServerMappingBehavior mappingBehavior, CancellationToken cancellationToken)
         {
             if (razorDocumentUri is null)
             {
@@ -59,7 +62,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 Kind = languageKind,
                 RazorDocumentUri = razorDocumentUri,
-                ProjectedRanges = projectedRanges
+                ProjectedRanges = projectedRanges,
+                MappingBehavior = mappingBehavior,
             };
 
             var documentMappingResponse = await _requestInvoker.ReinvokeRequestOnServerAsync<RazorMapToDocumentRangesParams, RazorMapToDocumentRangesResponse>(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
@@ -12,6 +12,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     {
         public abstract Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range[] projectedRanges, CancellationToken cancellationToken);
 
+        public abstract Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range[] projectedRanges, LanguageServerMappingBehavior mappingBehavior, CancellationToken cancellationToken);
+
         public abstract Task<Location[]> RemapLocationsAsync(Location[] locations, CancellationToken cancellationToken);
 
         public abstract Task<TextEdit[]> RemapTextEditsAsync(Uri uri, TextEdit[] edits, CancellationToken cancellationToken);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
@@ -16,12 +16,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public Range[] ProjectedRanges { get; set; }
 
+        public LanguageServerMappingBehavior MappingBehavior { get; set; }
+
         public bool Equals(RazorMapToDocumentRangesParams other)
         {
             return
                 other != null &&
                 Kind == other.Kind &&
                 RazorDocumentUri == other.RazorDocumentUri &&
+                MappingBehavior == other.MappingBehavior &&
                 Enumerable.SequenceEqual(ProjectedRanges, other.ProjectedRanges);
         }
 
@@ -36,6 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             hash.Add(Kind);
             hash.Add(RazorDocumentUri);
             hash.Add(ProjectedRanges);
+            hash.Add(MappingBehavior);
             return hash;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LanguageServerMappingBehavior.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LanguageServerMappingBehavior.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         ///     - Overlaps > 1 generated range = No mapping
         ///     - Intersects > 1 generated range = No mapping
         ///     - Overlaps 1 generated range = Will reduce the provided range down to the generated range.
-        ///     - Intersects 1 generated range = Will use the generated ranges mapping
+        ///     - Intersects 1 generated range = Will use the generated range mappings
         /// </summary>
         Inclusive
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LanguageServerMappingBehavior.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/LanguageServerMappingBehavior.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    // This should be kept in-sync with the language server's MappingBehavior enum.
+
+    internal enum LanguageServerMappingBehavior
+    {
+        Strict,
+
+        /// <summary>
+        /// Inclusive mapping behavior will attempt to map overlapping or intersecting generated ranges with a provided projection range.
+        ///
+        /// Behavior:
+        ///     - Overlaps > 1 generated range = No mapping
+        ///     - Intersects > 1 generated range = No mapping
+        ///     - Overlaps 1 generated range = Will reduce the provided range down to the generated range.
+        ///     - Intersects 1 generated range = Will use the generated ranges mapping
+        /// </summary>
+        Inclusive
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -16,6 +16,313 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     public class DefaultRazorDocumentMappingServiceTest
     {
         [Fact]
+        public void TryMapFromProjectedDocumentRange_Strict_StartOnlyMaps_ReturnsFalse()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 10),
+                End = new Position(0, 19),
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Strict,
+                out var originalRange);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Strict_EndOnlyMaps_ReturnsFalse()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 0),
+                End = new Position(0, 12),
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Strict,
+                out var originalRange);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Strict_StartAndEndMap_ReturnsTrue()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 6),
+                End = new Position(0, 18),
+            };
+            var expectedOriginalRange = new Range()
+            {
+                Start = new Position(0, 4),
+                End = new Position(0, 16)
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Strict,
+                out var originalRange);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedOriginalRange, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inclusive_DirectlyMaps_ReturnsTrue()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 6),
+                End = new Position(0, 18),
+            };
+            var expectedOriginalRange = new Range()
+            {
+                Start = new Position(0, 4),
+                End = new Position(0, 16)
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inclusive,
+                out var originalRange);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedOriginalRange, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inclusive_StartSinglyIntersects_ReturnsTrue()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 10),
+                End = new Position(0, 19),
+            };
+            var expectedOriginalRange = new Range()
+            {
+                Start = new Position(0, 4),
+                End = new Position(0, 16)
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inclusive,
+                out var originalRange);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedOriginalRange, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inclusive_EndSinglyIntersects_ReturnsTrue()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 0),
+                End = new Position(0, 10),
+            };
+            var expectedOriginalRange = new Range()
+            {
+                Start = new Position(0, 4),
+                End = new Position(0, 16)
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inclusive,
+                out var originalRange);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedOriginalRange, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inclusive_StartDoublyIntersects_ReturnsFalse()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[]
+                {
+                    new SourceMapping(new SourceSpan(4, 8), new SourceSpan(6, 8)), // DateTime
+                    new SourceMapping(new SourceSpan(12, 4), new SourceSpan(14, 4)) // .Now
+                });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 14),
+                End = new Position(0, 19),
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inclusive,
+                out var originalRange);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inclusive_EndDoublyIntersects_ReturnsFalse()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[]
+                {
+                    new SourceMapping(new SourceSpan(4, 8), new SourceSpan(6, 8)), // DateTime
+                    new SourceMapping(new SourceSpan(12, 4), new SourceSpan(14, 4)) // .Now
+                });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 0),
+                End = new Position(0, 14),
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inclusive,
+                out var originalRange);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inclusive_OverlapsSingleMapping_ReturnsTrue()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 0),
+                End = new Position(0, 19),
+            };
+            var expectedOriginalRange = new Range()
+            {
+                Start = new Position(0, 4),
+                End = new Position(0, 16)
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inclusive,
+                out var originalRange);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedOriginalRange, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inclusive_OverlapsTwoMappings_ReturnsFalse()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService();
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[]
+                {
+                    new SourceMapping(new SourceSpan(4, 8), new SourceSpan(6, 8)), // DateTime
+                    new SourceMapping(new SourceSpan(12, 4), new SourceSpan(14, 4)) // .Now
+                });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 0),
+                End = new Position(0, 19),
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inclusive,
+                out var originalRange);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, originalRange);
+        }
+
+        [Fact]
         public void TryMapToProjectedDocumentPosition_NotMatchingAnyMapping()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -271,10 +271,14 @@ $@"public class SomeRazorFile
                 _mappings = mappings;
             }
 
+            public override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, Range[] projectedRanges, CancellationToken cancellationToken)
+                => MapToDocumentRangesAsync(languageKind, razorDocumentUri, projectedRanges, LanguageServerMappingBehavior.Strict, cancellationToken);
+
             public override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(
                 RazorLanguageKind languageKind,
                 Uri razorDocumentUri,
                 Range[] projectedRanges,
+                LanguageServerMappingBehavior mappingBehavior,
                 CancellationToken cancellationToken)
             {
                 _mappings.TryGetValue(projectedRanges[0], out var response);


### PR DESCRIPTION
- Added a `MappingBehavior` concept to our language servers ability to map projected ranges. Currently there's only two types, `Strict` and `Inclusive`. Their meaning:
```
Inclusive mapping behavior will attempt to map overlapping or intersecting generated ranges with a provided projection range.

Behavior:
    - Overlaps > 1 generated range = No mapping
    - Intersects > 1 generated range = No mapping
    - Overlaps 1 generated range = Will reduce the provided range down to the generated range.
    - Intersects 1 generated range = Will use the generated ranges mapping
```
- Added tests to validate our `MapFromProjectedDocumentRange` API for the pre-existing "Strict" type mappings (for some reason we didn't have tests for that) and the new "Inclusive" mappings.
- Updated our `LSPDocumentMappingProvider` on the VS client to take in mapping behaviors to enable our breakpoint resolver to pass in an "Inclusive" mapping to enable breakpoints in implicit expressions and TagHelper/component attributes.

![niYIZrpmbV](https://user-images.githubusercontent.com/2008729/96930980-7020f480-1471-11eb-8088-68b1234a171c.gif)

Fixes dotnet/aspnetcore#26643