### PR TITLE
Don't send documentation in completion list responses.

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/CompletionListSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/CompletionListSerializationBenchmark.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Razor.Performance
 
             var completionQueryLocation = new SourceSpan(queryIndex, length: 0);
             var razorCompletionItems = componentCompletionProvider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, completionQueryLocation);
-            var completionList = RazorCompletionEndpoint.CreateLSPCompletionList(razorCompletionItems);
+            var completionList = RazorCompletionEndpoint.CreateLSPCompletionList(razorCompletionItems, new CompletionListCache());
             return completionList;
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemExtensions.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Razor.Completion;
-using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -11,11 +9,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
     internal static class CompletionItemExtensions
     {
-        private const string TagHelperElementDataKey = "_TagHelperElementData_";
-        private const string AttributeCompletionDataKey = "_AttributeCompletion_";
-        private const string RazorCompletionItemKind = "_CompletionItemKind_";
+        private const string ResultIdKey = "_resultId";
 
-        public static void SetRazorCompletionKind(this CompletionItem completion, RazorCompletionItemKind completionItemKind)
+        public static void SetCompletionListResultId(this CompletionItem completion, long resultId)
         {
             if (completion is null)
             {
@@ -23,86 +19,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             }
 
             var data = completion.Data ?? new JObject();
-            data[RazorCompletionItemKind] = JToken.FromObject(completionItemKind);
+            data[ResultIdKey] = resultId;
             completion.Data = data;
         }
 
-        public static bool TryGetRazorCompletionKind(this CompletionItem completion, out RazorCompletionItemKind completionItemKind)
+        public static bool TryGetCompletionListResultId(this CompletionItem completion, out int resultId)
         {
             if (completion is null)
             {
                 throw new ArgumentNullException(nameof(completion));
             }
 
-            if (completion.Data is JObject data && data.ContainsKey(RazorCompletionItemKind))
+            if (completion.Data is JObject data && data.ContainsKey(ResultIdKey))
             {
-                completionItemKind = data[RazorCompletionItemKind].ToObject<RazorCompletionItemKind>();
+                resultId = data[ResultIdKey].ToObject<int>();
                 return true;
             }
 
-            completionItemKind = default;
+            resultId = default;
             return false;
-        }
-
-        public static bool IsTagHelperElementCompletion(this CompletionItem completion)
-        {
-            if (completion.Data is JObject data && data.ContainsKey(TagHelperElementDataKey))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public static void SetDescriptionInfo(this CompletionItem completion, AggregateBoundElementDescription elementDescriptionInfo)
-        {
-            var data = completion.Data ?? new JObject();
-            data[TagHelperElementDataKey] = JObject.FromObject(elementDescriptionInfo);
-            completion.Data = data;
-        }
-
-        public static void SetDescriptionInfo(this CompletionItem completion, AggregateBoundAttributeDescription attributeDescriptionInfo)
-        {
-            if (completion is null)
-            {
-                throw new ArgumentNullException(nameof(completion));
-            }
-
-            if (attributeDescriptionInfo is null)
-            {
-                throw new ArgumentNullException(nameof(attributeDescriptionInfo));
-            }
-
-            var data = completion.Data ?? new JObject();
-            data[AttributeCompletionDataKey] = JObject.FromObject(attributeDescriptionInfo);
-            completion.Data = data;
-        }
-
-        public static AggregateBoundElementDescription GetElementDescriptionInfo(this CompletionItem completion)
-        {
-            if (completion.Data is JObject data && data.ContainsKey(TagHelperElementDataKey))
-            {
-                var descriptionInfo = data[TagHelperElementDataKey].ToObject<AggregateBoundElementDescription>();
-                return descriptionInfo;
-            }
-
-            return AggregateBoundElementDescription.Default;
-        }
-
-        public static AggregateBoundAttributeDescription GetAttributeDescriptionInfo(this CompletionItem completion)
-        {
-            if (completion is null)
-            {
-                throw new ArgumentNullException(nameof(completion));
-            }
-
-            if (completion.Data is JObject data && data.ContainsKey(AttributeCompletionDataKey))
-            {
-                var descriptionInfo = data[AttributeCompletionDataKey].ToObject<AggregateBoundAttributeDescription>();
-                return descriptionInfo;
-            }
-
-            return null;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListCache.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Razor.Completion;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal sealed class CompletionListCache
+    {
+        // Internal for testing
+        internal static readonly int MaxCacheSize = 3;
+
+        private readonly object _accessLock;
+        private readonly List<(long, IReadOnlyList<RazorCompletionItem>)> _resultIdToCompletionList;
+        private long _nextResultId;
+
+        public CompletionListCache()
+        {
+            _accessLock = new object();
+            _resultIdToCompletionList = new List<(long, IReadOnlyList<RazorCompletionItem>)>();
+        }
+
+        public long Set(IReadOnlyList<RazorCompletionItem> razorCompletionList)
+        {
+            if (razorCompletionList is null)
+            {
+                throw new ArgumentNullException(nameof(razorCompletionList));
+            }
+
+            lock (_accessLock)
+            {
+                // If cache exceeds maximum size, remove the oldest list in the cache
+                if (_resultIdToCompletionList.Count >= MaxCacheSize)
+                {
+                    _resultIdToCompletionList.RemoveAt(0);
+                }
+
+                var resultId = _nextResultId++;
+
+                _resultIdToCompletionList.Add((resultId, razorCompletionList));
+
+                // Return generated resultId so completion list can later be retrieved from cache
+                return resultId;
+            }
+        }
+
+        public bool TryGet(long resultId, out IReadOnlyList<RazorCompletionItem>? completionList)
+        {
+            lock (_accessLock)
+            {
+                // Search back -> front because the items in the back are the most recently added which are most frequently accessed.
+                for (var i = _resultIdToCompletionList.Count - 1; i >= 0; i--)
+                {
+                    var (cachedResultId, cachedCompletionList) = _resultIdToCompletionList[i];
+                    if (cachedResultId == resultId)
+                    {
+                        completionList = cachedCompletionList;
+                        return true;
+                    }
+                }
+
+                // A completion list associated with the given resultId was not found
+                completionList = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListCacheTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    public class CompletionListCacheTest
+    {
+        private CompletionListCache CompletionListCache { get; } = new CompletionListCache();
+
+        [Fact]
+        public void TryGet_SetCompletionList_ReturnsTrue()
+        {
+            // Arrange
+            var completionList = new RazorCompletionItem[1];
+            var resultId = CompletionListCache.Set(completionList);
+
+            // Act
+            var result = CompletionListCache.TryGet(resultId, out var retrievedCompletionList);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(completionList, retrievedCompletionList);
+        }
+
+        [Fact]
+        public void TryGet_UnknownCompletionList_ReturnsTrue()
+        {
+            // Act
+            var result = CompletionListCache.TryGet(1234, out var retrievedCompletionList);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(retrievedCompletionList);
+        }
+
+        [Fact]
+        public void TryGet_EvictedCompletionList_ReturnsFalse()
+        {
+            // Arrange
+            var initialCompletionList = new RazorCompletionItem[1];
+            var initialCompletionListResultId = CompletionListCache.Set(initialCompletionList);
+            for (var i = 0; i < CompletionListCache.MaxCacheSize; i++)
+            {
+                // We now fill the completion list cache up until its cache max so that the initial completion list we set gets evicted.
+                CompletionListCache.Set(new RazorCompletionItem[1]);
+            }
+
+            // Act
+            var result = CompletionListCache.TryGet(initialCompletionListResultId, out var retrievedCompletionList);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(retrievedCompletionList);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -1,24 +1,24 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language.Components;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor.Razor;
 using Moq;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
-using Microsoft.CodeAnalysis.Razor.Tooltip;
-using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
@@ -65,9 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.DisplayText, converted.FilterText);
             Assert.Equal(completionItem.DisplayText, converted.SortText);
             Assert.Null(converted.Detail);
-            Assert.Equal(description, converted.Documentation.String);
-            Assert.True(converted.TryGetRazorCompletionKind(out var convertedKind));
-            Assert.Equal(RazorCompletionItemKind.Directive, convertedKind);
+            Assert.Null(converted.Documentation);
         }
 
         [Fact]
@@ -99,7 +97,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var completionItem = DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem;
-            var description = completionItem.GetDirectiveCompletionDescription().Description;
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, out var converted);
@@ -112,10 +109,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.DisplayText, converted.FilterText);
             Assert.Equal(completionItem.DisplayText, converted.SortText);
             Assert.Null(converted.Detail);
-            Assert.Equal(description, converted.Documentation.String);
+            Assert.Null(converted.Documentation);
             Assert.NotNull(converted.Command);
-            Assert.True(converted.TryGetRazorCompletionKind(out var convertedKind));
-            Assert.Equal(RazorCompletionItemKind.Directive, convertedKind);
         }
 
         [Fact]
@@ -123,7 +118,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var completionItem = MarkupTransitionCompletionItemProvider.MarkupTransitionCompletionItem;
-            var description = completionItem.GetMarkupTransitionCompletionDescription().Description;
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, out var converted);
@@ -135,7 +129,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.DisplayText, converted.FilterText);
             Assert.Equal(completionItem.DisplayText, converted.SortText);
             Assert.Null(converted.Detail);
-            Assert.Equal(description, converted.Documentation.String);
+            Assert.Null(converted.Documentation);
             Assert.Equal(converted.CommitCharacters, completionItem.CommitCharacters);
         }
 
