### PR TITLE
Cache completion item -> request to minimize completion payload.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,6 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         private readonly LSPDocumentManager _documentManager;
         private readonly LSPProjectionProvider _projectionProvider;
         private readonly ITextStructureNavigatorSelectorService _textStructureNavigator;
+        private readonly CompletionRequestContextCache _completionRequestContextCache;
 
         [ImportingConstructor]
         public CompletionHandler(
@@ -60,7 +62,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             LSPRequestInvoker requestInvoker,
             LSPDocumentManager documentManager,
             LSPProjectionProvider projectionProvider,
-            ITextStructureNavigatorSelectorService textStructureNavigator)
+            ITextStructureNavigatorSelectorService textStructureNavigator,
+            CompletionRequestContextCache completionRequestContextCache)
         {
             if (joinableTaskContext is null)
             {
@@ -87,11 +90,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(textStructureNavigator));
             }
 
+            if (completionRequestContextCache is null)
+            {
+                throw new ArgumentNullException(nameof(completionRequestContextCache));
+            }
+
             _joinableTaskFactory = joinableTaskContext.Factory;
             _requestInvoker = requestInvoker;
             _documentManager = documentManager;
             _projectionProvider = projectionProvider;
             _textStructureNavigator = textStructureNavigator;
+            _completionRequestContextCache = completionRequestContextCache;
         }
 
         public async Task<SumType<CompletionItem[], CompletionList>?> HandleRequestAsync(CompletionParams request, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
@@ -152,36 +161,60 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     cancellationToken).ConfigureAwait(false);
             }
 
-            if (result.HasValue)
+            if (TryConvertToCompletionList(result, out var completionList))
             {
-                // Set some context on the CompletionItem so the CompletionResolveHandler can handle it accordingly.
-                result = SetResolveData(result.Value, serverKind, request.TextDocument.Uri, projectionResult.Uri);
-
                 if (serverKind == LanguageServerKind.CSharp)
                 {
-                    result = MassageCSharpCompletions(request, documentSnapshot, result.Value);
+                    MassageCSharpCompletions(request, documentSnapshot, completionList);
                 }
+
+                var requestContext = new CompletionRequestContext(documentSnapshot.Uri, projectionResult.Uri, serverKind);
+                var resultId = _completionRequestContextCache.Set(requestContext);
+                SetResolveData(resultId, completionList);
             }
 
-            return result;
+            return completionList;
+
+            static bool TryConvertToCompletionList(SumType<CompletionItem[], CompletionList>? original, out CompletionList completionList)
+            {
+                if (!original.HasValue)
+                {
+                    completionList = null;
+                    return false;
+                }
+
+                if (original.Value.TryGetFirst(out var completionItems))
+                {
+                    completionList = new CompletionList()
+                    {
+                        Items = completionItems,
+                        IsIncomplete = false
+                    };
+                }
+                else if (!original.Value.TryGetSecond(out completionList))
+                {
+                    Debug.Fail("This should be impossible, the completion result should be either a completion list or a set of completion items.");
+                    completionList = null;
+                    return false;
+                }
+
+                return true;
+            }
         }
 
-        private SumType<CompletionItem[], CompletionList>? MassageCSharpCompletions(
+        private void MassageCSharpCompletions(
             CompletionParams request,
             LSPDocumentSnapshot documentSnapshot,
-            SumType<CompletionItem[], CompletionList> result)
+            CompletionList completionList)
         {
-            var updatedResult = result;
-
             var wordExtent = documentSnapshot.Snapshot.GetWordExtent(request.Position.Line, request.Position.Character, _textStructureNavigator);
             if (IsSimpleImplicitExpression(request, documentSnapshot, wordExtent))
             {
-                updatedResult = DoNotPreselect(updatedResult);
-                updatedResult = IncludeCSharpKeywords(updatedResult);
+                DoNotPreselect(completionList);
+                IncludeCSharpKeywords(completionList);
             }
 
-            updatedResult = RemoveDesignTimeItems(documentSnapshot, wordExtent, updatedResult);
-            return updatedResult;
+            RemoveDesignTimeItems(documentSnapshot, wordExtent, completionList);
         }
 
         private static IReadOnlyCollection<CompletionItem> GenerateCompletionItems(IReadOnlyCollection<string> completionItems)
