### PR TITLE
Swallow task cancelled exceptions when resolving TagHelpers.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
@@ -161,6 +161,11 @@ namespace Microsoft.CodeAnalysis.Razor
                         workspaceState = new ProjectWorkspaceState(tagHelperResolutionResult.Descriptors, csharpLanguageVersion);
                     }
                 }
+                catch (TaskCanceledException)
+                {
+                    // Abort work if we get a task cancelled exception
+                    return;
+                }
                 catch (Exception ex)
                 {
                     await Task.Factory.StartNew(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/OOPTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/OOPTagHelperResolver.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
 
                 return result;
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!(exception is TaskCanceledException))
             {
                 throw new InvalidOperationException($"An unexpected exception occurred when invoking '{typeof(DefaultTagHelperResolver).FullName}.{nameof(GetTagHelpersAsync)}' on the Razor language service.", exception);
             }


### PR DESCRIPTION
- Currently this exception is treated like any other exception and results in an activity log entry. Swallow this exception to not create any noise.