### PR TITLE
Remove most usages of "ElementAt".

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -253,7 +253,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             for (var i = 0; i < results.Length; i++)
             {
-                var result = results.ElementAt(i);
+                var result = results[i];
 
                 if (!(result is null))
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorSemanticTokensLegend.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorSemanticTokensLegend.cs
@@ -3,7 +3,6 @@
 #pragma warning disable CS0618
 #nullable enable
 using System.Collections.Generic;
-using System.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
 
@@ -56,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models
         public static int CSharpString => TokenTypesLegend["string"];
         public static int CSharpPunctuation => TokenTypesLegend["punctuation"];
 
-        public static readonly IReadOnlyCollection<string> TokenTypes = new string[] {
+        public static readonly IReadOnlyList<string> TokenTypes = new string[] {
             // C# token types
             "namespace", // 0
             "type",
@@ -164,12 +163,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models
             TokenTypes = new Container<string>(TokenTypes),
         };
 
-        private static IReadOnlyDictionary<string, int> GetMap(IReadOnlyCollection<string> tokens)
+        private static IReadOnlyDictionary<string, int> GetMap(IReadOnlyList<string> tokens)
         {
             var result = new Dictionary<string, int>();
             for (var i = 0; i < tokens.Count; i++)
             {
-                result[tokens.ElementAt(i)] = i;
+                result[tokens[i]] = i;
             }
 
             return result;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -223,7 +223,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             if (referenceText is ClassifiedTextElement textElement &&
-                FilterReferenceClassifiedRuns(textElement.Runs))
+                FilterReferenceClassifiedRuns(textElement.Runs.ToArray()))
             {
                 var filteredRuns = textElement.Runs.Skip(4); // `__o`, ` `, `=`, ` `
                 filteredRuns = filteredRuns.Take(filteredRuns.Count() - 1); // Trailing `;`
@@ -233,18 +233,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return referenceText;
         }
 
-        private bool FilterReferenceClassifiedRuns(IEnumerable<ClassifiedTextRun> runs)
+        private bool FilterReferenceClassifiedRuns(IReadOnlyList<ClassifiedTextRun> runs)
         {
-            if (runs.Count() < 5)
+            if (runs.Count < 5)
             {
                 return false;
             }
 
-            return VerifyRunMatches(runs.ElementAt(0), "field name", "__o") &&
-                VerifyRunMatches(runs.ElementAt(1), "text", " ") &&
-                VerifyRunMatches(runs.ElementAt(2), "operator", "=") &&
-                VerifyRunMatches(runs.ElementAt(3), "text", " ") &&
-                VerifyRunMatches(runs.Last(), "punctuation", ";");
+            return VerifyRunMatches(runs[0], "field name", "__o") &&
+                VerifyRunMatches(runs[1], "text", " ") &&
+                VerifyRunMatches(runs[2], "operator", "=") &&
+                VerifyRunMatches(runs[3], "text", " ") &&
+                VerifyRunMatches(runs[runs.Count - 1], "punctuation", ";");
 
             static bool VerifyRunMatches(ClassifiedTextRun run, string expectedClassificationType, string expectedText)
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -66,11 +66,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             // Assert
             Assert.Equal(SupportedCodeActions.Length, providedCodeActions.Count);
-
-            for (var i = 0; i < SupportedCodeActions.Length; i++)
-            {
-                Assert.Equal(SupportedCodeActions[i].Title, providedCodeActions.ElementAt(i).Title);
-            }
+            var providedTitles = providedCodeActions.Select(action => action.Title);
+            var expectedTitles = SupportedCodeActions.Select(action => action.Title);
+            Assert.Equal(expectedTitles, providedTitles);
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
@@ -472,8 +472,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         });
                     }
 
-                    var filteredDiagnostics = diagnostics.Where(d => !CanDiagnosticBeFiltered(d));
-                    if (!filteredDiagnostics.Any())
+                    var filteredDiagnostics = diagnostics.Where(d => !CanDiagnosticBeFiltered(d)).ToArray();
+                    if (filteredDiagnostics.Length == 0)
                     {
                         return Task.FromResult(new RazorDiagnosticsResponse()
                         {
@@ -484,9 +484,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
                     var mappedDiagnostics = new List<Diagnostic>();
 
-                    for (var i = 0; i < filteredDiagnostics.Count(); i++)
+                    for (var i = 0; i < filteredDiagnostics.Length; i++)
                     {
-                        var diagnostic = filteredDiagnostics.ElementAt(i);
+                        var diagnostic = filteredDiagnostics[i];
                         var range = expectedRanges[i];
 
                         if (range.IsUndefined())


### PR DESCRIPTION
- Dug through the code base and there were several easy to remove "ElementAt" cases. Thankfully we didn't have any super crazy performance hitting cases but removed them nevertheless to encourage better usage in the future
- Because IEnumerable's are lazy and uncached you can get into some (O)n^2 scenarios super easily unless you force evaluation of the array you're ElementAting (ToArray).

Fixes dotnet/aspnetcore#29538