@@ -221,61 +254,44 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         // We should remove Razor design time helpers from C#'s completion list. If the current identifier being targeted does not start with a double
         // underscore, we trim out all items starting with "__" from the completion list. If the current identifier does start with a double underscore
         // (e.g. "__ab[||]"), we only trim out common design time helpers from the completion list.
-        private SumType<CompletionItem[], CompletionList> RemoveDesignTimeItems(
+        private void RemoveDesignTimeItems(
             LSPDocumentSnapshot documentSnapshot,
             TextExtent? wordExtent,
-            SumType<CompletionItem[], CompletionList> completionResult)
+            CompletionList completionList)
         {
-            var result = completionResult.Match<SumType<CompletionItem[], CompletionList>>(
-                items =>
-                {
-                    items = RemoveDesignTimeItems(documentSnapshot, wordExtent, items);
-                    return items;
-                },
-                list =>
-                {
-                    list.Items = RemoveDesignTimeItems(documentSnapshot, wordExtent, list.Items);
-                    return list;
-                });
+            var filteredItems = completionList.Items.Except(DesignTimeHelpersCompletionItems, CompletionItemComparer.Instance).ToArray();
 
-            return result;
-
-            static CompletionItem[] RemoveDesignTimeItems(LSPDocumentSnapshot documentSnapshot, TextExtent? wordExtent, CompletionItem[] items)
+            // If the current identifier starts with "__", only trim out common design time helpers from the list.
+            // In all other cases, trim out both common design time helpers and all completion items starting with "__".
+            if (RemoveAllDesignTimeItems(documentSnapshot, wordExtent))
             {
-                var filteredItems = items.Except(DesignTimeHelpersCompletionItems, CompletionItemComparer.Instance).ToArray();
+                filteredItems = filteredItems.Where(item => item.Label != null && !item.Label.StartsWith("__", StringComparison.Ordinal)).ToArray();
+            }
 
-                // If the current identifier starts with "__", only trim out common design time helpers from the list.
-                // In all other cases, trim out both common design time helpers and all completion items starting with "__".
-                if (RemoveAllDesignTimeItems(documentSnapshot, wordExtent))
+            completionList.Items = filteredItems;
+
+            static bool RemoveAllDesignTimeItems(LSPDocumentSnapshot documentSnapshot, TextExtent? wordExtent)
+            {
+                if (!wordExtent.HasValue)
                 {
-                    filteredItems = filteredItems.Where(item => item.Label != null && !item.Label.StartsWith("__", StringComparison.Ordinal)).ToArray();
-                }
-
-                return filteredItems;
-
-                static bool RemoveAllDesignTimeItems(LSPDocumentSnapshot documentSnapshot, TextExtent? wordExtent)
-                {
-                    if (!wordExtent.HasValue)
-                    {
-                        return true;
-                    }
-
-                    var wordSpan = wordExtent.Value.Span;
-                    if (wordSpan.Length < 2)
-                    {
-                        return true;
-                    }
-
-                    var snapshot = documentSnapshot.Snapshot;
-                    var startIndex = wordSpan.Start.Position;
-
-                    if (snapshot[startIndex] == '_' && snapshot[startIndex + 1] == '_')
-                    {
-                        return false;
-                    }
-
                     return true;
                 }
+
+                var wordSpan = wordExtent.Value.Span;
+                if (wordSpan.Length < 2)
+                {
+                    return true;
+                }
+
+                var snapshot = documentSnapshot.Snapshot;
+                var startIndex = wordSpan.Start.Position;
+
+                if (snapshot[startIndex] == '_' && snapshot[startIndex + 1] == '_')
+                {
+                    return false;
+                }
+
+                return true;
             }
         }
 
@@ -372,99 +388,34 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         }
 
         // In cases like "@{" preselection can lead to unexpected behavior, so let's exclude it.
