### PR TITLE
Use IsLSPEditorFeatureEnabled instead of the editor variant.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         internal void ProjectSnapshotManager_Changed(object sender, ProjectChangeEventArgs args)
         {
-            if (!_lspEditorFeatureDetector.IsLSPEditorAvailable(args.ProjectFilePath, hierarchy: null))
+            if (!_lspEditorFeatureDetector.IsLSPEditorFeatureEnabled())
             {
                 return;
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
@@ -11,14 +11,13 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.OperationProgress;
-using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using Xunit;
 using Xunit.Sdk;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
 {
-    public class TestServiceProvider: IServiceProvider
+    public class TestServiceProvider : IServiceProvider
     {
         public TestServiceProvider()
         {
@@ -478,7 +477,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             static TestDefaultRazorProjectChangePublisher()
             {
                 _lspEditorFeatureDetector
-                    .Setup(t => t.IsLSPEditorAvailable(It.IsAny<string>(), It.IsAny<IVsHierarchy>()))
+                    .Setup(t => t.IsLSPEditorFeatureEnabled())
                     .Returns(true);
             }
 


### PR DESCRIPTION
- Turns out checking if a specific file has the LSP editor available wasn't needed in this location because all we really care about is the fact of if the editor is enabled at all. Also turns out that the editor check was quite expensive in regards to perf because at solution close time every Razor file is removed from the project manager which results in a 1-1 mapping of "IsEditoravailable" checks per file which indirectly requires the need to lookup VS' hierarchy.

Fixes dotnet/aspnetcore#29861