### PR TITLE
Improve messages and prevent StackOverflow

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
@@ -30,10 +30,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                 return 1;
             }
 
-            Debug.Assert(Range.Start.CompareTo(other.Range.Start) == 0 || !Range.OverlapsWith(other.Range));
+            Debug.Assert(Range.Start.CompareTo(other.Range.Start) == 0 || !Range.OverlapsWith(other.Range), $"{this} overlapped with {other}");
 
             // Since overlapping SemanticRanges are STRICTLY FORBIDDEN we need only compare the starts 
             return Range.Start.CompareTo(other.Range.Start);
+        }
+
+        public override string ToString()
+        {
+            return $"[Kind: {Kind}, Range: {Range}]";
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -54,6 +54,6 @@ namespace Microsoft.CodeAnalysis.Razor
             return new TagHelperResolutionResult(results, Array.Empty<RazorDiagnostic>());
         }
 
-        protected virtual Task<TagHelperResolutionResult> GetTagHelpersAsync(Project workspaceProject, RazorProjectEngine engine) => GetTagHelpersAsync(workspaceProject, engine);
+        protected virtual Task<TagHelperResolutionResult> GetTagHelpersAsync(Project workspaceProject, RazorProjectEngine engine) => GetTagHelpersAsync(workspaceProject, engine, CancellationToken.None);
     }
 }


### PR DESCRIPTION
Firstly I try to improve the message that is presented if the SemanticRange debug assert is thrown (since I still am not able to make it happen and would like to confirm my theory that it's caused by C# and Razor tokens coliding when document versions are out of sync).

Secondly I resolve a problem of StackOverflowExceptions thrown by GetTagHelpersAsync because it calls itself. It's unclear to me how this wasn't causing trouble for other people.