-        private SumType<CompletionItem[], CompletionList> DoNotPreselect(SumType<CompletionItem[], CompletionList> completionResult)
+        private void DoNotPreselect(CompletionList completionList)
         {
-            var result = completionResult.Match<SumType<CompletionItem[], CompletionList>>(
-                items =>
-                {
-                    foreach (var i in items)
-                    {
-                        i.Preselect = false;
-                    }
-
-                    return items;
-                },
-                list =>
-                {
-                    foreach (var i in list.Items)
-                    {
-                        i.Preselect = false;
-                    }
-
-                    return list;
-                });
-
-            return result;
+            foreach (var item in completionList.Items)
+            {
+                item.Preselect = false;
+            }
         }
 
         // C# keywords were previously provided by snippets, but as of now C# LSP doesn't provide snippets. 
         // We're providing these for now to improve the user experience (not having to ESC out of completions to finish),
         // but once C# starts providing them their completion will be offered instead, at which point we should be able to remove this step.
-        private SumType<CompletionItem[], CompletionList> IncludeCSharpKeywords(SumType<CompletionItem[], CompletionList> completionResult)
+        private void IncludeCSharpKeywords(CompletionList completionList)
         {
-            var result = completionResult.Match<SumType<CompletionItem[], CompletionList>>(
-                items =>
-                {
-                    var newList = items.Union(KeywordCompletionItems, CompletionItemComparer.Instance);
-                    return newList.ToArray();
-                },
-                list =>
-                {
-                    var newList = list.Items.Union(KeywordCompletionItems, CompletionItemComparer.Instance);
-                    list.Items = newList.ToArray();
-
-                    return list;
-                });
-
-            return result;
+            var newList = completionList.Items.Union(KeywordCompletionItems, CompletionItemComparer.Instance);
+            completionList.Items = newList.ToArray();
         }
 
