### PR TITLE
Support GoToDef on Components with Attributes & Closing Tags

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             _capability = capability;
         }
 
-        private static async Task<TagHelperBinding> GetOriginTagHelperBindingAsync(
+        internal static async Task<TagHelperBinding> GetOriginTagHelperBindingAsync(
             DocumentSnapshot documentSnapshot,
             RazorCodeDocument codeDocument,
             Position position)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -135,23 +135,41 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
                 return null;
             }
 
-            var node = owner.Ancestors().FirstOrDefault(n => n.Kind == SyntaxKind.MarkupTagHelperStartTag);
-            if (node == null || !(node is MarkupTagHelperStartTagSyntax tagHelperStartTag))
+            var node = owner.Ancestors().FirstOrDefault(n =>
+                n.Kind == SyntaxKind.MarkupTagHelperStartTag ||
+                n.Kind == SyntaxKind.MarkupTagHelperEndTag);
+            if (node is null)
             {
                 return null;
             }
 
-            if (!tagHelperStartTag.Name.Span.Contains(location.AbsoluteIndex))
+            var name = GetStartOrEndTagName(node);
+            if (name is null)
             {
                 return null;
             }
 
-            if (!(tagHelperStartTag?.Parent is MarkupTagHelperElementSyntax tagHelperElement))
+            if (!name.Span.Contains(location.AbsoluteIndex))
+            {
+                return null;
+            }
+
+            if (!(node.Parent is MarkupTagHelperElementSyntax tagHelperElement))
             {
                 return null;
             }
 
             return tagHelperElement.TagHelperInfo.BindingResult;
+        }
+
+        private static SyntaxNode GetStartOrEndTagName(SyntaxNode node)
+        {
+            return node switch
+            {
+                MarkupTagHelperStartTagSyntax tagHelperStartTag => tagHelperStartTag.Name,
+                MarkupTagHelperEndTagSyntax tagHelperEndTag => tagHelperEndTag.Name,
+                _ => null
+            };
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
                 return null;
             }
 
-            var originTagDescriptor = originTagHelperBinding.Descriptors.SingleOrDefault();
+            var originTagDescriptor = originTagHelperBinding.Descriptors.FirstOrDefault();
             if (originTagDescriptor is null)
             {
                 return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -115,12 +115,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             _capability = capability;
         }
 
-        private async Task<TagHelperBinding> GetOriginTagHelperBindingAsync(DocumentSnapshot documentSnapshot, RazorCodeDocument codeDocument, Position position)
+        private static async Task<TagHelperBinding> GetOriginTagHelperBindingAsync(DocumentSnapshot documentSnapshot, RazorCodeDocument codeDocument, Position position)
         {
             var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
-            var linePosition = new LinePosition((int)position.Line, (int)position.Character);
+            var linePosition = new LinePosition(position.Line, position.Character);
             var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
-            var location = new SourceLocation(hostDocumentIndex, (int)position.Line, (int)position.Character);
+            var location = new SourceLocation(hostDocumentIndex, position.Line, position.Character);
 
             var change = new SourceChange(location.AbsoluteIndex, length: 0, newText: string.Empty);
             var syntaxTree = codeDocument.GetSyntaxTree();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -81,8 +81,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
                 return null;
             }
 
-            // We use EndsWith as the Descriptor.Name is fully qualified but the TagName doesn't have to be
-            var originTagDescriptor = originTagHelperBinding.Descriptors.FirstOrDefault(d => !IsAttributeDescriptor(d));
+            var originTagDescriptor = originTagHelperBinding.Descriptors.FirstOrDefault(d => !d.IsAttributeDescriptor());
             if (originTagDescriptor is null)
             {
                 return null;
@@ -109,12 +108,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
                     Range = new Range(new Position(0, 0), new Position(0, 0)),
                 }),
             });
-
-            static bool IsAttributeDescriptor(TagHelperDescriptor d)
-            {
-                return d.Metadata.TryGetValue(TagHelperMetadata.Common.ClassifyAttributesOnly, out var value) ||
-                    string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase);
-            }
         }
 
         public void SetCapability(DefinitionCapability capability)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             }
 
             // We use EndsWith as the Descriptor.Name is fully qualified but the TagName doesn't have to be
