### PR TITLE
Support overlapping Semantic tokens

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
@@ -30,10 +30,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                 return 1;
             }
 
-            Debug.Assert(Range.Start.CompareTo(other.Range.Start) == 0 || !Range.OverlapsWith(other.Range), $"{this} overlapped with {other}");
-
-            // Since overlapping SemanticRanges are STRICTLY FORBIDDEN we need only compare the starts 
-            return Range.Start.CompareTo(other.Range.Start);
+            var startCompare = Range.Start.CompareTo(other.Range.Start);
+            return startCompare != 0 ? startCompare : Range.End.CompareTo(other.Range.End);
         }
 
         public override string ToString()


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/29203.

Since the SemanticTokens spec has changed to (depending on your options) allow overlapping tokens I'm modifying this so that we handle that case instead of `Debug.Assert`'ing.