-        // Internal for testing
-        internal SumType<CompletionItem[], CompletionList>? SetResolveData(SumType<CompletionItem[], CompletionList> completionResult, LanguageServerKind kind, Uri hostDocumentUri, Uri projectedDocumentUri)
+        internal void SetResolveData(long resultId, CompletionList completionList)
         {
-            var result = completionResult.Match<SumType<CompletionItem[], CompletionList>?>(
-                items =>
-                {
-                    var newItems = items.Select(item => SetData(hostDocumentUri, projectedDocumentUri, item)).ToArray();
-                    return newItems;
-                },
-                list =>
-                {
-                    var newItems = list.Items.Select(item => SetData(hostDocumentUri, projectedDocumentUri, item)).ToArray();
-                    if (list is VSCompletionList vsList)
-                    {
-                        return new VSCompletionList()
-                        {
-                            Items = newItems,
-                            IsIncomplete = vsList.IsIncomplete,
-                            SuggestionMode = vsList.SuggestionMode,
-                            ContinueCharacters = vsList.ContinueCharacters
-                        };
-                    }
-
-                    return new CompletionList()
-                    {
-                        Items = newItems,
-                        IsIncomplete = list.IsIncomplete,
-                    };
-                },
-                () => null);
-
-            return result;
-
-            CompletionItem SetData(Uri hostDocumentUri, Uri projectedDocumentUri, CompletionItem item)
+            for (var i = 0; i < completionList.Items.Length; i++)
             {
+                var item = completionList.Items[i];
                 var data = new CompletionResolveData()
                 {
-                    HostDocumentUri = hostDocumentUri,
-                    ProjectedDocumentUri = projectedDocumentUri,
-                    LanguageServerKind = kind,
-                    OriginalData = item.Data
+                    ResultId = resultId,
+                    OriginalData = item.Data,
                 };
-
                 item.Data = data;
-
-                return item;
             }
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionRequestContext.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionRequestContext.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Newtonsoft.Json;
+#nullable enable
+
+using System;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
-    internal class CompletionResolveData
-    {
-        public long ResultId { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public object OriginalData { get; set; }
-    }
+    internal record CompletionRequestContext(Uri HostDocumentUri, Uri ProjectedDocumentUri, LanguageServerKind LanguageServerKind);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionRequestContextCache.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionRequestContextCache.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    [Shared]
+    [Export(typeof(CompletionRequestContextCache))]
+    internal sealed class CompletionRequestContextCache
+    {
+        // Internal for testing
+        internal static readonly int MaxCacheSize = 3;
+
+        private readonly object _accessLock;
+        private readonly List<CompletionRequestCacheItem> _completionRequests;
+        private long _nextResultId;
+
+        public CompletionRequestContextCache()
+        {
+            _accessLock = new object();
+            _completionRequests = new List<CompletionRequestCacheItem>();
+        }
+
+        public long Set(CompletionRequestContext requestContext)
+        {
+            if (requestContext is null)
+            {
+                throw new ArgumentNullException(nameof(requestContext));
+            }
+
+            lock (_accessLock)
+            {
+                // If cache exceeds maximum size, remove the oldest list in the cache
+                if (_completionRequests.Count >= MaxCacheSize)
+                {
+                    _completionRequests.RemoveAt(0);
+                }
+
+                var resultId = _nextResultId++;
+
+                var cacheItem = new CompletionRequestCacheItem(resultId, requestContext);
+                _completionRequests.Add(cacheItem);
+
+                // Return generated resultId so completion list can later be retrieved from cache
+                return resultId;
+            }
+        }
+
+        public bool TryGet(long resultId, out CompletionRequestContext? requestContext)
+        {
+            lock (_accessLock)
+            {
+                // Search back -> front because the items in the back are the most recently added which are most frequently accessed.
+                for (var i = _completionRequests.Count - 1; i >= 0; i--)
+                {
+                    var cacheItem = _completionRequests[i];
+                    if (cacheItem.ResultId == resultId)
+                    {
+                        requestContext = cacheItem.RequestContext;
+                        return true;
+                    }
+                }
+
+                // A completion list associated with the given resultId was not found
+                requestContext = null;
+                return false;
+            }
+        }
+
+        private record CompletionRequestCacheItem(long ResultId, CompletionRequestContext RequestContext);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/IsExternalInit.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/IsExternalInit.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System.Runtime.CompilerServices
+{
+    // Used to compile against C# 9 in a net472 app.
+    internal class IsExternalInit
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -6,6 +6,7 @@
     <EnableApiCheck>false</EnableApiCheck>
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -25,11 +25,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             TextStructureNavigatorSelectorService = navigatorSelector;
 
             Uri = new Uri("C:/path/to/file.razor");
+
+            CompletionRequestContextCache = new CompletionRequestContextCache();
         }
 
         private JoinableTaskContext JoinableTaskContext { get; }
 
         private ITextStructureNavigatorSelectorService TextStructureNavigatorSelectorService { get; }
+
+        private CompletionRequestContextCache CompletionRequestContextCache { get; }
 
         private Uri Uri { get; }
 
@@ -40,7 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentManager = new TestDocumentManager();
             var requestInvoker = Mock.Of<LSPRequestInvoker>(MockBehavior.Strict);
             var projectionProvider = Mock.Of<LSPProjectionProvider>(MockBehavior.Strict);
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -65,7 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict).Object;
             Mock.Get(projectionProvider).Setup(projectionProvider => projectionProvider.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), CancellationToken.None))
                 .Returns(Task.FromResult<ProjectionResult>(null));
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
             var completionRequest = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier() { Uri = Uri },
@@ -116,14 +120,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.True(called);
-            var item = Assert.Single((CompletionItem[])result.Value);
+            var item = Assert.Single(((CompletionList)result.Value).Items);
             Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
@@ -163,14 +167,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.True(called);
-            var item = ((CompletionItem[])result.Value).First();
+            var item = ((CompletionList)result.Value).Items.First();
             Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
@@ -211,7 +215,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -272,7 +276,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -334,7 +338,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -393,7 +397,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -402,9 +406,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             var _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array =>
+                array => throw new NotImplementedException(),
+                list =>
                 {
-                    Assert.Collection(array,
+                    Assert.Collection(list.Items,
                         item => Assert.Equal("DateTime", item.InsertText),
                         item =>
                         {
@@ -420,13 +425,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         item => Assert.Equal("try", item.Label),
                         item => Assert.Equal("do", item.Label),
                         item => Assert.Equal("using", item.Label)
-                    ); ;
+                    );
 
-                    return array;
-                },
-                list =>
-                {
-                    throw new NotImplementedException();
+                    return list;
                 });
         }
 
