### PR TITLE
Defend against disposed exceptions when waiting for parcels.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
@@ -185,7 +185,14 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     }
                 }
 
-                _hasParcel?.Wait(_cancelSource.Token);
+                try
+                {
+                    _hasParcel?.Wait(_cancelSource.Token);
+                }
+                catch (Exception)
+                {
+                    // Swallow any exceptions caused by waiting on the parcel to avoid crashing VS.
+                }
 
                 lock (_disposeLock)
                 {


### PR DESCRIPTION
- This was the result of a high number of crashes in VS and given we're moving away from the pre-existing tech try-catching was a sufficient, low cost alternative to crashing VS.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1177023