@@ -154,8 +148,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void TryConvert_DirectiveAttribute_ReturnsTrue()
         {
             // Arrange
-            var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, new [] { "=", ":" });
-            completionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
+            var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, new[] { "=", ":" });
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, out var converted);
@@ -170,8 +163,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
             Assert.Null(converted.Command);
-            Assert.True(converted.TryGetRazorCompletionKind(out var convertedKind));
-            Assert.Equal(RazorCompletionItemKind.DirectiveAttribute, convertedKind);
         }
 
         [Fact]
@@ -179,7 +170,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var completionItem = new RazorCompletionItem("format", "format", RazorCompletionItemKind.DirectiveAttributeParameter);
-            completionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, out var converted);
@@ -193,8 +183,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
             Assert.Null(converted.Command);
-            Assert.True(converted.TryGetRazorCompletionKind(out var convertedKind));
-            Assert.Equal(RazorCompletionItemKind.DirectiveAttributeParameter, convertedKind);
         }
 
         [Fact]
@@ -202,7 +190,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var completionItem = new RazorCompletionItem("format", "format", RazorCompletionItemKind.TagHelperElement);
-            completionItem.SetTagHelperElementDescriptionInfo(new AggregateBoundElementDescription(Array.Empty<BoundElementDescriptionInfo>()));
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, out var converted);
@@ -216,8 +203,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
             Assert.Null(converted.Command);
