### PR TITLE
Use a Brokered Service to indicate RazorLSPServerReady

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -123,9 +123,11 @@
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
     <OmniSharpExtensionsLanguageServerPackageVersion>0.18.1</OmniSharpExtensionsLanguageServerPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.33.0</OmniSharpMSBuildPackageVersion>
+    <StreamJsonRpcPackageVersion>2.7.66-alpha</StreamJsonRpcPackageVersion>
     <SystemPrivateUriPackageVersion>4.3.2</SystemPrivateUriPackageVersion>
     <SystemCompositionPackageVersion>1.0.31.0</SystemCompositionPackageVersion>
     <SystemCollectionsImmutablePackageVersion>5.0.0</SystemCollectionsImmutablePackageVersion>
+    <SystemIOPipelinesPackageVersion>5.0.1</SystemIOPipelinesPackageVersion>
     <VS_NewtonsoftJsonPackageVersion>12.0.2</VS_NewtonsoftJsonPackageVersion>
     <VSMAC_NewtonsoftJsonPackageVersion>12.0.2</VSMAC_NewtonsoftJsonPackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.3.2</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -130,20 +130,20 @@
     <VSMAC_NewtonsoftJsonPackageVersion>12.0.2</VSMAC_NewtonsoftJsonPackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.3.2</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>5.0.3</Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCommonPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisCommonPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCommonPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisCommonPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)</Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>
     <Tooling_RoslynDiagnosticsAnalyzersPackageVersion>$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)</Tooling_RoslynDiagnosticsAnalyzersPackageVersion>
-    <Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>3.9.0-3.20604.2</Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>3.10.0-1.21109.14</Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitCombinatorialPackageVersion>1.4.1</XunitCombinatorialPackageVersion>
     <XunitVersion>2.4.1</XunitVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/CSharpProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/CSharpProximityExpressionResolver.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
 {
     internal abstract class CSharpProximityExpressionResolver
     {
-        public abstract IReadOnlyList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex);
+        public abstract IReadOnlyList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultCSharpProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultCSharpProximityExpressionResolver.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Reflection;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
@@ -26,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
                     "Do",
                     BindingFlags.NonPublic | BindingFlags.Static,
                     binder: null,
-                    types: new[] { typeof(SyntaxTree), typeof(int) },
+                    types: new[] { typeof(SyntaxTree), typeof(int), typeof(CancellationToken) },
                     modifiers: Array.Empty<ParameterModifier>());
 
                 if (_getProximityExpressionAsync == null)
@@ -43,14 +44,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
             }
         }
 
-        public override IReadOnlyList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex)
+        public override IReadOnlyList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex, CancellationToken cancellationToken)
         {
             if (syntaxTree is null)
             {
                 throw new ArgumentNullException(nameof(syntaxTree));
             }
 
-            var parameters = new object[] { syntaxTree, absoluteIndex };
+            var parameters = new object[] { syntaxTree, absoluteIndex, cancellationToken };
             var result = _getProximityExpressionAsync.Invoke(obj: null, parameters);
             var expressions = (IReadOnlyList<string>)result;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
 
             var sourceText = virtualDocument.Snapshot.AsText();
             var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, cancellationToken: cancellationToken);
-            var proximityExpressions = _csharpProximityExpressionResolver.GetProximityExpressions(syntaxTree, projectionResult.PositionIndex);
+            var proximityExpressions = _csharpProximityExpressionResolver.GetProximityExpressions(syntaxTree, projectionResult.PositionIndex, cancellationToken);
 
 
             return proximityExpressions;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly TrackingLSPDocumentManager _documentManager;
         private readonly JoinableTaskFactory _joinableTaskFactory;
         private readonly LSPRequestInvoker _requestInvoker;
-        private readonly RazorUIContextManager _uiContextManager;
+        private readonly RazorUIContextManager _uIContextManager;
         private readonly IDisposable _razorReadyListener;
 
         private const string RazorReadyFeature = "Razor-Initialization";
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
         }
 
+        // Testing constructor
         internal DefaultRazorLanguageServerCustomMessageTarget(
             LSPDocumentManager documentManager,
             JoinableTaskContext joinableTaskContext,
@@ -89,7 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             _joinableTaskFactory = joinableTaskContext.Factory;
             _requestInvoker = requestInvoker;
-            _uiContextManager = uIContextManager;
+            _uIContextManager = uIContextManager;
             _razorReadyListener = razorReadyListener;
         }
 
