### PR TITLE
Support remapping C# override completions in Razor documents.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultFormattingOptionsProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultFormattingOptionsProvider.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Composition;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
+{
+    [Shared]
+    [Export(typeof(FormattingOptionsProvider))]
+    internal class DefaultFormattingOptionsProvider : FormattingOptionsProvider
+    {
+        private readonly LSPDocumentManager _documentManager;
+        private readonly IIndentationManagerService _indentationManagerService;
+
+        [ImportingConstructor]
+        public DefaultFormattingOptionsProvider(
+            LSPDocumentManager documentManager,
+            IIndentationManagerService indentationManagerService)
+        {
+            if (documentManager is null)
+            {
+                throw new ArgumentNullException(nameof(documentManager));
+            }
+
+            if (indentationManagerService is null)
+            {
+                throw new ArgumentNullException(nameof(indentationManagerService));
+            }
+
+            _documentManager = documentManager;
+            _indentationManagerService = indentationManagerService;
+        }
+
+        public override FormattingOptions? GetOptions(Uri lspDocumentUri)
+        {
+            if (lspDocumentUri is null)
+            {
+                throw new ArgumentNullException(nameof(lspDocumentUri));
+            }
+
+            if (!_documentManager.TryGetDocument(lspDocumentUri, out var documentSnapshot))
+            {
+                // Couldn't resolve document and therefore can't resolve the corresponding formatting options.
+                return null;
+            }
+
+            _indentationManagerService.GetIndentation(documentSnapshot.Snapshot.TextBuffer, explicitFormat: false, out var insertSpaces, out var tabSize, out _);
+            var formattingOptions = new FormattingOptions()
+            {
+                InsertSpaces = insertSpaces,
+                TabSize = tabSize,
+            };
+
+            return formattingOptions;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/FormattingOptionsProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/FormattingOptionsProvider.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
+{
+    public abstract class FormattingOptionsProvider
+    {
+        public abstract FormattingOptions? GetOptions(Uri lspDocumentUri);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveData.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveData.cs
@@ -1,10 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     internal class CompletionResolveData
     {
+        public Uri HostDocumentUri { get; set; }
+
+        public Uri ProjectedDocumentUri { get; set; }
+
         public LanguageServerKind LanguageServerKind { get; set; }
 
         public object OriginalData { get; set; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
@@ -16,16 +17,33 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     internal class CompletionResolveHandler : IRequestHandler<CompletionItem, CompletionItem>
     {
         private readonly LSPRequestInvoker _requestInvoker;
+        private readonly LSPDocumentMappingProvider _documentMappingProvider;
+        private readonly FormattingOptionsProvider _formattingOptionsProvider;
 
         [ImportingConstructor]
-        public CompletionResolveHandler(LSPRequestInvoker requestInvoker)
+        public CompletionResolveHandler(
+            LSPRequestInvoker requestInvoker,
+            LSPDocumentMappingProvider documentMappingProvider,
+            FormattingOptionsProvider formattingOptionsProvider)
         {
             if (requestInvoker is null)
             {
                 throw new ArgumentNullException(nameof(requestInvoker));
             }
 
+            if (documentMappingProvider is null)
+            {
+                throw new ArgumentNullException(nameof(documentMappingProvider));
+            }
+
+            if (formattingOptionsProvider is null)
+            {
+                throw new ArgumentNullException(nameof(formattingOptionsProvider));
+            }
+
             _requestInvoker = requestInvoker;
+            _documentMappingProvider = documentMappingProvider;
+            _formattingOptionsProvider = formattingOptionsProvider;
         }
 
         public async Task<CompletionItem> HandleRequestAsync(CompletionItem request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
@@ -55,7 +73,56 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 request,
                 cancellationToken).ConfigureAwait(false);
 
+            result = await PostProcessCompletionItemAsync(request, result, resolveData, cancellationToken).ConfigureAwait(false);
             return result;
+        }
+
+        private async Task<CompletionItem> PostProcessCompletionItemAsync(
+            CompletionItem preResolveCompletionItem,
+            CompletionItem resolvedCompletionItem,
+            CompletionResolveData resolveData,
+            CancellationToken cancellationToken)
+        {
+            // This is a special contract between the Visual Studio LSP platform and language servers where if insert text and text edit's are not present
+            // then the "resolve" endpoint is guaranteed to run prior to a completion item's content being comitted. This gives language servers the
+            // opportunity to lazily evaluate text edits which in turn we need to remap. Given text edits generated through this mechanism tend to be
+            // more exntensive we do a full remapping gesture which includes formatting of said text-edits.
+            var shouldRemapTextEdits = preResolveCompletionItem.InsertText == null && preResolveCompletionItem.TextEdit == null;
+            if (!shouldRemapTextEdits)
+            {
+                // Don't need to remap anything, return early.
+                return resolvedCompletionItem;
+            }
+
+            var formattingOptions = _formattingOptionsProvider.GetOptions(resolveData.HostDocumentUri);
+            if (resolvedCompletionItem.TextEdit != null)
+            {
+                var containsSnippet = resolvedCompletionItem.InsertTextFormat == InsertTextFormat.Snippet;
+                var remappedEdits = await _documentMappingProvider.RemapFormattedTextEditsAsync(
+                    resolveData.ProjectedDocumentUri,
+                    new[] { resolvedCompletionItem.TextEdit },
+                    formattingOptions,
+                    containsSnippet,
+                    cancellationToken).ConfigureAwait(false);
+
+                // We only passed in a single edit to be remapped
+                var remappedEdit = remappedEdits.Single();
+                resolvedCompletionItem.TextEdit = remappedEdit;
+            }
+
+            if (resolvedCompletionItem.AdditionalTextEdits != null)
+            {
+                var remappedEdits = await _documentMappingProvider.RemapFormattedTextEditsAsync(
+                    resolveData.ProjectedDocumentUri,
+                    resolvedCompletionItem.AdditionalTextEdits,
+                    formattingOptions,
+                    containsSnippet: false, // Additional text edits can't contain snippets
+                    cancellationToken).ConfigureAwait(false);
+
+                resolvedCompletionItem.AdditionalTextEdits = remappedEdits;
+            }
+
+            return resolvedCompletionItem;
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultFormattingOptionsProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultFormattingOptionsProviderTest.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text.Editor;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
+{
+    public class DefaultFormattingOptionsProviderTest
+    {
+        [Fact]
+        public void GetOptions_CannotFindDocument_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var indentationManagerService = new Mock<IIndentationManagerService>(MockBehavior.Strict);
+            var provider = new DefaultFormattingOptionsProvider(documentManager, indentationManagerService.Object);
+            var documentUri = new Uri("C:/path/to/unknown/razorfile.razor");
+
+            // Act
+            var options = provider.GetOptions(documentUri);
+
+            // Assert
+            Assert.Null(options);
+        }
+
+        [Fact]
+        public void GetOptions_UsesIndentationManagerInformation()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var documentUri = new Uri("C:/path/to/razorfile.razor");
+            var documentSnapshot = new TestLSPDocumentSnapshot(documentUri, version: 0);
+            documentManager.AddDocument(documentSnapshot.Uri, documentSnapshot);
+            var expectedInsertSpaces = true;
+            var expectedTabSize = 1337;
+            var unneededIndentSize = 123;
+            var indentationManagerService = new Mock<IIndentationManagerService>(MockBehavior.Strict);
+            indentationManagerService
+                .Setup(service => service.GetIndentation(documentSnapshot.Snapshot.TextBuffer, false, out expectedInsertSpaces, out expectedTabSize, out unneededIndentSize))
+                .Verifiable();
+            var provider = new DefaultFormattingOptionsProvider(documentManager, indentationManagerService.Object);
+
+            // Act
+            var options = provider.GetOptions(documentUri);
+
+            // Assert
+            indentationManagerService.VerifyAll();
+            Assert.Equal(expectedInsertSpaces, options.InsertSpaces);
+            Assert.Equal(expectedTabSize, options.TabSize);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             // Arrange
             var called = false;
-            var expectedItem = new CompletionItem() { InsertText = "Sample"};
+            var expectedItem = new CompletionItem() { InsertText = "Sample" };
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -221,7 +221,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(result.HasValue);
             var _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
                 array => throw new NotImplementedException(),
-                list => {
+                list =>
+                {
                     Assert.Collection(list.Items,
                         item => Assert.Equal("DateTime", item.Label)
                     );
@@ -281,7 +282,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(result.HasValue);
             var _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
                 array => throw new NotImplementedException(),
-                list => {
+                list =>
+                {
 
                     Assert.Collection(list.Items,
                         item =>
@@ -320,7 +322,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     Assert.Equal(RazorLSPConstants.CSharpContentTypeName, serverContentType);
                     called = true;
                 })
-                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(new CompletionList{
+                .Returns(Task.FromResult<SumType<CompletionItem[], CompletionList>?>(new CompletionList
+                {
                     Items = new[] { expectedItem }
                 }));
 
@@ -341,7 +344,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(result.HasValue);
             var _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
                 array => throw new NotImplementedException(),
-                list => {
+                list =>
+                {
                     Assert.Collection(list.Items,
                         item => Assert.Equal("DateTime", item.Label)
                     );
@@ -398,10 +402,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             var _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array => {
+                array =>
+                {
                     Assert.Collection(array,
                         item => Assert.Equal("DateTime", item.InsertText),
-                        item => {
+                        item =>
+                        {
                             Assert.Equal("for", item.Label);
                             Assert.Equal("FROMCSHARP", item.InsertText);
                         },
@@ -418,7 +424,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
                     return array;
                 },
-                list => {
+                list =>
+                {
                     throw new NotImplementedException();
                 });
         }
@@ -475,10 +482,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             var _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array => {
+                array =>
+                {
                     Assert.Collection(array,
                         item => Assert.Equal("DateTime", item.InsertText),
-                        item => {
+                        item =>
+                        {
                             Assert.Equal("for", item.Label);
                             Assert.Equal("FROMCSHARP", item.InsertText);
                         },
@@ -495,7 +504,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
                     return array;
                 },
-                list => {
+                list =>
+                {
                     throw new NotImplementedException();
                 });
         }
@@ -547,7 +557,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array => {
+                array =>
+                {
                     Assert.Collection(array,
                         item => Assert.Equal("for", item.Label),
                         item => Assert.Equal("foreach", item.Label),
@@ -850,7 +861,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array => {
+                array =>
+                {
                     Assert.Collection(array,
                         item => Assert.Equal("__x", item.Label)
                     ); ;
@@ -914,13 +926,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 new CompletionItem() { InsertText = "Hello", Data = originalData }
             };
+            var hostDocumentUri = new Uri("C:/path/to/file.razor");
+            var projectedDocumentUri = new Uri("C:/path/to/file.razor.g.cs");
             var documentManager = new TestDocumentManager();
             var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict).Object;
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict).Object;
             var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, TextStructureNavigatorSelectorService);
 
             // Act
-            var result = completionHandler.SetResolveData(items, LanguageServerKind.CSharp);
+            var result = completionHandler.SetResolveData(items, LanguageServerKind.CSharp, hostDocumentUri, projectedDocumentUri);
 
             // Assert
             Assert.True(result.HasValue);
@@ -928,6 +942,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var newData = Assert.IsType<CompletionResolveData>(item.Data);
             Assert.Equal(LanguageServerKind.CSharp, newData.LanguageServerKind);
             Assert.Same(originalData, newData.OriginalData);
+            Assert.Same(hostDocumentUri, newData.HostDocumentUri);
+            Assert.Same(projectedDocumentUri, newData.ProjectedDocumentUri);
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
@@ -12,6 +14,134 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     public class CompletionResolveHandlerTest
     {
+        private TestDocumentMappingProvider DocumentMappingProvider { get; } = new TestDocumentMappingProvider();
+
+        private TestFormattingOptionsProvider FormattingOptionsProvider { get; } = new TestFormattingOptionsProvider();
+
+        [Fact]
+        public async Task HandleRequestAsync_NonNullOriginalInsertText_DoesNotRemapTextEdit()
+        {
+            // Arrange
+            var originalEdit = new TextEdit() { NewText = "original" };
+            var mappedEdit = new TextEdit() { NewText = "mapped" };
+            DocumentMappingProvider.AddMapping(originalEdit, mappedEdit);
+
+            var requestedCompletionItem = new CompletionItem()
+            {
+                InsertText = "DateTime",
+                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
+            };
+            var resolvedCompletionItem = new CompletionItem()
+            {
+                TextEdit = originalEdit,
+            };
+            var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+
+            // Act
+            var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Same(originalEdit, result.TextEdit);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_NonNullOriginalTextEdit_DoesNotRemapTextEdit()
+        {
+            // Arrange
+            var originalEdit = new TextEdit() { NewText = "original" };
+            var mappedEdit = new TextEdit() { NewText = "mapped" };
+            DocumentMappingProvider.AddMapping(originalEdit, mappedEdit);
+
+            var requestedCompletionItem = new CompletionItem()
+            {
+                TextEdit = originalEdit,
+                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
+            };
+            var resolvedCompletionItem = new CompletionItem()
+            {
+                InsertText = "DateTime",
+                TextEdit = originalEdit,
+            };
+            var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+
+            // Act
+            var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Same(originalEdit, result.TextEdit);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_ResolvedNullTextEdit_Noops()
+        {
+            // Arrange
+            var requestedCompletionItem = new CompletionItem()
+            {
+                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
+            };
+            var resolvedCompletionItem = new CompletionItem()
+            {
+                InsertText = "DateTime",
+            };
+            var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+
+            // Act & Assert
+            var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_NullInsertTextAndTextEdit_RemapsResolvedTextEdit()
+        {
+            // Arrange
+            var originalEdit = new TextEdit() { NewText = "original" };
+            var mappedEdit = new TextEdit() { NewText = "mapped" };
+            DocumentMappingProvider.AddMapping(originalEdit, mappedEdit);
+            var requestedCompletionItem = new CompletionItem()
+            {
+                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
+            };
+            var resolvedCompletionItem = new CompletionItem()
+            {
+                TextEdit = originalEdit,
+            };
+            var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+
+            // Act
+            var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Same(mappedEdit, result.TextEdit);
+        }
+
+        [Fact]
+        public async Task HandleRequestAsync_NullInsertTextAndTextEdit_RemapsAdditionalTextEdits()
+        {
+            // Arrange
+            var originalEdit = new TextEdit() { NewText = "original" };
+            var mappedEdit = new TextEdit() { NewText = "mapped" };
+            DocumentMappingProvider.AddMapping(originalEdit, mappedEdit);
+            var requestedCompletionItem = new CompletionItem()
+            {
+                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
+            };
+            var resolvedCompletionItem = new CompletionItem()
+            {
+                AdditionalTextEdits = new[] { originalEdit },
+            };
+            var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+
+            // Act
+            var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(new[] { mappedEdit }, result.AdditionalTextEdits);
+        }
+
         [Fact]
         public async Task HandleRequestAsync_InvokesCSharpLanguageServer()
         {
@@ -29,20 +159,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 Data = originalData,
                 Detail = "Some documentation"
             };
+            var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) =>
+            {
+                Assert.Equal(Methods.TextDocumentCompletionResolveName, method);
+                Assert.Equal(RazorLSPConstants.CSharpContentTypeName, serverContentType);
+                Assert.Same(originalData, completionItem.Data);
+                called = true;
 
-            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
-            requestInvoker
-                .Setup(r => r.ReinvokeRequestOnServerAsync<CompletionItem, CompletionItem>(It.IsAny<string>(), RazorLSPConstants.CSharpContentTypeName, It.IsAny<CompletionItem>(), It.IsAny<CancellationToken>()))
-                .Callback<string, string, CompletionItem, CancellationToken>((method, serverContentType, completionItem, ct) =>
-                {
-                    Assert.Equal(Methods.TextDocumentCompletionResolveName, method);
-                    Assert.Equal(RazorLSPConstants.CSharpContentTypeName, serverContentType);
-                    Assert.Same(originalData, completionItem.Data);
-                    called = true;
-                })
-                .Returns(Task.FromResult<CompletionItem>(expectedResponse));
+                return expectedResponse;
+            });
 
-            var handler = new CompletionResolveHandler(requestInvoker.Object);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
 
             // Act
             var result = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -69,20 +196,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 Data = originalData,
                 Detail = "Some documentation"
             };
+            var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) =>
+            {
+                Assert.Equal(Methods.TextDocumentCompletionResolveName, method);
+                Assert.Equal(RazorLSPConstants.HtmlLSPContentTypeName, serverContentType);
+                Assert.Same(originalData, completionItem.Data);
+                called = true;
+                return expectedResponse;
+            });
 
-            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
-            requestInvoker
-                .Setup(r => r.ReinvokeRequestOnServerAsync<CompletionItem, CompletionItem>(It.IsAny<string>(), RazorLSPConstants.HtmlLSPContentTypeName, It.IsAny<CompletionItem>(), It.IsAny<CancellationToken>()))
-                .Callback<string, string, CompletionItem, CancellationToken>((method, serverContentType, completionItem, ct) =>
-                {
-                    Assert.Equal(Methods.TextDocumentCompletionResolveName, method);
-                    Assert.Equal(RazorLSPConstants.HtmlLSPContentTypeName, serverContentType);
-                    Assert.Same(originalData, completionItem.Data);
-                    called = true;
-                })
-                .Returns(Task.FromResult<CompletionItem>(expectedResponse));
-
-            var handler = new CompletionResolveHandler(requestInvoker.Object);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
 
             // Act
             var result = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -90,6 +213,60 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Assert
             Assert.True(called);
             Assert.Same(expectedResponse, result);
+        }
+
+        private LSPRequestInvoker CreateRequestInvoker(Func<string, string, CompletionItem, CompletionItem> reinvokeCallback)
+        {
+            CompletionItem response = null;
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<CompletionItem, CompletionItem>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CompletionItem>(), It.IsAny<CancellationToken>()))
+                .Callback<string, string, CompletionItem, CancellationToken>((method, serverContentType, completionItem, ct) =>
+                {
+                    response = reinvokeCallback(method, serverContentType, completionItem);
+                })
+                .Returns(() => Task.FromResult(response));
+
+            return requestInvoker.Object;
+        }
+
+        private class TestFormattingOptionsProvider : FormattingOptionsProvider
+        {
+            public override FormattingOptions GetOptions(Uri lspDocumentUri) => null;
+        }
+
+        private class TestDocumentMappingProvider : LSPDocumentMappingProvider
+        {
+            private readonly Dictionary<TextEdit, TextEdit> _mappings = new Dictionary<TextEdit, TextEdit>();
+
+            public void AddMapping(TextEdit original, TextEdit mapping)
+            {
+                _mappings[original] = mapping;
+            }
+
+            public override Task<TextEdit[]> RemapFormattedTextEditsAsync(Uri uri, TextEdit[] edits, FormattingOptions options, bool containsSnippet, CancellationToken cancellationToken)
+            {
+                var newEdits = new List<TextEdit>();
+                for (var i = 0; i < edits.Length; i++)
+                {
+                    if (_mappings.TryGetValue(edits[i], out var mappedEdit))
+                    {
+                        newEdits.Add(mappedEdit);
+                    }
+                }
+
+                return Task.FromResult(newEdits.ToArray());
+            }
+
+            public override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, LanguageServer.Protocol.Range[] projectedRanges, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public override Task<RazorMapToDocumentRangesResponse> MapToDocumentRangesAsync(RazorLanguageKind languageKind, Uri razorDocumentUri, LanguageServer.Protocol.Range[] projectedRanges, LanguageServerMappingBehavior mappingBehavior, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public override Task<Location[]> RemapLocationsAsync(Location[] locations, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public override Task<TextEdit[]> RemapTextEditsAsync(Uri uri, TextEdit[] edits, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public override Task<WorkspaceEdit> RemapWorkspaceEditAsync(WorkspaceEdit workspaceEdit, CancellationToken cancellationToken) => throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
- At a lower layer this changeset enables text edit remapping at completion item resolve time. We needed to lazily evaluate/remap text edits for C# overrides for multiple reasons:
    1. After inserting C# override content we need to ensure the inserted content is properly formatted in the context of a Razor document
    2. C# overrides can take a significant amount of time to evaluate so evaluating them after an item is selected enables us to not evaluate "all" of them.
    3. Providing & remapping complex C# content in the initial completion request would require additional asynchronous calls to language servers to properly remap/format that content which could slow completion significantly.
- Added a new `DefaultFormattingOptionsProvider` that will lookup an associated LSP document and create formatting options based off of it. In our case this is important because we need to do formatting behaviors at completion resolve time (no formatting options immediately available). This seemed like a general utility so I put it in the ContainedLanguage framework library.
- To enable completion resolve to "do the right thing" I had to populate some additional fields in the completion items data fields. Ultimately this is probably the most concerning portion of this PR because it means every C# item now has additional content that gets serialized/deserialized when passed over the wire. I will need to do a follow up that caches completion items so we can lookup their data without putting extra content into the serialization stream.
- Ultimately this PR depends on a contract in the VS LSP platform where if at commit time if a completion item's TextEdit & InsertText are `null` it will wait on the UI thread to resolve that completion item in an effort to have that content populated. Because of this contract we can guarantee that our "remapped" text edits at resolve time will be applied (we cross-check this in our resolve handler as well).
- Eventually the VS platform will remove the ability to replace TextEdits at resolve time at which point we'll need a secondary contract to work with in order to resolve actual text content; however, we've gotten buy-off from the platform for this intermediary measure until that point.
- Added new tests to account for the completion handler, resolver and document formatting options provider.

Part of dotnet/aspnetcore#29619