### PR TITLE
Disable If expression suggestion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,9 @@ indent_size = 2
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 
+# IDE0046: If expression can be simplified
+dotnet_style_prefer_conditional_expression_over_return = false:silent
+
 # Don't use this. qualifier
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion


### PR DESCRIPTION
This is just a personal annoyance for me, I like my Error list to be empty when at all possible and these tend to be low-value fixes.

If other contributors have strong preferences feel free to object.