### PR TITLE
Fix Add Using Code Action with @page Directive

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -104,16 +105,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             var uri = request.TextDocument.Uri;
             var position = request.Position;
 
-            var formattingContext = FormattingContext.Create(uri, document, codeDocument, request.Options, new Range(position, position));
-            for (var i = 0; i < applicableProviders.Count; i++)
+            using (var formattingContext = FormattingContext.Create(uri, document, codeDocument, request.Options, new Range(position, position)))
             {
-                if (applicableProviders[i].TryResolveInsertion(position, formattingContext, out var textEdit, out var format))
+                for (var i = 0; i < applicableProviders.Count; i++)
                 {
-                    return new OnAutoInsertResponse()
+                    if (applicableProviders[i].TryResolveInsertion(position, formattingContext, out var textEdit, out var format))
                     {
-                        TextEdit = textEdit,
-                        TextEditFormat = format,
-                    };
+                        Debugger.Launch();
+                        return new OnAutoInsertResponse()
+                        {
+                            TextEdit = textEdit,
+                            TextEditFormat = format,
+                        };
+                    }
                 }
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -111,7 +110,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 {
                     if (applicableProviders[i].TryResolveInsertion(position, formattingContext, out var textEdit, out var format))
                     {
-                        Debugger.Launch();
                         return new OnAutoInsertResponse()
                         {
                             TextEdit = textEdit,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionResolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
@@ -229,7 +230,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         {
             if (node is RazorDirectiveSyntax directiveNode)
             {
-                return directiveNode.DirectiveDescriptor == ComponentPageDirective.Directive || directiveNode.DirectiveDescriptor == NamespaceDirective.Directive;
+                return directiveNode.DirectiveDescriptor == ComponentPageDirective.Directive ||
+                    directiveNode.DirectiveDescriptor == NamespaceDirective.Directive ||
+                    directiveNode.DirectiveDescriptor == PageDirective.Directive;
             }
             return false;
         }


### PR DESCRIPTION
### Summary of the changes
 - Added `using` to the `formattingContext` to avoid undisposed warning
 - Added `PageDirective` (in addition to `ComponentPageDirective`)
   - This is mainly for the `mvc` case where the `ComponentPageDirective` isn't recognized

### Before
![Original](https://user-images.githubusercontent.com/2008729/97918214-9d3f9380-1d0a-11eb-87b5-38df91ad2294.gif)

### After
![FixedUsingWithPage](https://user-images.githubusercontent.com/14852843/104235382-e30f8b00-5422-11eb-8e28-63559375b690.gif)


Fixes: https://github.com/dotnet/aspnetcore/issues/27453
