### PR TITLE
Add support Blazor WASM debugging Auto window.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/CSharpProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/CSharpProximityExpressionResolver.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    internal abstract class CSharpProximityExpressionResolver
+    {
+        public abstract IReadOnlyList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultCSharpProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultCSharpProximityExpressionResolver.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    [Export(typeof(CSharpProximityExpressionResolver))]
+    internal class DefaultCSharpProximityExpressionResolver : CSharpProximityExpressionResolver
+    {
+        private readonly MethodInfo _getProximityExpressionAsync;
+
+        public DefaultCSharpProximityExpressionResolver()
+        {
+            try
+            {
+                var assemblyName = typeof(SyntaxTree).Assembly.GetName();
+                assemblyName.Name = "Microsoft.CodeAnalysis.CSharp.Features";
+                var assembly = Assembly.Load(assemblyName);
+                var type = assembly.GetType("Microsoft.CodeAnalysis.CSharp.Debugging.CSharpProximityExpressionsService");
+                _getProximityExpressionAsync = type.GetMethod(
+                    "Do",
+                    BindingFlags.NonPublic | BindingFlags.Static,
+                    binder: null,
+                    types: new[] { typeof(SyntaxTree), typeof(int) },
+                    modifiers: Array.Empty<ParameterModifier>());
+
+                if (_getProximityExpressionAsync == null)
+                {
+                    throw new InvalidOperationException(
+                        "Error occured when acessing the Do method on Roslyn's CSharpProximityExpressionsService's type. Roslyn may have changed in an unexpected way.");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    "Error occured when creating an instance of Roslyn's CSharpProximityExpressionsService's type. Roslyn may have changed in an unexpected way.",
+                    ex);
+            }
+        }
+
+        public override IReadOnlyList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex)
+        {
+            if (syntaxTree is null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            var parameters = new object[] { syntaxTree, absoluteIndex };
+            var result = _getProximityExpressionAsync.Invoke(obj: null, parameters);
+            var expressions = (IReadOnlyList<string>)result;
+
+            return expressions;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    [Export(typeof(RazorProximityExpressionResolver))]
+    internal class DefaultRazorProximityExpressionResolver : RazorProximityExpressionResolver
+    {
+        private readonly FileUriProvider _fileUriProvider;
+        private readonly LSPDocumentManager _documentManager;
+        private readonly LSPProjectionProvider _projectionProvider;
+        private readonly CSharpProximityExpressionResolver _csharpProximityExpressionResolver;
+
+        [ImportingConstructor]
+        public DefaultRazorProximityExpressionResolver(
+            FileUriProvider fileUriProvider,
+            LSPDocumentManager documentManager,
+            LSPProjectionProvider projectionProvider,
+            CSharpProximityExpressionResolver csharpProximityExpressionResolver)
+        {
+            if (fileUriProvider is null)
+            {
+                throw new ArgumentNullException(nameof(fileUriProvider));
+            }
+
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (projectionProvider is null)
+            {
+                throw new ArgumentNullException(nameof(projectionProvider));
+            }
+
+            if (csharpProximityExpressionResolver is null)
+            {
+                throw new ArgumentNullException(nameof(csharpProximityExpressionResolver));
+            }
+
+            _fileUriProvider = fileUriProvider;
+            _documentManager = documentManager;
+            _projectionProvider = projectionProvider;
+            _csharpProximityExpressionResolver = csharpProximityExpressionResolver;
+        }
+
+        public override async Task<IReadOnlyList<string>> TryResolveProximityExpressionsAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
+        {
+            if (textBuffer is null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            if (!_fileUriProvider.TryGet(textBuffer, out var documentUri))
+            {
+                // Not an addressable Razor document. Do not allow expression resolution here. In practice this shouldn't happen, just being defensive.
+                return null;
+            }
+
+            if (!_documentManager.TryGetDocument(documentUri, out var documentSnapshot))
+            {
+                // No associated Razor document. Do not resolve expressions here. In practice this shouldn't happen, just being defensive.
+                return null;
+            }
+
+            var lspPosition = new Position(lineIndex, characterIndex);
+            var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, lspPosition, cancellationToken).ConfigureAwait(false);
+            if (projectionResult == null)
+            {
+                // Can't map the position, invalid breakpoint location.
+                return null;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (projectionResult.LanguageKind != RazorLanguageKind.CSharp)
+            {
+                // We only allow proximity expressions in C#
+                return null;
+            }
+
+            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var virtualDocument))
+            {
+                Debug.Fail($"Some how there's no C# document associated with the host Razor document {documentUri.OriginalString} when retrieving proximity expressions.");
+                return null;
+            }
+
+            var sourceText = virtualDocument.Snapshot.AsText();
+            var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, cancellationToken: cancellationToken);
+            var proximityExpressions = _csharpProximityExpressionResolver.GetProximityExpressions(syntaxTree, projectionResult.PositionIndex);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return proximityExpressions;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
@@ -102,7 +102,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
             var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, cancellationToken: cancellationToken);
             var proximityExpressions = _csharpProximityExpressionResolver.GetProximityExpressions(syntaxTree, projectionResult.PositionIndex);
 
-            cancellationToken.ThrowIfCancellationRequested();
 
             return proximityExpressions;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
 
             if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var virtualDocument))
             {
-                Debug.Fail($"Some how there's no C# document associated with the host Razor document {documentUri.OriginalString} when retrieving proximity expressions.");
+                Debug.Fail($"Somehow there's no C# document associated with the host Razor document {documentUri.OriginalString} when retrieving proximity expressions.");
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/RazorProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/RazorProximityExpressionResolver.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    internal abstract class RazorProximityExpressionResolver
+    {
+        public abstract Task<IReadOnlyList<string>> TryResolveProximityExpressionsAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/VsEnumBSTR.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/VsEnumBSTR.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    internal class VsEnumBSTR : IVsEnumBSTR
+    {
+        // Internal for testing
+        internal readonly IReadOnlyList<string> _values;
+
+        private int _currentIndex;
+
+        public VsEnumBSTR(IReadOnlyList<string> values)
+        {
+            _values = values;
+            _currentIndex = 0;
+        }
+
+        public int Clone(out IVsEnumBSTR ppEnum)
+        {
+            ppEnum = new VsEnumBSTR(_values);
+            return VSConstants.S_OK;
+        }
+
+        public int GetCount(out uint pceltCount)
+        {
+            pceltCount = (uint)_values.Count;
+            return VSConstants.S_OK;
+        }
+
+        public int Next(uint celt, string[] rgelt, out uint pceltFetched)
+        {
+            var i = 0;
+            for (; i < celt && _currentIndex < _values.Count; i++, _currentIndex++)
+            {
+                rgelt[i] = _values[_currentIndex];
+            }
+
+            pceltFetched = (uint)i;
+            return i < celt
+                ? VSConstants.S_FALSE
+                : VSConstants.S_OK;
+        }
+
+        public int Reset()
+        {
+            _currentIndex = 0;
+            return VSConstants.S_OK;
+        }
+
+        public int Skip(uint celt)
+        {
+            _currentIndex += (int)celt;
+            return _currentIndex < _values.Count
+                ? VSConstants.S_OK
+                : VSConstants.S_FALSE;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -54,6 +54,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 languageQueryParams,
                 cancellationToken).ConfigureAwait(false);
 
+            if (languageResponse == null)
+            {
+                // The language server is still being spun up. Could not resolve the projection.
+                return null;
+            }
+
             VirtualDocumentSnapshot virtualDocument;
             if (languageResponse.Kind == RazorLanguageKind.CSharp &&
                 documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -40,9 +40,10 @@ namespace Microsoft.VisualStudio.RazorExtension
             {
                 var componentModel = (IComponentModel)GetGlobalService(typeof(SComponentModel));
                 var breakpointResolver = componentModel.GetService<RazorBreakpointResolver>();
+                var proximityExpressionResolver = componentModel.GetService<RazorProximityExpressionResolver>();
                 var waitDialogFactory = componentModel.GetService<WaitDialogFactory>();
                 var editorAdaptersFactory = componentModel.GetService<IVsEditorAdaptersFactoryService>();
-                return new RazorLanguageService(breakpointResolver, waitDialogFactory, editorAdaptersFactory);
+                return new RazorLanguageService(breakpointResolver, proximityExpressionResolver, waitDialogFactory, editorAdaptersFactory);
             }, promote: true);
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -120,7 +120,7 @@ $@"public class SomeRazorFile
             // Arrange
             var hostDocumentPosition = GetPosition(InvalidBreakpointCSharp, HostTextbuffer);
             var csharpDocumentPosition = GetPosition(InvalidBreakpointCSharp, CSharpTextBuffer);
-            var csharpDocumentIndex = CSharpTextBuffer.CurrentSnapshot.GetText().IndexOf(ValidBreakpointCSharp, StringComparison.Ordinal);
+            var csharpDocumentIndex = CSharpTextBuffer.CurrentSnapshot.GetText().IndexOf(InvalidBreakpointCSharp, StringComparison.Ordinal);
             var projectionProvider = new TestLSPProjectionProvider(
                 DocumentUri,
                 new Dictionary<Position, ProjectionResult>()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorProximityExpressionResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorProximityExpressionResolverTest.cs
@@ -1,0 +1,243 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+using Microsoft.VisualStudio.Test;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
+{
+    public class DefaultRazorProximityExpressionResolverTest
+    {
+        public DefaultRazorProximityExpressionResolverTest()
+        {
+            DocumentUri = new Uri("file://C:/path/to/file.razor", UriKind.Absolute);
+
+            ValidProximityExpressionRoot = "var abc = 123;";
+            InvalidProximityExpressionRoot = "private int bar;";
+            var csharpTextSnapshot = new StringTextSnapshot(
+$@"public class SomeRazorFile
+{{
+    {InvalidProximityExpressionRoot}
+
+    public void Render()
+    {{
+        {ValidProximityExpressionRoot}
+    }}
+}}
+");
+            CSharpTextBuffer = new TestTextBuffer(csharpTextSnapshot);
+
+            var textBufferSnapshot = new StringTextSnapshot($"@{{{InvalidProximityExpressionRoot}}} @code {{{ValidProximityExpressionRoot}}}");
+            HostTextbuffer = new TestTextBuffer(textBufferSnapshot);
+        }
+
+        private string ValidProximityExpressionRoot { get; }
+
+        private string InvalidProximityExpressionRoot { get; }
+
+        private ITextBuffer CSharpTextBuffer { get; }
+
+        private Uri DocumentUri { get; }
+
+        private ITextBuffer HostTextbuffer { get; }
+
+        [Fact]
+        public async Task TryResolveProximityExpressionsAsync_UnaddressableTextBuffer_ReturnsNull()
+        {
+            // Arrange
+            var differentTextBuffer = Mock.Of<ITextBuffer>();
+            var resolver = CreateResolverWith();
+
+            // Act
+            var expressions = await resolver.TryResolveProximityExpressionsAsync(differentTextBuffer, lineIndex: 0, characterIndex: 1, CancellationToken.None);
+
+            // Assert
+            Assert.Null(expressions);
+        }
+
+        [Fact]
+        public async Task TryResolveProximityExpressionsAsync_UnknownRazorDocument_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = Mock.Of<LSPDocumentManager>();
+            var resolver = CreateResolverWith(documentManager: documentManager);
+
+            // Act
+            var result = await resolver.TryResolveProximityExpressionsAsync(HostTextbuffer, lineIndex: 0, characterIndex: 1, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task TryResolveProximityExpressionsAsync_UnprojectedLocation_ReturnsNull()
+        {
+            // Arrange
+            var resolver = CreateResolverWith();
+
+            // Act
+            var expressions = await resolver.TryResolveProximityExpressionsAsync(HostTextbuffer, lineIndex: 0, characterIndex: 1, CancellationToken.None);
+
+            // Assert
+            Assert.Null(expressions);
+        }
+
+        [Fact]
+        public async Task TryResolveProximityExpressionsAsync_RazorProjectedLocation_ReturnsNull()
+        {
+            // Arrange
+            var position = new Position(line: 0, character: 2);
+            var projectionProvider = new TestLSPProjectionProvider(
+                DocumentUri,
+                new Dictionary<Position, ProjectionResult>()
+                {
+                    [position] = new ProjectionResult()
+                    {
+                        LanguageKind = RazorLanguageKind.Razor,
+                        HostDocumentVersion = 0,
+                        Position = position,
+                    }
+                });
+            var resolver = CreateResolverWith(projectionProvider: projectionProvider);
+
+            // Act
+            var expressions = await resolver.TryResolveProximityExpressionsAsync(HostTextbuffer, position.Line, position.Character, CancellationToken.None);
+
+            // Assert
+            Assert.Null(expressions);
+        }
+
+        [Fact]
+        public async Task TryResolveProximityExpressionsAsync_NotValidLocation_ReturnsNull()
+        {
+            // Arrange
+            var hostDocumentPosition = GetPosition(InvalidProximityExpressionRoot, HostTextbuffer);
+            var csharpDocumentPosition = GetPosition(InvalidProximityExpressionRoot, CSharpTextBuffer);
+            var csharpDocumentIndex = CSharpTextBuffer.CurrentSnapshot.GetText().IndexOf(InvalidProximityExpressionRoot, StringComparison.Ordinal);
+            var projectionProvider = new TestLSPProjectionProvider(
+                DocumentUri,
+                new Dictionary<Position, ProjectionResult>()
+                {
+                    [hostDocumentPosition] = new ProjectionResult()
+                    {
+                        LanguageKind = RazorLanguageKind.CSharp,
+                        HostDocumentVersion = 0,
+                        Position = csharpDocumentPosition,
+                        PositionIndex = csharpDocumentIndex,
+                    }
+                });
+            var resolver = CreateResolverWith(projectionProvider: projectionProvider);
+
+            // Act
+            var expressions = await resolver.TryResolveProximityExpressionsAsync(HostTextbuffer, hostDocumentPosition.Line, hostDocumentPosition.Character, CancellationToken.None);
+
+            // Assert
+            Assert.Null(expressions);
+        }
+
+        [Fact]
+        public async Task TryResolveProximityExpressionsAsync_MappableCSharpLocation_ReturnsExpressions()
+        {
+            // Arrange
+            var hostDocumentPosition = GetPosition(ValidProximityExpressionRoot, HostTextbuffer);
+            var csharpDocumentPosition = GetPosition(ValidProximityExpressionRoot, CSharpTextBuffer);
+            var csharpDocumentIndex = CSharpTextBuffer.CurrentSnapshot.GetText().IndexOf(ValidProximityExpressionRoot, StringComparison.Ordinal);
+            var projectionProvider = new TestLSPProjectionProvider(
+                DocumentUri,
+                new Dictionary<Position, ProjectionResult>()
+                {
+                    [hostDocumentPosition] = new ProjectionResult()
+                    {
+                        LanguageKind = RazorLanguageKind.CSharp,
+                        HostDocumentVersion = 0,
+                        Position = csharpDocumentPosition,
+                        PositionIndex = csharpDocumentIndex,
+                    }
+                });
+            var resolver = CreateResolverWith(projectionProvider: projectionProvider);
+
+            // Act
+            var expressions = await resolver.TryResolveProximityExpressionsAsync(HostTextbuffer, hostDocumentPosition.Line, hostDocumentPosition.Character, CancellationToken.None);
+
+            // Assert
+            Assert.NotEmpty(expressions);
+        }
+
+        private RazorProximityExpressionResolver CreateResolverWith(
+            FileUriProvider uriProvider = null,
+            LSPDocumentManager documentManager = null,
+            LSPProjectionProvider projectionProvider = null)
+        {
+            var documentUri = DocumentUri;
+            uriProvider ??= Mock.Of<FileUriProvider>(provider => provider.TryGet(HostTextbuffer, out documentUri) == true);
+            var csharpDocumentUri = new Uri(DocumentUri.OriginalString + ".g.cs", UriKind.Absolute);
+            var csharpVirtualDocumentSnapshot = new CSharpVirtualDocumentSnapshot(csharpDocumentUri, CSharpTextBuffer.CurrentSnapshot, hostDocumentSyncVersion: 0);
+            LSPDocumentSnapshot documentSnapshot = new TestLSPDocumentSnapshot(DocumentUri, 0, csharpVirtualDocumentSnapshot);
+            documentManager ??= Mock.Of<LSPDocumentManager>(manager => manager.TryGetDocument(DocumentUri, out documentSnapshot) == true);
+            projectionProvider ??= Mock.Of<LSPProjectionProvider>();
+            var csharpProximityExpressionResolver = new DefaultCSharpProximityExpressionResolver();
+            var razorProximityExpressionResolver = new DefaultRazorProximityExpressionResolver(
+                uriProvider,
+                documentManager,
+                projectionProvider,
+                csharpProximityExpressionResolver);
+
+            return razorProximityExpressionResolver;
+        }
+
+        private Position GetPosition(string content, ITextBuffer textBuffer)
+        {
+            var index = textBuffer.CurrentSnapshot.GetText().IndexOf(content, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(content));
+            }
+
+            textBuffer.CurrentSnapshot.GetLineAndCharacter(index, out var lineIndex, out var characterIndex);
+            return new Position(lineIndex, characterIndex);
+        }
+
+        private class TestLSPProjectionProvider : LSPProjectionProvider
+        {
+            private readonly Uri _documentUri;
+            private readonly IReadOnlyDictionary<Position, ProjectionResult> _mappings;
+
+            public TestLSPProjectionProvider(Uri documentUri, IReadOnlyDictionary<Position, ProjectionResult> mappings)
+            {
+                if (documentUri is null)
+                {
+                    throw new ArgumentNullException(nameof(documentUri));
+                }
+
+                if (mappings is null)
+                {
+                    throw new ArgumentNullException(nameof(mappings));
+                }
+
+                _documentUri = documentUri;
+                _mappings = mappings;
+            }
+
+            public override Task<ProjectionResult> GetProjectionAsync(LSPDocumentSnapshot documentSnapshot, Position position, CancellationToken cancellationToken)
+            {
+                if (documentSnapshot.Uri != _documentUri)
+                {
+                    return Task.FromResult((ProjectionResult)null);
+                }
+
+                _mappings.TryGetValue(position, out var projectionResult);
+
+                return Task.FromResult(projectionResult);
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Guest/RazorGuestInitializationServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Guest/RazorGuestInitializationServiceTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Guest
                 {
                     return Task.Run(() =>
                     {
-                        cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(3));
+                        cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5));
 
                         Assert.True(disposedService);
                         return Array.Empty<Uri>();


### PR DESCRIPTION
- Added a proximity expression resolver abstraction to Razor that takes a buffer and a location then does the magic to lookup the corresponding Razor document, determine if the location is C# and pass all the information needed over to C# to resolve expressions at that location.
- Had to utilize private reflection to invoke the CSharp proximity expression resolver APIs. Need to follow up and add these APIs to Roslyn's external access Razor layer so we can utilize them.
- Expanded our `RazorLanguageServiceIVsLanguageDebugInfo` to glue together the proximity expression resolution code so that the autos window shows up.
- Autos window now shows however there's a quirk where the JavaScript type information is used for C# items. This is a separate issue that we'll need to address
- Added tests to validate all pieces of the implementation.
![image](https://user-images.githubusercontent.com/2008729/104772013-8d3f2980-5727-11eb-9580-53ff4c32f331.png)


Fixes dotnet/aspnetcore#29320