@@ -473,7 +474,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, navigatorSelector);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, navigatorSelector, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -482,9 +483,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             var _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array =>
+                array => throw new NotImplementedException(),
+                list =>
                 {
-                    Assert.Collection(array,
+                    Assert.Collection(list.Items,
                         item => Assert.Equal("DateTime", item.InsertText),
                         item =>
                         {
@@ -502,11 +504,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         item => Assert.Equal("using", item.Label)
                     ); ;
 
-                    return array;
-                },
-                list =>
-                {
-                    throw new NotImplementedException();
+                    return list;
                 });
         }
 
@@ -548,7 +546,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, navigatorSelector);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, navigatorSelector, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -557,9 +555,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array =>
+                array => throw new NotImplementedException(),
+                list =>
                 {
-                    Assert.Collection(array,
+                    Assert.Collection(list.Items,
                         item => Assert.Equal("for", item.Label),
                         item => Assert.Equal("foreach", item.Label),
                         item => Assert.Equal("while", item.Label),
@@ -570,11 +569,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         item => Assert.Equal("try", item.Label),
                         item => Assert.Equal("do", item.Label),
                         item => Assert.Equal("using", item.Label)
-                    ); ;
+                    );
 
-                    return array;
-                },
-                list => throw new NotImplementedException());
+                    return list;
+                });
         }
 
         [Fact]
@@ -600,7 +598,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -632,7 +630,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -675,15 +673,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.True(called);
-            Assert.NotEmpty((CompletionItem[])result.Value);
-            var item = ((CompletionItem[])result.Value).First();
+            Assert.NotEmpty(((CompletionList)result.Value).Items);
+            var item = ((CompletionList)result.Value).Items.First();
             Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
@@ -722,15 +720,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.True(called);
-            Assert.NotEmpty((CompletionItem[])result.Value);
-            var item = ((CompletionItem[])result.Value).First();
+            Assert.NotEmpty(((CompletionList)result.Value).Items);
+            var item = ((CompletionList)result.Value).Items.First();
             Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
@@ -776,7 +774,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -785,9 +783,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array =>
+                array => throw new NotImplementedException(),
+                list =>
                 {
-                    Assert.Collection(array,
+                    Assert.Collection(list.Items,
                         item => Assert.Equal("DateTime", item.InsertText),
                         item => Assert.Equal("for", item.Label),
                         item => Assert.Equal("foreach", item.Label),
@@ -801,9 +800,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         item => Assert.Equal("using", item.Label)
                     ); ;
 
-                    return array;
-                },
-                list => throw new NotImplementedException());
+                    return list;
+                });
         }
 
         [Fact]
@@ -852,7 +850,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, navigatorSelector);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, navigatorSelector, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -861,15 +859,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.True(called);
             Assert.True(result.HasValue);
             _ = result.Value.Match<SumType<CompletionItem[], CompletionList>>(
-                array =>
+                array => throw new NotImplementedException(),
+                list =>
                 {
-                    Assert.Collection(array,
-                        item => Assert.Equal("__x", item.Label)
-                    ); ;
-
-                    return array;
-                },
-                list => throw new NotImplementedException());
+                    Assert.Collection(list.Items, item => Assert.Equal("__x", item.Label));
+                    return list;
+                });
         }
 
         [Fact]
@@ -906,14 +901,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.True(called);
-            var item = Assert.Single((CompletionItem[])result.Value);
+            var item = Assert.Single(((CompletionList)result.Value).Items);
             Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
@@ -926,24 +921,22 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 new CompletionItem() { InsertText = "Hello", Data = originalData }
             };
-            var hostDocumentUri = new Uri("C:/path/to/file.razor");
-            var projectedDocumentUri = new Uri("C:/path/to/file.razor.g.cs");
+            var completionList = new CompletionList()
+            {
+                Items = items,
+            };
             var documentManager = new TestDocumentManager();
             var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict).Object;
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict).Object;
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
-            var result = completionHandler.SetResolveData(items, LanguageServerKind.CSharp, hostDocumentUri, projectedDocumentUri);
+            completionHandler.SetResolveData(123, completionList);
 
             // Assert
-            Assert.True(result.HasValue);
-            var item = Assert.Single((CompletionItem[])result.Value);
+            var item = Assert.Single(completionList.Items);
             var newData = Assert.IsType<CompletionResolveData>(item.Data);
-            Assert.Equal(LanguageServerKind.CSharp, newData.LanguageServerKind);
             Assert.Same(originalData, newData.OriginalData);
