### PR TITLE
Remove _Imports from completion list

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             "__tagHelperExecutionContext",
             "__tagHelperRunner",
             "__typeHelper",
+            "_Imports",
             "BuildRenderTree"
         };
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -732,6 +732,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 new CompletionItem() { InsertText = "DateTime", Label = "DateTime" },
                 new CompletionItem() { InsertText = "__o", Label = "__o" },
                 new CompletionItem() { InsertText = "__RazorDirectiveTokenHelpers__", Label = "__RazorDirectiveTokenHelpers__" },
+                new CompletionItem() { InsertText = "_Imports", Label = "_Imports" },
             };
 
             var completionRequest = new CompletionParams()
@@ -801,6 +802,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 new CompletionItem() { InsertText = "__RazorDirectiveTokenHelpers__", Label = "__RazorDirectiveTokenHelpers__" },
                 new CompletionItem() { InsertText = "__o", Label = "__o" },
                 new CompletionItem() { InsertText = "__x", Label = "__x" },
+                new CompletionItem() { InsertText = "_Imports", Label = "_Imports" },
             };
 
             // Requesting completion at:


### PR DESCRIPTION
### Summary of the changes
 - Removes `_Imports` from the completion list.
 - Pretty much just a one-line change. 😄 

Fixes: 
https://github.com/dotnet/aspnetcore/issues/29562