### PR TITLE
Add `[AssemblyMetadata("Serviceable", "true")]` to all assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,9 +54,5 @@
       Suppress warnings about assembly conflicts. This happens for assemblies that ship in VS so it's irrelevant.
     -->
     <NoWarn>$(NoWarn);MSB3277</NoWarn>
-    <!--
-      Ignore PackageIconUrl deprecation. Work to convert to embedded icons is tracked in https://github.com/dotnet/aspnetcore-Internal/issues/3146.
-    -->
-    <NoWarn>$(NoWarn);NU5048</NoWarn>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,9 +25,7 @@
       <!-- Only update the targeting pack version for preview builds. -->
       <TargetingPackVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppRefPackageVersion)</TargetingPackVersion>
     </KnownFrameworkReference>
-  </ItemGroup>
 
-  <ItemGroup>
     <!-- Track compiler separately from Arcade.-->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset"
         Version="$(MicrosoftNetCompilersToolsetPackageVersion)"
@@ -37,4 +35,16 @@
     <!-- Remove unneeded reference to AspNetCore.App -->
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
   </ItemGroup>
+
+  <Target Name="GetCustomAssemblyAttributes"
+          BeforeTargets="GetAssemblyAttributes"
+          Condition=" '$(MSBuildProjectExtension)' == '.csproj' "
+          DependsOnTargets="InitializeSourceControlInformation">
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(Serviceable)' == 'true'">
+        <_Parameter1>Serviceable</_Parameter1>
+        <_Parameter2>True</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
- dotnet/aspnetcore#18930
- also remove leftover NU5048 suppression; Arcade adds the icon for us