-            Assert.Same(hostDocumentUri, newData.HostDocumentUri);
-            Assert.Same(projectedDocumentUri, newData.ProjectedDocumentUri);
         }
 
         [Fact]
@@ -972,7 +965,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             };
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var (succeeded, result) = await completionHandler.TryGetProvisionalCompletionsAsync(completionRequest, new TestLSPDocumentSnapshot(new Uri("C:/path/file.razor"), 0), projectionResult, CancellationToken.None).ConfigureAwait(false);
@@ -1008,7 +1001,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             };
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var (succeeded, result) = await completionHandler.TryGetProvisionalCompletionsAsync(completionRequest, new TestLSPDocumentSnapshot(new Uri("C:/path/file.razor"), 0), projectionResult, CancellationToken.None).ConfigureAwait(false);
@@ -1050,7 +1043,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(previousCharacterProjection));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var (succeeded, result) = await completionHandler.TryGetProvisionalCompletionsAsync(completionRequest, new TestLSPDocumentSnapshot(new Uri("C:/path/file.razor"), 0), projectionResult, CancellationToken.None).ConfigureAwait(false);
@@ -1092,7 +1085,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(previousCharacterProjection));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var (succeeded, result) = await completionHandler.TryGetProvisionalCompletionsAsync(completionRequest, new TestLSPDocumentSnapshot(new Uri("C:/path/file.razor"), 0), projectionResult, CancellationToken.None).ConfigureAwait(false);
@@ -1150,7 +1143,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(previousCharacterProjection));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var (succeeded, result) = await completionHandler.TryGetProvisionalCompletionsAsync(completionRequest, new TestLSPDocumentSnapshot(new Uri("C:/path/file.razor"), 0), projectionResult, CancellationToken.None).ConfigureAwait(false);
@@ -1210,7 +1203,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
             projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(previousCharacterProjection));
 
-            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache);
 
             // Act
             var (succeeded, result) = await completionHandler.TryGetProvisionalCompletionsAsync(completionRequest, new TestLSPDocumentSnapshot(new Uri("C:/path/file.razor"), 0), projectionResult, CancellationToken.None).ConfigureAwait(false);
