### PR TITLE
Workaround to support curly-brace OnAutoInsert

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -93,6 +93,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 return formattedEdits;
             }
 
+            // If we only received a single edit, let's always return a single edit back.
+            // Otherwise, merge only if explicitly asked.
+            collapseEdits |= formattedEdits.Length == 1;
+
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
             using var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, isFormatOnType: true);
             var result = new FormattingResult(formattedEdits, kind);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnAutoInsertHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnAutoInsertHandlerTest.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 {
                     invokedServer = true;
                 })
-                .Returns(Task.FromResult(new DocumentOnAutoInsertResponseItem() { TextEdit = new TextEdit() { Range = new Range(), NewText = "sometext" } }));
+                .Returns(Task.FromResult(new DocumentOnAutoInsertResponseItem() { TextEdit = new TextEdit() { Range = new Range(), NewText = "sometext" }, TextEditFormat = InsertTextFormat.Snippet }));
 
             var projectionUri = new Uri(Uri.AbsoluteUri + "__virtual.html");
             var projectionResult = new ProjectionResult()
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 {
                     invokedServer = true;
                 })
-                .Returns(Task.FromResult(new DocumentOnAutoInsertResponseItem() { TextEdit = new TextEdit() { Range = new Range(), NewText = "sometext" } }));
+                .Returns(Task.FromResult(new DocumentOnAutoInsertResponseItem() { TextEdit = new TextEdit() { Range = new Range(), NewText = "sometext" }, TextEditFormat = InsertTextFormat.Snippet }));
 
             var projectionUri = new Uri(Uri.AbsoluteUri + "__virtual.html");
             var projectionResult = new ProjectionResult()
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider
                 .Setup(d => d.RemapFormattedTextEditsAsync(projectionUri, It.IsAny<TextEdit[]>(), It.IsAny<FormattingOptions>(), /*containsSnippet*/ true, It.IsAny<CancellationToken>()))
                 .Callback(() => { mappedTextEdits = true; })
-                .Returns(Task.FromResult(new[] { new TextEdit() }));
+                .Returns(Task.FromResult(new[] { new TextEdit() { NewText = "mapped-sometext" } }));
 
             var handler = new OnAutoInsertHandler(documentManager, requestInvoker.Object, projectionProvider.Object, documentMappingProvider.Object);
             var request = new DocumentOnAutoInsertParams()


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/23753

The problem is that C# formatting doesn't work when the document looks like,

![image](https://user-images.githubusercontent.com/1579269/100152692-ef7e5b00-2e57-11eb-9de8-e00a1bb7d2e5.png)

