### PR TITLE
Consume Microsoft.AspNetCore.Testing from aspnetcore

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,6 +13,10 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>fd44a05bf70b580263d5978d78b5a98984d7f981</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Testing" Version="6.0.0-alpha.1.20555.3">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>fd44a05bf70b580263d5978d78b5a98984d7f981</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.0-alpha.1.20555.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>fd44a05bf70b580263d5978d78b5a98984d7f981</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,6 +51,7 @@
     <MicrosoftCodeAnalysisRazorPackageVersion>6.0.0-alpha.1.20555.3</MicrosoftCodeAnalysisRazorPackageVersion>
     <MicrosoftAspNetCoreRazorInternalTransportPackageVersion>6.0.0-alpha.1.20555.3</MicrosoftAspNetCoreRazorInternalTransportPackageVersion>
     <MicrosoftAspNetCoreRazorLanguagePackageVersion>6.0.0-alpha.1.20555.3</MicrosoftAspNetCoreRazorLanguagePackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>6.0.0-alpha.1.20555.3</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>6.0.0-alpha.1.20555.3</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>6.0.0-alpha.1.20555.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>6.0.0-alpha.1.20555.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
@@ -83,8 +84,6 @@
     Versions below this comment are not managed by automation and can be changed as needed.
   -->
   <PropertyGroup Label="Manual">
-    <!-- We are temporarily pinning sources packages and M.AspNetCore.Testing until we migrate this repo to aspnetcore -->
-    <MicrosoftAspNetCoreTestingPackageVersion>5.0.0-preview.2.20121.3</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.2.20121.3</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>15.8.166</MicrosoftBuildFrameworkPackageVersion>


### PR DESCRIPTION
Use the testing package from aspnetcore now that it's migrated and the package is produced from there.