-            var descriptionInfo = completionItem.GetTagHelperElementDescriptionInfo();
-            Assert.NotNull(descriptionInfo);
         }
 
         [Fact]
@@ -225,7 +210,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var completionItem = new RazorCompletionItem("format", "format", RazorCompletionItemKind.TagHelperAttribute);
-            completionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, out var converted);
@@ -239,12 +223,46 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
             Assert.Null(converted.Command);
-            var descriptionInfo = completionItem.GetAttributeCompletionDescription();
-            Assert.NotNull(descriptionInfo);
         }
 
         [Fact]
-        public async Task Handle_DirectiveAttributeCompletion_ReturnsCompletionItemWithDocumentation()
+        public async Task Handle_Resolve_DirectiveCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var descriptionFactory = Mock.Of<TagHelperTooltipFactory>();
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, descriptionFactory, LoggerFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.Directive);
+            razorCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription("Test directive"));
+            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // Act
+            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_MarkupTransitionCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var descriptionFactory = Mock.Of<TagHelperTooltipFactory>();
+            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, descriptionFactory, LoggerFactory);
+            var razorCompletionItem = new RazorCompletionItem("@...", "@", RazorCompletionItemKind.MarkupTransition);
+            razorCompletionItem.SetMarkupTransitionCompletionDescription(new MarkupTransitionCompletionDescription("Test description"));
+            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // Act
+            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_DirectiveAttributeCompletion_ReturnsCompletionItemWithDocumentation()
         {
             // Arrange
             var descriptionFactory = new Mock<TagHelperTooltipFactory>();
@@ -256,9 +274,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             descriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
                 .Returns(true);
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, descriptionFactory.Object, LoggerFactory);
-            var completionItem = new CompletionItem();
-            completionItem.SetDescriptionInfo(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
-            completionItem.SetRazorCompletionKind(RazorCompletionItemKind.DirectiveAttribute);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttribute);
+            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
+            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
 
             // Act
             var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
