### PR TITLE
Don't re-parse the world on document change.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
@@ -327,7 +327,6 @@ namespace Microsoft.CodeAnalysis.Razor
                     }
 
                 case ProjectChangeKind.DocumentAdded:
-                case ProjectChangeKind.DocumentChanged:
                     {
                         var project = e.Newer;
                         var document = project.GetDocument(e.DocumentFilePath);
@@ -360,9 +359,6 @@ namespace Microsoft.CodeAnalysis.Razor
                         // ignore
                         break;
                     }
-
-                default:
-                    throw new InvalidOperationException($"Unknown ProjectChangeKind {e.Kind}");
             }
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -255,69 +255,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
         }
 
-        [ForegroundFact(Skip = "https://github.com/dotnet/aspnetcore/issues/14805")]
-        public async Task DocumentChanged_ReparsesRelatedFiles()
-        {
-            // Arrange
-            var projectManager = new TestProjectSnapshotManager(Dispatcher, Workspace)
-            {
-                AllowNotifyListeners = true,
-            };
-            var documents = new[]
-            {
-                TestProjectData.SomeProjectComponentFile1,
-                TestProjectData.SomeProjectImportFile
-            };
-            projectManager.ProjectAdded(HostProject1);
-            for (var i = 0; i < documents.Length; i++)
-            {
-                projectManager.DocumentAdded(HostProject1, documents[i], null);
-            }
-
-            var queue = new BackgroundDocumentGenerator(Dispatcher, DynamicFileInfoProvider)
-            {
-                Delay = TimeSpan.FromMilliseconds(1),
-                BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
-                NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false),
-                NotifyBackgroundCapturedWorkload = new ManualResetEventSlim(initialState: false),
-                BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false),
-                NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false),
-            };
-
-            var changedSourceText = SourceText.From("@inject DateTime Time");
-            queue.Initialize(projectManager);
-
-            // Act & Assert
-            projectManager.DocumentChanged(HostProject1.FilePath, TestProjectData.SomeProjectImportFile.FilePath, changedSourceText);
-
-            Assert.True(queue.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
-            Assert.True(queue.HasPendingNotifications, "Queue should have a notification created during Enqueue");
-
-            for (var i = 0; i < documents.Length; i++)
-            {
-                var key = new DocumentKey(HostProject1.FilePath, documents[i].FilePath);
-                Assert.True(queue._work.ContainsKey(key));
-            }
-
-            // Allow the background work to start.
-            queue.BlockBackgroundWorkStart.Set();
-
-            await Task.Run(() => queue.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(1)));
-
-            Assert.True(queue.IsScheduledOrRunning, "Worker should be processing now");
-
-            await Task.Run(() => queue.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(1)));
-            Assert.False(queue.HasPendingNotifications, "Worker should have taken all notifications");
-
-            // Allow work to complete
-            queue.BlockBackgroundWorkCompleting.Set();
-
-            await Task.Run(() => queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
-
-            Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
-            Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
-        }
-
         [ForegroundFact]
         public async Task DocumentRemoved_ReparsesRelatedFiles()
         {


### PR DESCRIPTION
- There's no reason for our background document generator to re-parse the world on document changes. The intent is that when a document changes that it could potentially influence TagHelpers for the current project; however, in that case a `ProjectChanged` event triggers in which we then re-parse the world.
- We also don't need to re-parse the current document that's open because in non-LSP scenarios that's being handled via the `DefaultVisualStudioRazorParser` and in LSP scenarios that's being handled by the language server.
- Removed skipped test because this is no longer a scenario.

Part of dotnet/aspnetcore#31031