### PR TITLE
Fix Missing References with Rich Nav

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -187,6 +187,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 referenceItem.DefinitionText = FilterReferenceDisplayText(referenceItem.DefinitionText);
                 referenceItem.Text = FilterReferenceDisplayText(referenceItem.Text);
 
+                // Indicates the reference item is directly available in the code
+                referenceItem.Origin = ItemOrigin.Exact;
+
                 if (!RazorLSPConventions.IsVirtualCSharpFile(referenceItem.Location.Uri) &&
                     !RazorLSPConventions.IsVirtualHtmlFile(referenceItem.Location.Uri))
                 {


### PR DESCRIPTION
### Summary of the changes
 - Ensures reference results aren't filtered out. `Exact` origin indicates the code is directly accessible.

Fixes: https://github.com/dotnet/aspnetcore/issues/29887

Thanks @AmadeusW!