@@ -268,7 +287,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public async Task Handle_DirectiveAttributeParameterCompletion_ReturnsCompletionItemWithDocumentation()
+        public async Task Handle_Resolve_DirectiveAttributeParameterCompletion_ReturnsCompletionItemWithDocumentation()
         {
             // Arrange
             var descriptionFactory = new Mock<TagHelperTooltipFactory>();
@@ -280,9 +299,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             descriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
                 .Returns(true);
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, descriptionFactory.Object, LoggerFactory);
-            var completionItem = new CompletionItem();
-            completionItem.SetDescriptionInfo(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
-            completionItem.SetRazorCompletionKind(RazorCompletionItemKind.DirectiveAttributeParameter);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttributeParameter);
+            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
+            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
 
             // Act
             var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
@@ -292,7 +312,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public async Task Handle_TagHelperElementCompletion_ReturnsCompletionItemWithDocumentation()
+        public async Task Handle_Resolve_TagHelperElementCompletion_ReturnsCompletionItemWithDocumentation()
         {
             // Arrange
             var descriptionFactory = new Mock<TagHelperTooltipFactory>();
@@ -304,8 +324,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             descriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), out markdown))
                 .Returns(true);
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, descriptionFactory.Object, LoggerFactory);
-            var completionItem = new CompletionItem();
-            completionItem.SetDescriptionInfo(AggregateBoundElementDescription.Default);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperElement);
+            razorCompletionItem.SetTagHelperElementDescriptionInfo(new AggregateBoundElementDescription(Array.Empty<BoundElementDescriptionInfo>()));
+            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
 
             // Act
             var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
@@ -315,20 +337,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public async Task Handle_TagHelperAttribute_ReturnsCompletionItemWithDocumentation()
+        public async Task Handle_Resolve_TagHelperAttribute_ReturnsCompletionItemWithDocumentation()
         {
             // Arrange
             var descriptionFactory = new Mock<TagHelperTooltipFactory>();
-            var markdown = new MarkupContent{
+            var markdown = new MarkupContent
+            {
                 Kind = MarkupKind.Markdown,
                 Value = "Some Markdown"
             };
             descriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
                 .Returns(true);
             var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, descriptionFactory.Object, LoggerFactory);
-            var completionItem = new CompletionItem();
-            completionItem.SetDescriptionInfo(AggregateBoundAttributeDescription.Default);
-            completionItem.SetRazorCompletionKind(RazorCompletionItemKind.TagHelperAttribute);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperAttribute);
+            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
+            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
 
             // Act
             var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
@@ -338,7 +362,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public async Task Handle_NonTagHelperCompletion_Noops()
+        public async Task Handle_Resolve_NonTagHelperCompletion_Noops()
         {
             // Arrange
             var descriptionFactory = new Mock<TagHelperTooltipFactory>();
@@ -357,81 +381,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             // Assert
             Assert.Null(newCompletionItem.Documentation);
-        }
-
-        [Fact]
-        public void CanResolve_DirectiveAttributeCompletion_ReturnsTrue()
-        {
-            // Arrange
-            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperTooltipFactory, LoggerFactory);
-            var completionItem = new CompletionItem();
-            completionItem.SetRazorCompletionKind(RazorCompletionItemKind.DirectiveAttribute);
-
-            // Act
-            var result = completionEndpoint.CanResolve(completionItem);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void CanResolve_DirectiveAttributeParameterCompletion_ReturnsTrue()
-        {
-            // Arrange
-            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperTooltipFactory, LoggerFactory);
-            var completionItem = new CompletionItem();
-            completionItem.SetRazorCompletionKind(RazorCompletionItemKind.DirectiveAttributeParameter);
-
-            // Act
-            var result = completionEndpoint.CanResolve(completionItem);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void CanResolve_TagHelperElementCompletion_ReturnsTrue()
-        {
-            // Arrange
-            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperTooltipFactory, LoggerFactory);
-            var completionItem = new CompletionItem();
-            completionItem.SetDescriptionInfo(AggregateBoundElementDescription.Default);
-
-            // Act
-            var result = completionEndpoint.CanResolve(completionItem);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void CanResolve_TagHelperAttribute_ReturnsTrue()
-        {
-            // Arrange
-            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperTooltipFactory, LoggerFactory);
-            var completionItem = new CompletionItem();
-            completionItem.SetDescriptionInfo(AggregateBoundAttributeDescription.Default);
-            completionItem.SetRazorCompletionKind(RazorCompletionItemKind.TagHelperAttribute);
-
-            // Act
-            var result = completionEndpoint.CanResolve(completionItem);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void CanResolve_NonTagHelperCompletion_ReturnsFalse()
-        {
-            // Arrange
-            var completionEndpoint = new RazorCompletionEndpoint(Dispatcher, EmptyDocumentResolver, CompletionFactsService, TagHelperTooltipFactory, LoggerFactory);
-            var completionItem = new CompletionItem();
-
-            // Act
-            var result = completionEndpoint.CanResolve(completionItem);
-
-            // Assert
-            Assert.False(result);
         }
 
         // This is more of an integration test to validate that all the pieces work together