@@ -290,7 +291,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public override async Task RazorServerReadyAsync(CancellationToken cancellationToken)
         {
             // Doing both UIContext and BrokeredService while integrating
-            await _uiContextManager.SetUIContextAsync(RazorLSPConstants.RazorActiveUIContextGuid, isActive: true, cancellationToken);
+            await _uIContextManager.SetUIContextAsync(RazorLSPConstants.RazorActiveUIContextGuid, isActive: true, cancellationToken);
             _razorReadyListener.Dispose();
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="System.Composition" Version="$(SystemCompositionPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="$(MicrosoftInternalVisualStudioShellEmbeddablePackageVersion)" />
     <PackageReference Include="Microsoft.ServiceHub.Framework" Version="$(MicrosoftServiceHubFrameworkPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataPackageVersion)" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
     <PackageReference Include="System.Composition" Version="$(SystemCompositionPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="$(MicrosoftVisualStudioShellInteropPackageVersion)" />
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
   </ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Microsoft.VisualStudio.LiveShare.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Microsoft.VisualStudio.LiveShare.Razor.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LiveShare" Version="$(MicrosoftVisualStudioLiveSharePackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/Microsoft.CodeAnalysis.Remote.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/Microsoft.CodeAnalysis.Remote.Razor.Test.csproj
@@ -15,6 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingPackageVersion)" />
+    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using SystemDebugger = System.Diagnostics.Debugger;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +16,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Moq;
 using Xunit;
+using SystemDebugger = System.Diagnostics.Debugger;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using SystemDebugger = System.Diagnostics.Debugger;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -611,7 +611,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         private static void DoWithTimeoutIfNotDebugging(Func<int, bool> withTimeout)
         {
 #if DEBUG
-            if (Debugger.IsAttached)
+            if (SystemDebugger.IsAttached)
             {
                 withTimeout(Timeout.Infinite);
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -76,8 +76,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var documentManager = Mock.Of<TrackingLSPDocumentManager>(MockBehavior.Strict);
             var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
+            var disposable = new Mock<IDisposable>(MockBehavior.Strict);
 
-            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object, disposable.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -107,8 +108,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             Mock.Get(documentManager).Setup(m => m.TryGetDocument(new Uri("c:/Some/path/to/file.razor"), out It.Ref<LSPDocumentSnapshot>.IsAny)).Returns(false);
             var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
+            var disposable = new Mock<IDisposable>(MockBehavior.Strict);
 
-            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object, disposable.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -151,10 +153,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             requestInvoker
                 .Setup(r => r.ReinvokeRequestOnServerAsync<DocumentRangeFormattingParams, TextEdit[]>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DocumentRangeFormattingParams>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new[] { expectedEdit }));
-
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
+            var disposable = new Mock<IDisposable>(MockBehavior.Strict);
 
-            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object, disposable.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -260,8 +262,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             )).Returns(Task.FromResult(expectedResults));
 
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
+            var disposable = new Mock<IDisposable>(MockBehavior.Strict);
 
-            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object, disposable.Object);
             var request = new CodeActionParams()
             {
                 TextDocument = new LanguageServer.Protocol.TextDocumentIdentifier()
@@ -307,8 +310,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             )).Returns(Task.FromResult(expectedResponses));
 
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
+            var disposable = new Mock<IDisposable>(MockBehavior.Strict);
 
-            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object, disposable.Object);
             var request = new VSCodeAction()
             {
                 Title = "Something",
@@ -399,8 +403,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             )).Returns(Task.FromResult(expectedcSharpResults));
 
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
+            var disposable = new Mock<IDisposable>(MockBehavior.Strict);
 
-            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object, disposable.Object);
             var request = new SemanticTokensParams()
             {
                 TextDocument = new TextDocumentIdentifier()
@@ -418,7 +423,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         [Fact]
-        public async Task RazorServerReadyAsync_SetsUIContext()
+        public async Task RazorServerReady_SetsUIContextAsync()
         {
             // Arrange
             var testDocUri = new Uri("C:/path/to/file.razor");
@@ -446,14 +451,19 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             uIContextManager.Setup(m => m.SetUIContextAsync(RazorLSPConstants.RazorActiveUIContextGuid, true, It.IsAny<CancellationToken>()))
                 .Returns(() => Task.CompletedTask)
                 .Verifiable();
+            var disposable = new Mock<IDisposable>(MockBehavior.Strict);
+            disposable
+                .Setup(d => d.Dispose())
+                .Verifiable();
 
-            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object);
+            var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, JoinableTaskContext, requestInvoker.Object, uIContextManager.Object, disposable.Object);
 
             // Act
             await target.RazorServerReadyAsync(CancellationToken.None);
 
             // Assert
             uIContextManager.Verify();
+            disposable.Verify();
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -153,6 +153,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             requestInvoker
                 .Setup(r => r.ReinvokeRequestOnServerAsync<DocumentRangeFormattingParams, TextEdit[]>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DocumentRangeFormattingParams>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new[] { expectedEdit }));
+
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
             var disposable = new Mock<IDisposable>(MockBehavior.Strict);
 
@@ -423,7 +424,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         [Fact]
-        public async Task RazorServerReady_SetsUIContextAsync()
+        public async Task RazorServerReadyAsync_ReportsReadyAsync()
         {
             // Arrange
             var testDocUri = new Uri("C:/path/to/file.razor");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/29883.

The basic flow here is that we use the `IRazorAsynchronousOperationListenerProviderAccessor` to create an async context which we can later resolve. Then on the DDRIT side we call [IApexAsynchronousOperationListenerProviderAccessor](https://github.com/dotnet/roslyn/blob/c9a68b6a2fed69b1a48505b401dd1bb3d09dc45a/src/Tools/ExternalAccess/Apex/IApexAsynchronousOperationListenerProviderAccessor.cs).WaitAll on the same feature name so see if it's been resolved, and wait if it hasn't.