### PR TITLE
Avoid StreamJsonRpc for Razor lang calls.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -274,6 +274,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return Task.FromResult(razorLanguageServer);
         }
 
+        // Today we only extract services from the language server in scenarios we know are eventually going away.
+        // For instance, at the time of writing this comment we're extracting some endpoitns from the server for
+        // perf concerns to avoid doing StreamJsonRpc hops to resolve things like an applicable language at a location.
+        // Eventually language queries will be done only at the language server layer at which point inproc/vs out of proc
+        // wont be a thing because it'll all be in one process.
+        [Obsolete("Do not use this API.")]
+        internal RazorLanguageEndpoint GetLanguageEndpoint() => _innerServer.Services.GetRequiredService<RazorLanguageEndpoint>();
+
         public void Dispose()
         {
             lock (_disposeLock)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -275,10 +275,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         // Today we only extract services from the language server in scenarios we know are eventually going away.
-        // For instance, at the time of writing this comment we're extracting some endpoitns from the server for
+        // For instance, at the time of writing this comment we're extracting some endpoints from the server for
         // perf concerns to avoid doing StreamJsonRpc hops to resolve things like an applicable language at a location.
-        // Eventually language queries will be done only at the language server layer at which point inproc/vs out of proc
-        // wont be a thing because it'll all be in one process.
+        // Eventually language queries will be done only at the language server layer at which point inproc/versus out
+        // of proc wont be a thing because it'll all be in one process.
         [Obsolete("Do not use this API.")]
         internal RazorLanguageEndpoint GetLanguageEndpoint() => _innerServer.Services.GetRequiredService<RazorLanguageEndpoint>();
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -6,10 +6,8 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
@@ -19,14 +17,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     {
         private readonly LSPRequestInvoker _requestInvoker;
         private readonly LSPDocumentSynchronizer _documentSynchronizer;
-        private readonly ILogger _logger;
+        private readonly RazorLogger _logger;
         private Func<RazorLanguageQueryParams, CancellationToken, Task<RazorLanguageQueryResponse>> _inProcLanguageQueryMethod;
 
         [ImportingConstructor]
         public DefaultLSPProjectionProvider(
             LSPRequestInvoker requestInvoker,
             LSPDocumentSynchronizer documentSynchronizer,
-            HTMLCSharpLanguageServerFeedbackFileLoggerProvider logger)
+            RazorLogger logger)
         {
             if (requestInvoker is null)
             {
@@ -45,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             _requestInvoker = requestInvoker;
             _documentSynchronizer = documentSynchronizer;
-            _logger = logger.CreateLogger(nameof(DefaultLSPProjectionProvider));
+            _logger = logger;
         }
 
         public void UseInProcLanguageQueries(Func<RazorLanguageQueryParams, CancellationToken, Task<RazorLanguageQueryResponse>> inProcLanguageQueryMethod)
@@ -116,7 +114,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 // There should always be a document version attached to an open document.
                 // Log it and move on as if it was synchronized.
-                _logger.LogTrace($"Could not find a document version associated with the document '{documentSnapshot.Uri}'");
+                _logger.LogVerbose($"Could not find a document version associated with the document '{documentSnapshot.Uri}'");
             }
             else
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/InProcLanguageServerAdapter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/InProcLanguageServerAdapter.cs
@@ -1,0 +1,360 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+using ClientFormattingOptions = Microsoft.VisualStudio.LanguageServer.Protocol.FormattingOptions;
+using ClientPosition = Microsoft.VisualStudio.LanguageServer.Protocol.Position;
+using ClientRange = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+using ClientRazorLanguageKind = Microsoft.VisualStudio.LanguageServerClient.Razor.RazorLanguageKind;
+using ClientRazorLanguageQueryParams = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorLanguageQueryParams;
+using ClientRazorLanguageQueryResponse = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorLanguageQueryResponse;
+using ClientRazorMapToDocumentEditsParams = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorMapToDocumentEditsParams;
+using ClientRazorMapToDocumentEditsResponse = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorMapToDocumentEditsResponse;
+using ClientRazorMapToDocumentRangesParams = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorMapToDocumentRangesParams;
+using ClientRazorMapToDocumentRangesResponse = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorMapToDocumentRangesResponse;
+using ClientTextEdit = Microsoft.VisualStudio.LanguageServer.Protocol.TextEdit;
+using ServerRazorLanguageQueryResponse = Microsoft.AspNetCore.Razor.LanguageServer.RazorLanguageQueryResponse;
+using ServerFormattingOptions = OmniSharp.Extensions.LanguageServer.Protocol.Models.FormattingOptions;
+using ServerMappingBehavior = Microsoft.AspNetCore.Razor.LanguageServer.MappingBehavior;
+using ServerPosition = OmniSharp.Extensions.LanguageServer.Protocol.Models.Position;
+using ServerRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using ServerRazorLanguageKind = Microsoft.AspNetCore.Razor.LanguageServer.RazorLanguageKind;
+using ServerRazorLanguageQueryParams = Microsoft.AspNetCore.Razor.LanguageServer.RazorLanguageQueryParams;
+using ServerRazorMapToDocumentEditsParams = Microsoft.AspNetCore.Razor.LanguageServer.RazorMapToDocumentEditsParams;
+using ServerRazorMapToDocumentEditsResponse = Microsoft.AspNetCore.Razor.LanguageServer.RazorMapToDocumentEditsResponse;
+using ServerRazorMapToDocumentRangesParams = Microsoft.AspNetCore.Razor.LanguageServer.RazorMapToDocumentRangesParams;
+using ServerRazorMapToDocumentRangesResponse = Microsoft.AspNetCore.Razor.LanguageServer.RazorMapToDocumentRangesResponse;
+using ServerTextEdit = OmniSharp.Extensions.LanguageServer.Protocol.Models.TextEdit;
+using ServerTextEditKind = Microsoft.AspNetCore.Razor.LanguageServer.TextEditKind;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    // This class is more or less a "hack". Its intent is to bridge the end-user experience gap until we're able to re-design some of the Razor language server components.
+    // Ultimately this "inproc" adapter enables us to perform common Razor language interactions without going over StreamJsonRpc. This is important because StreamJsonRpc
+    // has its own thread/synchornization model (that we don't care about here) that frequently gets blocked and requires constant serialization/deserialization which is
+    // expensive. After some spot-testing StreamJsonRpc requests in real scenarios they were taking anywhere from 0-100ms to complete typically averaging out at round 40ms.
+    //
+    // The "re-design" i'm referring to here would involve us taking our virtual document model that currently resides in-proc in Visual Studio and shifting that understanding
+    // into the Razor Language Server where it has all the remapping logic in-proc. This means the Razor language server would ultimately own the remapping behavior of C#/HTML
+    // by doing server -> client requests for re-invocations. We do this already for things like light bulbs, semantic tokens and OnTypeFormatting; the intent here would be to
+    // expand that surface area to all requests and build a document synchronization model for virtual documents that could exist on any platform.
+    [Export(typeof(InProcLanguageServerAdapter))]
+    internal class InProcLanguageServerAdapter
+    {
+        private readonly DefaultLSPProjectionProvider _projectionProvider;
+        private readonly DefaultLSPDocumentMappingProvider _mappingProvider;
+
+        [ImportingConstructor]
+        public InProcLanguageServerAdapter(
+            [Import(typeof(LSPProjectionProvider))] DefaultLSPProjectionProvider projectionProvider,
+            [Import(typeof(LSPDocumentMappingProvider))] DefaultLSPDocumentMappingProvider mappingProvider)
+        {
+            if (projectionProvider is null)
+            {
+                throw new ArgumentNullException(nameof(projectionProvider));
+            }
+
+            if (mappingProvider is null)
+            {
+                throw new ArgumentNullException(nameof(mappingProvider));
+            }
+
+            _projectionProvider = projectionProvider;
+            _mappingProvider = mappingProvider;
+        }
+
+        public void Bind(RazorLanguageServer server)
+        {
+            if (server is null)
+            {
+                throw new ArgumentNullException(nameof(server));
+            }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            var languageEndpoint = server.GetLanguageEndpoint();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            _projectionProvider.UseInProcLanguageQueries(async (request, cancellationToken) =>
+            {
+                var serverRequest = ConvertToServer(request);
+                var serverResponse = await languageEndpoint.Handle(serverRequest, cancellationToken).ConfigureAwait(false);
+                var clientResponse = ConvertToClient(serverResponse);
+
+                return clientResponse;
+            });
+
+            _mappingProvider.UseInProcRangeMapping(async (request, cancellationToken) =>
+            {
+                var serverRequest = ConvertToServer(request);
+                var serverResponse = await languageEndpoint.Handle(serverRequest, cancellationToken).ConfigureAwait(false);
+                var clientResponse = ConvertToClient(serverResponse);
+
+                return clientResponse;
+            });
+
+            _mappingProvider.UseInProcEditMapping(async (request, cancellationToken) =>
+            {
+                var serverRequest = ConvertToServer(request);
+                var serverResponse = await languageEndpoint.Handle(serverRequest, cancellationToken).ConfigureAwait(false);
+                var clientResponse = ConvertToClient(serverResponse);
+
+                return clientResponse;
+            });
+        }
+
+        // Internal for testing
+        internal static ClientRazorMapToDocumentEditsResponse ConvertToClient(ServerRazorMapToDocumentEditsResponse serverResponse)
+        {
+            return new ClientRazorMapToDocumentEditsResponse()
+            {
+                TextEdits = ConvertToClient(serverResponse.TextEdits),
+                HostDocumentVersion = (long)serverResponse.HostDocumentVersion,
+            };
+        }
+
+        // Internal for testing
+        internal static ServerRazorMapToDocumentEditsParams ConvertToServer(ClientRazorMapToDocumentEditsParams request)
+        {
+            return new ServerRazorMapToDocumentEditsParams()
+            {
+                Kind = (ServerRazorLanguageKind)request.Kind,
+                TextEditKind = (ServerTextEditKind)request.TextEditKind,
+                RazorDocumentUri = request.RazorDocumentUri,
+                FormattingOptions = ConvertToServer(request.FormattingOptions),
+                ProjectedTextEdits = ConvertToServer(request.ProjectedTextEdits),
+            };
+        }
+
+        // Internal for testing
+        internal static ClientRazorMapToDocumentRangesResponse ConvertToClient(ServerRazorMapToDocumentRangesResponse serverResponse)
+        {
+            return new ClientRazorMapToDocumentRangesResponse()
+            {
+                Ranges = ConvertToClient(serverResponse.Ranges),
+                HostDocumentVersion = serverResponse.HostDocumentVersion,
+            };
+        }
+
+        // Internal for testing
+        internal static ServerRazorMapToDocumentRangesParams ConvertToServer(ClientRazorMapToDocumentRangesParams request)
+        {
+            return new ServerRazorMapToDocumentRangesParams()
+            {
+                Kind = (ServerRazorLanguageKind)request.Kind,
+                MappingBehavior = (ServerMappingBehavior)request.MappingBehavior,
+                ProjectedRanges = ConvertToServer(request.ProjectedRanges),
+                RazorDocumentUri = request.RazorDocumentUri,
+            };
+        }
+
+        // Internal for testing
+        internal static ClientRazorLanguageQueryResponse ConvertToClient(ServerRazorLanguageQueryResponse serverResponse)
+        {
+            return new ClientRazorLanguageQueryResponse()
+            {
+                HostDocumentVersion = serverResponse.HostDocumentVersion,
+                Kind = (ClientRazorLanguageKind)serverResponse.Kind,
+                Position = ConvertToClient(serverResponse.Position),
+                PositionIndex = serverResponse.PositionIndex,
+            };
+        }
+
+        // Internal for testing
+        internal static ServerRazorLanguageQueryParams ConvertToServer(ClientRazorLanguageQueryParams request)
+        {
+            return new ServerRazorLanguageQueryParams()
+            {
+                Position = ConvertToServer(request.Position),
+                Uri = request.Uri,
+            };
+        }
+
+        private static ServerPosition ConvertToServer(ClientPosition position)
+        {
+            if (position == null)
+            {
+                return null;
+            }
+
+            return new ServerPosition(position.Line, position.Character);
+        }
+
+        private static ClientPosition ConvertToClient(ServerPosition position)
+        {
+            if (position == null)
+            {
+                return null;
+            }
+
+            return new ClientPosition
+            {
+                Character = position.Character,
+                Line = position.Line,
+            };
+        }
+
+        private static ServerRange[] ConvertToServer(ClientRange[] ranges)
+        {
+            if (ranges == null)
+            {
+                return null;
+            }
+            var serverRanges = new ServerRange[ranges.Length];
+            for (var i = 0; i < ranges.Length; i++)
+            {
+                var serverRange = ConvertToServer(ranges[i]);
+                serverRanges[i] = serverRange;
+            }
+
+            return serverRanges;
+        }
+
+        private static ClientRange[] ConvertToClient(ServerRange[] ranges)
+        {
+            if (ranges == null)
+            {
+                return null;
+            }
+
+            var clientRanges = new ClientRange[ranges.Length];
+            for (var i = 0; i < ranges.Length; i++)
+            {
+                var clientRange = ConvertToClient(ranges[i]);
+                clientRanges[i] = clientRange;
+            }
+
+            return clientRanges;
+        }
+
+        private static ServerRange ConvertToServer(ClientRange range)
+        {
+            if (range == null)
+            {
+                return null;
+            }
+
+            var serverStart = ConvertToServer(range.Start);
+            var serverEnd = ConvertToServer(range.End);
+            return new ServerRange(serverStart, serverEnd);
+        }
+
+        private static ClientRange ConvertToClient(ServerRange range)
+        {
+            if (range == null)
+            {
+                return null;
+            }
+
+            var clientStart = ConvertToClient(range.Start);
+            var clientEnd = ConvertToClient(range.End);
+            return new ClientRange
+            {
+                Start = clientStart,
+                End = clientEnd,
+            };
+        }
+
+        private static ServerTextEdit[] ConvertToServer(ClientTextEdit[] textEdits)
+        {
+            if (textEdits == null)
+            {
+                return null;
+            }
+
+            var serverTextEdits = new ServerTextEdit[textEdits.Length];
+            for (var i = 0; i < textEdits.Length; i++)
+            {
+                var clientRange = ConvertToServer(textEdits[i]);
+                serverTextEdits[i] = clientRange;
+            }
+
+            return serverTextEdits;
+        }
+
+        private static ClientTextEdit[] ConvertToClient(ServerTextEdit[] textEdits)
+        {
+            if (textEdits == null)
+            {
+                return null;
+            }
+
+            var clientRanges = new ClientTextEdit[textEdits.Length];
+            for (var i = 0; i < textEdits.Length; i++)
+            {
+                var clientRange = ConvertToClient(textEdits[i]);
+                clientRanges[i] = clientRange;
+            }
+
+            return clientRanges;
+        }
+
+        private static ServerTextEdit ConvertToServer(ClientTextEdit textEdit)
+        {
+            if (textEdit == null)
+            {
+                return null;
+            }
+
+            var serverRange = ConvertToServer(textEdit.Range);
+            return new ServerTextEdit
+            {
+                Range = serverRange,
+                NewText = textEdit.NewText,
+            };
+        }
+
+        private static ClientTextEdit ConvertToClient(ServerTextEdit textEdit)
+        {
+            if (textEdit == null)
+            {
+                return null;
+            }
+
+            var clientRange = ConvertToClient(textEdit.Range);
+            return new ClientTextEdit
+            {
+                Range = clientRange,
+                NewText = textEdit.NewText,
+            };
+        }
+
+        private static ServerFormattingOptions ConvertToServer(ClientFormattingOptions clientOptions)
+        {
+            if (clientOptions == null)
+            {
+                return null;
+            }
+
+            var serverOptions = new ServerFormattingOptions()
+            {
+                TabSize = clientOptions.TabSize,
+                InsertSpaces = clientOptions.InsertSpaces,
+            };
+
+            if (clientOptions.OtherOptions != null)
+            {
+                foreach (var clientOption in clientOptions.OtherOptions)
+                {
+                    switch (clientOption.Value)
+                    {
+                        case string stringValue:
+                            serverOptions[clientOption.Key] = stringValue;
+                            break;
+                        case long numberValue:
+                            serverOptions[clientOption.Key] = numberValue;
+                            break;
+                        case bool boolValue:
+                            serverOptions[clientOption.Key] = boolValue;
+                            break;
+                    }
+                }
+            }
+
+
+            return serverOptions;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
         private readonly RazorLanguageServerFeedbackFileLoggerProviderFactory _feedbackFileLoggerProviderFactory;
         private readonly VSLanguageServerFeatureOptions _vsLanguageServerFeatureOptions;
-
+        private readonly InProcLanguageServerAdapter _inProcLanguageServerAdapter;
         private object _shutdownLock;
         private RazorLanguageServer _server;
         private IDisposable _serverShutdownDisposable;
@@ -52,7 +52,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             LSPRequestInvoker requestInvoker,
             ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
             RazorLanguageServerFeedbackFileLoggerProviderFactory feedbackFileLoggerProviderFactory,
-            VSLanguageServerFeatureOptions vsLanguageServerFeatureOptions)
+            VSLanguageServerFeatureOptions vsLanguageServerFeatureOptions,
+            InProcLanguageServerAdapter inProcLanguageServerAdapter)
         {
             if (customTarget is null)
             {
@@ -84,13 +85,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(vsLanguageServerFeatureOptions));
             }
 
+            if (inProcLanguageServerAdapter is null)
+            {
+                throw new ArgumentNullException(nameof(inProcLanguageServerAdapter));
+            }
+
             _customMessageTarget = customTarget;
             _middleLayer = middleLayer;
             _requestInvoker = requestInvoker;
             _projectConfigurationFilePathStore = projectConfigurationFilePathStore;
             _feedbackFileLoggerProviderFactory = feedbackFileLoggerProviderFactory;
             _vsLanguageServerFeatureOptions = vsLanguageServerFeatureOptions;
-
+            _inProcLanguageServerAdapter = inProcLanguageServerAdapter;
             _shutdownLock = new object();
         }
 
