### PR TITLE
Cache BPs/Proximity expressions to avoid going async.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorBreakpointResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorBreakpointResolver.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Text;
+using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
 {
@@ -26,6 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
         private readonly LSPProjectionProvider _projectionProvider;
         private readonly LSPDocumentMappingProvider _documentMappingProvider;
         private readonly VisualStudioWorkspaceAccessor _workspaceAccessor;
+        private readonly MemoryCache<CacheKey, Range> _cache;
 
         [ImportingConstructor]
         public DefaultRazorBreakpointResolver(
@@ -65,6 +67,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
             _projectionProvider = projectionProvider;
             _documentMappingProvider = documentMappingProvider;
             _workspaceAccessor = workspaceAccessor;
+
+            // 4 is a magic number that was determined based on the functionality of VisualStudio. Currently when you set or edit a breakpoint
+            // we get called with two different locations for the same breakpoint. Because of this 2 time call our size must be at least 2,
+            // we grow it to 4 just to be safe for lesser known scenarios.
+            _cache = new MemoryCache<CacheKey, Range>(sizeLimit: 4);
         }
 
         public override async Task<Range> TryResolveBreakpointRangeAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
@@ -84,6 +91,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
             {
                 // No associated Razor document. Do not allow a breakpoint here. In practice this shouldn't happen, just being defensive.
                 return null;
+            }
+
+            var cacheKey = new CacheKey(documentSnapshot.Uri, documentSnapshot.Version, lineIndex, characterIndex);
+            if (_cache.TryGetValue(cacheKey, out var cachedRange))
+            {
+                // We've seen this request before, no need to go async.
+                return cachedRange;
             }
 
             var lspPosition = new Position(lineIndex, characterIndex);
@@ -136,7 +150,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
             cancellationToken.ThrowIfCancellationRequested();
 
             var hostDocumentRange = hostDocumentMapping.Ranges.FirstOrDefault();
+
+            // Cache range so if we're asked again for this document/line/character we don't have to go async.
+            _cache.Set(cacheKey, hostDocumentRange);
+
             return hostDocumentRange;
         }
+
+        private record CacheKey(Uri DocumentUri, int DocumentVersion, int Line, int Character);
     }
 }


### PR DESCRIPTION
- Added caching logic to our BP & proximity expression resolver to enable us to avoid going async as often. Ultimately this is a workaround to the platform's innability to have an async debugging API.

Fixes dotnet/aspnetcore#30223