-            var originTagDescriptor = originTagHelperBinding.Descriptors.FirstOrDefault(d => d.Name.EndsWith(originTagHelperBinding.TagName));
+            var originTagDescriptor = originTagHelperBinding.Descriptors.FirstOrDefault(d => !IsAttributeDescriptor(d));
             if (originTagDescriptor is null)
             {
                 return null;
@@ -109,6 +109,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
                     Range = new Range(new Position(0, 0), new Position(0, 0)),
                 }),
             });
+
+            static bool IsAttributeDescriptor(TagHelperDescriptor d)
+            {
+                return d.Metadata.TryGetValue(TagHelperMetadata.Common.ClassifyAttributesOnly, out var value) ||
+                    string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         public void SetCapability(DefinitionCapability capability)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -81,7 +81,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
                 return null;
             }
 
-            var originTagDescriptor = originTagHelperBinding.Descriptors.FirstOrDefault();
+            // We use EndsWith as the Descriptor.Name is fully qualified but the TagName doesn't have to be
+            var originTagDescriptor = originTagHelperBinding.Descriptors.FirstOrDefault(d => d.Name.EndsWith(originTagHelperBinding.TagName));
             if (originTagDescriptor is null)
             {
                 return null;
@@ -115,7 +116,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             _capability = capability;
         }
 
