### PR TITLE
Reduce the timeout for tests

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text.Adornments;
+using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
@@ -107,8 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             if (!_lspProgressListener.TryListenForProgress(
                 token,
                 onProgressNotifyAsync: (value, ct) => ProcessReferenceItemsAsync(value, request.PartialResultToken, ct),
-                WaitForProgressNotificationTimeout,
-                ImmediateNotificationTimeout,
+                DelayAfterLastNotifyAsync,
                 cancellationToken,
                 out var onCompleted))
             {
@@ -137,6 +137,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Results returned through Progress notification
             var remappedResults = await RemapReferenceItemsAsync(result, cancellationToken).ConfigureAwait(false);
             return remappedResults;
+
+            // Local functions
+            async Task DelayAfterLastNotifyAsync(CancellationToken cancellationToken)
+            {
+                using var combined = ImmediateNotificationTimeout.CombineWith(cancellationToken);
+
+                try
+                {
+                    await Task.Delay(WaitForProgressNotificationTimeout, combined.Token).ConfigureAwait(false);
+                }
+                catch (TaskCanceledException) when (ImmediateNotificationTimeout.IsCancellationRequested)
+                {
+                    // The delay was requested to complete immediately
+                }
+            }
         }
 
         private async Task ProcessReferenceItemsAsync(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -108,6 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 token,
                 onProgressNotifyAsync: (value, ct) => ProcessReferenceItemsAsync(value, request.PartialResultToken, ct),
                 WaitForProgressNotificationTimeout,
+                ImmediateNotificationTimeout,
                 cancellationToken,
                 out var onCompleted))
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPProgressListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPProgressListener.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             string token,
             Func<JToken, CancellationToken, Task> onProgressNotifyAsync,
             TimeSpan timeoutAfterLastNotify,
+            CancellationToken immediateNotificationTimeout,
             CancellationToken handlerCancellationToken,
             out Task onCompleted);
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPProgressListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPProgressListener.cs
@@ -13,8 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         public abstract bool TryListenForProgress(
             string token,
             Func<JToken, CancellationToken, Task> onProgressNotifyAsync,
-            TimeSpan timeoutAfterLastNotify,
-            CancellationToken immediateNotificationTimeout,
+            Func<CancellationToken, Task> delayAfterLastNotifyAsync,
             CancellationToken handlerCancellationToken,
             out Task onCompleted);
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPProgressListenerHandlerBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LSPProgressListenerHandlerBase.cs
@@ -14,9 +14,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         // Consequently, at ~ time > 0.5s ~ after the last notification, we don't know whether Roslyn is
         // done searching for results, or just hasn't found any additional results yet.
         // To work around this, we wait for up to 3.5s since the last notification before timing out.
-        //
-        // Internal for testing
-        internal virtual TimeSpan WaitForProgressNotificationTimeout { get; set; } = TimeSpan.FromSeconds(3.5);
+        private protected TimeSpan WaitForProgressNotificationTimeout { get; private set; } = TimeSpan.FromSeconds(3.5);
+
+        /// <summary>
+        /// Cancellation token indicating that waiting for progress notifications is no longer required.
+        /// </summary>
+        private protected CancellationToken ImmediateNotificationTimeout { get; private set; }
 
         public async Task<TResult> HandleRequestAsync(TParams requestParams, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
         {
@@ -27,5 +30,30 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         // Internal for testing
         internal abstract Task<TResult> HandleRequestAsync(TParams request, ClientCapabilities clientCapabilities, string token, CancellationToken cancellationToken);
+
+        internal TestAccessor GetTestAccessor()
+            => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly LSPProgressListenerHandlerBase<TParams, TResult> _instance;
+
+            public TestAccessor(LSPProgressListenerHandlerBase<TParams, TResult> instance)
+            {
+                _instance = instance;
+            }
+
+            public TimeSpan WaitForProgressNotificationTimeout
+            {
+                get => _instance.WaitForProgressNotificationTimeout;
+                set => _instance.WaitForProgressNotificationTimeout = value;
+            }
+
+            public CancellationToken ImmediateNotificationTimeout
+            {
+                get => _instance.ImmediateNotificationTimeout;
+                set => _instance.ImmediateNotificationTimeout = value;
+            }
+        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -197,8 +197,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 l.TryListenForProgress(
                     It.IsAny<string>(),
                     It.IsAny<Func<JToken, CancellationToken, Task>>(),
-                    It.IsAny<TimeSpan>(),
-                    It.IsAny<CancellationToken>(),
+                    It.IsAny<Func<CancellationToken, Task>>(),
                     It.IsAny<CancellationToken>(),
                     out onCompleted) == false, MockBehavior.Strict);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -40,8 +40,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = Mock.Of<LSPProjectionProvider>(MockBehavior.Strict);
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>(MockBehavior.Strict);
             var progressListener = Mock.Of<LSPProgressListener>(MockBehavior.Strict);
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
             var referenceRequest = new ReferenceParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -67,8 +69,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Returns(Task.FromResult<ProjectionResult>(null));
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>(MockBehavior.Strict);
             var progressListener = Mock.Of<LSPProgressListener>(MockBehavior.Strict);
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
             var referenceRequest = new ReferenceParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -143,8 +147,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.Html, It.IsAny<Uri>(), It.IsAny<Range[]>(), It.IsAny<CancellationToken>()))
                 .Returns<RazorLanguageKind, Uri, Range[], CancellationToken>((languageKind, uri, ranges, ct) => Task.FromResult(uri.LocalPath.Contains("file1") ? remappingResult1 : remappingResult2));
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object, lspProgressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -153,6 +159,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     a => AssertVSReferenceItem(expectedLocation1, a),
                     b => AssertVSReferenceItem(expectedLocation2, b));
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -192,10 +199,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     It.IsAny<Func<JToken, CancellationToken, Task>>(),
                     It.IsAny<TimeSpan>(),
                     It.IsAny<CancellationToken>(),
