### PR TITLE
Fix underscores from being duplicated when completions committed.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     {
         private static readonly IReadOnlyList<string> RazorTriggerCharacters = new[] { "@" };
         private static readonly IReadOnlyList<string> CSharpTriggerCharacters = new[] { " ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", ">", "~" };
-        private static readonly IReadOnlyList<string> HtmlTriggerCharacters = new[] { ":", "@", "#", ".", "!", "*", ",", "(", "[", "=", "_", "-", "<", "&", "\\", "/", "'", "\"", "=", ":", " " };
+        private static readonly IReadOnlyList<string> HtmlTriggerCharacters = new[] { ":", "@", "#", ".", "!", "*", ",", "(", "[", "=", "-", "<", "&", "\\", "/", "'", "\"", "=", ":", " " };
 
         public static readonly IReadOnlyList<string> AllTriggerCharacters = new HashSet<string>(
             CSharpTriggerCharacters


### PR DESCRIPTION
- The language server platform restricts the bounding of the "applicable commit span" based on the active trigger/commit characters. Since `_` is already part of our "identifier" trigger set we don't need to specify it.

Before:
![image](https://user-images.githubusercontent.com/2008729/101828670-b6481b00-3ae6-11eb-8fb4-ba1f984bd625.gif)

After:
![image](https://i.imgur.com/0XDdkQS.gif)

Fixes dotnet/aspnetcore#28578