### PR TITLE
[DO NOT MERGE] Tag Support Change

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -102,7 +102,7 @@
     <MicrosoftVisualStudioEditorPackageVersion>16.8.272</MicrosoftVisualStudioEditorPackageVersion>
     <MicrosoftVisualStudioLanguagePackageVersion>16.8.272</MicrosoftVisualStudioLanguagePackageVersion>
     <MicrosoftVisualStudioLanguageIntellisensePackageVersion>16.8.272</MicrosoftVisualStudioLanguageIntellisensePackageVersion>
-    <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>16.9.87</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
+    <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>16.9.81-g106a61c661</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
     <MicrosoftVisualStudioPackageLanguageService150PackageVersion>16.7.30204.53-pre</MicrosoftVisualStudioPackageLanguageService150PackageVersion>
     <MicrosoftVisualStudioLiveSharePackageVersion>0.3.1074</MicrosoftVisualStudioLiveSharePackageVersion>
     <MicrosoftVisualStudioOLEInteropPackageVersion>7.10.6071</MicrosoftVisualStudioOLEInteropPackageVersion>


### PR DESCRIPTION
### Summary of the changes
- Support LSP Platform's Tag Support change
- Verified existing & LSP powered editor initializes
- Ran a live share session with extension host as liveshare host and guest without this new support
- Verified push & pull diagnostics
- Note; this was done by patching Razor into Roslyn's TagSupport patched build: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/289763 
- Following (expected for now) yellow bars remain:
![image](https://user-images.githubusercontent.com/14852843/101200452-4fcd8380-3634-11eb-831a-27c07de3962f.png)
![image](https://user-images.githubusercontent.com/14852843/101200465-54923780-3634-11eb-8a4b-9acb808a3c00.png)
  - Hence no HTML hovers and so on could be verified
- Note; **DO NOT MERGE**, this will just be a validation insertion.

fyi/ @NTaylorMullen @ajaybhargavb @ryanbrandenburg @dibarbet 


Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1249511
Fixes: https://github.com/dotnet/aspnetcore/issues/28288
