### PR TITLE
Enhance support for configuring debuggers used for Blazor WASM apps

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -116,11 +116,90 @@
                   },
                   "dotNetConfig": {
                     "description": "Options passed to the underlying .NET debugger. For more info, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger.md.",
-                    "type": "object"
+                    "type": "object",
+                    "required": [],
+                    "default": {},
+                    "properties": {
+                      "justMyCode": {
+                        "type": "boolean",
+                        "description": "Optional flag to only show user code.",
+                        "default": true
+                      },
+                      "sourceFileMap": {
+                        "type": "object",
+                        "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "default": {
+                          "<insert-source-path-here>": "<insert-target-path-here>"
+                        }
+                      },
+                      "logging": {
+                        "description": "Optional flags to determine what types of messages should be logged to the output window.",
+                        "type": "object",
+                        "required": [],
+                        "default": {},
+                        "properties": {
+                          "exceptions": {
+                            "type": "boolean",
+                            "description": "Optional flag to determine whether exception messages should be logged to the output window.",
+                            "default": true
+                          },
+                          "moduleLoad": {
+                            "type": "boolean",
+                            "description": "Optional flag to determine whether module load events should be logged to the output window.",
+                            "default": true
+                          },
+                          "programOutput": {
+                            "type": "boolean",
+                            "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
+                            "default": true
+                          },
+                          "engineLogging": {
+                            "type": "boolean",
+                            "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
+                            "default": false
+                          },
+                          "browserStdOut": {
+                            "type": "boolean",
+                            "description": "Optional flag to determine if stdout text from the launching the web browser should be logged to the output window.",
+                            "default": true
+                          },
+                          "elapsedTiming": {
+                            "type": "boolean",
+                            "description": "If true, engine logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took.",
+                            "default": false
+                          },
+                          "threadExit": {
+                            "type": "boolean",
+                            "description": "Controls if a message is logged when a thread in the target process exits. Default: `false`.",
+                            "default": false
+                          },
+                          "processExit": {
+                            "type": "boolean",
+                            "description": "Controls if a message is logged when the target process exits, or debugging is stopped. Default: `true`.",
+                            "default": true
+                          }
+                        }
+                      }
+                    }
                   },
                   "browserConfig": {
                     "description": "Options based to the underlying JavaScript debugger. For more info, see https://github.com/microsoft/vscode-js-debug/blob/master/OPTIONS.md.",
-                    "type": "object"
+                    "type": "object",
+                    "required": [],
+                    "default": {},
+                    "properties": {
+                      "outputCapture": {
+                        "enum": [
+                          "console",
+                          "std"
+                        ],
+                        "description": "From where to capture output messages: the default debug API if set to `console`, or stdout/stderr streams if set to `std`.",
+                        "default": "console"
+                      }
+                    }
                   }
                 }
               },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -114,53 +114,13 @@
                     "type": "object",
                     "description": "Environment variables passed to dotnet. Only valid for hosted apps."
                   },
-                  "logging": {
-                    "description": "Optional flags to determine what types of messages should be logged to the output window. Applicable only for the app server of hosted Blazor WASM apps.",
-                    "type": "object",
-                    "required": [],
-                    "default": {},
-                    "properties": {
-                      "exceptions": {
-                        "type": "boolean",
-                        "description": "Optional flag to determine whether exception messages should be logged to the output window.",
-                        "default": true
-                      },
-                      "moduleLoad": {
-                        "type": "boolean",
-                        "description": "Optional flag to determine whether module load events should be logged to the output window.",
-                        "default": true
-                      },
-                      "programOutput": {
-                        "type": "boolean",
-                        "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
-                        "default": true
-                      },
-                      "engineLogging": {
-                        "type": "boolean",
-                        "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
-                        "default": false
-                      },
-                      "browserStdOut": {
-                        "type": "boolean",
-                        "description": "Optional flag to determine if stdout text from the launching the web browser should be logged to the output window.",
-                        "default": true
-                      },
-                      "elapsedTiming": {
-                        "type": "boolean",
-                        "description": "If true, engine logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took.",
-                        "default": false
-                      },
-                      "threadExit": {
-                        "type": "boolean",
-                        "description": "Controls if a message is logged when a thread in the target process exits. Default: `false`.",
-                        "default": false
-                      },
-                      "processExit": {
-                        "type": "boolean",
-                        "description": "Controls if a message is logged when the target process exits, or debugging is stopped. Default: `true`.",
-                        "default": true
-                      }
-                    }
+                  "dotNetConfig": {
+                    "description": "Options passed to ",
+                    "type": "object"
+                  },
+                  "browserConfig": {
+                    "description": "Options based",
+                    "type": "object"
                   }
                 }
               },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -115,11 +115,11 @@
                     "description": "Environment variables passed to dotnet. Only valid for hosted apps."
                   },
                   "dotNetConfig": {
-                    "description": "Options passed to ",
+                    "description": "Options passed to the underlying .NET debugger. For more info, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger.md.",
                     "type": "object"
                   },
                   "browserConfig": {
-                    "description": "Options based",
+                    "description": "Options based to the underlying JavaScript debugger. For more info, see https://github.com/microsoft/vscode-js-debug/blob/master/OPTIONS.md.",
                     "type": "object"
                   }
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/Constants.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/Constants.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-export const HOSTED_APP_NAME = '.NET Core Launch (Blazor Hosted)';
+export const SERVER_APP_NAME = '.NET Application Server';
 export const JS_DEBUG_NAME = 'Debug Blazor Web Assembly in Browser';

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
@@ -8,10 +8,10 @@ import { DebugSession } from 'vscode';
 
 import { RazorLogger } from '../RazorLogger';
 
-import { HOSTED_APP_NAME, JS_DEBUG_NAME } from './Constants';
+import { JS_DEBUG_NAME, SERVER_APP_NAME } from './Constants';
 
 const isValidEvent = (name: string) => {
-  const VALID_EVENT_NAMES = [HOSTED_APP_NAME, JS_DEBUG_NAME];
+  const VALID_EVENT_NAMES = [SERVER_APP_NAME, JS_DEBUG_NAME];
   if (!VALID_EVENT_NAMES.includes(name)) {
     return false;
   }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
@@ -80,7 +80,7 @@ async function terminateByProcessName(
   }
 
   const devserver = processes.find(
-    (process: psList.ProcessDescriptor) => !!(process && process.cmd && process.cmd.includes(targetProcess)));
+    (process: psList.ProcessDescriptor) => !!(process && process.cmd && process.cmd.match(targetProcess)));
   targetPid = devserver ? devserver.pid : undefined;
 
   killProcess(targetPid, logger);


### PR DESCRIPTION
### Summary of the changes
- Adds support for passing underlying config to JS and .NET debuggers
  - Allows users to customize the hosted .NET debugger more fully
  - Allows users to configure prelaunch tasks for standalone server (for example, launching a local Azure Functions app)
- Always launch .NET app using debugger to support passing custom config
  - Update  clean up logic to check for standalone server launch from .NET debugger
  - Update config name for app launched via .NET debugger

Fixes: https://github.com/dotnet/aspnetcore/issues/27518, https://github.com/OmniSharp/omnisharp-vscode/issues/4161, https://github.com/OmniSharp/omnisharp-vscode/issues/4108
