### PR TITLE
Semantic null vs code

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
@@ -57,7 +57,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             }
 
             var semanticTokens = await HandleAsync(request.TextDocument, cancellationToken, request.Range);
-            _logger.LogInformation($"Returned {semanticTokens.Data.Length / 5} semantic tokens for range {request.Range} in {request.TextDocument.Uri}.");
+            var amount = semanticTokens is null ? "no" : (semanticTokens.Data.Length / 5).ToString(Thread.CurrentThread.CurrentCulture);
+
+            _logger.LogInformation($"Returned {amount} semantic tokens for range {request.Range} in {request.TextDocument.Uri}.");
 
             return semanticTokens;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -286,7 +286,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             var request = await _languageServer.SendRequestAsync(LanguageServerConstants.RazorProvideSemanticTokensEndpoint, parameter);
             var csharpResponse = await request.Returning<ProvideSemanticTokensResponse>(cancellationToken);
 
-            if (csharpResponse is null || csharpResponse.HostDocumentSyncVersion != documentVersion)
+            if (csharpResponse is null ||
+                (csharpResponse.HostDocumentSyncVersion != null && csharpResponse.HostDocumentSyncVersion != documentVersion))
             {
                 // No C# response or C# is out of sync with us. Unrecoverable, return null to indicate no change. It will retry in a bit.
                 return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Semantic/ProvideSemanticTokensResponse.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Semantic/ProvideSemanticTokensResponse.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SemanticTokensResponse } from './SemanticTokensResponse';
+
+export class ProvideSemanticTokensResponse {
+    // tslint:disable-next-line: variable-name
+    constructor(public Result: SemanticTokensResponse, public HostDocumentSyncVersion: number | null) {}
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Semantic/SemanticTokensHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Semantic/SemanticTokensHandler.ts
@@ -7,26 +7,29 @@ import * as vscode from 'vscode';
 import { RequestType } from 'vscode-languageclient';
 import { RazorLanguageServerClient } from '../RazorLanguageServerClient';
 import { SerializableSemanticTokensParams } from '../RPC/SerializableSemanticTokensParams';
+import { ProvideSemanticTokensResponse } from './ProvideSemanticTokensResponse';
 import { SemanticTokensResponse } from './SemanticTokensResponse';
 
 export class SemanticTokensHandler {
     private static readonly getSemanticTokensEndpoint = 'razor/provideSemanticTokens';
-    private semanticTokensRequestType: RequestType<SerializableSemanticTokensParams, SemanticTokensResponse, any, any> = new RequestType(SemanticTokensHandler.getSemanticTokensEndpoint);
-    private emptySemanticTokensResponse: SemanticTokensResponse = new SemanticTokensResponse(new Array<number>(), '');
+    private semanticTokensRequestType: RequestType<SerializableSemanticTokensParams, ProvideSemanticTokensResponse, any, any> = new RequestType(SemanticTokensHandler.getSemanticTokensEndpoint);
+    private emptySemanticTokensResponse: ProvideSemanticTokensResponse = new ProvideSemanticTokensResponse(
+        new SemanticTokensResponse(new Array<number>(), ''),
+        null);
 
     constructor(private readonly serverClient: RazorLanguageServerClient) {
     }
 
     public register() {
         // tslint:disable-next-line: no-floating-promises
-        this.serverClient.onRequestWithParams<SerializableSemanticTokensParams, SemanticTokensResponse, any, any>(
+        this.serverClient.onRequestWithParams<SerializableSemanticTokensParams, ProvideSemanticTokensResponse, any, any>(
             this.semanticTokensRequestType,
             async (request, token) => this.getSemanticTokens(request, token));
     }
 
     private async getSemanticTokens(
         semanticTokensParams: SerializableSemanticTokensParams,
-        cancellationToken: vscode.CancellationToken) {
+        cancellationToken: vscode.CancellationToken): Promise<ProvideSemanticTokensResponse> {
 
         // This is currently a No-Op because we don't have a way to get the semantic tokens from CSharp.
         // Other functions accomplish this with `vscode.execute<Blank>Provider`, but that doesn't exiset for Semantic Tokens yet because it's still not an official part of the spec.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -29,6 +29,27 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
     {
         #region CSharp
         [Fact]
+        public async Task GetSemanticTokens_CSharp_VSCodeWorks()
+        {
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}@{{ var d = }}";
+            var expectedData = new List<int> {
+                0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
+                0, 1, 12, RazorSemanticTokensLegend.RazorDirective, 0,
+            };
+
+            var cSharpTokens = new SemanticTokens {
+                Data = ImmutableArray<int>.Empty,
+                ResultId = null,
+            };
+
+            var cSharpResponse = new ProvideSemanticTokensResponse(cSharpTokens, hostDocumentSyncVersion: null);
+
+            var mappings = Array.Empty<(OmniSharpRange, OmniSharpRange)>();
+
+            await AssertSemanticTokens(txt, expectedData, isRazor: false, csharpTokens: cSharpResponse, documentMappings: mappings, documentVersion: 1);
+        }
+
+        [Fact]
         public async Task GetSemanticTokens_CSharp_VersionMismatch()
         {
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}@{{ var d = }}";


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/28130.

I noticed this because of the null-ref that `RazorSemanticTokensEndpoint` throws in this case.

The `result.Data` field from VSCode is being serialized as null (even though I made it return an empty array specifically to avoid this), which causes the Razor LSP to throw out the whole request (it thinks that the reason it's null is the DocumentVersions were out of sync).