### PR TITLE
Fix SemanticToken Visitor

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -5,10 +5,8 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
-using Microsoft.VisualStudio.Editor.Razor;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
@@ -170,14 +168,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
 
         public override void VisitRazorMetaCode(RazorMetaCodeSyntax node)
         {
-            switch (node.Kind)
+            if(node.Kind == SyntaxKind.RazorMetaCode)
             {
-                // These are Braces for things like "@code {}" and "@functions {}".
-                // Hypothetically the braces are the only metacode which should ever reach this,
-                // but I added the switch statement just in case.
-                case SyntaxKind.RazorMetaCode:
                     AddSemanticRange(node, RazorSemanticTokensLegend.RazorTransition);
-                    break;
+            }
+            else
+            {
+                throw new NotSupportedException("Attempted to visit a RazorMetaCode other than '{' or '}'.");
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -168,6 +168,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             Visit(node.Body);
         }
 
+        public override void VisitRazorMetaCode(RazorMetaCodeSyntax node)
+        {
+            switch (node.Kind)
+            {
+                // These are Braces for things like "@code {}" and "@functions {}".
+                // Hypothetically the braces are the only metacode which should ever reach this,
+                // but I added the switch statement just in case.
+                case SyntaxKind.RazorMetaCode:
+                    AddSemanticRange(node, RazorSemanticTokensLegend.RazorTransition);
+                    break;
+            }
+        }
+
         public override void VisitRazorDirectiveBody(RazorDirectiveBodySyntax node)
         {
             // We can't provide colors for CSharp because if we both provided them then they would overlap, which violates the LSP spec.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -175,6 +175,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             {
                 AddSemanticRange(node.Keyword, RazorSemanticTokensLegend.RazorDirective);
             }
+            else
+            {
+                Visit(node.Keyword);
+            }
+
+            Visit(node.CSharpCode);
         }
 
         public override void VisitMarkupTagHelperStartTag(MarkupTagHelperStartTagSyntax node)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultTagHelperServiceTestBase.cs
@@ -56,6 +56,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 attribute.TypeName = typeof(int).FullName;
             });
 
