### PR TITLE
E2E Logging For C# Pull Based Diagnostics & HTML Interceptor

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLogWriter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLogWriter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
         private string _logFile;
         private bool _disposed;
 
-        public DefaultFeedbackFileLogWriter(FeedbackLogDirectoryProvider feedbackLogDirectoryProvider)
+        public DefaultFeedbackFileLogWriter(FeedbackLogDirectoryProvider feedbackLogDirectoryProvider, string logFileIdentifier)
         {
             if (feedbackLogDirectoryProvider is null)
             {
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
             _writeToLock = new object();
             _feedbackLogDirectoryProvider = feedbackLogDirectoryProvider;
 
-            InitializeLogFile();
+            InitializeLogFile(logFileIdentifier);
 
             _logWriterTask = Task.Run(WriteToLogAsync);
         }
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
             }
         }
 
-        private void InitializeLogFile()
+        private void InitializeLogFile(string logFileIdentifier)
         {
             var logDirectory = _feedbackLogDirectoryProvider.GetDirectory();
 
@@ -100,7 +100,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
             {
                 var fileName = string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0:yyyyMMdd_HHmmss}{1}.log",
+                    "{0}_{1:yyyyMMdd_HHmmss}{2}.log",
+                    logFileIdentifier,
                     DateTime.UtcNow,
                     index == 0 ? string.Empty : "." + index);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/DefaultFeedbackFileLoggerProviderFactory.cs
