### PR TITLE
Disable Feature Flag Caching

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly Lazy<IVsUIShellOpenDocument> _vsUIShellOpenDocument;
         private readonly IVsFeatureFlags _featureFlags;
 
-        private bool? _featureFlagEnabled;
         private bool? _environmentFeatureEnabled;
         private bool? _isVSServer;
 
@@ -162,12 +161,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         // Private protected virtual for testing
         private protected virtual bool IsFeatureFlagEnabledCached()
         {
-            if (!_featureFlagEnabled.HasValue)
-            {
-                _featureFlagEnabled = _featureFlags.IsFeatureEnabled(RazorLSPEditorFeatureFlag, defaultValue: false);
-            }
-
-            return _featureFlagEnabled.Value;
+            var featureFlagEnabled = _featureFlags.IsFeatureEnabled(RazorLSPEditorFeatureFlag, defaultValue: false);
+            return featureFlagEnabled;
         }
 
         // Private protected virtual for testing


### PR DESCRIPTION
Essentially reverts https://github.com/dotnet/aspnetcore-tooling/pull/2037

Caching now done at the LSP Platform layer: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1128651
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/260509

Did some basic validation in local/liveshare with new/old editors.

Fixes: https://github.com/dotnet/aspnetcore/issues/30303
