### PR TITLE
Format edits from onAutoInsert response

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             TextEdit[] formattedEdits,
             FormattingOptions options,
             CancellationToken cancellationToken,
-            bool bypassValidationPasses = false);
+            bool bypassValidationPasses = false,
+            bool collapseEdits = false);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -223,10 +223,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 };
             }
 
-            if (request.ShouldFormat)
+            if (request.TextEditKind == TextEditKind.FormatOnType)
             {
                 var mappedEdits = await _razorFormattingService.ApplyFormattedEditsAsync(
                     request.RazorDocumentUri, documentSnapshot, request.Kind, request.ProjectedTextEdits, request.FormattingOptions, cancellationToken);
+
+                return new RazorMapToDocumentEditsResponse()
+                {
+                    TextEdits = mappedEdits,
+                    HostDocumentVersion = documentVersion,
+                };
+            }
+            else if (request.TextEditKind == TextEditKind.Snippet)
+            {
+                var mappedEdits = await _razorFormattingService.ApplyFormattedEditsAsync(
+                    request.RazorDocumentUri,
+                    documentSnapshot,
+                    request.Kind,
+                    request.ProjectedTextEdits,
+                    request.FormattingOptions,
+                    cancellationToken,
+                    bypassValidationPasses: true,
+                    collapseEdits: true);
 
                 return new RazorMapToDocumentEditsResponse()
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorMapToDocumentEditsParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorMapToDocumentEditsParams.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public TextEdit[] ProjectedTextEdits { get; set; }
 
-        public bool ShouldFormat { get; set; }
+        public TextEditKind TextEditKind { get; set; }
 
         public FormattingOptions FormattingOptions { get; set; }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextEditKind.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextEditKind.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal enum TextEditKind
+    {
+        Default,
+        FormatOnType,
+        Snippet,
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPDocumentMappingProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public abstract Task<TextEdit[]> RemapTextEditsAsync(Uri uri, TextEdit[] edits, CancellationToken cancellationToken);
 
-        public abstract Task<TextEdit[]> RemapFormattedTextEditsAsync(Uri uri, TextEdit[] edits, FormattingOptions options, CancellationToken cancellationToken);
+        public abstract Task<TextEdit[]> RemapFormattedTextEditsAsync(Uri uri, TextEdit[] edits, FormattingOptions options, bool containsSnippet, CancellationToken cancellationToken);
 
         public abstract Task<WorkspaceEdit> RemapWorkspaceEditAsync(WorkspaceEdit workspaceEdit, CancellationToken cancellationToken);
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
@@ -109,15 +109,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            var remappedEdit = await _documentMappingProvider.RemapTextEditsAsync(
+            var remappedEdit = await _documentMappingProvider.RemapFormattedTextEditsAsync(
                 projectionResult.Uri,
                 new[] { response.TextEdit },
+                request.Options,
+                containsSnippet: true,
                 cancellationToken).ConfigureAwait(false);
 
             if (!remappedEdit.Any())
             {
                 return null;
             }
+
             var remappedResponse = new DocumentOnAutoInsertResponseItem()
             {
                 TextEdit = remappedEdit.Single(),

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnTypeFormattingHandler.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var remappedEdits = await _documentMappingProvider.RemapFormattedTextEditsAsync(projectionResult.Uri, response, request.Options, cancellationToken).ConfigureAwait(false);
+            var remappedEdits = await _documentMappingProvider.RemapFormattedTextEditsAsync(projectionResult.Uri, response, request.Options, containsSnippet: false, cancellationToken).ConfigureAwait(false);
             return remappedEdits;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentEditsParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentEditsParams.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
+    // Note: This type should be kept in sync with the one in Razor.LanguageServer assembly.
     internal class RazorMapToDocumentEditsParams : IEquatable<RazorMapToDocumentEditsParams>
     {
         public RazorLanguageKind Kind { get; set; }
@@ -16,7 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         public TextEdit[] ProjectedTextEdits { get; set; }
 
-        public bool ShouldFormat { get; set; }
+        public TextEditKind TextEditKind { get; set; }
 
         public FormattingOptions FormattingOptions { get; set; }
 
@@ -34,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 RazorDocumentUri == other.RazorDocumentUri &&
                 Enumerable.SequenceEqual(ProjectedTextEdits?.Select(p => p.NewText), other.ProjectedTextEdits?.Select(p => p.NewText)) &&
                 Enumerable.SequenceEqual(ProjectedTextEdits?.Select(p => p.Range), other.ProjectedTextEdits?.Select(p => p.Range)) &&
-                ShouldFormat == other.ShouldFormat &&
+                TextEditKind == other.TextEditKind &&
                 IsEqual(other.FormattingOptions);
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
+    // Note: This type should be kept in sync with the one in Razor.LanguageServer assembly.
     internal class RazorMapToDocumentRangesParams : IEquatable<RazorMapToDocumentRangesParams>
     {
         public RazorLanguageKind Kind { get; set; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesResponse.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesResponse.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
+    // Note: This type should be kept in sync with the one in Razor.LanguageServer assembly.
     internal class RazorMapToDocumentRangesResponse
     {
         public Range[] Ranges { get; set; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/TextEditKind.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/TextEditKind.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.LanguageServer.Protocol;
-
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     // Note: This type should be kept in sync with the one in Razor.LanguageServer assembly.
-    internal class RazorMapToDocumentEditsResponse
+    internal enum TextEditKind
     {
-        public TextEdit[] TextEdits { get; set; }
-
-        public long HostDocumentVersion { get; set; }
+        Default,
+        FormatOnType,
+        Snippet,
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionResolverTest.cs
@@ -220,7 +220,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                                 It.IsAny<TextEdit[]>(),
                                 It.IsAny<FormattingOptions>(),
                                 It.IsAny<CancellationToken>(),
-                                /*bypassValidationPasses:*/ true) == Task.FromResult(DefaultFormattedEdits));
+                                /*bypassValidationPasses:*/ true,
+                                It.IsAny<bool>()) == Task.FromResult(DefaultFormattedEdits));
             return razorFormattingService;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DefaultRazorFormattingServiceTest.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    public class DefaultRazorFormattingServiceTest
+    {
+        [Fact]
+        public void MergeEdits_ReturnsSingleEditAsExpected()
+        {
+            // Arrange
+            var source = @"
+@code {
+public class Foo{}
+}
+";
+            var sourceText = SourceText.From(source);
+            var edits = new[]
+            {
+                new TextEdit()
+                {
+                    NewText = "Bar",
+                    Range = new Range(new Position(2, 13), new Position(2, 16))
+                },
+                new TextEdit()
+                {
+                    NewText = "    ",
+                    Range = new Range(new Position(2, 0), new Position(2, 0))
+                },
+            };
+
+            // Act
+            var collapsedEdit = DefaultRazorFormattingService.MergeEdits(edits, sourceText);
+
+            // Assert
+            var multiEditChange = sourceText.WithChanges(edits.Select(e => e.AsTextChange(sourceText)));
+            var singleEditChange = sourceText.WithChanges(collapsedEdit.AsTextChange(sourceText));
+
+            Assert.Equal(multiEditChange.ToString(), singleEditChange.ToString());
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             public bool Called { get; private set; }
 
-            public override Task<TextEdit[]> ApplyFormattedEditsAsync(DocumentUri uri, DocumentSnapshot documentSnapshot, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options, CancellationToken cancellationToken, bool bypassValidationPasses = false)
+            public override Task<TextEdit[]> ApplyFormattedEditsAsync(DocumentUri uri, DocumentSnapshot documentSnapshot, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options, CancellationToken cancellationToken, bool bypassValidationPasses = false, bool collapseEdits = false)
             {
                 throw new NotImplementedException();
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -285,7 +285,7 @@ $@"public class SomeRazorFile
                 return Task.FromResult(response);
             }
 
-            public override Task<TextEdit[]> RemapFormattedTextEditsAsync(Uri uri, TextEdit[] edits, FormattingOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public override Task<TextEdit[]> RemapFormattedTextEditsAsync(Uri uri, TextEdit[] edits, FormattingOptions options, bool containsSnippet, CancellationToken cancellationToken) => throw new NotImplementedException();
 
             public override Task<Location[]> RemapLocationsAsync(Location[] locations, CancellationToken cancellationToken) => throw new NotImplementedException();
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnAutoInsertHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnAutoInsertHandlerTest.cs
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
             documentMappingProvider
-                .Setup(d => d.RemapTextEditsAsync(projectionUri, It.IsAny<TextEdit[]>(), It.IsAny<CancellationToken>()))
+                .Setup(d => d.RemapFormattedTextEditsAsync(projectionUri, It.IsAny<TextEdit[]>(), It.IsAny<FormattingOptions>(), /*containsSnippet*/ true, It.IsAny<CancellationToken>()))
                 .Callback(() => { mappedTextEdits = true; })
                 .Returns(Task.FromResult(new[] { new TextEdit() }));
 
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
             documentMappingProvider
-                .Setup(d => d.RemapTextEditsAsync(projectionUri, It.IsAny<TextEdit[]>(), It.IsAny<CancellationToken>()))
+                .Setup(d => d.RemapFormattedTextEditsAsync(projectionUri, It.IsAny<TextEdit[]>(), It.IsAny<FormattingOptions>(), /*containsSnippet*/ true, It.IsAny<CancellationToken>()))
                 .Callback(() => { mappedTextEdits = true; })
                 .Returns(Task.FromResult(new[] { new TextEdit() }));
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnTypeFormattingHandlerTest.cs
@@ -256,7 +256,7 @@ public string _foo;
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
             var mappingProvider = new Mock<LSPDocumentMappingProvider>();
             mappingProvider
-                .Setup(m => m.RemapFormattedTextEditsAsync(It.IsAny<Uri>(), It.IsAny<TextEdit[]>(), It.IsAny<FormattingOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.RemapFormattedTextEditsAsync(It.IsAny<Uri>(), It.IsAny<TextEdit[]>(), It.IsAny<FormattingOptions>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Callback(() => { remapped = true; })
                 .Returns(Task.FromResult(new[] { remappedEdit }));
 


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/23753

- Handle edits from onAutoInsert response correctly but flowing it through our formatting pipeline
- Added a `TextEditKind` enum to help customize that behavior
- Added support for collapsing multiple edits into one in the formatting service
- Added/updated tests