### PR TITLE
Lazily parse document in semantic tokens edit.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -167,13 +167,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             string? previousResultId,
             CancellationToken cancellationToken)
         {
-            var codeDocument = await GetRazorCodeDocumentAsync(documentSnapshot);
-            if (codeDocument is null)
-            {
-                throw new ArgumentNullException(nameof(codeDocument));
-            }
-            cancellationToken.ThrowIfCancellationRequested();
-
             VersionStamp? cachedSemanticVersion = null;
             IReadOnlyList<int>? previousResults = null;
             if (previousResultId != null)
@@ -190,6 +183,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             // SemanticVersion is different if there's been any text edits to the razor file or ProjectVersion has changed.
             if (semanticVersion == default || cachedSemanticVersion != semanticVersion)
             {
+                var codeDocument = await GetRazorCodeDocumentAsync(documentSnapshot);
+                if (codeDocument is null)
+                {
+                    throw new ArgumentNullException(nameof(codeDocument));
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var razorSemanticRanges = TagHelperSemanticRangeVisitor.VisitAllNodes(codeDocument);
                 var csharpSemanticRanges = await GetCSharpSemanticRangesAsync(codeDocument, textDocumentIdentifier, range: null, documentVersion, cancellationToken);
 


### PR DESCRIPTION
- A user reported that while Razor documents were open their CPU would constantly spin. They decided to profile what was happening in VS and part of the profile indicated that Razor was constantly re-parsing on every semantic token edit poll. Found that we were aggressively generating a code document so just moved the code document calculation logic down a few steps to allow our caching layer to cache without re-parse.

Part of https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1286124