### PR TITLE
Synchronize Documents with LSP Pull Diagnostics

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
### Summary of the changes
 - We need to ensure the virtual and razor documents are in sync before we query roslyn for document diagnostics.
- Part of: https://github.com/dotnet/aspnetcore/issues/21121

Fixes: https://github.com/dotnet/aspnetcore/issues/27970
