### PR TITLE
Fix Component End-Tag Completion At End of Document

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -244,7 +244,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // of the document.
             if (classifiedSpans.Count != 0 && absoluteIndex == documentLength)
             {
-                return GetLanguageFromClassifiedSpan(classifiedSpans.Last());
+                var lastClassifiedSpan = classifiedSpans.Last();
+                return GetLanguageFromClassifiedSpan(lastClassifiedSpan);
             }
 
             // Default to Razor

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -178,7 +178,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var syntaxTree = codeDocument.GetSyntaxTree();
             var classifiedSpans = syntaxTree.GetClassifiedSpans();
             var tagHelperSpans = syntaxTree.GetTagHelperSpans();
-            var languageKind = GetLanguageKindCore(classifiedSpans, tagHelperSpans, originalIndex);
+            var documentLength = codeDocument.GetSourceText().Length;
+            var languageKind = GetLanguageKindCore(classifiedSpans, tagHelperSpans, originalIndex, documentLength);
 
             return languageKind;
         }
@@ -187,7 +188,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         internal static RazorLanguageKind GetLanguageKindCore(
             IReadOnlyList<ClassifiedSpanInternal> classifiedSpans,
             IReadOnlyList<TagHelperSpanInternal> tagHelperSpans,
-            int absoluteIndex)
+            int absoluteIndex,
+            int documentLength)
         {
             for (var i = 0; i < classifiedSpans.Count; i++)
             {
@@ -211,18 +213,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                             }
                         }
 
-                        // Overlaps with request
-                        switch (classifiedSpan.SpanKind)
-                        {
-                            case SpanKindInternal.Markup:
-                                return RazorLanguageKind.Html;
-                            case SpanKindInternal.Code:
-                                return RazorLanguageKind.CSharp;
-                        }
-
-                        // Content type was non-C# or Html or we couldn't find a classified span overlapping the request position.
-                        // All other classified span kinds default back to Razor
-                        return RazorLanguageKind.Razor;
+                        return GetLanguageFromClassifiedSpan(classifiedSpan);
                     }
                 }
             }
@@ -249,8 +240,29 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 }
             }
 
+            // Use the language of the last classified span if we're at the end
+            // of the document.
+            if (classifiedSpans.Count != 0 && absoluteIndex == documentLength)
+            {
+                return GetLanguageFromClassifiedSpan(classifiedSpans.Last());
+            }
+
             // Default to Razor
             return RazorLanguageKind.Razor;
+
+            static RazorLanguageKind GetLanguageFromClassifiedSpan(ClassifiedSpanInternal classifiedSpan)
+            {
+                // Overlaps with request
+                return classifiedSpan.SpanKind switch
+                {
+                    SpanKindInternal.Markup => RazorLanguageKind.Html,
+                    SpanKindInternal.Code => RazorLanguageKind.CSharp,
+
+                    // Content type was non-C# or Html or we couldn't find a classified span overlapping the request position.
+                    // All other classified span kinds default back to Razor
+                    _ => RazorLanguageKind.Razor,
+                };
+            }
         }
 
         private bool TryMapFromProjectedDocumentRangeStrict(RazorCodeDocument codeDocument, Range projectedRange, out Range originalRange)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -619,7 +619,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text, new[] { descriptor.Build() });
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 32 + Environment.NewLine.Length);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 32 + Environment.NewLine.Length, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, languageKind);
@@ -632,11 +632,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
             descriptor.TagMatchingRule(rule => rule.TagName = "test");
             descriptor.SetTypeName("TestTagHelper");
-            var text = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test></test>";
+            var text = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test></test>@DateTime.Now";
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text, new[] { descriptor.Build() });
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 42 + Environment.NewLine.Length);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 42 + Environment.NewLine.Length, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Razor, languageKind);
@@ -659,7 +659,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text, new[] { descriptor.Build() });
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 46 + Environment.NewLine.Length);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 46 + Environment.NewLine.Length, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -673,7 +673,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 5);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 5, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -687,7 +687,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 5);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 5, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, languageKind);
@@ -701,10 +701,39 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, text.Length + 1);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, text.Length + 1, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Razor, languageKind);
+        }
+
+        [Fact]
+        public void GetLanguageKindCore_GetsLastClassifiedSpanLanguageIfAtEndOfDocument()
+        {
+            // Arrange
+            var text = $"<strong>Something</strong>{Environment.NewLine}<App>";
+            var classifiedSpans = new List<ClassifiedSpanInternal>()
+            {
+               new ClassifiedSpanInternal(
+                   new SourceSpan(0, 0),
+                   blockSpan: new SourceSpan(absoluteIndex: 0, lineIndex: 0, characterIndex: 0, length: text.Length),
+                   SpanKindInternal.Transition,
+                   blockKind: default,
+                   acceptedCharacters: default),
+               new ClassifiedSpanInternal(
+                   new SourceSpan(0, 26),
+                   blockSpan: default,
+                   SpanKindInternal.Markup,
+                   blockKind: default,
+                   acceptedCharacters: default)
+            };
+            var tagHelperSpans = Array.Empty<TagHelperSpanInternal>();
+
+            // Act
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, text.Length, text.Length);
+
+            // Assert
+            Assert.Equal(RazorLanguageKind.Html, languageKind);
         }
 
         [Fact]
@@ -715,7 +744,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, text.Length);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, text.Length, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, languageKind);
@@ -729,7 +758,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, text.Length);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, text.Length, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -743,7 +772,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 2);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 2, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -757,7 +786,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 12);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 12, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -771,7 +800,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 2);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 2, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -785,7 +814,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 4);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 4, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -799,7 +828,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 1);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 1, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -813,7 +842,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 3);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 3, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, languageKind);
@@ -827,13 +856,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text);
 
             // Act
-            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 2);
+            var languageKind = DefaultRazorDocumentMappingService.GetLanguageKindCore(classifiedSpans, tagHelperSpans, 2, text.Length);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, languageKind);
         }
 
-        private (IReadOnlyList<ClassifiedSpanInternal> classifiedSpans, IReadOnlyList<TagHelperSpanInternal> tagHelperSpans) GetClassifiedSpans(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
+        private static (IReadOnlyList<ClassifiedSpanInternal> classifiedSpans, IReadOnlyList<TagHelperSpanInternal> tagHelperSpans) GetClassifiedSpans(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
         {
             var codeDocument = CreateCodeDocument(text, tagHelpers);
             var syntaxTree = codeDocument.GetSyntaxTree();
@@ -844,7 +873,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
         {
-            tagHelpers = tagHelpers ?? Array.Empty<TagHelperDescriptor>();
+            tagHelpers ??= Array.Empty<TagHelperDescriptor>();
             var sourceDocument = TestRazorSourceDocument.Create(text);
             var projectEngine = RazorProjectEngine.Create(builder => { });
             var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, "mvc", Array.Empty<RazorSourceDocument>(), tagHelpers);


### PR DESCRIPTION
### Summary of the changes
- End of document didn't have an associated classified span. We now apply the last classified span when asked to determine the language of the end of the document.
  -  Further discussion in the issue https://github.com/dotnet/aspnetcore/issues/23907

![FixComponentAutoComplete](https://user-images.githubusercontent.com/14852843/104368981-d2c2e300-54ea-11eb-8b36-3df6e1e4d0f5.gif)

[note; ignore the colorization, local issue]


Fixes: https://github.com/dotnet/aspnetcore/issues/23907