-        private static async Task<TagHelperBinding> GetOriginTagHelperBindingAsync(DocumentSnapshot documentSnapshot, RazorCodeDocument codeDocument, Position position)
+        private static async Task<TagHelperBinding> GetOriginTagHelperBindingAsync(
+            DocumentSnapshot documentSnapshot,
+            RazorCodeDocument codeDocument,
+            Position position)
         {
             var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
             var linePosition = new LinePosition(position.Line, position.Character);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptorExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TagHelperDescriptorExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class TagHelperDescriptorExtensions
+    {
+        public static bool IsAttributeDescriptor(this TagHelperDescriptor d)
+        {
+            return d.Metadata.TryGetValue(TagHelperMetadata.Common.ClassifyAttributesOnly, out var value) ||
+                string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             return CreateCodeDocument(text, CSHtmlFile, tagHelpers);
         }
 
-        protected TextDocumentIdentifier GetIdentifier(bool isRazor)
+        protected static TextDocumentIdentifier GetIdentifier(bool isRazor)
         {
             var file = isRazor ? RazorFile : CSHtmlFile;
             return new TextDocumentIdentifier(new Uri($"c:\\${file}"));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -42,11 +42,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
         }
 
         [Fact]
-        public async Task GetOriginTagHelperBindingAsync_TagHelper_Attribute()
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_StartTag_WithAttribute()
         {
             // Arrange
             SetupDocument(out var codeDocument, out var documentSnapshot);
             var position = new Position(1, 2);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal("Component1", binding.TagName);
+            Assert.Collection(binding.Descriptors,
+                d => Assert.Equal("Component1TagHelper", d.Name),
+                d => Assert.Equal("TestDirectiveAttribute", d.Name));
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_EndTag_WithAttribute()
+        {
+            // Arrange
+            SetupDocument(out var codeDocument, out var documentSnapshot);
+            var position = new Position(1, 35);
 
             // Act
             var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -4,14 +4,13 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
-using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 {
     public class RazorDefinitionEndpointTest : TagHelperServiceTestBase
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
+{
+    public class RazorDefinitionEndpointTest : TagHelperServiceTestBase
+    {
+        private const string DefaultContent = @"@addTagHelper *, TestAssembly
+<Component1 @test=""Increment""></Component1>
+@code {
+    public void Increment()
+    {
+    }
+}";
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_Element()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+            var srcText = SourceText.From(txt);
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var documentSnapshot = Mock.Of<DocumentSnapshot>(d => d.GetTextAsync() == Task.FromResult(srcText), MockBehavior.Strict);
+            var position = new Position(1, 2);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal("test1", binding.TagName);
+            var descriptor = Assert.Single(binding.Descriptors);
+            Assert.Equal("Test1TagHelper", descriptor.Name);
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_Attribute()
+        {
+            // Arrange
+            SetupDocument(out var codeDocument, out var documentSnapshot);
+            var position = new Position(1, 2);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal("Component1", binding.TagName);
+            Assert.Collection(binding.Descriptors,
+                d => Assert.Equal("Component1TagHelper", d.Name),
+                d => Assert.Equal("TestDirectiveAttribute", d.Name));
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_Attribute_ReturnsNull()
+        {
+            // Arrange
+            SetupDocument(out var codeDocument, out var documentSnapshot);
+            var position = new Position(1, 14);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_AttributeValue_ReturnsNull()
+        {
+            // Arrange
+            SetupDocument(out var codeDocument, out var documentSnapshot);
+            var position = new Position(1, 24);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_AfterAttributeEquals_ReturnsNull()
+        {
+            // Arrange
+            SetupDocument(out var codeDocument, out var documentSnapshot);
+            var position = new Position(1, 18);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_AttributeEnd_ReturnsNull()
+        {
+            // Arrange
+            SetupDocument(out var codeDocument, out var documentSnapshot);
+            var position = new Position(1, 29);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_MultipleAttributes()
+        {
+            // Arrange
+            var content = @"@addTagHelper *, TestAssembly
+<Component1 @test=""Increment"" @minimized></Component1>
+@code {
+    public void Increment()
+    {
+    }
+}";
+            SetupDocument(out var codeDocument, out var documentSnapshot, content);
+            var position = new Position(1, 2);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal("Component1", binding.TagName);
+            Assert.Collection(binding.Descriptors,
+                d => Assert.Equal("Component1TagHelper", d.Name),
+                d => Assert.Equal("TestDirectiveAttribute", d.Name),
+                d => Assert.Equal("MinimizedDirectiveAttribute", d.Name));
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_MalformedElement()
+        {
+            // Arrange
+            var content = @"@addTagHelper *, TestAssembly
+<Component1</Component1>
+@code {
+    public void Increment()
+    {
+    }
+}";
+            SetupDocument(out var codeDocument, out var documentSnapshot, content);
+            var position = new Position(1, 2);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal("Component1", binding.TagName);
+            var descriptor = Assert.Single(binding.Descriptors);
+            Assert.Equal("Component1TagHelper", descriptor.Name);
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_MalformedAttribute()
+        {
+
+            // Arrange
+            var content = @"@addTagHelper *, TestAssembly
+<Component1 @test=""Increment></Component1>
+@code {
+    public void Increment()
+    {
+    }
+}";
+            SetupDocument(out var codeDocument, out var documentSnapshot, content);
+            var position = new Position(1, 2);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal("Component1", binding.TagName);
+            Assert.Collection(binding.Descriptors,
+                d => Assert.Equal("Component1TagHelper", d.Name),
+                d => Assert.Equal("TestDirectiveAttribute", d.Name));
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_HTML_MarkupElement()
+        {
+            // Arrange
+            var content = $"@addTagHelper *, TestAssembly{Environment.NewLine}<p><strong></strong></p>";
+            SetupDocument(out var codeDocument, out var documentSnapshot, content);
+            var position = new Position(1, 6);
+
+            // Act
+            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(documentSnapshot, codeDocument, position).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        private void SetupDocument(out Language.RazorCodeDocument codeDocument, out DocumentSnapshot documentSnapshot, string content = DefaultContent)
+        {
+            var sourceText = SourceText.From(content);
+            codeDocument = CreateCodeDocument(content, "text.razor", DefaultTagHelpers);
+            documentSnapshot = Mock.Of<DocumentSnapshot>(d => d.GetTextAsync() == Task.FromResult(sourceText), MockBehavior.Strict);
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the changes
 - Support GoToDef on components with attributes
 - Support GoToDef on end/closing tags

Fixes: https://github.com/dotnet/aspnetcore/issues/29565
Fixes: https://github.com/dotnet/aspnetcore/issues/30277
