### PR TITLE
Filter Diagnostics Within Attributes Containing C#

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsEndpoint.cs
@@ -161,7 +161,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             var sourceText = await documentSnapshot.GetTextAsync();
             var syntaxTree = codeDocument.GetSyntaxTree();
-            var classifiedSpans = syntaxTree.GetClassifiedSpans();
 
             var processedAttributes = new Dictionary<TextSpan, bool>();
 
@@ -169,7 +168,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 .Where(d =>
                     // TODO: undesired HTML Diagnostic codes
                     // (https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1257401) ||
-                    !InAttributeContainingCSharp(d, sourceText, syntaxTree, classifiedSpans, processedAttributes))
+                    !InAttributeContainingCSharp(d, sourceText, syntaxTree, processedAttributes))
                 .ToArray();
 
             return filteredDiagnostics;
@@ -178,7 +177,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Diagnostic d,
                 SourceText sourceText,
                 RazorSyntaxTree syntaxTree,
-                IReadOnlyList<ClassifiedSpanInternal> classifiedSpans,
                 Dictionary<TextSpan, bool> processedAttributes)
             {
                 // Examine the _end_ of the diagnostic to see if we're at the

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsEndpoint.cs
@@ -7,12 +7,16 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -108,8 +112,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 };
             }
 
+            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+            if (codeDocument?.IsUnsupported() != false)
+            {
+                _logger.LogInformation("Unsupported code document.");
+                return new RazorDiagnosticsResponse()
+                {
+                    Diagnostics = Array.Empty<Diagnostic>(),
+                    HostDocumentVersion = documentVersion
+                };
+            }
+
             var unmappedDiagnostics = request.Diagnostics;
-            var filteredDiagnostics = unmappedDiagnostics.Where(d => !CanDiagnosticBeFiltered(request.Kind, d)).ToArray();
+            var filteredDiagnostics = request.Kind == RazorLanguageKind.CSharp ?
+                FilterCSharpDiagnostics(unmappedDiagnostics) :
+                await FilterHTMLDiagnosticsAsync(unmappedDiagnostics, codeDocument, documentSnapshot).ConfigureAwait(false);
             if (!filteredDiagnostics.Any())
             {
                 _logger.LogInformation("No diagnostics remaining after filtering.");
@@ -123,10 +140,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _logger.LogInformation($"{filteredDiagnostics.Length}/{unmappedDiagnostics.Length} diagnostics remain after filtering.");
 
-            var mappedDiagnostics = await MapDiagnosticsAsync(
+            var mappedDiagnostics = MapDiagnostics(
                 request,
                 filteredDiagnostics,
-                documentSnapshot).ConfigureAwait(false);
+                codeDocument);
 
             _logger.LogInformation($"Returning {mappedDiagnostics.Length} mapped diagnostics.");
 
@@ -135,38 +152,86 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Diagnostics = mappedDiagnostics,
                 HostDocumentVersion = documentVersion,
             };
-
-            // TODO; HTML filtering blocked on https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1257401
-            static bool CanDiagnosticBeFiltered(RazorLanguageKind kind, Diagnostic d)
-            {
-                return kind == RazorLanguageKind.CSharp ?
-                    CanCSharpDiagnosticBeFiltered(d) :
-                    CanHTMLDiagnosticBeFiltered(d);
-            }
-
-            static bool CanCSharpDiagnosticBeFiltered(Diagnostic d) =>
-                (DiagnosticsToIgnore.Contains(d.Code?.String) &&
-                 d.Severity != DiagnosticSeverity.Error);
-
-            static bool CanHTMLDiagnosticBeFiltered(Diagnostic d) => false;
         }
 
-        private async Task<Diagnostic[]> MapDiagnosticsAsync(
+        private async Task<Diagnostic[]> FilterHTMLDiagnosticsAsync(
+            Diagnostic[] unmappedDiagnostics,
+            RazorCodeDocument codeDocument,
+            DocumentSnapshot documentSnapshot)
+        {
+            var sourceText = await documentSnapshot.GetTextAsync();
+
+            var syntaxTree = codeDocument.GetSyntaxTree();
+
+            var csharpContainingAttributes = new HashSet<TextSpan>();
+
+            var filteredDiagnostics = unmappedDiagnostics
+                // Sorting done to enable sequential filtering.
+                // Ex. If we encounter C# within an attribute,
+                // we filter out all subsequent diagnostics from
+                // that attribute.
+                .OrderBy(d => d.Range.Start)
+
+                .Where(d =>
+                    // TODO: undesired HTML Diagnostic codes
+                    // (https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1257401) ||
+                    !InAttributeContainingCSharp(d, sourceText, syntaxTree))
+                .ToArray();
+
+            return filteredDiagnostics;
+
+            bool InAttributeContainingCSharp(Diagnostic d, SourceText sourceText, RazorSyntaxTree syntaxTree)
+            {
+                // Examine the _end_ of the diagnostic to see if we're at the
+                // start of an (im/ex)plicit expression. Looking at the start
+                // of the diagnostic isn't sufficient.
+                var absoluteIndex = d.Range.End.GetAbsoluteIndex(sourceText);
+                var change = new SourceChange(absoluteIndex, 0, string.Empty);
+                var owner = syntaxTree.Root.LocateOwner(change);
+
+                var containsCSharp = false;
+
+                while (owner != null)
+                {
+                    if (owner is CSharpSyntaxNode)
+                    {
+                        containsCSharp = true;
+                    }
+                    else if (owner is MarkupAttributeBlockSyntax markupAttributeNode)
+                    {
+                        if (containsCSharp)
+                        {
+                            csharpContainingAttributes.Add(markupAttributeNode.FullSpan);
+                            return true;
+                        }
+
+                        return csharpContainingAttributes.Contains(markupAttributeNode.FullSpan);
+                    }
+
+                    owner = owner.Parent;
+                }
+
+                return false;
+            }
+        }
+
+        private Diagnostic[] FilterCSharpDiagnostics(Diagnostic[] unmappedDiagnostics)
+        {
+            return unmappedDiagnostics.Where(d =>
+                !(DiagnosticsToIgnore.Contains(d.Code?.String) &&
+                  d.Severity != DiagnosticSeverity.Error))
+                .ToArray();
+        }
+
+        private Diagnostic[] MapDiagnostics(
             RazorDiagnosticsParams request,
             IReadOnlyList<Diagnostic> filteredDiagnostics,
-            DocumentSnapshot documentSnapshot)
+            RazorCodeDocument codeDocument)
         {
             if (request.Kind != RazorLanguageKind.CSharp)
             {
                 // All other non-C# requests map directly to where they are in the document.
                 return filteredDiagnostics.ToArray();
-            }
-
-            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
-            if (codeDocument?.IsUnsupported() != false)
-            {
-                _logger.LogInformation("Unsupported code document.");
-                return Array.Empty<Diagnostic>();
             }
 
             var mappedDiagnostics = new List<Diagnostic>();


### PR DESCRIPTION
### Summary of the changes
- Once we determine an HTML diagnostic is within a markup attribute, we check if that markup attribute also contains C#. If it does, we disable all diagnostics within that markup attribute (and cache the results).
- ~~TODO: testing once the approach is cleared.~~

#### Before
![image](https://user-images.githubusercontent.com/14852843/105214851-8a28ac80-5b1e-11eb-9338-5644e8f2f601.png)

 
#### After
![image](https://user-images.githubusercontent.com/14852843/105212977-19809080-5b1c-11eb-8863-3c220f62c238.png)


Fixes: https://github.com/dotnet/aspnetcore/issues/29079
