### PR TITLE
Ignore API Warnings in test shims

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Razor.Test.ComponentShim.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Razor.Test.ComponentShim.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <!-- Ignore API warnings in shim files -->
-    <NoWarn>$(NoWarn);IDE0044</NoWarn>
+    <!-- Ignore API warnings in shim projects -->
+    <NoWarn>$(NoWarn);IDE0044;IDE0060</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Razor.Test.ComponentShim.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Razor.Test.ComponentShim.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <!-- Ignore API warnings in shim files -->
+    <NoWarn>$(NoWarn);IDE0044</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib/Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib/Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- Ignore API warnings in shim projects -->
+    <NoWarn>$(NoWarn);IDE0060</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <!-- Ignore API warnings in shim files -->
-    <NoWarn>$(NoWarn);CA1822;CA1018</NoWarn>
+    <!-- Ignore API warnings in shim projects -->
+    <NoWarn>$(NoWarn);CA1822;CA1018;IDE0060</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <!-- Ignore API warnings in shim files -->
     <NoWarn>$(NoWarn);CA1822;CA1018</NoWarn>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <NoWarn>$(NoWarn);CA1822;CA1018</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <!-- Ignore API warnings in shim files -->
+    <NoWarn>$(NoWarn);CA1822;CA1018</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X/Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <!-- Ignore API warnings in shim files -->
-    <NoWarn>$(NoWarn);CA1822;CA1018</NoWarn>
+    <!-- Ignore API warnings in shim projects -->
+    <NoWarn>$(NoWarn);CA1822;CA1018;IDE0060</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Test.MvcShim.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Test.MvcShim.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-      <!-- Ignore API warnings in shim files -->
-    <NoWarn>$(NoWarn);CA1822;CA1018</NoWarn>
+    <!-- Ignore API warnings in shim projects -->
+    <NoWarn>$(NoWarn);CA1822;CA1018;IDE0060</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Test.MvcShim.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Test.MvcShim.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);net461</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+      <!-- Ignore API warnings in shim files -->
+    <NoWarn>$(NoWarn);CA1822;CA1018</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These warnings annoy my VS Error list because they're totally un-actionable in shim projects.