### PR TITLE
Remove IProgress from Pull-Diagnostics

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
@@ -85,11 +86,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 PreviousResultId = request.PreviousResultId
             };
 
-            var result = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentDiagnosticsParams, DiagnosticReport[]>(
+            var resultsFromAllLanguageServers = await _requestInvoker.ReinvokeRequestOnMultipleServersAsync<DocumentDiagnosticsParams, DiagnosticReport[]>(
                 MSLSPMethods.DocumentPullDiagnosticName,
                 RazorLSPConstants.CSharpContentTypeName,
                 referenceParams,
                 cancellationToken).ConfigureAwait(false);
+
+            var result = resultsFromAllLanguageServers.SelectMany(l => l).ToArray();
 
             var processedResults = await RemapDocumentDiagnosticsAsync(
                 result,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -5,32 +5,33 @@ using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     [Shared]
     [ExportLspMethod(MSLSPMethods.DocumentPullDiagnosticName)]
     internal class DocumentPullDiagnosticsHandler :
-        LSPProgressListenerHandlerBase<DocumentDiagnosticsParams, DiagnosticReport[]>,
         IRequestHandler<DocumentDiagnosticsParams, DiagnosticReport[]>
     {
+        private static readonly HashSet<string> DiagnosticsToIgnore = new HashSet<string>()
+        {
+            "RemoveUnnecessaryImportsFixable",
+            "IDE0005_gen", // Using directive is unnecessary
+        };
+
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly LSPDocumentManager _documentManager;
         private readonly LSPDocumentMappingProvider _documentMappingProvider;
-        private readonly LSPProgressListener _lspProgressListener;
 
         [ImportingConstructor]
         public DocumentPullDiagnosticsHandler(
             LSPRequestInvoker requestInvoker,
             LSPDocumentManager documentManager,
-            LSPDocumentMappingProvider documentMappingProvider,
-            LSPProgressListener lspProgressListener)
+            LSPDocumentMappingProvider documentMappingProvider)
         {
             if (requestInvoker is null)
             {
@@ -47,19 +48,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(documentMappingProvider));
             }
 
-            if (lspProgressListener is null)
-            {
-                throw new ArgumentNullException(nameof(lspProgressListener));
-            }
-
             _requestInvoker = requestInvoker;
             _documentManager = documentManager;
             _documentMappingProvider = documentMappingProvider;
-            _lspProgressListener = lspProgressListener;
         }
 
         // Internal for testing
-        internal async override Task<DiagnosticReport[]> HandleRequestAsync(DocumentDiagnosticsParams request, ClientCapabilities clientCapabilities, string token, CancellationToken cancellationToken)
+        public async Task<DiagnosticReport[]> HandleRequestAsync(DocumentDiagnosticsParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
         {
             if (request is null)
             {
@@ -81,60 +76,28 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            var referenceParams = new SerializableDocumentDiagnosticsParams()
+            var referenceParams = new DocumentDiagnosticsParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
                     Uri = csharpDoc.Uri
                 },
-                PreviousResultId = request.PreviousResultId,
-                PartialResultToken = token
+                PreviousResultId = request.PreviousResultId
             };
 
-            if (!_lspProgressListener.TryListenForProgress(
-                token,
-                onProgressNotifyAsync: (value, ct) => ProcessDocumentDiagnosticsAsync(value, request.PartialResultToken, request.TextDocument.Uri, documentSnapshot, ct),
-                WaitForProgressNotificationTimeout,
-                cancellationToken,
-                out var onCompleted))
-            {
-                return null;
-            }
-
-            var result = await _requestInvoker.ReinvokeRequestOnServerAsync<SerializableDocumentDiagnosticsParams, DiagnosticReport[]>(
+            var result = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentDiagnosticsParams, DiagnosticReport[]>(
                 MSLSPMethods.DocumentPullDiagnosticName,
                 RazorLSPConstants.CSharpContentTypeName,
                 referenceParams,
                 cancellationToken).ConfigureAwait(false);
 
-            // We must not return till we have received the progress notifications
-            // and reported the results via the PartialResultToken
-            await onCompleted.ConfigureAwait(false);
-
-            return null;
-        }
-
-        private async Task ProcessDocumentDiagnosticsAsync(
-            JToken value,
-            IProgress<DiagnosticReport[]> progress,
-            Uri razorDocumentUri,
-            LSPDocumentSnapshot documentSnapshot,
-            CancellationToken cancellationToken)
-        {
-            var result = value.ToObject<DiagnosticReport[]>();
-
-            if (result == null || result.Length == 0)
-            {
-                return;
-            }
-
-            var remappedResults = await RemapDocumentDiagnosticsAsync(
+            var processedResults = await RemapDocumentDiagnosticsAsync(
                 result,
-                razorDocumentUri,
+                request.TextDocument.Uri,
                 documentSnapshot,
                 cancellationToken).ConfigureAwait(false);
 
-            progress.Report(remappedResults);
+            return processedResults;
         }
 
         private async Task<DiagnosticReport[]> RemapDocumentDiagnosticsAsync(
@@ -152,16 +115,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             foreach (var diagnosticReport in unmappedDiagnosticReports)
             {
-                if (diagnosticReport?.Diagnostics?.Length == 0)
+                // Check if there are any diagnostics in this report
+                if (diagnosticReport?.Diagnostics?.Any() != true)
                 {
                     mappedDiagnosticReports.Add(diagnosticReport);
                     continue;
                 }
 
                 var unmappedDiagnostics = diagnosticReport.Diagnostics;
-                var mappedDiagnostics = new List<Diagnostic>(unmappedDiagnostics.Length);
+                var filteredDiagnostics = unmappedDiagnostics.Where(d => !DiagnosticsToIgnore.Contains(d.Code));
+                var mappedDiagnostics = new List<Diagnostic>(filteredDiagnostics.Count());
 
-                var rangesToMap = unmappedDiagnostics.Select(r => r.Range).ToArray();
+                var rangesToMap = filteredDiagnostics.Select(r => r.Range).ToArray();
                 var mappingResult = await _documentMappingProvider.MapToDocumentRangesAsync(
                     RazorLanguageKind.CSharp,
                     razorDocumentUri,
@@ -175,9 +140,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     return Array.Empty<DiagnosticReport>();
                 }
 
-                for (var i = 0; i < unmappedDiagnostics.Length; i++)
+                for (var i = 0; i < filteredDiagnostics.Count(); i++)
                 {
-                    var diagnostic = unmappedDiagnostics[i];
+                    var diagnostic = filteredDiagnostics.ElementAt(i);
                     var range = mappingResult.Ranges[i];
                     if (range.IsUndefined())
                     {
@@ -194,13 +159,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             return mappedDiagnosticReports.ToArray();
-        }
-
-        [DataContract]
-        private class SerializableDocumentDiagnosticsParams : DiagnosticParams
-        {
-            [DataMember(Name = "partialResultToken")]
-            public string PartialResultToken { get; set; }
         }
     }
 }


### PR DESCRIPTION
- Remove `IProgress<T>`
- Filter out `unused using` diagnostics 
  - Helps with `_Imports.razor`
  - Regular unused usings aren't accurate due to the `<auto-generated>` [issue](https://github.com/dotnet/aspnetcore/issues/26815).
- Ensures we support the case when both C# and Razor clients support pull-diagnostics