### PR TITLE
Update Pull Diagnostics Return Logic

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -68,12 +68,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                return CreateNoDiagnosticsChangeResponse(request);
+                return null;
             }
 
             if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
             {
-                return CreateNoDiagnosticsChangeResponse(request);
+                return null;
             }
 
             var referenceParams = new DocumentDiagnosticsParams()
@@ -100,17 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(false);
 
             return processedResults;
-        }
 
-        private static DiagnosticReport[] CreateNoDiagnosticsChangeResponse(DocumentDiagnosticsParams request)
-        {
-            return new DiagnosticReport[]
-            {
-                new DiagnosticReport()
-                {
-                    ResultId = request.PreviousResultId
-                }
-            };
         }
 
         private async Task<DiagnosticReport[]> RemapDocumentDiagnosticsAsync(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -101,6 +101,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             return processedResults;
 
+            // | ---------------------------------------------------------------------------------- |
+            // |                       LSP Platform Expected Response Semantics                     |
+            // | ---------------------------------------------------------------------------------- |
+            // | DiagnosticReport.Diagnostics     | DiagnosticReport.ResultId | Meaning             |
+            // | -------------------------------- | ------------------------- | ------------------- |
+            // | `null`                           | `null`                    | document gone       |
+            // | `null`                           | valid                     | nothing changed     |
+            // | valid (non-null including empty) | valid                     | diagnostics changed |
+            // | ---------------------------------------------------------------------------------- |
         }
 
         private async Task<DiagnosticReport[]> RemapDocumentDiagnosticsAsync(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -99,7 +99,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 documentSnapshot,
                 cancellationToken).ConfigureAwait(false);
 
-            return processedResults;
 
             // | ---------------------------------------------------------------------------------- |
             // |                       LSP Platform Expected Response Semantics                     |
@@ -110,6 +109,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // | `null`                           | valid                     | nothing changed     |
             // | valid (non-null including empty) | valid                     | diagnostics changed |
             // | ---------------------------------------------------------------------------------- |
+            return processedResults;
         }
 
         private async Task<DiagnosticReport[]> RemapDocumentDiagnosticsAsync(

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
@@ -116,9 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var result = await documentDiagnosticsHandler.HandleRequestAsync(diagnosticRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            var returnedReport = Assert.Single(result);
-            Assert.Equal(returnedReport.ResultId, diagnosticRequest.PreviousResultId);
-            Assert.Null(returnedReport.Diagnostics);
+            Assert.Null(result);
         }
 
         [Fact]
@@ -271,7 +269,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Assert
             Assert.True(called);
             var returnedReport = Assert.Single(result);
-            Assert.Equal(returnedReport.ResultId, RoslynDiagnosticResponse.First().ResultId);
+            Assert.Equal(RoslynDiagnosticResponse.First().ResultId, returnedReport.ResultId);
             Assert.Null(returnedReport.Diagnostics);
         }
 
@@ -306,7 +304,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Assert
             Assert.True(called);
             var returnedReport = Assert.Single(result);
-            Assert.Equal(returnedReport.ResultId, RoslynDiagnosticResponse.First().ResultId);
+            Assert.Equal(RoslynDiagnosticResponse.First().ResultId, returnedReport.ResultId);
             Assert.Null(returnedReport.Diagnostics);
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
@@ -116,7 +116,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var result = await documentDiagnosticsHandler.HandleRequestAsync(diagnosticRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            Assert.Null(result);
+            var returnedReport = Assert.Single(result);
+            Assert.Equal(returnedReport.ResultId, diagnosticRequest.PreviousResultId);
+            Assert.Null(returnedReport.Diagnostics);
         }
 
         [Fact]
@@ -268,7 +270,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.True(called);
-            Assert.Empty(result);
+            var returnedReport = Assert.Single(result);
+            Assert.Equal(returnedReport.ResultId, RoslynDiagnosticResponse.First().ResultId);
+            Assert.Null(returnedReport.Diagnostics);
         }
 
         [Fact]
@@ -301,7 +305,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.True(called);
-            Assert.Empty(result);
+            var returnedReport = Assert.Single(result);
+            Assert.Equal(returnedReport.ResultId, RoslynDiagnosticResponse.First().ResultId);
+            Assert.Null(returnedReport.Diagnostics);
         }
 
         private LSPRequestInvoker GetRequestInvoker<TParams, TResult>(TResult expectedResponse, Action<string, string, TParams, CancellationToken> callback)


### PR DESCRIPTION
Part of: https://github.com/dotnet/aspnetcore/issues/21121

Goal of this PR is to update our return behavior to be in line with what LSP Platform expects from us;

|DiagnosticReport.Diagnostics|DiagnosticReport.ResultId|Meaning|
|---|---|---|
|`null`|`null`|document gone|
|`null`|valid|nothing changed|
|valid (non-null including empty)|valid|diagnostics changed|

Thanks @CyrusNajmabadi for clarifying this behavior!