### PR TITLE
HTML Embedded Language Publish Diagnostics, Fix RazorMapToDocumentRangesResponse

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -156,6 +157,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             await Task.Factory.StartNew(() =>
             {
                 _documentResolver.TryResolveDocument(request.RazorDocumentUri.GetAbsoluteOrUNCPath(), out documentSnapshot);
+
+                Debug.Assert(documentSnapshot != null, "Failed to get the document snapshot, could not map to document ranges.");
+
                 if (documentSnapshot is null ||
                     !_documentVersionCache.TryGetDocumentVersion(documentSnapshot, out documentVersion))
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -156,7 +156,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             await Task.Factory.StartNew(() =>
             {
                 _documentResolver.TryResolveDocument(request.RazorDocumentUri.GetAbsoluteOrUNCPath(), out documentSnapshot);
-                if (!_documentVersionCache.TryGetDocumentVersion(documentSnapshot, out documentVersion))
+                if (documentSnapshot is null ||
+                    !_documentVersionCache.TryGetDocumentVersion(documentSnapshot, out documentVersion))
                 {
                     documentVersion = null;
                 }
@@ -170,6 +171,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Ranges = request.ProjectedRanges,
                     HostDocumentVersion = documentVersion,
                 };
+            }
+
+            if (documentSnapshot is null)
+            {
+                return null;
             }
 
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorMapToDocumentRangesResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorMapToDocumentRangesResponse.cs
@@ -5,6 +5,8 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
+    // NOTE: Changes here MUST be copied over to
+    // Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorMapToDocumentRangesResponse
     internal class RazorMapToDocumentRangesResponse
     {
         public Range[] Ranges { get; set; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDocumentMappingProvider.cs
@@ -92,11 +92,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 var uri = location.Uri;
                 RazorLanguageKind languageKind;
-                if (RazorLSPConventions.IsRazorCSharpFile(uri))
+                if (RazorLSPConventions.IsVirtualCSharpFile(uri))
                 {
                     languageKind = RazorLanguageKind.CSharp;
                 }
-                else if (RazorLSPConventions.IsRazorHtmlFile(uri))
+                else if (RazorLSPConventions.IsVirtualHtmlFile(uri))
                 {
                     languageKind = RazorLanguageKind.Html;
                 }
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(edits));
             }
 
-            if (!RazorLSPConventions.IsRazorCSharpFile(uri) && !RazorLSPConventions.IsRazorHtmlFile(uri))
+            if (!RazorLSPConventions.IsVirtualCSharpFile(uri) && !RazorLSPConventions.IsVirtualHtmlFile(uri))
             {
                 // This is not a virtual razor file. No need to remap.
                 return edits;
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(edits));
             }
 
-            if (!RazorLSPConventions.IsRazorCSharpFile(uri) && !RazorLSPConventions.IsRazorHtmlFile(uri))
+            if (!RazorLSPConventions.IsVirtualCSharpFile(uri) && !RazorLSPConventions.IsVirtualHtmlFile(uri))
             {
                 // This is not a virtual razor file. No need to remap.
                 return edits;
@@ -317,11 +317,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             FormattingOptions formattingOptions = null)
         {
             var languageKind = RazorLanguageKind.Razor;
-            if (RazorLSPConventions.IsRazorCSharpFile(uri))
+            if (RazorLSPConventions.IsVirtualCSharpFile(uri))
             {
                 languageKind = RazorLanguageKind.CSharp;
             }
-            else if (RazorLSPConventions.IsRazorHtmlFile(uri))
+            else if (RazorLSPConventions.IsVirtualHtmlFile(uri))
             {
                 languageKind = RazorLanguageKind.Html;
             }
@@ -360,7 +360,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         private static bool CanRemap(Uri uri)
         {
-            return RazorLSPConventions.IsRazorCSharpFile(uri) || RazorLSPConventions.IsRazorHtmlFile(uri);
+            return RazorLSPConventions.IsVirtualCSharpFile(uri) || RazorLSPConventions.IsVirtualHtmlFile(uri);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -171,8 +171,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 referenceItem.DefinitionText = FilterReferenceDisplayText(referenceItem.DefinitionText);
                 referenceItem.Text = FilterReferenceDisplayText(referenceItem.Text);
 
-                if (!RazorLSPConventions.IsRazorCSharpFile(referenceItem.Location.Uri) &&
-                    !RazorLSPConventions.IsRazorHtmlFile(referenceItem.Location.Uri))
+                if (!RazorLSPConventions.IsVirtualCSharpFile(referenceItem.Location.Uri) &&
+                    !RazorLSPConventions.IsVirtualHtmlFile(referenceItem.Location.Uri))
                 {
                     // This location doesn't point to a virtual cs file. No need to remap.
                     remappedLocations.Add(referenceItem);
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
 
                 var razorDocumentUri = RazorLSPConventions.GetRazorDocumentUri(referenceItem.Location.Uri);
-                var languageKind = RazorLSPConventions.IsRazorCSharpFile(referenceItem.Location.Uri) ? RazorLanguageKind.CSharp : RazorLanguageKind.Html;
+                var languageKind = RazorLSPConventions.IsVirtualCSharpFile(referenceItem.Location.Uri) ? RazorLanguageKind.CSharp : RazorLanguageKind.Html;
                 var mappingResult = await _documentMappingProvider.MapToDocumentRangesAsync(
                     languageKind,
                     razorDocumentUri,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesResponse.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesResponse.cs
@@ -10,6 +10,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     {
         public Range[] Ranges { get; set; }
 
-        public long HostDocumentVersion { get; set; }
+        public int? HostDocumentVersion { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -165,8 +165,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return new InterceptionResult(newToken, changedDocumentUri: true);
             }
 
-            static bool CanDiagnosticBeFiltered(Diagnostic d) =>
-                string.IsNullOrEmpty(d.Code) && d.Severity != DiagnosticSeverity.Error; 
+            static bool CanDiagnosticBeFiltered(Diagnostic d) => false;
+            // TODO; blocked on https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1257401
+            // string.IsNullOrEmpty(d.Code) && d.Severity != DiagnosticSeverity.Error; 
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -2,16 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.MessageInterception;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
-using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
-using System.Linq;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.MessageInterception;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+using System.Linq;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Export(typeof(MessageInterceptor))]
+    [InterceptMethod(Methods.TextDocumentPublishDiagnosticsName)]
+    internal class RazorHtmlPublishDiagnosticsInterceptor : MessageInterceptor
+    {
+        private readonly LSPRequestInvoker _requestInvoker;
+        private readonly LSPDocumentManager _documentManager;
+        private readonly LSPDocumentMappingProvider _documentMappingProvider;
+        private readonly LSPDocumentSynchronizer _documentSynchronizer;
+
+        [ImportingConstructor]
+        public RazorHtmlPublishDiagnosticsInterceptor(
+            LSPRequestInvoker requestInvoker,
+            LSPDocumentManager documentManager,
+            LSPDocumentMappingProvider documentMappingProvider,
+            LSPDocumentSynchronizer documentSynchronizer)
+        {
+            if (requestInvoker is null)
+            {
+                throw new ArgumentNullException(nameof(requestInvoker));
+            }
+
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (documentMappingProvider is null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingProvider));
+            }
+
+            if (documentSynchronizer is null)
+            {
+                throw new ArgumentNullException(nameof(documentSynchronizer));
+            }
+
+            _requestInvoker = requestInvoker;
+            _documentManager = documentManager;
+            _documentMappingProvider = documentMappingProvider;
+            _documentSynchronizer = documentSynchronizer;
+        }
+
+        public override async Task<InterceptionResult> ApplyChangesAsync(JToken token, string containedLanguageName, CancellationToken cancellationToken)
+        {
+            if (token is null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var diagnosticParams = token.ToObject<VSPublishDiagnosticParams>();
+
+            if (diagnosticParams is null)
+            {
+                throw new ArgumentException("Conversion of token failed.");
+            }
+
+            // We only support interception of Virtual HTML Files
+            if (!RazorLSPConventions.IsVirtualHtmlFile(diagnosticParams.Uri))
+            {
+                return CreateDefaultResponse(token);
+            }
+
+            var razorDocumentUri = RazorLSPConventions.GetRazorDocumentUri(diagnosticParams.Uri);
+
+            if (!_documentManager.TryGetDocument(razorDocumentUri, out var razorDocumentSnapshot))
+            {
+                return CreateDefaultResponse(token);
+            }
+
+            if (!razorDocumentSnapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var htmlDocumentSnapshot))
+            {
+                return CreateDefaultResponse(token);
+            }
+
+            // Ensure we're working with the virtual document specified in the diagnostic params
+            if (!htmlDocumentSnapshot.Uri.Equals(diagnosticParams.Uri))
+            {
+                return CreateDefaultResponse(token);
+            }
+
+            // Note; this is an `interceptor` & not a handler, hence 
+            // it's possible another interceptor mutates this request 
+            // later in the toolchain. Such an interceptor would likely 
+            // expect a `__virtual.html` suffix instead of `.razor`.
+            diagnosticParams.Uri = razorDocumentUri;
+
+            // Return early if there aren't any diagnostics to process
+            if (diagnosticParams.Diagnostics?.Any() != true)
+            {
+                return CreateResponse(diagnosticParams);
+            }
+
+            var synchronized = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync(
+                razorDocumentSnapshot.Version,
+                htmlDocumentSnapshot,
+                cancellationToken).ConfigureAwait(false);
+            if (!synchronized)
+            {
+                // Could not synchronize, we'll clear out the diagnostics as we don't
+                // know whether or not they're still valid in the current state of the
+                // document.
+                return CreateResponse(diagnosticParams, clearDiagnostics: true);
+            }
+
+            var unmappedDiagnostics = diagnosticParams.Diagnostics;
+            var filteredDiagnostics = unmappedDiagnostics.Where(d => !CanDiagnosticBeFiltered(d));
+            if (!filteredDiagnostics.Any())
+            {
+                return CreateResponse(diagnosticParams, clearDiagnostics: true);
+            }
+
+            var rangesToMap = filteredDiagnostics.Select(r => r.Range).ToArray();
+            var mappingResult = await _documentMappingProvider.MapToDocumentRangesAsync(
+                RazorLanguageKind.Html,
+                razorDocumentUri,
+                rangesToMap,
+                LanguageServerMappingBehavior.Inclusive,
+                cancellationToken).ConfigureAwait(false);
+
+            if (mappingResult == null || mappingResult.HostDocumentVersion != razorDocumentSnapshot.Version)
+            {
+                return CreateResponse(diagnosticParams, clearDiagnostics: true);
+            }
+
+            var mappedDiagnostics = new List<Diagnostic>(filteredDiagnostics.Count());
+
+            for (var i = 0; i < filteredDiagnostics.Count(); i++)
+            {
+                var diagnostic = filteredDiagnostics.ElementAt(i);
+                var range = mappingResult.Ranges[i];
+
+                if (range.IsUndefined())
+                {
+                    // Couldn't remap the range correctly.
+                    // If this isn't an `Error` Severity Diagnostic we can discard it.
+                    if (diagnostic.Severity != DiagnosticSeverity.Error)
+                    {
+                        continue;
+                    }
+
+                    // For `Error` Severity diagnostics we still show the diagnostics to
+                    // the user, however we set the range to an undefined range to ensure
+                    // clicking on the diagnostic doesn't cause errors.
+                }
+
+                diagnostic.Range = range;
+                mappedDiagnostics.Add(diagnostic);
+            }
+
+            diagnosticParams.Diagnostics = mappedDiagnostics.ToArray();
+
+            return CreateResponse(diagnosticParams);
+
+
+            static InterceptionResult CreateDefaultResponse(JToken token) =>
+                new InterceptionResult(token, changedDocumentUri: false);
+
+            static InterceptionResult CreateResponse(
+                VSPublishDiagnosticParams diagnosticParams,
+                bool clearDiagnostics = false,
+                bool changedDocumentUri = true)
+            {
+                if (clearDiagnostics)
+                {
+                    diagnosticParams.Diagnostics = Array.Empty<Diagnostic>();
+                }
+
+                var newToken = JToken.FromObject(diagnosticParams);
+                return new InterceptionResult(newToken, changedDocumentUri);
+            }
+
+            static bool CanDiagnosticBeFiltered(Diagnostic d) => false;
+            // TODO:
+            // DiagnosticsToIgnore.Contains(d.Code) && d.Severity != DiagnosticSeverity.Error; 
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConventions.cs
@@ -8,25 +8,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     internal static class RazorLSPConventions
     {
-        public static bool IsRazorCSharpFile(Uri uri)
-        {
-            if (uri is null)
-            {
-                throw new ArgumentNullException(nameof(uri));
-            }
+        public static bool IsVirtualCSharpFile(Uri uri) => CheckIfFileUriAndExtensionMatch(uri, RazorLSPConstants.VirtualCSharpFileNameSuffix);
 
-            return uri.GetAbsoluteOrUNCPath()?.EndsWith(RazorLSPConstants.VirtualCSharpFileNameSuffix, StringComparison.Ordinal) ?? false;
-        }
+        public static bool IsVirtualHtmlFile(Uri uri) => CheckIfFileUriAndExtensionMatch(uri, RazorLSPConstants.VirtualHtmlFileNameSuffix);
 
-        public static bool IsRazorHtmlFile(Uri uri)
-        {
-            if (uri is null)
-            {
-                throw new ArgumentNullException(nameof(uri));
-            }
+        public static bool IsRazorFile(Uri uri) => CheckIfFileUriAndExtensionMatch(uri, RazorLSPConstants.RazorFileExtension);
 
-            return uri.GetAbsoluteOrUNCPath()?.EndsWith(RazorLSPConstants.VirtualHtmlFileNameSuffix, StringComparison.Ordinal) ?? false;
-        }
+        public static bool IsCSHTMLFile(Uri uri) => CheckIfFileUriAndExtensionMatch(uri, RazorLSPConstants.CSHTMLFileExtension);
 
         public static Uri GetRazorDocumentUri(Uri virtualDocumentUri)
         {
@@ -41,6 +29,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var uri = new Uri(path, UriKind.Absolute);
             return uri;
+        }
+
+        private static bool CheckIfFileUriAndExtensionMatch(Uri uri, string extension)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (string.IsNullOrEmpty(extension))
+            {
+                throw new ArgumentNullException(nameof(extension));
+            }
+
+            return uri.GetAbsoluteOrUNCPath()?.EndsWith(extension, StringComparison.Ordinal) ?? false;
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
@@ -259,7 +259,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             var remappingResult = new RazorMapToDocumentRangesResponse()
             {
-                Ranges = new[] { expectedRange }
+                Ranges = new[] { expectedRange },
+                HostDocumentVersion = expectedVersion
             };
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict);
             documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(languageKind, Uri, It.IsAny<Range[]>(), It.IsAny<CancellationToken>())).

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var projectionResult = new ProjectionResult()
             {
-                LanguageKind = RazorLanguageKind.CSharp,
+                LanguageKind = RazorLanguageKind.CSharp
             };
             var projectionProvider = new Mock<LSPProjectionProvider>();
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
@@ -136,7 +136,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         Start = new Position(0, 0),
                         End = new Position(0, 1)
                     }
-                }
+                },
+                HostDocumentVersion = 0
             };
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
             documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range[]>(), It.IsAny<CancellationToken>())).
@@ -222,7 +223,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         Start = new Position(0, 0),
                         End = new Position(0, 1)
                     }
-                }
+                },
+                HostDocumentVersion = 0
             };
             var documentMappingProvider = new Mock<LSPDocumentMappingProvider>();
             documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.Html, It.IsAny<Uri>(), It.IsAny<Range[]>(), It.IsAny<CancellationToken>())).


### PR DESCRIPTION
### Summary of the changes
 - Fixes RazorMapToDocumentRangesResponse null response support
    - Previously this resulted in an exception being thrown and the message being lost
- Updated Razor LSP Conventions (added .razor and .cshtml support)
- Added Razor HTML publish diagnostics
  - Note; this still needs to be flushed out (primarily filtering): https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1257401
  - Tests are WIP: Will be part of https://github.com/dotnet/aspnetcore/issues/27563

Fixes: https://github.com/dotnet/aspnetcore/issues/26830