+                    It.IsAny<CancellationToken>(),
                     out onCompleted) == false, MockBehavior.Strict);
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
             var referenceRequest = new ReferenceParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -270,8 +280,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, It.IsAny<Uri>(), It.IsAny<Range[]>(), It.IsAny<CancellationToken>()))
                 .Returns<RazorLanguageKind, Uri, Range[], CancellationToken>((languageKind, uri, ranges, ct) => Task.FromResult(uri.LocalPath.Contains("file1") ? remappingResult1 : remappingResult2));
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object, lspProgressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -280,6 +292,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     a => AssertVSReferenceItem(expectedLocation1, a),
                     b => AssertVSReferenceItem(expectedLocation2, b));
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -327,8 +340,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, externalUri, new[] { csharpLocation.Location.Range }, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -336,6 +351,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 var actualLocation = Assert.Single(results);
                 AssertVSReferenceItem(expectedLocation, actualLocation);
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -384,8 +400,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, externalUri, new[] { csharpLocation.Location.Range }, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -393,6 +411,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 var actualReferenceItem = Assert.Single(results);
                 AssertVSReferenceItem(expectedReferenceItem, actualReferenceItem);
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -453,8 +472,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentMappingProvider.Setup(d => d.MapToDocumentRangesAsync(RazorLanguageKind.CSharp, externalUri, new[] { csharpLocation.Location.Range }, It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(remappingResult));
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -462,6 +483,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 var actualReferenceItem = Assert.Single(results);
                 AssertVSReferenceItem(expectedReferenceItem, actualReferenceItem);
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -499,8 +521,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentMappingProvider = Mock.Of<LSPDocumentMappingProvider>(MockBehavior.Strict);
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>(MockBehavior.Strict);
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
@@ -508,6 +532,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 var actualLocation = Assert.Single(results);
                 AssertVSReferenceItem(externalCsharpLocation, actualLocation);
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -554,14 +579,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>(MockBehavior.Strict);
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
                 var results = Assert.IsType<VSReferenceItem[]>(val);
                 Assert.Empty(results);
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -611,14 +639,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>(MockBehavior.Strict);
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
                 var results = Assert.IsType<VSReferenceItem[]>(val);
                 Assert.Empty(results);
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -660,14 +691,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var languageServiceBroker = Mock.Of<ILanguageServiceBroker2>(MockBehavior.Strict);
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker, documentManager, projectionProvider.Object, documentMappingProvider.Object, progressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressToken = new ProgressWithCompletion<object>((val) =>
             {
                 var results = Assert.IsType<VSReferenceItem[]>(val);
                 Assert.Empty(results);
                 progressReported = true;
+                completedTokenSource.CancelAfter(0);
             });
             var referenceRequest = new ReferenceParams()
             {
@@ -780,8 +814,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     return Task.FromResult(response);
                 });
 
+            using var completedTokenSource = new CancellationTokenSource();
             var referencesHandler = new FindAllReferencesHandler(requestInvoker.Object, documentManager, projectionProvider.Object, documentMappingProvider.Object, lspProgressListener);
-            referencesHandler.WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().WaitForProgressNotificationTimeout = TestWaitForProgressNotificationTimeout;
+            referencesHandler.GetTestAccessor().ImmediateNotificationTimeout = completedTokenSource.Token;
 
             var progressBatchesReported = new ConcurrentBag<VSReferenceItem[]>();
             var progressToken = new ProgressWithCompletion<object>((val) =>
@@ -789,6 +825,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 var results = Assert.IsType<VSReferenceItem[]>(val);
                 Assert.Equal(BATCH_SIZE, results.Length);
                 progressBatchesReported.Add(results);
+                if (progressBatchesReported.Count == NUM_BATCHES)
+                {
+                    // All expected results were received
+                    completedTokenSource.CancelAfter(0);
+                }
             });
             var referenceRequest = new ReferenceParams()
             {


### PR DESCRIPTION
This change shaves ~6 minutes off the test execution time. It's possible it introduces some flakiness, but that can be addressed separately (and without reintroducing this delay) if it arises.