+            var builder3 = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "Component1TagHelper", "TestAssembly");
+            builder3.TagMatchingRule(rule => rule.TagName = "Component1");
+            builder3.SetTypeName("Component1");
+            builder3.Metadata[ComponentMetadata.Component.NameMatchKey] = ComponentMetadata.Component.FullyQualifiedNameMatch;
+            builder3.BindAttribute(attribute => {
+                attribute.Name = "bool-val";
+                attribute.SetPropertyName("BoolVal");
+                attribute.TypeName = typeof(bool).FullName;
+            });
+            builder3.BindAttribute(attribute => {
+                attribute.Name = "int-val";
+                attribute.SetPropertyName("IntVal");
+                attribute.TypeName = typeof(int).FullName;
+            });
+
             var directiveAttribute1 = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "TestDirectiveAttribute", "TestAssembly");
             directiveAttribute1.TagMatchingRule(rule =>
             {
@@ -130,7 +145,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             directiveAttribute2.Metadata[ComponentMetadata.Component.NameMatchKey] = ComponentMetadata.Component.FullyQualifiedNameMatch;
             directiveAttribute2.SetTypeName("TestDirectiveAttribute");
 
-            DefaultTagHelpers = new[] { builder1.Build(), builder2.Build(), directiveAttribute1.Build(), directiveAttribute2.Build() };
+            DefaultTagHelpers = new[] { builder1.Build(), builder2.Build(), builder3.Build(), directiveAttribute1.Build(), directiveAttribute2.Build() };
 
             HtmlFactsService = new DefaultHtmlFactsService();
             TagHelperFactsService = new DefaultTagHelperFactsService();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -863,7 +863,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             var expectedData = new List<int>
             {
                 0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
-                0, 1, 4, RazorSemanticTokensLegend.RazorDirective, 0
+                0, 1, 4, RazorSemanticTokensLegend.RazorDirective, 0,
+                0, 5, 1, RazorSemanticTokensLegend.RazorTransition, 0,
+                0, 1, 1, RazorSemanticTokensLegend.RazorTransition, 0,
             }.ToImmutableArray();
 
             await AssertSemanticTokens(txt, expectedData, isRazor: true);
@@ -882,7 +884,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             {
                 0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
                 0, 1, 4, RazorSemanticTokensLegend.RazorDirective, 0,
+                0, 5, 1, RazorSemanticTokensLegend.RazorTransition, 0, // left bracket
                 3, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0,
+                2, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, // right bracket
             }.ToImmutableArray();
 
             await AssertSemanticTokens(txt, expectedData, isRazor: true);
@@ -907,7 +911,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             var expectedData = new List<int>
             {
                 0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0,
-                0, 1, 9, RazorSemanticTokensLegend.RazorDirective, 0
+                0, 1, 9, RazorSemanticTokensLegend.RazorDirective, 0,
+                0, 10, 1, RazorSemanticTokensLegend.RazorTransition, 0,
+                0, 1, 1, RazorSemanticTokensLegend.RazorTransition, 0,
             }.ToImmutableArray();
 
             await AssertSemanticTokens(txt, expectedData, isRazor: true);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -703,7 +703,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
                 0, 1, 12, RazorSemanticTokensLegend.RazorDirective, 0,
                 1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 11, RazorSemanticTokensLegend.MarkupElement, 0,
+                0, 1, 11, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
                 0, 12, 1, RazorSemanticTokensLegend.RazorTransition, 0,
                 0, 1, 9, RazorSemanticTokensLegend.RazorDirectiveAttribute, 0,
                 0, 9, 1, RazorSemanticTokensLegend.RazorDirectiveColon, 0,
@@ -793,25 +793,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             await AssertSemanticTokens(txt, expectedData, isRazor: true);
         }
 
-        [Fact]
-        public async Task GetSemanticTokens_Razor_DoNotColorNonHTMLElementsAsync()
-        {
-            var txt = $"{Environment.NewLine}<p1 @test='Function'></p1> ";
-            var expectedData = new List<int> {
-                1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,  //line, character pos, length, tokenType, modifier
-                0, 1, 2, RazorSemanticTokensLegend.MarkupElement, 0,
-                0, 3, 1, RazorSemanticTokensLegend.RazorTransition, 0,
-                0, 1, 4, RazorSemanticTokensLegend.RazorDirectiveAttribute, 0,
-                0, 4, 1, RazorSemanticTokensLegend.MarkupOperator, 0,
-                0, 11, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 2, RazorSemanticTokensLegend.MarkupElement, 0,
-                0, 2, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-            };
-
-            await AssertSemanticTokens(txt, expectedData, isRazor: true);
-        }
         [Fact]
         public async Task GetSemanticTokens_Razor_DoNotColorNonTagHelpersAsync()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -796,7 +796,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_Razor_DoNotColorNonHTMLElementsAsync()
         {
-            var txt = $"{Environment.NewLine}<p1 @test='Function'></p> ";
+            var txt = $"{Environment.NewLine}<p1 @test='Function'></p1> ";
             var expectedData = new List<int> {
                 1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,  //line, character pos, length, tokenType, modifier
                 0, 1, 2, RazorSemanticTokensLegend.MarkupElement, 0,
@@ -806,8 +806,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 0, 11, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
                 0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
                 0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 1, RazorSemanticTokensLegend.MarkupElement, 0,
-                0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
+                0, 1, 2, RazorSemanticTokensLegend.MarkupElement, 0,
+                0, 2, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
             };
 
             await AssertSemanticTokens(txt, expectedData, isRazor: true);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -703,7 +703,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
                 0, 1, 12, RazorSemanticTokensLegend.RazorDirective, 0,
                 1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 11, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
+                0, 1, 11, RazorSemanticTokensLegend.MarkupElement, 0,
                 0, 12, 1, RazorSemanticTokensLegend.RazorTransition, 0,
                 0, 1, 9, RazorSemanticTokensLegend.RazorDirectiveAttribute, 0,
                 0, 9, 1, RazorSemanticTokensLegend.RazorDirectiveColon, 0,
@@ -718,13 +718,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_Razor_DirectiveAttributesParametersAsync()
         {
-            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 @test:something='Function'></test1> ";
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<Component1 @test:something='Function'></Component1> ";
             var expectedData = new List<int> {
                 0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
                 0, 1, 12, RazorSemanticTokensLegend.RazorDirective, 0,
                 1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 5, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
-                0, 6, 1, RazorSemanticTokensLegend.RazorTransition, 0,
+                0, 1, 10, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
+                0, 11, 1, RazorSemanticTokensLegend.RazorTransition, 0,
                 0, 1, 4, RazorSemanticTokensLegend.RazorDirectiveAttribute, 0,
                 0, 4, 1, RazorSemanticTokensLegend.RazorDirectiveColon, 0,
                 0, 1, 9, RazorSemanticTokensLegend.RazorDirectiveAttribute, 0,
@@ -732,8 +732,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 0, 11, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
                 0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
                 0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 5, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
-                0, 5, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
+                0, 1, 10, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
+                0, 10, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
             };
 
             await AssertSemanticTokens(txt, expectedData, isRazor: true);
@@ -763,20 +763,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_Razor_DirectivesAsync()
         {
-            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 @test='Function'></test1> ";
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<Component1 @test='Function'></Component1> ";
             var expectedData = new List<int> {
                 0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
                 0, 1, 12, RazorSemanticTokensLegend.RazorDirective, 0,
                 1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 5, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
-                0, 6, 1, RazorSemanticTokensLegend.RazorTransition, 0,
+                0, 1, 10, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
+                0, 11, 1, RazorSemanticTokensLegend.RazorTransition, 0,
                 0, 1, 4, RazorSemanticTokensLegend.RazorDirectiveAttribute, 0,
                 0, 4, 1, RazorSemanticTokensLegend.MarkupOperator, 0,
                 0, 11, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
                 0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
                 0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
-                0, 1, 5, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
-                0, 5, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
+                0, 1, 10, RazorSemanticTokensLegend.RazorTagHelperElement, 0,
+                0, 10, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
             };
 
             await AssertSemanticTokens(txt, expectedData, isRazor: true);
@@ -793,6 +793,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             await AssertSemanticTokens(txt, expectedData, isRazor: true);
         }
 
+        [Fact]
+        public async Task GetSemanticTokens_Razor_DoNotColorNonHTMLElementsAsync()
+        {
+            var txt = $"{Environment.NewLine}<p1 @test='Function'></p> ";
+            var expectedData = new List<int> {
+                1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,  //line, character pos, length, tokenType, modifier
+                0, 1, 2, RazorSemanticTokensLegend.MarkupElement, 0,
+                0, 3, 1, RazorSemanticTokensLegend.RazorTransition, 0,
+                0, 1, 4, RazorSemanticTokensLegend.RazorDirectiveAttribute, 0,
+                0, 4, 1, RazorSemanticTokensLegend.MarkupOperator, 0,
+                0, 11, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
+                0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
+                0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
+                0, 1, 1, RazorSemanticTokensLegend.MarkupElement, 0,
+                0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
+            };
+
+            await AssertSemanticTokens(txt, expectedData, isRazor: true);
+        }
         [Fact]
         public async Task GetSemanticTokens_Razor_DoNotColorNonTagHelpersAsync()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -798,7 +798,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"{Environment.NewLine}<p @test='Function'></p> ";
             var expectedData = new List<int> {
-                1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
+                1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,  //line, character pos, length, tokenType, modifier
                 0, 1, 1, RazorSemanticTokensLegend.MarkupElement, 0,
                 0, 2, 1, RazorSemanticTokensLegend.RazorTransition, 0,
                 0, 1, 4, RazorSemanticTokensLegend.RazorDirectiveAttribute, 0,
@@ -818,7 +818,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         {
             var txt = $"@addTagHelpers *, TestAssembly{Environment.NewLine}<p></p> ";
             var expectedData = new List<int> {
-                0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0,
+                0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
                 1, 0, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
                 0, 1, 1, RazorSemanticTokensLegend.MarkupElement, 0,
                 0, 1, 1, RazorSemanticTokensLegend.MarkupTagDelimiter, 0,
@@ -862,8 +862,27 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             var txt = $"@code {{}}";
             var expectedData = new List<int>
             {
-                0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0,
+                0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
                 0, 1, 4, RazorSemanticTokensLegend.RazorDirective, 0
+            }.ToImmutableArray();
+
+            await AssertSemanticTokens(txt, expectedData, isRazor: true);
+        }
+
+        [Fact]
+        public async Task GetSemanticTokens_Razor_CodeDirectiveBodyAsync()
+        {
+            var txt = @$"@code {{
+    public void SomeMethod()
+    {{
+@DateTime.Now
+    }}
+}}";
+            var expectedData = new List<int>
+            {
+                0, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0, //line, character pos, length, tokenType, modifier
+                0, 1, 4, RazorSemanticTokensLegend.RazorDirective, 0,
+                3, 0, 1, RazorSemanticTokensLegend.RazorTransition, 0,
             }.ToImmutableArray();
 
             await AssertSemanticTokens(txt, expectedData, isRazor: true);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/27109.

We can't colorize portions of the tree that we don't visit, I thought I had caught everything in my previous pass but apparently things remain to be found.

Before and after in the issue.

Also fixes https://github.com/dotnet/aspnetcore/issues/27136 by semantically coloring the braces in these case.
There was no explicit reference to these items so I took advantage of the fact that no other RazorMetaCode (as far as I can find) should get Visited.