@@ -1228,7 +1221,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         public void TriggerAppliedToProjection_Razor_ReturnsFalse()
         {
             // Arrange
-            var completionHandler = new CompletionHandler(JoinableTaskContext, Mock.Of<LSPRequestInvoker>(MockBehavior.Strict), Mock.Of<LSPDocumentManager>(MockBehavior.Strict), Mock.Of<LSPProjectionProvider>(MockBehavior.Strict), TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, Mock.Of<LSPRequestInvoker>(MockBehavior.Strict), Mock.Of<LSPDocumentManager>(MockBehavior.Strict), Mock.Of<LSPProjectionProvider>(MockBehavior.Strict), TextStructureNavigatorSelectorService, CompletionRequestContextCache);
             var context = new CompletionContext();
 
             // Act
@@ -1257,7 +1250,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         public void TriggerAppliedToProjection_Html_ReturnsExpectedResult(string character, CompletionTriggerKind kind, bool expected)
         {
             // Arrange
-            var completionHandler = new CompletionHandler(JoinableTaskContext, Mock.Of<LSPRequestInvoker>(MockBehavior.Strict), Mock.Of<LSPDocumentManager>(MockBehavior.Strict), Mock.Of<LSPProjectionProvider>(MockBehavior.Strict), TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, Mock.Of<LSPRequestInvoker>(MockBehavior.Strict), Mock.Of<LSPDocumentManager>(MockBehavior.Strict), Mock.Of<LSPProjectionProvider>(MockBehavior.Strict), TextStructureNavigatorSelectorService, CompletionRequestContextCache);
             var context = new CompletionContext()
             {
                 TriggerCharacter = character,
@@ -1281,7 +1274,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         public void TriggerAppliedToProjection_CSharp_ReturnsExpectedResult(string character, CompletionTriggerKind kind, bool expected)
         {
             // Arrange
-            var completionHandler = new CompletionHandler(JoinableTaskContext, Mock.Of<LSPRequestInvoker>(MockBehavior.Strict), Mock.Of<LSPDocumentManager>(MockBehavior.Strict), Mock.Of<LSPProjectionProvider>(MockBehavior.Strict), TextStructureNavigatorSelectorService);
+            var completionHandler = new CompletionHandler(JoinableTaskContext, Mock.Of<LSPRequestInvoker>(MockBehavior.Strict), Mock.Of<LSPDocumentManager>(MockBehavior.Strict), Mock.Of<LSPProjectionProvider>(MockBehavior.Strict), TextStructureNavigatorSelectorService, CompletionRequestContextCache);
             var context = new CompletionContext()
             {
                 TriggerCharacter = character,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionRequestContextCacheTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionRequestContextCacheTest.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
+{
+    public class CompletionRequestContextCacheTest
+    {
+        private Uri HostDocumentUri { get; } = new Uri("C:/path/to/file.razor");
+
+        private Uri ProjectedUri { get; } = new Uri("C:/path/to/file.foo");
+
+        private LanguageServerKind LanguageServerKind { get; } = LanguageServerKind.CSharp;
+
+        private CompletionRequestContextCache Cache { get; } = new CompletionRequestContextCache();
+
+        [Fact]
+        public void TryGet_SetRequestContext_ReturnsTrue()
+        {
+            // Arrange
+            var requestContext = new CompletionRequestContext(HostDocumentUri, ProjectedUri, LanguageServerKind);
+            var resultId = Cache.Set(requestContext);
+
+            // Act
+            var result = Cache.TryGet(resultId, out var retrievedRequestContext);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(requestContext, retrievedRequestContext);
+        }
+
+        [Fact]
+        public void TryGet_UnknownRequestContext_ReturnsTrue()
+        {
+            // Act
+            var result = Cache.TryGet(1234, out var retrievedRequestContext);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(retrievedRequestContext);
+        }
+
+        [Fact]
+        public void TryGet_EvictedCompletionList_ReturnsFalse()
+        {
+            // Arrange
+            var initialRequestContext = new CompletionRequestContext(HostDocumentUri, ProjectedUri, LanguageServerKind);
+            var initialRequestContextId = Cache.Set(initialRequestContext);
+            for (var i = 0; i < CompletionRequestContextCache.MaxCacheSize; i++)
+            {
+                // We now fill the completion list cache up until its cache max so that the initial completion list we set gets evicted.
+                Cache.Set(new CompletionRequestContext(HostDocumentUri, ProjectedUri, LanguageServerKind));
+            }
+
+            // Act
+            var result = Cache.TryGet(initialRequestContextId, out var retrievedRequestContext);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(retrievedRequestContext);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
@@ -18,6 +18,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         private TestFormattingOptionsProvider FormattingOptionsProvider { get; } = new TestFormattingOptionsProvider();
 
+        private CompletionRequestContextCache CompletionRequestContextCache { get; } = new CompletionRequestContextCache();
+
         [Fact]
         public async Task HandleRequestAsync_NonNullOriginalInsertText_DoesNotRemapTextEdit()
         {
@@ -29,14 +31,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestedCompletionItem = new CompletionItem()
             {
                 InsertText = "DateTime",
-                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
             };
+            AssociateRequest(LanguageServerKind.CSharp, requestedCompletionItem, CompletionRequestContextCache);
             var resolvedCompletionItem = new CompletionItem()
             {
                 TextEdit = originalEdit,
             };
             var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
-            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider, CompletionRequestContextCache);
 
             // Act
             var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -56,15 +58,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var requestedCompletionItem = new CompletionItem()
             {
                 TextEdit = originalEdit,
-                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
             };
+            AssociateRequest(LanguageServerKind.CSharp, requestedCompletionItem, CompletionRequestContextCache);
             var resolvedCompletionItem = new CompletionItem()
             {
                 InsertText = "DateTime",
                 TextEdit = originalEdit,
             };
             var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
-            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider, CompletionRequestContextCache);
 
             // Act
             var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -77,16 +79,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         public async Task HandleRequestAsync_ResolvedNullTextEdit_Noops()
         {
             // Arrange
-            var requestedCompletionItem = new CompletionItem()
-            {
-                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
-            };
+            var requestedCompletionItem = new CompletionItem();
+            AssociateRequest(LanguageServerKind.CSharp, requestedCompletionItem, CompletionRequestContextCache);
             var resolvedCompletionItem = new CompletionItem()
             {
                 InsertText = "DateTime",
             };
             var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
-            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider, CompletionRequestContextCache);
 
             // Act & Assert
             var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -99,16 +99,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var originalEdit = new TextEdit() { NewText = "original" };
             var mappedEdit = new TextEdit() { NewText = "mapped" };
             DocumentMappingProvider.AddMapping(originalEdit, mappedEdit);
-            var requestedCompletionItem = new CompletionItem()
-            {
-                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
-            };
+            var requestedCompletionItem = new CompletionItem();
+            AssociateRequest(LanguageServerKind.CSharp, requestedCompletionItem, CompletionRequestContextCache);
             var resolvedCompletionItem = new CompletionItem()
             {
                 TextEdit = originalEdit,
             };
             var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
-            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider, CompletionRequestContextCache);
 
             // Act
             var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -124,16 +122,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var originalEdit = new TextEdit() { NewText = "original" };
             var mappedEdit = new TextEdit() { NewText = "mapped" };
             DocumentMappingProvider.AddMapping(originalEdit, mappedEdit);
-            var requestedCompletionItem = new CompletionItem()
-            {
-                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp }
-            };
+            var requestedCompletionItem = new CompletionItem();
+            AssociateRequest(LanguageServerKind.CSharp, requestedCompletionItem, CompletionRequestContextCache);
             var resolvedCompletionItem = new CompletionItem()
             {
                 AdditionalTextEdits = new[] { originalEdit },
             };
             var requestInvoker = CreateRequestInvoker((method, serverContentType, completionItem) => resolvedCompletionItem);
-            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider, CompletionRequestContextCache);
 
             // Act
             var result = await handler.HandleRequestAsync(requestedCompletionItem, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -151,8 +147,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var request = new CompletionItem()
             {
                 InsertText = "DateTime",
-                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.CSharp, OriginalData = originalData }
             };
+            AssociateRequest(LanguageServerKind.CSharp, request, CompletionRequestContextCache, originalData);
             var expectedResponse = new CompletionItem()
             {
                 InsertText = "DateTime",
@@ -169,7 +165,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return expectedResponse;
             });
 
-            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider, CompletionRequestContextCache);
 
             // Act
             var result = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -188,8 +184,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var request = new CompletionItem()
             {
                 InsertText = "strong",
-                Data = new CompletionResolveData() { LanguageServerKind = LanguageServerKind.Html, OriginalData = originalData }
             };
+            AssociateRequest(LanguageServerKind.Html, request, CompletionRequestContextCache, originalData);
             var expectedResponse = new CompletionItem()
             {
                 InsertText = "strong",
@@ -205,7 +201,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return expectedResponse;
             });
 
-            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider);
+            var handler = new CompletionResolveHandler(requestInvoker, DocumentMappingProvider, FormattingOptionsProvider, CompletionRequestContextCache);
 
             // Act
             var result = await handler.HandleRequestAsync(request, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
@@ -228,6 +224,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Returns(() => Task.FromResult(response));
 
             return requestInvoker.Object;
+        }
+
+        private static void AssociateRequest(LanguageServerKind requestKind, CompletionItem item, CompletionRequestContextCache cache, object originalData = null)
+        {
+            var documentUri = new Uri("C:/path/to/file.razor");
+            var projectedUri = new Uri("C:/path/to/file.razor.g.xyz");
+            var requestContext = new CompletionRequestContext(documentUri, projectedUri, requestKind);
+
+            var resultId = cache.Set(requestContext);
+            var data = new CompletionResolveData()
+            {
+                ResultId = resultId,
+                OriginalData = originalData,
+            };
+            item.Data = data;
         }
 
         private class TestFormattingOptionsProvider : FormattingOptionsProvider


### PR DESCRIPTION
- Added a `CompletionRequestContextCache` and instead of storing host document and projected uri's along with language server kinds on completion items we now store them in the cahce to be retrieved at resolve time.
- Updated the languageserver client project to target latest C# lang version to use records!!
    - Added IsExternalInit to enable this.
- Added new tests for request context cache.
- Updated existing tests to validate the new behavior.

Part of dotnet/aspnetcore#29619