### PR TITLE
Remove design time helpers from C# completion list

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -231,7 +231,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         // C# design time helpers are not applicable in Razor and can be excluded from the completion list. If the current identifier being targeted
         // does not start with a double underscore, we trim out all items starting with "__" from the completion list. If the current identifier does
-        // start with a double underscore (e.g. '__ab[||]'), we only trim out common design time helpers from the completion list.
+        // start with a double underscore (e.g. "__ab[||]"), we only trim out common design time helpers from the completion list.
         private SumType<CompletionItem[], CompletionList>? RemoveInvalidCompletionItems(
             SumType<CompletionItem[], CompletionList> completionResult,
             LSPDocumentSnapshot documentSnapshot,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     result = IncludeCSharpKeywords(result.Value);
                 }
 
-                result = RemoveInvalidCompletionItems(result.Value, documentSnapshot, wordExtent, serverKind);
+                result = RemoveDesignTimeItems(result.Value, documentSnapshot, wordExtent, serverKind);
             }
 
             return result;
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         // We should remove Razor design time helpers from C#'s completion list. If the current identifier being targeted does not start with a double
         // underscore, we trim out all items starting with "__" from the completion list. If the current identifier does start with a double underscore
         // (e.g. "__ab[||]"), we only trim out common design time helpers from the completion list.
