### PR TITLE
Fix MemoryCache Compact performance.

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/MemoryCacheBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Performance/MemoryCacheBenchmark.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Serialization;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.Razor.Performance
+{
+    public class MemoryCacheBenchmark
+    {
+        public MemoryCacheBenchmark()
+        {
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+            while (current != null && !File.Exists(Path.Combine(current.FullName, "taghelpers.json")))
+            {
+                current = current.Parent;
+            }
+
+            var tagHelperFilePath = Path.Combine(current.FullName, "taghelpers.json");
+            var tagHelperBuffer = File.ReadAllBytes(tagHelperFilePath);
+
+            // Deserialize from json file.
+            var serializer = new JsonSerializer();
+            serializer.Converters.Add(new TagHelperDescriptorJsonConverter());
+            using (var stream = new MemoryStream(tagHelperBuffer))
+            using (var reader = new JsonTextReader(new StreamReader(stream)))
+            {
+                TagHelpers = serializer.Deserialize<IReadOnlyList<TagHelperDescriptor>>(reader);
+                TagHelperHashes = TagHelpers.Select(th => th.GetHashCode()).ToList();
+            }
+
+            // Set cache size to 400 so anything more then that will force compacts
+            Cache = new MemoryCache<int, TagHelperDescriptor>(400);
+        }
+
+        private IReadOnlyList<int> TagHelperHashes { get; }
+
+        private IReadOnlyList<TagHelperDescriptor> TagHelpers { get; }
+
+        private MemoryCache<int, TagHelperDescriptor> Cache { get; }
+
+        [Benchmark(Description = "MemoryCache Set performance with limited size")]
+        public void Set_Performance()
+        {
+            for (var i = 0; i < TagHelpers.Count; i++)
+            {
+                Cache.Set(TagHelperHashes[i], TagHelpers[i]);
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/MemoryCache.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/MemoryCache.cs
@@ -62,11 +62,11 @@ namespace Microsoft.CodeAnalysis.Razor
 
         protected virtual void Compact()
         {
-            var kvps = _dict.OrderBy(x => x.Value.LastAccess);
+            var kvps = _dict.OrderBy(x => x.Value.LastAccess).ToArray();
 
             for (var i = 0; i < _sizeLimit / 2; i++)
             {
-                _dict.Remove(kvps.ElementAt(i).Key);
+                _dict.Remove(kvps[i].Key);
             }
         }
 


### PR DESCRIPTION
- Added a benchmark to validate the performance gains
- As the amount of elements gets larger in the cache the gains get significantly higher too because of how the old "OrderBy" & "ElementAt" calls work. Aka, every ElementAt call would re-calculate the entirety of the OrderBy.

Before:
|                                          Method |     Mean |    Error |   StdDev |  Op/s |     Gen 0 |    Gen 1 | Gen 2 | Allocated |
|------------------------------------------------ |---------:|---------:|---------:|------:|----------:|---------:|------:|----------:|
| 'MemoryCache Set performance with limited size' | 17.47 ms | 0.137 ms | 0.114 ms | 57.23 | 2281.2500 | 156.2500 |     - |  13.78 MB |

After:
|                                          Method |     Mean |    Error |   StdDev |    Op/s |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------------------------------------ |---------:|---------:|---------:|--------:|--------:|-------:|------:|----------:|
| 'MemoryCache Set performance with limited size' | 695.9 us | 13.34 us | 14.27 us | 1,437.0 | 42.9688 | 3.9063 |     - |    266 KB |

**Gains:** 25x speed improvement

/cc @ToddGrun I forget, did you all utilize the MemoryCache in places?

Fixes dotnet/aspnetcore#29500