### PR TITLE
Delegate InvokeKind to sub-languages.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -173,11 +173,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             // Trigger character not associated with the current langauge. Transform the context into an invoked context.
-
-            var rewrittenContext = new CompletionContext()
+            var rewrittenContext = new VSCompletionContext()
             {
-                TriggerKind = CompletionTriggerKind.Invoked
+                TriggerKind = CompletionTriggerKind.Invoked,
             };
+
+            var invokeKind = (context as VSCompletionContext)?.InvokeKind;
+            if (invokeKind.HasValue)
+            {
+                rewrittenContext.InvokeKind = invokeKind.Value;
+            }
+
             return rewrittenContext;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
 
@@ -34,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(outputStream));
             }
 
-            _jsonRpc = new JsonRpc(outputStream, inputStream, this);
+            _jsonRpc = CreateJsonRpc(inputStream, outputStream, target: this);
             _jsonRpc.StartListening();
         }
 
@@ -249,6 +250,42 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             return handler.HandleRequestAsync(request, clientCapabilities, cancellationToken);
+        }
+
+        private static JsonRpc CreateJsonRpc(Stream inputStream, Stream outputStream, object target)
+        {
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var messageFormatter = new JsonMessageFormatter();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+            var serializer = messageFormatter.JsonSerializer;
+            AddVSExtensionConverters(serializer);
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var messageHandler = new HeaderDelimitedMessageHandler(outputStream, inputStream, messageFormatter);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+            // The JsonRpc object owns disposing the message handler which disposes the formatter.
+            var jsonRpc = new JsonRpc(messageHandler, target);
+            return jsonRpc;
+
+            // Can be removed for serializer.AddVSExtensionConverters() once we are able to update to a newer LSP protocol Extensions version.
+            void AddVSExtensionConverters(JsonSerializer serializer)
+            {
+                serializer.Converters.Add(new VSExtensionConverter<ClientCapabilities, VSClientCapabilities>());
+                serializer.Converters.Add(new VSExtensionConverter<CodeAction, VSCodeAction>());
+                serializer.Converters.Add(new VSExtensionConverter<CodeActionContext, VSCodeActionContext>());
+                serializer.Converters.Add(new VSExtensionConverter<CompletionContext, VSCompletionContext>());
+                serializer.Converters.Add(new VSExtensionConverter<CompletionItem, VSCompletionItem>());
+                serializer.Converters.Add(new VSExtensionConverter<CompletionList, VSCompletionList>());
+                serializer.Converters.Add(new VSExtensionConverter<Diagnostic, VSDiagnostic>());
+                serializer.Converters.Add(new VSExtensionConverter<Hover, VSHover>());
+                serializer.Converters.Add(new VSExtensionConverter<ServerCapabilities, VSServerCapabilities>());
+                serializer.Converters.Add(new VSExtensionConverter<SignatureInformation, VSSignatureInformation>());
+                serializer.Converters.Add(new VSExtensionConverter<SymbolInformation, VSSymbolInformation>());
+                serializer.Converters.Add(new VSExtensionConverter<TextDocumentClientCapabilities, VSTextDocumentClientCapabilities>());
+                serializer.Converters.Add(new VSExtensionConverter<TextDocumentIdentifier, VSTextDocumentIdentifier>());
+            }
         }
 
         private static ImmutableDictionary<string, Lazy<IRequestHandler, IRequestHandlerMetadata>> CreateMethodToHandlerMap(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(outputStream));
             }
 
-            _jsonRpc = CreateJsonRpc(inputStream, outputStream, target: this);
+            _jsonRpc = CreateJsonRpc(outputStream, inputStream, target: this);
             _jsonRpc.StartListening();
         }
 
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return handler.HandleRequestAsync(request, clientCapabilities, cancellationToken);
         }
 
-        private static JsonRpc CreateJsonRpc(Stream inputStream, Stream outputStream, object target)
+        private static JsonRpc CreateJsonRpc(Stream outputStream, Stream inputStream, object target)
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var messageFormatter = new JsonMessageFormatter();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
-                Context = new CompletionContext() { TriggerKind = CompletionTriggerKind.TriggerCharacter, TriggerCharacter = "<" },
+                Context = new VSCompletionContext() { TriggerKind = CompletionTriggerKind.TriggerCharacter, TriggerCharacter = "<", InvokeKind = VSCompletionInvokeKind.Typing },
                 Position = new Position(0, 1)
             };
 
@@ -93,6 +93,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 {
                     Assert.Equal(Methods.TextDocumentCompletionName, method);
                     Assert.Equal(RazorLSPConstants.HtmlLSPContentTypeName, serverContentType);
+                    var vsCompletionContext = Assert.IsType<VSCompletionContext>(completionParams.Context);
+                    Assert.Equal(VSCompletionInvokeKind.Typing, vsCompletionContext.InvokeKind);
                     called = true;
                 })
                 .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(new[] { expectedItem }));
@@ -124,7 +126,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
-                Context = new CompletionContext() { TriggerKind = CompletionTriggerKind.Invoked },
+                Context = new VSCompletionContext() { TriggerKind = CompletionTriggerKind.Invoked, InvokeKind = VSCompletionInvokeKind.Explicit },
                 Position = new Position(0, 1)
             };
 
@@ -138,6 +140,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 {
                     Assert.Equal(Methods.TextDocumentCompletionName, method);
                     Assert.Equal(RazorLSPConstants.CSharpContentTypeName, serverContentType);
+                    var vsCompletionContext = Assert.IsType<VSCompletionContext>(completionParams.Context);
+                    Assert.Equal(VSCompletionInvokeKind.Explicit, vsCompletionContext.InvokeKind);
                     called = true;
                 })
                 .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(new[] { expectedItem }));


### PR DESCRIPTION
- When the VS language server platform's Json converters are added to our JsonRpc object we're able to see additional information as part of LSP completion requests. This additional information can help influence our sub-languages to "do the right thing".
    - To add JsonConverters to our JsonRpc object I had to change the way we construct the object. Also, since we can't rely on a newer LSP protocol version quite yet I had to copy and paste their converter additions into one of our own.
- Updated two existing tests to validate that the `InvokeKind` flows properly.

/cc @allisonchou @ToddGrun 

Fixes dotnet/aspnetcore#27927