@@ -126,6 +132,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var traceLevel = GetVerbosity();
             _server = await RazorLanguageServer.CreateAsync(serverStream, serverStream, traceLevel, ConfigureLanguageServer).ConfigureAwait(false);
+
+            _inProcLanguageServerAdapter.Bind(_server);
 
             // Fire and forget for Initialized. Need to allow the LSP infrastructure to run in order to actually Initialize.
             _server.InitializedAsync(token).FileAndForget("RazorLanguageServerClient_ActivateAsync");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -39,6 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly RazorLanguageServerFeedbackFileLoggerProviderFactory _feedbackFileLoggerProviderFactory;
         private readonly VSLanguageServerFeatureOptions _vsLanguageServerFeatureOptions;
         private readonly InProcLanguageServerAdapter _inProcLanguageServerAdapter;
+        
         private object _shutdownLock;
         private RazorLanguageServer _server;
         private IDisposable _serverShutdownDisposable;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProjectionProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProjectionProviderTest.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Xunit;
@@ -14,6 +16,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     public class DefaultLSPProjectionProviderTest
     {
+        public DefaultLSPProjectionProviderTest()
+        {
+            var logger = new Mock<ILogger>(MockBehavior.Strict).Object;
+            Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>())).Verifiable();
+            LoggerProvider = Mock.Of<HTMLCSharpLanguageServerFeedbackFileLoggerProvider>(l => l.CreateLogger(It.IsAny<string>()) == logger, MockBehavior.Strict);
+        }
+
+        internal HTMLCSharpLanguageServerFeedbackFileLoggerProvider LoggerProvider { get; }
+
         [Fact]
         public async Task GetProjectionAsync_RazorProjection_ReturnsNull()
         {
@@ -33,7 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>(MockBehavior.Strict));
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot.Object, new Position(), CancellationToken.None).ConfigureAwait(false);
@@ -73,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>(MockBehavior.Strict));
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot, new Position(), CancellationToken.None).ConfigureAwait(false);
@@ -116,7 +127,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>(MockBehavior.Strict));
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot, new Position(), CancellationToken.None).ConfigureAwait(false);
@@ -159,9 +170,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
-            var logger = new Mock<RazorLogger>(MockBehavior.Strict);
-            logger.Setup(l => l.LogVerbose(It.IsAny<string>())).Verifiable();
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, logger.Object);
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot, new Position(), CancellationToken.None).ConfigureAwait(false);
@@ -204,7 +213,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(false));
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>(MockBehavior.Strict));
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot, new Position(), CancellationToken.None).ConfigureAwait(false);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProjectionProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPProjectionProviderTest.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Xunit;
@@ -16,15 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     public class DefaultLSPProjectionProviderTest
     {
-        public DefaultLSPProjectionProviderTest()
-        {
-            var logger = new Mock<ILogger>(MockBehavior.Strict).Object;
-            Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>())).Verifiable();
-            LoggerProvider = Mock.Of<HTMLCSharpLanguageServerFeedbackFileLoggerProvider>(l => l.CreateLogger(It.IsAny<string>()) == logger, MockBehavior.Strict);
-        }
-
-        internal HTMLCSharpLanguageServerFeedbackFileLoggerProvider LoggerProvider { get; }
-
         [Fact]
         public async Task GetProjectionAsync_RazorProjection_ReturnsNull()
         {
@@ -44,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>(MockBehavior.Strict));
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot.Object, new Position(), CancellationToken.None).ConfigureAwait(false);
@@ -84,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>(MockBehavior.Strict));
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot, new Position(), CancellationToken.None).ConfigureAwait(false);
@@ -127,7 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>(MockBehavior.Strict));
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot, new Position(), CancellationToken.None).ConfigureAwait(false);
@@ -170,7 +159,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(true));
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
+            var logger = new Mock<RazorLogger>(MockBehavior.Strict);
+            logger.Setup(l => l.LogVerbose(It.IsAny<string>())).Verifiable();
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, logger.Object);
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot, new Position(), CancellationToken.None).ConfigureAwait(false);
@@ -213,7 +204,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Setup(d => d.TrySynchronizeVirtualDocumentAsync(documentSnapshot.Version, virtualDocumentSnapshot, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(false));
 
-            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, LoggerProvider);
+            var projectionProvider = new DefaultLSPProjectionProvider(requestInvoker.Object, documentSynchronizer.Object, Mock.Of<RazorLogger>(MockBehavior.Strict));
 
             // Act
             var result = await projectionProvider.GetProjectionAsync(documentSnapshot, new Position(), CancellationToken.None).ConfigureAwait(false);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/InProcLanguageServerAdapterTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/InProcLanguageServerAdapterTest.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Xunit;