@@ -459,7 +408,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         // This is more of an integration test to validate that all the pieces work together
         [Fact]
-        public async Task Handle_ResolvesDirectiveCompletionItems()
+        public async Task Handle_ProvidesDirectiveCompletionItems()
         {
             // Arrange
             var documentPath = "C:/path/to/document.cshtml";
@@ -485,7 +434,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         // This is more of an integration test to validate that all the pieces work together
         [Fact]
-        public async Task Handle_ResolvesTagHelperElementCompletionItems()
+        public async Task Handle_ProvidesTagHelperElementCompletionItems()
         {
             // Arrange
             var documentPath = "C:/path/to/document.cshtml";
@@ -513,7 +462,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         // This is more of an integration test to validate that all the pieces work together
         [Fact]
-        public async Task Handle_ResolvesTagHelperAttributeItems()
+        public async Task Handle_ProvidesTagHelperAttributeItems()
         {
             // Arrange
             var documentPath = "C:/path/to/document.cshtml";


### PR DESCRIPTION
- We now only send completion item documentation when a completion item is resolved.
  - To accomplish this we now cache our Razor completion lists between responses and hold up to 3 in memory at a time. When a completion resolve request comes in we'll cross-check the completion item with our completion list cache and if we can find it we'll resolve/calculate the documentation information for that completion item.
- Expanded our pre-existing RazorCompletionEndpointTest's to encompass the new functionality
- Added separate CompletionListCache tests.

Baseline:
|                                              Method |      Mean |     Error |    StdDev |   Op/s |     Gen 0 |     Gen 1 |    Gen 2 | Allocated |
|---------------------------------------------------- |----------:|----------:|----------:|-------:|----------:|----------:|---------:|----------:|
| 'Component Completion List Roundtrip Serialization' | 29.436 ms | 0.5058 ms | 0.4731 ms |  33.97 | 2187.5000 | 1187.5000 | 250.0000 |   13.5 MB |
|           'Component Completion List Serialization' |  6.408 ms | 0.0853 ms | 0.0798 ms | 156.06 |  296.8750 |  242.1875 | 234.3750 |    2.3 MB |
|         'Component Completion List Deserialization' | 24.167 ms | 0.4655 ms | 0.6526 ms |  41.38 | 1968.7500 |  906.2500 | 125.0000 |  11.21 MB |

After:
|                                              Method |      Mean |     Error |    StdDev |   Op/s |     Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
|---------------------------------------------------- |----------:|----------:|----------:|-------:|----------:|---------:|--------:|-----------:|
| 'Component Completion List Roundtrip Serialization' | 15.999 ms | 0.3149 ms | 0.4714 ms |  62.50 | 1031.2500 | 531.2500 | 31.2500 | 6514.11 KB |
|           'Component Completion List Serialization' |  2.301 ms | 0.0286 ms | 0.0268 ms | 434.66 |  128.9063 |  85.9375 | 62.5000 |  811.62 KB |
|         'Component Completion List Deserialization' | 11.451 ms | 0.0883 ms | 0.0690 ms |  87.33 |  921.8750 | 437.5000 |       - | 5702.63 KB |

*Roundtrip op/s improvement:* 1.84x faster
*Serialization op/s improvement:* 2.79x faster
*Deserialization op/s improvement:* 2.11x faster

Fixes dotnet/aspnetcore#29096