### PR TITLE
Fix C# serialization break in VSCode

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocument.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/CSharp/CSharpProjectedDocument.ts
@@ -41,7 +41,7 @@ export class CSharpProjectedDocument implements IProjectedDocument {
         let content = this.content;
         for (const edit of edits.reverse()) {
             // TODO: Use a better data structure to represent the content, string concatenation is slow.
-            content = this.getEditedContent(edit.newText, edit.span.start, edit.span.end, content);
+            content = this.getEditedContent(edit.newText, edit.span.start, edit.span.start + edit.span.length, content);
         }
 
         this.setContent(content);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocument.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlProjectedDocument.ts
@@ -36,7 +36,7 @@ export class HtmlProjectedDocument implements IProjectedDocument {
         let content = this.content;
         for (const edit of edits.reverse()) {
             // TODO: Use a better data structure to represent the content, string concatenation is slow.
-            content = this.getEditedContent(edit.newText, edit.span.start, edit.span.end, content);
+            content = this.getEditedContent(edit.newText, edit.span.start, edit.span.start + edit.span.length, content);
         }
 
         this.setContent(content);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/ServerTextSpan.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RPC/ServerTextSpan.ts
@@ -5,6 +5,5 @@
 
 export interface ServerTextSpan {
     readonly start: number;
-    readonly end: number;
     readonly length: number;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/CSharpProjectedDocument.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/CSharpProjectedDocument.test.ts
@@ -19,7 +19,6 @@ describe('CSharpProjectedDocument', () => {
             newText: 'Hello World',
             span: {
                 start: 0,
-                end: 0,
                 length: 11,
             },
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/HtmlProjectedDocument.test.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/tests/HtmlProjectedDocument.test.ts
@@ -19,7 +19,6 @@ describe('HtmlProjectedDocument', () => {
             newText: 'Hello World',
             span: {
                 start: 0,
-                end: 0,
                 length: 11,
             },
         };


### PR DESCRIPTION
- After updating C# packages in VSCode going cross languages for their `TextSpan` type no longer worked. That was due to [this change](https://github.com/dotnet/roslyn/commit/e91ccb5cff76e826b1efd9e1a598bb4dd1a13986#diff-d7c14d06408992f74fe6b90dbb05737e99a0f492227562cf25e59c0242ba00e4R46). Basically instead of rendering an "end" for TextSpan's they only render start and length and expect the other side to calculate the end. Reasonable but broke our JS impl.

Part of dotnet/aspnetcore#30834