@@ -30,13 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
         {
             lock (_creationLock)
             {
-                if (_currentFileLogWriter != null)
-                {
-                    // Dispose last log writer so we can start a new session. Technically only one should only ever be active at a time.
-                    _currentFileLogWriter.Dispose();
-                }
-
-                _currentFileLogWriter = new DefaultFeedbackFileLogWriter(_feedbackLogDirectoryProvider);
+                _currentFileLogWriter ??= new DefaultFeedbackFileLogWriter(_feedbackLogDirectoryProvider);
                 var provider = new FeedbackFileLoggerProvider(_currentFileLogWriter);
 
                 return provider;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProvider.cs
@@ -2,15 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.Composition;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
 {
+    [Export(typeof(ILoggerProvider))]
     internal class FeedbackFileLoggerProvider : ILoggerProvider
     {
         // Internal for testing
         internal const string OmniSharpFrameworkCategoryPrefix = "OmniSharp.Extensions.LanguageServer.Server";
         private const string RazorLanguageServerPrefix = "Microsoft.AspNetCore.Razor.LanguageServer";
+        private const string VSLanguageServerClientPrefix = "Microsoft.VisualStudio.LanguageServerClient.Razor";
         private readonly FeedbackFileLogWriter _feedbackFileLogWriter;
         private readonly ILogger _noopLogger;
 
@@ -43,6 +46,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
                 // Reduce the size of the Razor language server categories. We assume nearly all logs here are going to be from the server and thus limiting
                 // the amount of noise they emit will be valuable for readability and will ultimately reduce the size of the log on the users box.
                 categoryName = categoryName.Substring(RazorLanguageServerPrefix.Length + 1 /* . */);
+            }
+
+            if (categoryName.StartsWith(VSLanguageServerClientPrefix, StringComparison.Ordinal))
+            {
+                categoryName = categoryName.Substring(VSLanguageServerClientPrefix.Length + 1 /* . */);
             }
 
             return new FeedbackFileLogger(categoryName, _feedbackFileLogWriter);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProvider.cs
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.ComponentModel.Composition;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
 {
-    [Export(typeof(ILoggerProvider))]
     internal class FeedbackFileLoggerProvider : ILoggerProvider
     {
         // Internal for testing

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
         /// <remarks>When VS looks for MEF exports it has to load assembly types that correspond to a contracts signature. SO in our case we used to
         /// return a <see cref="FeedbackFileLoggerProvider"/>; however, that resulted in MEF needing to load the ILoggerProvider (what it implements)
         /// assembly which was Microsoft.Extensions.Logging.Abstractions. This wasn't great because it required MEF to then load that assembly in order
-        /// to understand this type. Returning <c>object</c> works around requiring the logging aseembly.</remarks>
+        /// to understand this type. Returning <c>object</c> works around requiring the logging assembly.</remarks>
         /// <returns>A created <see cref="FeedbackFileLoggerProvider"/>.</returns>
         public abstract object GetOrCreate();
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactory.cs
@@ -12,7 +12,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
         /// return a <see cref="FeedbackFileLoggerProvider"/>; however, that resulted in MEF needing to load the ILoggerProvider (what it implements)
         /// assembly which was Microsoft.Extensions.Logging.Abstractions. This wasn't great because it required MEF to then load that assembly in order
         /// to understand this type. Returning <c>object</c> works around requiring the logging assembly.</remarks>
+        /// <param name="logFileIdentifier">An identifier to prefix the log file name with.</param>
         /// <returns>A created <see cref="FeedbackFileLoggerProvider"/>.</returns>
-        public abstract object GetOrCreate();
+        public abstract object GetOrCreate(string logFileIdentifier);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactoryBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/FeedbackFileLoggerProviderFactoryBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
             _creationLock = new object();
         }
 
-        public override object GetOrCreate()
+        public override object GetOrCreate(string logFileIdentifier)
         {
             lock (_creationLock)
             {
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
                     _currentFileLogWriter.Dispose();
                 }
 
-                _currentFileLogWriter = new DefaultFeedbackFileLogWriter(_feedbackLogDirectoryProvider);
+                _currentFileLogWriter = new DefaultFeedbackFileLogWriter(_feedbackLogDirectoryProvider, logFileIdentifier);
                 var provider = new FeedbackFileLoggerProvider(_currentFileLogWriter);
 
                 return provider;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/HTMLCSharpLanguageServerFeedbackFileLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/HTMLCSharpLanguageServerFeedbackFileLoggerProvider.cs
@@ -11,6 +11,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
     [Export(typeof(HTMLCSharpLanguageServerFeedbackFileLoggerProvider))]
     internal class HTMLCSharpLanguageServerFeedbackFileLoggerProvider : ILoggerProvider
     {
+        private static readonly string LogFileIdentifier = "HTMLCSharpLanguageServer";
+
         private readonly FeedbackFileLoggerProvider _loggerProvider;
 
         [ImportingConstructor]
@@ -22,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            _loggerProvider = (FeedbackFileLoggerProvider)loggerFactory.GetOrCreate();
+            _loggerProvider = (FeedbackFileLoggerProvider)loggerFactory.GetOrCreate(LogFileIdentifier);
         }
 
         public ILogger CreateLogger(string categoryName) => _loggerProvider.CreateLogger(categoryName);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/HTMLCSharpLanguageServerFeedbackFileLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/HTMLCSharpLanguageServerFeedbackFileLoggerProvider.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    [Shared]
+    [Export(typeof(HTMLCSharpLanguageServerFeedbackFileLoggerProvider))]
+    internal class HTMLCSharpLanguageServerFeedbackFileLoggerProvider : ILoggerProvider
+    {
+        private readonly FeedbackFileLoggerProvider _loggerProvider;
+
+        [ImportingConstructor]
+        public HTMLCSharpLanguageServerFeedbackFileLoggerProvider(
+            HTMLCSharpLanguageServerFeedbackFileLoggerProviderFactory loggerFactory)
+        {
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _loggerProvider = (FeedbackFileLoggerProvider)loggerFactory.GetOrCreate();
+        }
+
+        public ILogger CreateLogger(string categoryName) => _loggerProvider.CreateLogger(categoryName);
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/HTMLCSharpLanguageServerFeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/HTMLCSharpLanguageServerFeedbackFileLoggerProviderFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Composition;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    [Shared]
+    [Export(typeof(HTMLCSharpLanguageServerFeedbackFileLoggerProviderFactory))]
+    internal class HTMLCSharpLanguageServerFeedbackFileLoggerProviderFactory : FeedbackFileLoggerProviderFactoryBase
+    {
+        [ImportingConstructor]
+        public HTMLCSharpLanguageServerFeedbackFileLoggerProviderFactory(FeedbackLogDirectoryProvider feedbackLogDirectoryProvider)
+            : base(feedbackLogDirectoryProvider)
+        {
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/RazorLanguageServerFeedbackFileLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/RazorLanguageServerFeedbackFileLoggerProviderFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Composition;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
+{
+    [Shared]
+    [Export(typeof(RazorLanguageServerFeedbackFileLoggerProviderFactory))]
+    internal class RazorLanguageServerFeedbackFileLoggerProviderFactory : FeedbackFileLoggerProviderFactoryBase
+    {
+        [ImportingConstructor]
+        public RazorLanguageServerFeedbackFileLoggerProviderFactory(FeedbackLogDirectoryProvider feedbackLogDirectoryProvider)
+            : base(feedbackLogDirectoryProvider)
+        {
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -7,8 +7,10 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
@@ -21,13 +23,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         private readonly LSPDocumentManager _documentManager;
         private readonly LSPDocumentSynchronizer _documentSynchronizer;
         private readonly LSPDiagnosticsTranslator _diagnosticsProvider;
+        private readonly ILogger _logger;
 
         [ImportingConstructor]
         public DocumentPullDiagnosticsHandler(
             LSPRequestInvoker requestInvoker,
             LSPDocumentManager documentManager,
             LSPDocumentSynchronizer documentSynchronizer,
-            LSPDiagnosticsTranslator diagnosticsProvider)
+            LSPDiagnosticsTranslator diagnosticsProvider,
+            FeedbackFileLoggerProviderFactory loggerFactory)
         {
             if (requestInvoker is null)
             {
@@ -49,10 +53,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(diagnosticsProvider));
             }
 
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
             _requestInvoker = requestInvoker;
             _documentManager = documentManager;
             _documentSynchronizer = documentSynchronizer;
             _diagnosticsProvider = diagnosticsProvider;
+
+            var loggerProvider = (FeedbackFileLoggerProvider)loggerFactory.GetOrCreate();
+            _logger = loggerProvider.CreateLogger(nameof(DocumentPullDiagnosticsHandler));
         }
 
         // Internal for testing
@@ -70,11 +82,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
+                _logger.LogInformation($"Failed to find document {request.TextDocument.Uri}.");
                 return null;
             }
 
             if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
             {
+                _logger.LogInformation($"Failed to find virtual C# document for {request.TextDocument.Uri}.");
                 return null;
             }
 
@@ -84,6 +98,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(false);
             if (!synchronized)
             {
+                _logger.LogInformation($"Failed to synchronize document {csharpDoc.Uri}.");
+
                 // Could not synchronize, report nothing changed
                 return new DiagnosticReport[]
                 {
@@ -104,6 +120,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 PreviousResultId = request.PreviousResultId
             };
 
+            _logger.LogInformation($"Requesting document pull diagnostics for {csharpDoc.Uri} with previous result Id of {request.PreviousResultId}.");
+
             // End goal is to transition this from ReinvokeRequestOnMultipleServersAsync -> ReinvokeRequestOnServerAsync
             // We can't do this right now as we don't have the ability to specify the language client name we'd like to make the call out to
             // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1246135
@@ -113,10 +131,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 referenceParams,
                 cancellationToken).ConfigureAwait(false);
 
-            var result = resultsFromAllLanguageServers.SelectMany(l => l).ToArray();
+            var results = resultsFromAllLanguageServers.SelectMany(l => l).ToArray();
+
+            _logger.LogInformation($"Received {results?.Length} diagnostic reports.");
 
             var processedResults = await RemapDocumentDiagnosticsAsync(
-                result,
+                results,
                 request.TextDocument.Uri,
                 cancellationToken).ConfigureAwait(false);
 
@@ -149,9 +169,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 // Check if there are any diagnostics in this report
                 if (diagnosticReport?.Diagnostics?.Any() != true)
                 {
+                    _logger.LogInformation("Diagnostic report contained no diagnostics.");
                     mappedDiagnosticReports.Add(diagnosticReport);
                     continue;
                 }
+
+                _logger.LogInformation($"Requesting processing of {diagnosticReport.Diagnostics.Length} diagnostics.");
 
                 var processedDiagnostics = await _diagnosticsProvider.TranslateAsync(
                     RazorLanguageKind.CSharp,
@@ -163,12 +186,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 if (!_documentManager.TryGetDocument(razorDocumentUri, out var documentSnapshot) ||
                     documentSnapshot.Version != processedDiagnostics.HostDocumentVersion)
                 {
+                    _logger.LogInformation($"Document version mismatch, discarding {diagnosticReport.Diagnostics.Length} diagnostics.");
+
                     // We choose to discard diagnostics in this case & report nothing changed.
                     diagnosticReport.Diagnostics = null;
                     mappedDiagnosticReports.Add(diagnosticReport);
                     continue;
                 }
 
+                _logger.LogInformation($"Processed {processedDiagnostics.Diagnostics.Length} diagnostics.");
                 diagnosticReport.Diagnostics = processedDiagnostics.Diagnostics;
 
                 mappedDiagnosticReports.Add(diagnosticReport);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     continue;
                 }
 
-                _logger.LogInformation($"Processed {processedDiagnostics.Diagnostics.Length} diagnostics.");
+                _logger.LogInformation($"Returning {processedDiagnostics.Diagnostics.Length} diagnostics.");
                 diagnosticReport.Diagnostics = processedDiagnostics.Diagnostics;
 
                 mappedDiagnosticReports.Add(diagnosticReport);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             LSPDocumentManager documentManager,
             LSPDocumentSynchronizer documentSynchronizer,
             LSPDiagnosticsTranslator diagnosticsProvider,
-            FeedbackFileLoggerProviderFactory loggerFactory)
+            HTMLCSharpLanguageServerFeedbackFileLoggerProvider loggerProvider)
         {
             if (requestInvoker is null)
             {
@@ -53,9 +53,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(diagnosticsProvider));
             }
 
-            if (loggerFactory == null)
+            if (loggerProvider == null)
             {
-                throw new ArgumentNullException(nameof(loggerFactory));
+                throw new ArgumentNullException(nameof(loggerProvider));
             }
 
             _requestInvoker = requestInvoker;
@@ -63,7 +63,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             _documentSynchronizer = documentSynchronizer;
             _diagnosticsProvider = diagnosticsProvider;
 
-            var loggerProvider = (FeedbackFileLoggerProvider)loggerFactory.GetOrCreate();
             _logger = loggerProvider.CreateLogger(nameof(DocumentPullDiagnosticsHandler));
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             //
             // This'll need to be revisited based on preferences with flickering vs lingering.
 
-            _logger.LogInformation($"Processed {processedDiagnostics.Diagnostics.Length} diagnostics.");
+            _logger.LogInformation($"Returning {processedDiagnostics.Diagnostics.Length} diagnostics.");
             diagnosticParams.Diagnostics = processedDiagnostics.Diagnostics;
 
             return CreateResponse(diagnosticParams);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             cancellationToken.ThrowIfCancellationRequested();
             var diagnosticParams = token.ToObject<VSPublishDiagnosticParams>();
 
-            if (diagnosticParams is null)
+            if (diagnosticParams?.Uri is null)
             {
                 throw new ArgumentException("Conversion of token failed.");
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -6,9 +6,11 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.MessageInterception;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
 using Newtonsoft.Json.Linq;
 
@@ -20,11 +22,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         private readonly LSPDocumentManager _documentManager;
         private readonly LSPDiagnosticsTranslator _diagnosticsProvider;
+        private readonly ILogger _logger;
 
         [ImportingConstructor]
         public RazorHtmlPublishDiagnosticsInterceptor(
             LSPDocumentManager documentManager,
-            LSPDiagnosticsTranslator diagnosticsProvider)
+            LSPDiagnosticsTranslator diagnosticsProvider,
+            FeedbackFileLoggerProviderFactory loggerFactory)
         {
             if (documentManager is null)
             {
@@ -36,8 +40,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(diagnosticsProvider));
             }
 
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
             _documentManager = documentManager;
             _diagnosticsProvider = diagnosticsProvider;
+
+            var loggerProvider = (FeedbackFileLoggerProvider)loggerFactory.GetOrCreate();
+            _logger = loggerProvider.CreateLogger(nameof(RazorHtmlPublishDiagnosticsInterceptor));
         }
 
         public override async Task<InterceptionResult> ApplyChangesAsync(JToken token, string containedLanguageName, CancellationToken cancellationToken)
@@ -49,6 +61,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             cancellationToken.ThrowIfCancellationRequested();
             var diagnosticParams = token.ToObject<VSPublishDiagnosticParams>();
+
+            _logger.LogInformation($"Received HTML Publish diagnostic request for {diagnosticParams.Uri} with {diagnosticParams.Diagnostics.Length} diagnostics.");
 
             if (diagnosticParams is null)
             {
@@ -72,18 +86,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (!_documentManager.TryGetDocument(razorDocumentUri, out var razorDocumentSnapshot))
             {
+                _logger.LogInformation($"Failed to find document {razorDocumentUri}.");
                 return CreateEmptyDiagnosticsResponse(diagnosticParams);
             }
 
             if (!razorDocumentSnapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var htmlDocumentSnapshot) ||
                 !htmlDocumentSnapshot.Uri.Equals(htmlDocumentUri))
             {
+                _logger.LogInformation($"Failed to find virtual HTML document {htmlDocumentUri}.");
                 return CreateEmptyDiagnosticsResponse(diagnosticParams);
             }
 
             // Return early if there aren't any diagnostics to process
             if (diagnosticParams.Diagnostics?.Any() != true)
             {
+                _logger.LogInformation("No diagnostics to process.");
                 return CreateResponse(diagnosticParams);
             }
 
@@ -100,6 +117,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             //
             // This'll need to be revisited based on preferences with flickering vs lingering.
 
+            _logger.LogInformation($"Processed {processedDiagnostics.Diagnostics.Length} diagnostics.");
             diagnosticParams.Diagnostics = processedDiagnostics.Diagnostics;
 
             return CreateResponse(diagnosticParams);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public RazorHtmlPublishDiagnosticsInterceptor(
             LSPDocumentManager documentManager,
             LSPDiagnosticsTranslator diagnosticsProvider,
-            FeedbackFileLoggerProviderFactory loggerFactory)
+            HTMLCSharpLanguageServerFeedbackFileLoggerProvider loggerProvider)
         {
             if (documentManager is null)
             {
@@ -40,15 +40,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(diagnosticsProvider));
             }
 
-            if (loggerFactory == null)
+            if (loggerProvider == null)
             {
-                throw new ArgumentNullException(nameof(loggerFactory));
+                throw new ArgumentNullException(nameof(loggerProvider));
             }
 
             _documentManager = documentManager;
             _diagnosticsProvider = diagnosticsProvider;
 
-            var loggerProvider = (FeedbackFileLoggerProvider)loggerFactory.GetOrCreate();
             _logger = loggerProvider.CreateLogger(nameof(RazorHtmlPublishDiagnosticsInterceptor));
         }
 
@@ -62,12 +61,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             cancellationToken.ThrowIfCancellationRequested();
             var diagnosticParams = token.ToObject<VSPublishDiagnosticParams>();
 
-            _logger.LogInformation($"Received HTML Publish diagnostic request for {diagnosticParams.Uri} with {diagnosticParams.Diagnostics.Length} diagnostics.");
-
             if (diagnosticParams is null)
             {
                 throw new ArgumentException("Conversion of token failed.");
             }
+
+            _logger.LogInformation($"Received HTML Publish diagnostic request for {diagnosticParams.Uri} with {diagnosticParams.Diagnostics.Length} diagnostics.");
 
             // We only support interception of Virtual HTML Files
             if (!RazorLSPConventions.IsVirtualHtmlFile(diagnosticParams.Uri))

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly ILanguageClientMiddleLayer _middleLayer;
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
-        private readonly FeedbackFileLoggerProviderFactory _feedbackFileLoggerProviderFactory;
+        private readonly RazorLanguageServerFeedbackFileLoggerProviderFactory _feedbackFileLoggerProviderFactory;
         private readonly VSLanguageServerFeatureOptions _vsLanguageServerFeatureOptions;
 
         private object _shutdownLock;
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             RazorLanguageClientMiddleLayer middleLayer,
             LSPRequestInvoker requestInvoker,
             ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
-            FeedbackFileLoggerProviderFactory feedbackFileLoggerProviderFactory,
+            RazorLanguageServerFeedbackFileLoggerProviderFactory feedbackFileLoggerProviderFactory,
             VSLanguageServerFeatureOptions vsLanguageServerFeatureOptions)
         {
             if (customTarget is null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -209,7 +209,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             while (_server != null && ++attempts < WaitForShutdownAttempts)
             {
                 // Server failed to shutdown, lets wait a little bit and check again.
-                await Task.Delay(100, token);
+                await Task.Delay(100, token).ConfigureAwait(false);
             }
 
             lock (_shutdownLock)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -30,6 +30,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [ContentType(RazorLSPConstants.RazorLSPContentTypeName)]
     internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCustomMessage2, ILanguageClientPriority
     {
+        private static readonly string LogFileIdentifier = "RazorLanguageServer";
+
         private readonly RazorLanguageServerCustomMessageTarget _customMessageTarget;
         private readonly ILanguageClientMiddleLayer _middleLayer;
         private readonly LSPRequestInvoker _requestInvoker;
@@ -143,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             services.AddLogging(logging =>
             {
                 logging.AddFilter<FeedbackFileLoggerProvider>(level => true);
-                var loggerProvider = (FeedbackFileLoggerProvider)_feedbackFileLoggerProviderFactory.GetOrCreate();
+                var loggerProvider = (FeedbackFileLoggerProvider)_feedbackFileLoggerProviderFactory.GetOrCreate(LogFileIdentifier);
                 logging.AddProvider(loggerProvider);
             });
             services.AddSingleton<LanguageServerFeatureOptions>(_vsLanguageServerFeatureOptions);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsEndpointTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             documentResolver.Setup(resolver => resolver.TryResolveDocument(documentPath, out documentSnapshot))
                 .Returns(false);
 
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver.Object, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver.Object, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             documentVersionCache.Setup(cache => cache.TryGetDocumentVersion(It.IsAny<DocumentSnapshot>(), out version))
                 .Returns(false);
 
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, documentVersionCache.Object, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, documentVersionCache.Object, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentPath = "C:/path/to/document.cshtml";
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -298,7 +298,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var documentPath = "C:/path/to/document.cshtml";
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Razor,
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 });
             codeDocument.SetUnsupported();
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Xunit;
@@ -94,9 +95,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         public DocumentPullDiagnosticsHandlerTest()
         {
             Uri = new Uri("C:/path/to/file.razor");
+
+            var directoryProvider = new DefaultFeedbackLogDirectoryProvider();
+            var loggerFactory = new HTMLCSharpLanguageServerFeedbackFileLoggerProviderFactory(directoryProvider);
+            LoggerProvider = new HTMLCSharpLanguageServerFeedbackFileLoggerProvider(loggerFactory);
         }
 
         private Uri Uri { get; }
+        private HTMLCSharpLanguageServerFeedbackFileLoggerProvider LoggerProvider { get; }
 
         [Fact]
         public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
@@ -106,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestInvoker = Mock.Of<LSPRequestInvoker>();
             var diagnosticsProvider = Mock.Of<LSPDiagnosticsTranslator>();
             var documentSynchronizer = Mock.Of<LSPDocumentSynchronizer>();
-            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider);
+            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new DocumentDiagnosticsParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -139,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var diagnosticsProvider = GetDiagnosticsProvider(ValidDiagnostic_UnknownName_MappedRange, ValidDiagnostic_InvalidExpression_MappedRange);
             var documentSynchronizer = CreateDocumentSynchronizer();
 
-            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider);
+            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new DocumentDiagnosticsParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -189,7 +195,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(It.IsAny<int>(), It.IsAny<CSharpVirtualDocumentSnapshot>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(false));
 
-            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer.Object, diagnosticsProvider);
+            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer.Object, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new DocumentDiagnosticsParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -259,7 +265,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentSynchronizer = CreateDocumentSynchronizer();
 