-        private SumType<CompletionItem[], CompletionList>? RemoveInvalidCompletionItems(
+        private SumType<CompletionItem[], CompletionList>? RemoveDesignTimeItems(
             SumType<CompletionItem[], CompletionList> completionResult,
             LSPDocumentSnapshot documentSnapshot,
             TextExtent? wordExtent,
@@ -244,12 +244,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             var result = completionResult.Match<SumType<CompletionItem[], CompletionList>?>(
-                items => RemoveInvalidCompletionItemsHelper(items, documentSnapshot, wordExtent),
-                list => RemoveInvalidCompletionItemsHelper(list.Items, documentSnapshot, wordExtent));
+                items => RemoveDesignTimeItems(items, documentSnapshot, wordExtent),
+                list => RemoveDesignTimeItems(list.Items, documentSnapshot, wordExtent));
 
             return result;
 
-            static CompletionItem[] RemoveInvalidCompletionItemsHelper(CompletionItem[] items, LSPDocumentSnapshot documentSnapshot, TextExtent? wordExtent)
+            static CompletionItem[] RemoveDesignTimeItems(CompletionItem[] items, LSPDocumentSnapshot documentSnapshot, TextExtent? wordExtent)
             {
                 var designTimeHelpersCompletionItems = GenerateCompletionItems(DesignTimeHelpers);
                 if (wordExtent.HasValue)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -229,9 +229,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return false;
         }
 
-        // C# design time helpers are not applicable in Razor and can be excluded from the completion list. If the current identifier being targeted
-        // does not start with a double underscore, we trim out all items starting with "__" from the completion list. If the current identifier does
-        // start with a double underscore (e.g. "__ab[||]"), we only trim out common design time helpers from the completion list.
+        // We should remove Razor design time helpers from C#'s completion list. If the current identifier being targeted does not start with a double
+        // underscore, we trim out all items starting with "__" from the completion list. If the current identifier does start with a double underscore
+        // (e.g. "__ab[||]"), we only trim out common design time helpers from the completion list.
         private SumType<CompletionItem[], CompletionList>? RemoveInvalidCompletionItems(
             SumType<CompletionItem[], CompletionList> completionResult,
             LSPDocumentSnapshot documentSnapshot,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ITextSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ITextSnapshotExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Operations;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
@@ -19,6 +21,34 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             lineNumber = line.LineNumber;
             characterIndex = index - line.Start.Position;
+        }
+
+        public static TextExtent? GetWordExtent(
+            this ITextSnapshot snapshot,
+            int line, int character,
+            ITextStructureNavigatorSelectorService textStructureNavigatorService)
+        {
+            var navigator = textStructureNavigatorService.GetTextStructureNavigator(snapshot.TextBuffer);
+            var textSnapshotLine = snapshot.GetLineFromLineNumber(line);
+            var absoluteIndex = textSnapshotLine.Start + character;
+            if (absoluteIndex > snapshot.Length)
+            {
+                Debug.Fail("This should never happen given we're operating on snapshots.");
+                return null;
+            }
+
+            // Lets walk backwards to the character that caused completion (if one triggered it) to ensure that the "GetExtentOfWord" returns
+            // the word we care about and not whitespace following it. For instance:
+            //
+            //      @Date|\r\n
+            //
+            // Will return the \r\n as the "word" which is incorrect; however, this is actually fixed in newer VS CoreEditor builds but is behind
+            // the "Use word pattern in LSP completion" preview feature. Once this preview feature flag is the default we can remove this -1.
+            var completionCharacterIndex = Math.Max(0, absoluteIndex - 1);
+            var completionSnapshotPoint = new SnapshotPoint(snapshot, completionCharacterIndex);
+            var wordExtent = navigator.GetExtentOfWord(completionSnapshotPoint);
+
+            return wordExtent;
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ITextSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ITextSnapshotExtensions.cs
@@ -25,9 +25,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public static TextExtent? GetWordExtent(
             this ITextSnapshot snapshot,
-            int line, int character,
+            int line,
+            int character,
             ITextStructureNavigatorSelectorService textStructureNavigatorService)
         {
+            if (snapshot == null || textStructureNavigatorService == null)
+            {
+                return null;
+            }
+
             var navigator = textStructureNavigatorService.GetTextStructureNavigator(snapshot.TextBuffer);
             var textSnapshotLine = snapshot.GetLineFromLineNumber(line);
             var absoluteIndex = textSnapshotLine.Start + character;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedItem = new CompletionItem() { InsertText = "DateTime"};
+            var expectedItem = new CompletionItem() { InsertText = "DateTime", Label = "DateTime" };
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedItem = new CompletionItem() { InsertText = "__builder", Label = "__builder", Preselect = true };
+            var expectedItem = new CompletionItem() { InsertText = "AccessViolationException", Label = "AccessViolationException", Preselect = true };
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     Assert.Collection(list.Items,
                         item =>
                         {
-                            Assert.Equal("__builder", item.Label);
+                            Assert.Equal("AccessViolationException", item.Label);
                             Assert.False(item.Preselect, "Preselect should have been disabled.");
                         },
                         item => { }, item => { }, item => { }, item => { }, item => { }, item => { }, item => { }, item => { }, item => { }, item => { });
@@ -633,7 +633,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedItem = new CompletionItem() { InsertText = "DateTime" };
+            var expectedItem = new CompletionItem() { InsertText = "DateTime", Label = "DateTime" };
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -679,7 +679,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedItem = new CompletionItem() { InsertText = "DateTime" };
+            var expectedItem = new CompletionItem() { InsertText = "DateTime", Label = "DateTime" };
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -722,7 +722,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         }
 
         [Fact]
-        public async Task HandleRequestAsync_CSharpProjection_RemoveDesignTimeHelpers()
+        public async Task HandleRequestAsync_CSharpProjection_RemoveAllDesignTimeHelpers()
         {
             // Arrange
             var called = false;


### PR DESCRIPTION
### Summary of the changes
 - Removes Razor design time helpers from C#'s completion list since they will not be applicable.
 - If the current identifier being targeted does not start with a double underscore, we trim out all items starting with "__" from the completion list. If the current identifier does start with a double underscore (e.g. "__ab[||]"), we only trim out common design time helpers from the completion list.
 
Definitely open to adding more items to the "common" design time helpers list. I mainly just used the recommended ones from the original issue.

Fixes: 
https://github.com/dotnet/aspnetcore/issues/25091