+using ClientFormattingOptions = Microsoft.VisualStudio.LanguageServer.Protocol.FormattingOptions;
+using ClientPosition = Microsoft.VisualStudio.LanguageServer.Protocol.Position;
+using ClientRange = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+using ClientRazorLanguageKind = Microsoft.VisualStudio.LanguageServerClient.Razor.RazorLanguageKind;
+using ClientRazorLanguageQueryParams = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorLanguageQueryParams;
+using ClientRazorMapToDocumentEditsParams = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorMapToDocumentEditsParams;
+using ClientRazorMapToDocumentRangesParams = Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorMapToDocumentRangesParams;
+using ClientTextEdit = Microsoft.VisualStudio.LanguageServer.Protocol.TextEdit;
+using ServerPosition = OmniSharp.Extensions.LanguageServer.Protocol.Models.Position;
+using ServerRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using ServerRazorLanguageKind = Microsoft.AspNetCore.Razor.LanguageServer.RazorLanguageKind;
+using ServerRazorLanguageQueryResponse = Microsoft.AspNetCore.Razor.LanguageServer.RazorLanguageQueryResponse;
+using ServerRazorMapToDocumentEditsResponse = Microsoft.AspNetCore.Razor.LanguageServer.RazorMapToDocumentEditsResponse;
+using ServerRazorMapToDocumentRangesResponse = Microsoft.AspNetCore.Razor.LanguageServer.RazorMapToDocumentRangesResponse;
+using ServerTextEdit = OmniSharp.Extensions.LanguageServer.Protocol.Models.TextEdit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    public class InProcLanguageServerAdapterTest
+    {
+        private static ServerPosition TestServerPosition1 { get; } = new ServerPosition(1, 23);
+
+        private static ServerPosition TestServerPosition2 { get; } = new ServerPosition(4, 56);
+
+        private static ServerRange TestServerRange1 { get; } = new ServerRange()
+        {
+            Start = TestServerPosition1,
+            End = TestServerPosition1,
+        };
+
+        private static ServerRange TestServerRange2 { get; } = new ServerRange()
+        {
+            Start = TestServerPosition2,
+            End = TestServerPosition2,
+        };
+
+        private static ServerTextEdit TestServerTextEdit1 { get; } = new ServerTextEdit()
+        {
+            NewText = "test1",
+            Range = TestServerRange1,
+        };
+
+        private static ServerTextEdit TestServerTextEdit2 { get; } = new ServerTextEdit()
+        {
+            NewText = "test2",
+            Range = TestServerRange2,
+        };
+
+        private static ClientPosition TestClientPosition1 { get; } = new ClientPosition(7, 89);
+
+        private static ClientPosition TestClientPosition2 { get; } = new ClientPosition(10, 1112);
+
+        private static ClientRange TestClientRange1 { get; } = new ClientRange()
+        {
+            Start = TestClientPosition1,
+            End = TestClientPosition1,
+        };
+
+        private static ClientRange TestClientRange2 { get; } = new ClientRange()
+        {
+            Start = TestClientPosition2,
+            End = TestClientPosition2,
+        };
+
+        private static ClientTextEdit TestClientTextEdit1 { get; } = new ClientTextEdit()
+        {
+            NewText = "test1",
+            Range = TestClientRange1,
+        };
+
+        private static ClientTextEdit TestClientTextEdit2 { get; } = new ClientTextEdit()
+        {
+            NewText = "test2",
+            Range = TestClientRange2,
+        };
+
+        private static Uri TestUri { get; } = new Uri("C:/path/to/file.razor");
+
+        [Fact]
+        public void ConvertToClient_EditResponse()
+        {
+            // Arrange
+            var originalobject = new ServerRazorMapToDocumentEditsResponse()
+            {
+                HostDocumentVersion = 123,
+                TextEdits = new[] { TestServerTextEdit1, TestServerTextEdit2 }
+            };
+
+            // Act
+            var convertedObject = InProcLanguageServerAdapter.ConvertToClient(originalobject);
+
+            // Assert
+            AssertConversionIsEqual(originalobject, convertedObject);
+        }
+
+        [Fact]
+        public void ConvertToServer_EditParams()
+        {
+            // Arrange
+            var originalobject = new ClientRazorMapToDocumentEditsParams()
+            {
+                Kind = ClientRazorLanguageKind.Html,
+                TextEditKind = HtmlCSharp.TextEditKind.Snippet,
+                RazorDocumentUri = TestUri,
+                FormattingOptions = new ClientFormattingOptions()
+                {
+                    InsertSpaces = true,
+                    TabSize = 7,
+                    OtherOptions = new Dictionary<string, object>()
+                    {
+                        ["key"] = "value",
+                    },
+                },
+                ProjectedTextEdits = new[] { TestClientTextEdit1, TestClientTextEdit2 },
+            };
+
+            // Act
+            var convertedObject = InProcLanguageServerAdapter.ConvertToServer(originalobject);
+
+            // Assert
+            AssertConversionIsEqual(originalobject, convertedObject);
+        }
+
+        [Fact]
+        public void ConvertToClient_MapRangesResponse()
+        {
+            // Arrange
+            var originalobject = new ServerRazorMapToDocumentRangesResponse()
+            {
+                Ranges = new[] { TestServerRange1, TestServerRange2 },
+                HostDocumentVersion = 1234567,
+            };
+
+            // Act
+            var convertedObject = InProcLanguageServerAdapter.ConvertToClient(originalobject);
+
+            // Assert
+            AssertConversionIsEqual(originalobject, convertedObject);
+        }
+
+        [Fact]
+        public void ConvertToServer_MapRangesParams()
+        {
+            // Arrange
+            var originalobject = new ClientRazorMapToDocumentRangesParams()
+            {
+                Kind = ClientRazorLanguageKind.CSharp,
+                MappingBehavior = LanguageServerMappingBehavior.Inclusive,
+                ProjectedRanges = new[] { TestClientRange1, TestClientRange2 },
+                RazorDocumentUri = TestUri,
+            };
+
+            // Act
+            var convertedObject = InProcLanguageServerAdapter.ConvertToServer(originalobject);
+
+            // Assert
+            AssertConversionIsEqual(originalobject, convertedObject);
+        }
+
+        [Fact]
+        public void ConvertToClient_LanguageQueryResponse()
+        {
+            // Arrange
+            var originalobject = new ServerRazorLanguageQueryResponse()
+            {
+                HostDocumentVersion = 1337,
+                Kind = ServerRazorLanguageKind.Html,
+                Position = TestServerPosition2,
+                PositionIndex = 7890,
+            };
+
+            // Act
+            var convertedObject = InProcLanguageServerAdapter.ConvertToClient(originalobject);
+
+            // Assert
+            AssertConversionIsEqual(originalobject, convertedObject);
+        }
+
+        [Fact]
+        public void ConvertToServer_LanguageQueryParams()
+        {
+            // Arrange
+            var originalobject = new ClientRazorLanguageQueryParams()
+            {
+                Position = TestClientPosition1,
+                Uri = TestUri,
+            };
+
+            // Act
+            var convertedObject = InProcLanguageServerAdapter.ConvertToServer(originalobject);
+
+            // Assert
+            AssertConversionIsEqual(originalobject, convertedObject);
+        }
+
+        private void AssertConversionIsEqual<TOriginalType>(TOriginalType original, object converted)
+        {
+            var serializedOriginal = JsonConvert.SerializeObject(original);
+            var serializedConversion = JsonConvert.SerializeObject(converted);
+
+            // At this point we can't just compare serializedOriginal to serializedConversion because the data types may serialize slightly differently but may still in fact be equivalent.
+            // For instance, some may render `null` some may not, some may render in camelCase some may not. To ignore these differences we re-serialize the converted type into the original
+            // type so we can do a string comparison.
+            var deserializedConversionToOriginal = JsonConvert.DeserializeObject<TOriginalType>(serializedConversion);
+            var reserializedOriginalAfterConvert = JsonConvert.SerializeObject(deserializedConversionToOriginal);
+
+            Assert.Equal(serializedOriginal, reserializedOriginalAfterConvert);
+        }
+    }
+}