-            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider);
+            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new DocumentDiagnosticsParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -325,7 +331,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var diagnosticsProvider = GetDiagnosticsProvider(filteredDiagnostic_mappedRange);
             var documentSynchronizer = CreateDocumentSynchronizer();
 
-            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider);
+            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new DocumentDiagnosticsParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -363,7 +369,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var diagnosticsProvider = GetDiagnosticsProvider(ValidDiagnostic_UnknownName_MappedRange, ValidDiagnostic_InvalidExpression_MappedRange);
             var documentSynchronizer = CreateDocumentSynchronizer();
 
-            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider);
+            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new DocumentDiagnosticsParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -399,7 +405,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var diagnosticsProvider = GetDiagnosticsProvider();
             var documentSynchronizer = CreateDocumentSynchronizer();
 
-            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider);
+            var documentDiagnosticsHandler = new DocumentPullDiagnosticsHandler(requestInvoker, documentManager, documentSynchronizer, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new DocumentDiagnosticsParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorHtmlPublishDiagnosticsInterceptorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorHtmlPublishDiagnosticsInterceptorTest.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
 using Microsoft.VisualStudio.Text;
 using Moq;
@@ -17,7 +18,7 @@ using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    public class RazorHtmlPublishDiagnosticsInterceptorTest
+    public class RazorHtmlPublishDiagnosticsInterceptorTest : IDisposable
     {
         private static readonly Uri RazorUri = new Uri("C:/path/to/file.razor");
         private static readonly Uri CshtmlUri = new Uri("C:/path/to/file.cshtml");
@@ -50,6 +51,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             ValidDiagnostic_CSS
         };
 
+        public RazorHtmlPublishDiagnosticsInterceptorTest()
+        {
+            var directoryProvider = new DefaultFeedbackLogDirectoryProvider();
+            var loggerFactory = new HTMLCSharpLanguageServerFeedbackFileLoggerProviderFactory(directoryProvider);
+            LoggerProvider = new HTMLCSharpLanguageServerFeedbackFileLoggerProvider(loggerFactory);
+        }
+
+        private HTMLCSharpLanguageServerFeedbackFileLoggerProvider LoggerProvider { get; }
+
         [Fact]
         public async Task ApplyChangesAsync_InvalidParams_ThrowsException()
         {
@@ -57,7 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var documentManager = new TestDocumentManager();
             var diagnosticsProvider = Mock.Of<LSPDiagnosticsTranslator>();
 
-            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider);
+            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
@@ -81,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var documentManager = new TestDocumentManager();
             var diagnosticsProvider = Mock.Of<LSPDiagnosticsTranslator>();
 
-            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider);
+            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new VSPublishDiagnosticParams()
             {
                 Diagnostics = Diagnostics,
@@ -105,7 +115,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var documentManager = new TestDocumentManager();
             var diagnosticsProvider = Mock.Of<LSPDiagnosticsTranslator>();
 
-            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider);
+            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new VSPublishDiagnosticParams()
             {
                 Diagnostics = Diagnostics,
@@ -129,7 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var documentManager = new TestDocumentManager();
             var diagnosticsProvider = Mock.Of<LSPDiagnosticsTranslator>();
 
-            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider);
+            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new VSPublishDiagnosticParams()
             {
                 Diagnostics = Diagnostics,
@@ -153,7 +163,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var documentManager = new TestDocumentManager();
             var diagnosticsProvider = Mock.Of<LSPDiagnosticsTranslator>();
 
-            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider);
+            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new VSPublishDiagnosticParams()
             {
                 Diagnostics = Diagnostics,
@@ -183,7 +193,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             documentManager.Setup(manager => manager.TryGetDocument(It.IsAny<Uri>(), out testDocument))
                 .Returns(true);
 
-            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager.Object, diagnosticsProvider);
+            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager.Object, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new VSPublishDiagnosticParams()
             {
                 Diagnostics = Diagnostics,
@@ -208,7 +218,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var documentManager = CreateDocumentManager();
             var diagnosticsProvider = Mock.Of<LSPDiagnosticsTranslator>();
 
-            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider);
+            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new VSPublishDiagnosticParams()
             {
                 Diagnostics = Array.Empty<Diagnostic>(),
@@ -233,7 +243,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var documentManager = CreateDocumentManager();
             var diagnosticsProvider = GetDiagnosticsProvider();
 
-            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider);
+            var htmlDiagnosticsInterceptor = new RazorHtmlPublishDiagnosticsInterceptor(documentManager, diagnosticsProvider, LoggerProvider);
             var diagnosticRequest = new VSPublishDiagnosticParams()
             {
                 Diagnostics = Diagnostics,
@@ -302,6 +312,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 });
 
             return diagnosticsProvider.Object;
