### PR TITLE
Filter Invalid Expression `)` C# Diagnostic With Empty Attribute

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsEndpoint.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         IRazorDiagnosticsHandler
     {
         // Internal for testing
-        internal static readonly IReadOnlyCollection<string> DiagnosticsToIgnore = new HashSet<string>()
+        internal static readonly IReadOnlyCollection<string> CSharpDiagnosticsToIgnore = new HashSet<string>()
         {
             "RemoveUnnecessaryImportsFixable",
             "IDE0005_gen", // Using directive is unnecessary
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             var unmappedDiagnostics = request.Diagnostics;
             var filteredDiagnostics = request.Kind == RazorLanguageKind.CSharp ?
-                FilterCSharpDiagnostics(unmappedDiagnostics) :
+                FilterCSharpDiagnostics(unmappedDiagnostics, codeDocument) :
                 await FilterHTMLDiagnosticsAsync(unmappedDiagnostics, codeDocument, documentSnapshot).ConfigureAwait(false);
             if (!filteredDiagnostics.Any())
             {
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _logger.LogInformation($"{filteredDiagnostics.Length}/{unmappedDiagnostics.Length} diagnostics remain after filtering.");
 
             var mappedDiagnostics = MapDiagnostics(
-                request,
+                request.Kind,
                 filteredDiagnostics,
                 codeDocument);
 
@@ -166,13 +166,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var filteredDiagnostics = unmappedDiagnostics
                 .Where(d =>
                     !InAttributeContainingCSharp(d, sourceText, syntaxTree, processedAttributes) &&
-                    !FilterDiagnosticBasedOnErrorCode(d, sourceText, syntaxTree))
+                    !ShouldFilterHtmlDiagnosticBasedOnErrorCode(d, sourceText, syntaxTree))
                 .ToArray();
 
             return filteredDiagnostics;
         }
 
-        private static bool FilterDiagnosticBasedOnErrorCode(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree)
+        private static bool ShouldFilterHtmlDiagnosticBasedOnErrorCode(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree)
         {
             if (!diagnostic.Code.HasValue)
             {
@@ -238,49 +238,64 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
         }
 
-        private Diagnostic[] FilterCSharpDiagnostics(Diagnostic[] unmappedDiagnostics)
+        private Diagnostic[] FilterCSharpDiagnostics(Diagnostic[] unmappedDiagnostics, RazorCodeDocument codeDocument)
         {
             return unmappedDiagnostics.Where(d =>
-                !(DiagnosticsToIgnore.Contains(d.Code?.String) &&
-                  d.Severity != DiagnosticSeverity.Error))
-                .ToArray();
+                !ShouldFilterCSharpDiagnosticBasedOnErrorCode(d, codeDocument)).ToArray();
+        }
+
+        private bool ShouldFilterCSharpDiagnosticBasedOnErrorCode(Diagnostic diagnostic, RazorCodeDocument codeDocument)
+        {
+            if (!diagnostic.Code.HasValue)
+            {
+                return false;
+            }
+
+            return diagnostic.Code.Value.String switch
+            {
+                "CS1525" => IsInEmptyAttribute(diagnostic, codeDocument),
+                _ => CSharpDiagnosticsToIgnore.Contains(diagnostic.Code.Value.String) &&
+                        diagnostic.Severity != DiagnosticSeverity.Error,
+            };
+
+            bool IsInEmptyAttribute(Diagnostic diagnostic, RazorCodeDocument codeDocument)
+            {
+                if (TryGetOriginalDiagnosticRange(diagnostic.Range, diagnostic.Severity, codeDocument, out var originalRange) &&
+                    originalRange.IsUndefined())
+                {
+                    // Empty attribute values will take the following form in the generated C# document:
+                    // __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );
+                    // The trailing `)` with no value preceding it, will lead to a C# error which doesn't make sense within the razor file.
+                    // The empty attribute value is not directly mappable to Razor, hence we check if the diagnostic has an undefined range.
+                    // Note; Error RZ2008 informs the user that the empty attribute value is not allowed.
+                    // https://github.com/dotnet/aspnetcore/issues/30480
+                    return true;
+                }
+
+                return false;
+            }
         }
 
         private Diagnostic[] MapDiagnostics(
-            RazorDiagnosticsParams request,
-            IReadOnlyList<Diagnostic> filteredDiagnostics,
+            RazorLanguageKind languageKind,
+            IReadOnlyList<Diagnostic> diagnostics,
             RazorCodeDocument codeDocument)
         {
-            if (request.Kind != RazorLanguageKind.CSharp)
+            if (languageKind != RazorLanguageKind.CSharp)
             {
                 // All other non-C# requests map directly to where they are in the document.
-                return filteredDiagnostics.ToArray();
+                return diagnostics.ToArray();
             }
 
             var mappedDiagnostics = new List<Diagnostic>();
 
-            for (var i = 0; i < filteredDiagnostics.Count; i++)
+            for (var i = 0; i < diagnostics.Count; i++)
             {
-                var diagnostic = filteredDiagnostics[i];
-                var projectedRange = diagnostic.Range;
+                var diagnostic = diagnostics[i];
 
-                if (!_documentMappingService.TryMapFromProjectedDocumentRange(
-                        codeDocument,
-                        projectedRange,
-                        MappingBehavior.Inclusive,
-                        out var originalRange))
+                if (!TryGetOriginalDiagnosticRange(diagnostic.Range, diagnostic.Severity, codeDocument, out var originalRange))
                 {
-                    // Couldn't remap the range correctly.
-                    // If this isn't an `Error` Severity Diagnostic we can discard it.
-                    if (diagnostic.Severity != DiagnosticSeverity.Error)
-                    {
-                        continue;
-                    }
-
-                    // For `Error` Severity diagnostics we still show the diagnostics to
-                    // the user, however we set the range to an undefined range to ensure
-                    // clicking on the diagnostic doesn't cause errors.
-                    originalRange = RangeExtensions.UndefinedRange;
+                    continue;
                 }
 
                 diagnostic.Range = originalRange;
@@ -288,6 +303,30 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             return mappedDiagnostics.ToArray();
+        }
+
+        private bool TryGetOriginalDiagnosticRange(Range projectedRange, DiagnosticSeverity? severity, RazorCodeDocument codeDocument, out Range originalRange)
+        {
+            if (!_documentMappingService.TryMapFromProjectedDocumentRange(
+                           codeDocument,
+                           projectedRange,
+                           MappingBehavior.Inclusive,
+                           out originalRange))
+            {
+                // Couldn't remap the range correctly.
+                // If this isn't an `Error` Severity Diagnostic we can discard it.
+                if (severity != DiagnosticSeverity.Error)
+                {
+                    return false;
+                }
+
+                // For `Error` Severity diagnostics we still show the diagnostics to
+                // the user, however we set the range to an undefined range to ensure
+                // clicking on the diagnostic doesn't cause errors.
+                originalRange = RangeExtensions.UndefinedRange;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsEndpoint.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using RazorDiagnosticFactory = Microsoft.AspNetCore.Razor.Language.RazorDiagnosticFactory;
 using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
@@ -260,9 +261,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             bool ShouldIgnoreCS1525(Diagnostic diagnostic, RazorCodeDocument codeDocument)
             {
-                if (TryGetOriginalDiagnosticRange(diagnostic.Range, diagnostic.Severity, codeDocument, out var originalRange) &&
-                    originalRange.IsUndefined() &&
-                    CheckIfDocumentHasRazorDiagnostic(codeDocument, "RZ2008"))
+                if (CheckIfDocumentHasRazorDiagnostic(codeDocument, RazorDiagnosticFactory.TagHelper_EmptyBoundAttribute.Id) &&
+                    TryGetOriginalDiagnosticRange(diagnostic.Range, diagnostic.Severity, codeDocument, out var originalRange) &&
+                    originalRange.IsUndefined())
                 {
                     // Empty attribute values will take the following form in the generated C# document:
                     // __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );
@@ -315,10 +316,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private bool TryGetOriginalDiagnosticRange(Range projectedRange, DiagnosticSeverity? severity, RazorCodeDocument codeDocument, out Range originalRange)
         {
             if (!_documentMappingService.TryMapFromProjectedDocumentRange(
-                           codeDocument,
-                           projectedRange,
-                           MappingBehavior.Inclusive,
-                           out originalRange))
+                    codeDocument,
+                    projectedRange,
+                    MappingBehavior.Inclusive,
+                    out originalRange))
             {
                 // Couldn't remap the range correctly.
                 // If this isn't an `Error` Severity Diagnostic we can discard it.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticsEndpointTest.cs
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Diagnostics = new[] {
                     new Diagnostic() {
                         Range = new Range(new Position(0, 10), new Position(0, 22)),
-                        Code = RazorDiagnosticsEndpoint.DiagnosticsToIgnore.First(),
+                        Code = RazorDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
                         Severity = DiagnosticSeverity.Warning
                     }
                 },
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Diagnostics = new[] {
                     new Diagnostic() {
                         Range = new Range(new Position(0, 10), new Position(0, 22)),
-                        Code = RazorDiagnosticsEndpoint.DiagnosticsToIgnore.First(),
+                        Code = RazorDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
                         Severity = DiagnosticSeverity.Error
                     }
                 },
@@ -265,6 +265,75 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Assert
             Assert.Equal(RangeExtensions.UndefinedRange, response.Diagnostics[0].Range);
+            Assert.Equal(1337, response.HostDocumentVersion);
+        }
+
+        [Fact]
+        public async Task Handle_ProcessDiagnostics_CSharpError_CS1525_InAttribute_ReturnsNoDiagnostics()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var codeDocument = CreateCodeDocumentWithCSharpProjection(
+                "<p @onabort=\"\"></p>",
+                "__o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );",
+                sourceMappings: Array.Empty<SourceMapping>());
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
+            var request = new RazorDiagnosticsParams()
+            {
+                Kind = RazorLanguageKind.CSharp,
+                Diagnostics = new[] {
+                    new Diagnostic() {
+                        Code = new DiagnosticCode("CS1525"),
+                        Severity = DiagnosticSeverity.Error,
+                        Range = new Range(new Position(0, 0), new Position(0, 3))
+                    }
+                },
+                RazorDocumentUri = new Uri(documentPath),
+            };
+
+            // Act
+            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+
+            // Assert
+            Assert.Empty(response.Diagnostics);
+            Assert.Equal(1337, response.HostDocumentVersion);
+        }
+
+        [Fact]
+        public async Task Handle_ProcessDiagnostics_CSharpError_CS1525_NotInAttribute_ReturnsDiagnostics()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var codeDocument = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now)</p>",
+                "var __o = DateTime.Now)",
+                new[] {
+                    new SourceMapping(
+                        new SourceSpan(4, 13),
+                        new SourceSpan(10, 13))
+                });
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
+            var request = new RazorDiagnosticsParams()
+            {
+                Kind = RazorLanguageKind.CSharp,
+                Diagnostics = new[] {
+                    new Diagnostic() {
+                        Code = new DiagnosticCode("CS1525"),
+                        Severity = DiagnosticSeverity.Error,
+                        Range = new Range(new Position(0, 12), new Position(0, 13))
+                    }
+                },
+                RazorDocumentUri = new Uri(documentPath),
+            };
+            var expectedRange = new Range(new Position(0, 6), new Position(0, 7));
+
+            // Act
+            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+
+            // Assert
+            Assert.Equal(expectedRange, response.Diagnostics[0].Range);
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 


### PR DESCRIPTION
I was seeing `Invalid Expression )` error diagnostic for empty attributes. Examining the generated doc, it's reasonable why C# thinks there's an error, however it doesn't make sense in the Razor context (as RZ2008 already errors for empty attributes).

Razor:
```razor
<p @onabort=""></p>
```

Generated doc:
```csharp
__o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );
```


Fixes: https://github.com/dotnet/aspnetcore/issues/30480


#### Before
![image](https://user-images.githubusercontent.com/14852843/109235737-19128f80-7783-11eb-9a80-1f3b305d759b.png)