### PR DESCRIPTION
- StreamJsonRpc has significant overhead when invoking any requests. In practice I've seen timing range from 0-100ms. The purpose of this PR is to remove this overhead from common Razor language interactions (language query, range remapping, edit remapping) that will eventually go away anyways. Now I mention "will eventually go away anyways", this is in reference to a re-design that I am in the midst of writing up. For the interim, this PR actually adds some "not so great" restrictions to our design in an effort to deliver a superior user experience. Some of those are:
    - We lose the RPC logging in regards to resolving LSP projections. This shouldn't be an issue once Tanay's LogHub changes have made their way in and we have separate logging.
    - We're relying on things being "inproc". In a world where we go out of proc technically we'd still work but performance would degrade significantly until a re-design.
    - We further bind ourselves to our Razor Language Server types in VS.
- Added a `InProcLanguageServerAdapter` that serves as the binding layer between our language server and in-proc VS pieces. I tried to isolate this component as much as possible because it's where concerns bleed from server/client and ultimately is serving as a point-in-time perf solution for a lot of our common calls. Once we re-design the language server this will go away.
    - Added tests to validate the conversion mechanisms of client types -> server types and vice-versa.
- In the end I found that we went from around a  `40ms` average for language query invocations to ~3ms. This could be improved further by actually optimizing the language query logic; however, the 37ms improvement on average is quite noticeable especially given the sheer number of requests that happen when you insert a single character (4+ which prior to this were each around 40ms each).

Part of dotnet/aspnetcore#30223