+        }
+
+        public void Dispose()
+        {
+            LoggerProvider?.Dispose();
         }
     }
 }


### PR DESCRIPTION
### Summary of the changes
 - Logging for
   - DocumentPullDiagnosticsHandler
   - RazorDiagnosticsEndpoint
   - RazorHtmlPublishDiagnosticsInterceptor
 - Updated VS HTMLC# Language Server to support logging via feedback file logger
   - Updated DefaultFeedbackFileLoggerProviderFactory.cs to share the log writer

### Typical Trace
#### C#
```
09:17.710 | [DocumentPullDiagnosticsHandler] Requesting document pull diagnostics for file:///C:/Users/taparik/dev/blazorserver2/Pages/Counter.razor.g.cs with previous result Id of DocumentPullDiagnosticHandler:0.
...
09:23.837 | [DocumentPullDiagnosticsHandler] Received 1 diagnostic reports.
09:23.840 | [DocumentPullDiagnosticsHandler] Requesting processing of 12 diagnostics.
...
09:23.857 | [RazorDiagnosticsEndpoint] Received CSharp diagnostic request for file:///C:/Users/taparik/dev/blazorserver2/Pages/Counter.razor with 12 diagnostics.
09:23.859 | [RazorDiagnosticsEndpoint] 2/12 diagnostics remain after filtering.
09:23.865 | [RazorDiagnosticsEndpoint] Returning 2 mapped diagnostics.
...
09:23.909 | [DocumentPullDiagnosticsHandler] Processed 2 diagnostics.
```

#### HTML
```
42:26.096 | [RazorHtmlPublishDiagnosticsInterceptor] Received HTML Publish diagnostic request for file:///c:/Users/taparik/dev/blazorserver2/Pages/Counter.razor__virtual.html with 1 diagnostics.
...
42:26.098 | [RazorDiagnosticsEndpoint] Received Html diagnostic request for file:///c:/Users/taparik/dev/blazorserver2/Pages/Counter.razor with 1 diagnostics.
42:26.099 | [RazorDiagnosticsEndpoint] 1/1 diagnostics remain after filtering.
42:26.099 | [RazorDiagnosticsEndpoint] Returning 1 mapped diagnostics.
...
42:26.100 | [RazorHtmlPublishDiagnosticsInterceptor] Processed 1 diagnostics.
```

Fixes: https://github.com/dotnet/aspnetcore/issues/29073
