### PR TITLE
Fix duplicate C# CodeActions in Debug experimental VS instance

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -16,9 +16,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [Export(typeof(VirtualDocumentFactory))]
     internal class CSharpVirtualDocumentFactory : VirtualDocumentFactoryBase
     {
+        public static readonly string CSharpClientName = "RazorCSharp";
         private static readonly IReadOnlyDictionary<object, object> _languageBufferProperties = new Dictionary<object, object>
         {
-            { LanguageClientConstants.ClientNamePropertyKey, "RazorCSharp" }
+            { LanguageClientConstants.ClientNamePropertyKey, CSharpClientName }
         };
 
         private static IContentType _csharpContentType;


### PR DESCRIPTION
- We were aggressively booting too many language clients that weren't applicable in local scenarios. For instance, one of the language clients was LiveShare's that's only ever applicable on a Liveshare guest and another was IntelliCode. Both of these should never run in Razor scenarios but our act of aggressively booting them resulted in us getting double code actions.
- Had to re-implement a lot of the language client "LoadAsync" filtering logic in order to not boot language clients that were non-applicable.