### PR TITLE
Reduce VS memory pressure for large projects

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
@@ -110,6 +110,8 @@ namespace Microsoft.CodeAnalysis.Razor
                 }
             }
 
+            _semaphore.Dispose();
+
             BlockBackgroundWorkStart?.Set();
         }
 
@@ -200,7 +202,14 @@ namespace Microsoft.CodeAnalysis.Razor
             }
             finally
             {
-                _semaphore.Release();
+                try
+                {
+                    _semaphore.Release();
+                }
+                catch
+                {
+                    // Swallow exceptions that happen from releasing the semaphore.
+                }
             }
 
             OnBackgroundWorkCompleted();


### PR DESCRIPTION
- Only allow a single TagHelper resolver request to process at a time in order to reduce Visual Studio memory pressure. Typically a TagHelper resolution result can be upwards of 10mb+. So if we now do multiple requests to resolve TagHelpers simultaneously it results in only a single one executing at a time so that we don't have N number of requests in flight with these 10mb payloads waiting to be processed. For larger projects this was found to occasionally contribute to over a GB worth of memory occupying VS' 4gb memory limit.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1236296