### PR TITLE
LSP: Only background parse open documents

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
@@ -1,0 +1,317 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class OpenDocumentGenerator : ProjectSnapshotChangeTrigger
+    {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly IEnumerable<DocumentProcessedListener> _documentProcessedListeners;
+        private readonly Dictionary<string, DocumentSnapshot> _work;
+        private ProjectSnapshotManagerBase _projectManager;
+        private Timer _timer;
+
+        public OpenDocumentGenerator(
+            ForegroundDispatcher foregroundDispatcher,
+            IEnumerable<DocumentProcessedListener> documentProcessedListeners)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (documentProcessedListeners == null)
+            {
+                throw new ArgumentNullException(nameof(documentProcessedListeners));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+            _documentProcessedListeners = documentProcessedListeners;
+            _work = new Dictionary<string, DocumentSnapshot>(StringComparer.Ordinal);
+        }
+
+        // For testing only
+        protected OpenDocumentGenerator(ForegroundDispatcher foregroundDispatcher)
+        {
+            _foregroundDispatcher = foregroundDispatcher;
+            _work = new Dictionary<string, DocumentSnapshot>(StringComparer.Ordinal);
+            _documentProcessedListeners = Enumerable.Empty<DocumentProcessedListener>();
+        }
+
+        public bool HasPendingNotifications
+        {
+            get
+            {
+                lock (_work)
+                {
+                    return _work.Count > 0;
+                }
+            }
+        }
+
+        public TimeSpan Delay { get; set; } = TimeSpan.Zero;
+
+        public bool IsScheduledOrRunning => _timer != null;
+
+        // Used in tests to ensure we can control when background work starts.
+        public ManualResetEventSlim BlockBackgroundWorkStart { get; set; }
+
+        // Used in tests to ensure we can know when background work finishes.
+        public ManualResetEventSlim NotifyBackgroundWorkStarting { get; set; }
+
+        // Used in unit tests to ensure we can know when background has captured its current workload.
+        public ManualResetEventSlim NotifyBackgroundCapturedWorkload { get; set; }
+
+        // Used in tests to ensure we can control when background work completes.
+        public ManualResetEventSlim BlockBackgroundWorkCompleting { get; set; }
+
+        // Used in tests to ensure we can know when background work finishes.
+        public ManualResetEventSlim NotifyBackgroundWorkCompleted { get; set; }
+
+        public override void Initialize(ProjectSnapshotManagerBase projectManager)
+        {
+            if (projectManager == null)
+            {
+                throw new ArgumentNullException(nameof(projectManager));
+            }
+
+            _projectManager = projectManager;
+
+            _projectManager.Changed += ProjectSnapshotManager_Changed;
+
+            foreach (var documentProcessedListener in _documentProcessedListeners)
+            {
+                documentProcessedListener.Initialize(_projectManager);
+            }
+        }
+
+        private void OnStartingBackgroundWork()
+        {
+            if (BlockBackgroundWorkStart != null)
+            {
+                BlockBackgroundWorkStart.Wait();
+                BlockBackgroundWorkStart.Reset();
+            }
+
+            if (NotifyBackgroundWorkStarting != null)
+            {
+                NotifyBackgroundWorkStarting.Set();
+            }
+        }
+
+        private void OnCompletingBackgroundWork()
+        {
+            if (BlockBackgroundWorkCompleting != null)
+            {
+                BlockBackgroundWorkCompleting.Wait();
+                BlockBackgroundWorkCompleting.Reset();
+            }
+        }
+
+        private void OnCompletedBackgroundWork()
+        {
+            if (NotifyBackgroundWorkCompleted != null)
+            {
+                NotifyBackgroundWorkCompleted.Set();
+            }
+        }
+
+        private void OnBackgroundCapturedWorkload()
+        {
+            if (NotifyBackgroundCapturedWorkload != null)
+            {
+                NotifyBackgroundCapturedWorkload.Set();
+            }
+        }
+
+        // Internal for testing
+        internal void Enqueue(DocumentSnapshot document)
+        {
+            _foregroundDispatcher.AssertForegroundThread();
+
+            if (!_projectManager.IsDocumentOpen(document.FilePath))
+            {
+                // We don't parse closed documents
+                return;
+            }
+
+            lock (_work)
+            {
+                // We only want to store the last 'seen' version of any given document. That way when we pick one to process
+                // it's always the best version to use.
+                _work[document.FilePath] = document;
+
+                StartWorker();
+            }
+        }
+
+        private void StartWorker()
+        {
+            // Access to the timer is protected by the lock in Synchronize and in Timer_Tick
+            if (_timer == null)
+            {
+                // Timer will fire after a fixed delay, but only once.
+                _timer = new Timer(Timer_Tick, null, Delay, Timeout.InfiniteTimeSpan);
+            }
+        }
+
+#pragma warning disable VSTHRD100 // Avoid async void methods
+        private async void Timer_Tick(object state)
+#pragma warning restore VSTHRD100 // Avoid async void methods
+        {
+            try
+            {
+                _foregroundDispatcher.AssertBackgroundThread();
+
+                OnStartingBackgroundWork();
+
+                KeyValuePair<string, DocumentSnapshot>[] work;
+                lock (_work)
+                {
+                    work = _work.ToArray();
+                    _work.Clear();
+                }
+
+                OnBackgroundCapturedWorkload();
+
+                for (var i = 0; i < work.Length; i++)
+                {
+                    var document = work[i].Value;
+                    try
+                    {
+                        await document.GetGeneratedOutputAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        ReportError(ex);
+                    }
+                }
+
+                OnCompletingBackgroundWork();
+
+                await Task.Factory.StartNew(
+                    () =>
+                    {
+                        NotifyDocumentsProcessed(work);
+                    },
+                    CancellationToken.None,
+                    TaskCreationOptions.None,
+                    _foregroundDispatcher.ForegroundScheduler).ConfigureAwait(false);
+
+                lock (_work)
+                {
+                    // Resetting the timer allows another batch of work to start.
+                    _timer.Dispose();
+                    _timer = null;
+
+                    // If more work came in while we were running start the worker again.
+                    if (_work.Count > 0)
+                    {
+                        StartWorker();
+                    }
+                }
+
+                OnCompletedBackgroundWork();
+            }
+            catch (Exception ex)
+            {
+                // This is something totally unexpected, let's just send it over to the workspace.
+                ReportError(ex);
+
+                _timer?.Dispose();
+                _timer = null;
+            }
+        }
+
+        private void NotifyDocumentsProcessed(KeyValuePair<string, DocumentSnapshot>[] work)
+        {
+            for (var i = 0; i < work.Length; i++)
+            {
+                foreach (var documentProcessedTrigger in _documentProcessedListeners)
+                {
+                    var document = work[i].Value;
+                    documentProcessedTrigger.DocumentProcessed(document);
+                }
+            }
+        }
+
+        private void ProjectSnapshotManager_Changed(object sender, ProjectChangeEventArgs args)
+        {
+            _foregroundDispatcher.AssertForegroundThread();
+
+            switch (args.Kind)
+            {
+                case ProjectChangeKind.ProjectChanged:
+                    {
+                        var projectSnapshot = args.Newer;
+                        foreach (var documentFilePath in projectSnapshot.DocumentFilePaths)
+                        {
+                            var document = projectSnapshot.GetDocument(documentFilePath);
+                            Enqueue(document);
+                        }
+
+                        break;
+                    }
+
+                case ProjectChangeKind.DocumentAdded:
+                    {
+                        var projectSnapshot = args.Newer;
+                        var document = projectSnapshot.GetDocument(args.DocumentFilePath);
+
+                        // We don't enqueue the current document because added documents are by default closed.
+
+                        foreach (var relatedDocument in projectSnapshot.GetRelatedDocuments(document))
+                        {
+                            Enqueue(relatedDocument);
+                        }
+
+                        break;
+                    }
+
+                case ProjectChangeKind.DocumentChanged:
+                    {
+                        var projectSnapshot = args.Newer;
+                        var document = projectSnapshot.GetDocument(args.DocumentFilePath);
+                        Enqueue(document);
+
+                        foreach (var relatedDocument in projectSnapshot.GetRelatedDocuments(document))
+                        {
+                            Enqueue(relatedDocument);
+                        }
+
+                        break;
+                    }
+
+                case ProjectChangeKind.DocumentRemoved:
+                    {
+                        var olderProject = args.Older;
+                        var document = olderProject.GetDocument(args.DocumentFilePath);
+
+                        foreach (var relatedDocument in olderProject.GetRelatedDocuments(document))
+                        {
+                            var newerRelatedDocument = args.Newer.GetDocument(relatedDocument.FilePath);
+                            Enqueue(newerRelatedDocument);
+                        }
+                        break;
+                    }
+            }
+        }
+
+        private void ReportError(Exception ex)
+        {
+            _ = Task.Factory.StartNew(
+                () => _projectManager.ReportError(ex),
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                _foregroundDispatcher.ForegroundScheduler);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -159,7 +160,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (_timer == null)
             {
                 // Timer will fire after a fixed delay, but only once.
-                _timer = new Timer(Timer_Tick, null, Delay, Timeout.InfiniteTimeSpan);
+                _timer = NonCapturingTimer.Create(Timer_Tick, null, Delay, Timeout.InfiniteTimeSpan);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<ProjectResolver, DefaultProjectResolver>();
                         services.AddSingleton<DocumentResolver, DefaultDocumentResolver>();
                         services.AddSingleton<RazorProjectService, DefaultRazorProjectService>();
-                        services.AddSingleton<ProjectSnapshotChangeTrigger, BackgroundDocumentGenerator>();
+                        services.AddSingleton<ProjectSnapshotChangeTrigger, OpenDocumentGenerator>();
                         services.AddSingleton<RazorDocumentMappingService, DefaultRazorDocumentMappingService>();
                         services.AddSingleton<RazorFileChangeDetectorManager>();
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/BackgroundDocumentGeneratorTest.cs
@@ -29,8 +29,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             HostProject2 = new HostProject("c:/Test2/Test2.csproj", RazorConfiguration.Default, "TestRootNamespace");
         }
 
-        private IEnumerable<DocumentProcessedListener> Listeners => Enumerable.Empty<DocumentProcessedListener>();
-
         private HostDocument[] Documents { get; }
 
         private HostProject HostProject1 { get; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -1,0 +1,285 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class OpenDocumentGeneratorTest : LanguageServerTestBase
+    {
+        public OpenDocumentGeneratorTest()
+        {
+            Documents = new HostDocument[]
+            {
+                new HostDocument("c:/Test1/Index.cshtml", "Index.cshtml"),
+                new HostDocument("c:/Test1/Components/Counter.cshtml", "Components/Counter.cshtml"),
+            };
+
+            HostProject1 = new HostProject("c:/Test1/Test1.csproj", RazorConfiguration.Default, "TestRootNamespace");
+            HostProject2 = new HostProject("c:/Test2/Test2.csproj", RazorConfiguration.Default, "TestRootNamespace");
+        }
+
+        private HostDocument[] Documents { get; }
+
+        private HostProject HostProject1 { get; }
+
+        private HostProject HostProject2 { get; }
+
+        [Fact]
+        public void Enqueue_IgnoresClosedDocuments()
+        {
+            // Arrange
+            var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            projectManager.ProjectAdded(HostProject1);
+            projectManager.DocumentAdded(HostProject1, Documents[0], null);
+
+            var project = projectManager.GetLoadedProject(HostProject1.FilePath);
+
+            var queue = new TestOpenDocumentGenerator(Dispatcher);
+
+            queue.Initialize(projectManager);
+
+            // Act & Assert
+            queue.Enqueue(project.GetDocument(Documents[0].FilePath));
+
+            Assert.False(queue.IsScheduledOrRunning, "Queue should not have anything pending");
+        }
+
+        [Fact]
+        public void Enqueue_ProcessesNotifications_AndGoesBackToSleep()
+        {
+            // Arrange
+            var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            projectManager.ProjectAdded(HostProject1);
+            projectManager.ProjectAdded(HostProject2);
+            projectManager.DocumentAdded(HostProject1, Documents[0], null);
+            projectManager.DocumentOpened(HostProject1.FilePath, Documents[0].FilePath, SourceText.From(string.Empty));
+            projectManager.DocumentAdded(HostProject1, Documents[1], null);
+            projectManager.DocumentOpened(HostProject1.FilePath, Documents[1].FilePath, SourceText.From(string.Empty));
+
+            var project = projectManager.GetLoadedProject(HostProject1.FilePath);
+
+            var queue = new TestOpenDocumentGenerator(Dispatcher)
+            {
+                Delay = TimeSpan.FromMilliseconds(1),
+                BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false),
+                BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false),
+            };
+
+            queue.Initialize(projectManager);
+
+            // Act & Assert
+            queue.Enqueue(project.GetDocument(Documents[0].FilePath));
+
+            Assert.True(queue.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.True(queue.HasPendingNotifications, "Queue should have a notification created during Enqueue");
+
+            // Allow the background work to proceed.
+            queue.BlockBackgroundWorkStart.Set();
+            queue.BlockBackgroundWorkCompleting.Set();
+
+            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
+            Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
+        }
+
+        [Fact]
+        public void Enqueue_ProcessesNotifications_AndRestarts()
+        {
+            // Arrange
+            var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            projectManager.ProjectAdded(HostProject1);
+            projectManager.ProjectAdded(HostProject2);
+            projectManager.DocumentAdded(HostProject1, Documents[0], null);
+            projectManager.DocumentOpened(HostProject1.FilePath, Documents[0].FilePath, SourceText.From(string.Empty));
+            projectManager.DocumentAdded(HostProject1, Documents[1], null);
+            projectManager.DocumentOpened(HostProject1.FilePath, Documents[1].FilePath, SourceText.From(string.Empty));
+
+            var project = projectManager.GetLoadedProject(HostProject1.FilePath);
+
+            var queue = new TestOpenDocumentGenerator(Dispatcher)
+            {
+                Delay = TimeSpan.FromMilliseconds(1),
+                BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundCapturedWorkload = new ManualResetEventSlim(initialState: false),
+                BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false),
+            };
+
+            queue.Initialize(projectManager);
+
+            // Act & Assert
+            queue.Enqueue(project.GetDocument(Documents[0].FilePath));
+
+            Assert.True(queue.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.True(queue.HasPendingNotifications, "Queue should have a notification created during Enqueue");
+
+            // Allow the background work to start.
+            queue.BlockBackgroundWorkStart.Set();
+
+            queue.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(1));
+            Assert.True(queue.IsScheduledOrRunning, "Worker should be processing now");
+
+            queue.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(1));
+            Assert.False(queue.HasPendingNotifications, "Worker should have taken all notifications");
+
+            queue.Enqueue(project.GetDocument(Documents[1].FilePath));
+            Assert.True(queue.HasPendingNotifications); // Now we should see the worker restart when it finishes.
+
+            // Allow work to complete, which should restart the timer.
+            queue.BlockBackgroundWorkCompleting.Set();
+
+            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+            queue.NotifyBackgroundWorkCompleted.Reset();
+
+            // It should start running again right away.
+            Assert.True(queue.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.True(queue.HasPendingNotifications, "Queue should have a notification created during Enqueue");
+
+            // Allow the background work to proceed.
+            queue.BlockBackgroundWorkStart.Set();
+
+            queue.BlockBackgroundWorkCompleting.Set();
+            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
+            Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
+        }
+
+        // The below are more like integration tests where notifications start from the project snapshot manager and we ensure things flow as expected.
+
+        [Fact]
+        public void ProjectChanged_ProcessesNotifications_AndGoesBackToSleep()
+        {
+            // Arrange
+            var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            projectManager.ProjectAdded(HostProject1);
+            projectManager.ProjectAdded(HostProject2);
+            projectManager.DocumentAdded(HostProject1, Documents[0], null);
+            projectManager.DocumentOpened(HostProject1.FilePath, Documents[0].FilePath, SourceText.From(string.Empty));
+            projectManager.AllowNotifyListeners = true;
+
+            var queue = new TestOpenDocumentGenerator(Dispatcher)
+            {
+                Delay = TimeSpan.FromMilliseconds(1),
+                BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false),
+                BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false),
+            };
+            queue.Initialize(projectManager);
+
+            var newWorkspaceState = new ProjectWorkspaceState(Array.Empty<TagHelperDescriptor>(), LanguageVersion.CSharp7_3);
+
+
+            // Act & Assert
+            projectManager.ProjectWorkspaceStateChanged(HostProject1.FilePath, newWorkspaceState);
+
+            Assert.True(queue.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.True(queue.HasPendingNotifications, "Queue should have a notification created during Enqueue");
+
+            // Allow the background work to proceed.
+            queue.BlockBackgroundWorkStart.Set();
+            queue.BlockBackgroundWorkCompleting.Set();
+
+            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
+            Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
+        }
+
+        [Fact]
+        public void DocumentAdded_IgnoresClosedDocument()
+        {
+            // Arrange
+            var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            projectManager.ProjectAdded(HostProject1);
+            projectManager.ProjectAdded(HostProject2);
+            projectManager.AllowNotifyListeners = true;
+
+            var queue = new TestOpenDocumentGenerator(Dispatcher);
+            queue.Initialize(projectManager);
+
+            // Act & Assert
+            projectManager.DocumentAdded(HostProject1, Documents[0], null);
+
+            Assert.False(queue.IsScheduledOrRunning, "Queue should not be scheduled when a document is added for the first time (closed by default)");
+        }
+
+        [Fact]
+        public void DocumentChanged_ProcessesNotifications_AndGoesBackToSleep()
+        {
+            // Arrange
+            var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            projectManager.ProjectAdded(HostProject1);
+            projectManager.ProjectAdded(HostProject2);
+            projectManager.DocumentAdded(HostProject1, Documents[0], null);
+            projectManager.DocumentOpened(HostProject1.FilePath, Documents[0].FilePath, SourceText.From(string.Empty));
+            projectManager.AllowNotifyListeners = true;
+
+            var queue = new TestOpenDocumentGenerator(Dispatcher)
+            {
+                Delay = TimeSpan.FromMilliseconds(1),
+                BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false),
+                BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false),
+            };
+            queue.Initialize(projectManager);
+
+            // Act & Assert
+            projectManager.DocumentChanged(HostProject1.FilePath, Documents[0].FilePath, SourceText.From("Changed"));
+
+            Assert.True(queue.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.True(queue.HasPendingNotifications, "Queue should have a notification created during Enqueue");
+
+            // Allow the background work to proceed.
+            queue.BlockBackgroundWorkStart.Set();
+            queue.BlockBackgroundWorkCompleting.Set();
+
+            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
+            Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
+        }
+
+        [Fact]
+        public void DocumentRemoved_IgnoresClosedDocument()
+        {
+            // Arrange
+            var projectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            projectManager.ProjectAdded(HostProject1);
+            projectManager.ProjectAdded(HostProject2);
+            projectManager.DocumentAdded(HostProject1, Documents[0], null);
+            projectManager.DocumentOpened(HostProject1.FilePath, Documents[0].FilePath, SourceText.From(string.Empty));
+            projectManager.AllowNotifyListeners = true;
+
+            var queue = new TestOpenDocumentGenerator(Dispatcher);
+            queue.Initialize(projectManager);
+
+            // Act & Assert
+            projectManager.DocumentRemoved(HostProject1, Documents[0]);
+
+            Assert.False(queue.IsScheduledOrRunning, "Queue should not be scheduled when a document is added for the first time (closed by default)");
+        }
+
+        private class TestOpenDocumentGenerator : OpenDocumentGenerator
+        {
+            public TestOpenDocumentGenerator(ForegroundDispatcher foregroundDispatcher) : base(foregroundDispatcher)
+            {
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             queue.BlockBackgroundWorkStart.Set();
             queue.BlockBackgroundWorkCompleting.Set();
 
-            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
+            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)), "Timed out waiting for background work to complete");
 
             Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
@@ -129,10 +129,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Allow the background work to start.
             queue.BlockBackgroundWorkStart.Set();
 
-            Assert.True(queue.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(1)));
+            Assert.True(queue.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(1)), "Timed out waiting for background work to start");
             Assert.True(queue.IsScheduledOrRunning, "Worker should be processing now");
 
-            Assert.True(queue.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(1)));
+            Assert.True(queue.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(1)), "Timed out waiting for background work to be captured");
             Assert.False(queue.HasPendingNotifications, "Worker should have taken all notifications");
 
             queue.Enqueue(project.GetDocument(Documents[1].FilePath));
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Allow work to complete, which should restart the timer.
             queue.BlockBackgroundWorkCompleting.Set();
 
-            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
+            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)), "Timed out waiting for background work to complete");
             queue.NotifyBackgroundWorkCompleted.Reset();
 
             // It should start running again right away.
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             queue.BlockBackgroundWorkStart.Set();
 
             queue.BlockBackgroundWorkCompleting.Set();
-            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
+            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)), "Timed out waiting for background work to complete again");
 
             Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             queue.BlockBackgroundWorkStart.Set();
             queue.BlockBackgroundWorkCompleting.Set();
 
-            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
             Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
@@ -129,10 +129,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Allow the background work to start.
             queue.BlockBackgroundWorkStart.Set();
 
-            queue.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(1));
+            Assert.True(queue.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(1)));
             Assert.True(queue.IsScheduledOrRunning, "Worker should be processing now");
 
-            queue.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(1));
+            Assert.True(queue.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(1)));
             Assert.False(queue.HasPendingNotifications, "Worker should have taken all notifications");
 
             queue.Enqueue(project.GetDocument(Documents[1].FilePath));
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Allow work to complete, which should restart the timer.
             queue.BlockBackgroundWorkCompleting.Set();
 
-            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
             queue.NotifyBackgroundWorkCompleted.Reset();
 
             // It should start running again right away.
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             queue.BlockBackgroundWorkStart.Set();
 
             queue.BlockBackgroundWorkCompleting.Set();
-            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
             Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             queue.BlockBackgroundWorkStart.Set();
             queue.BlockBackgroundWorkCompleting.Set();
 
-            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
             Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
@@ -249,7 +249,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             queue.BlockBackgroundWorkStart.Set();
             queue.BlockBackgroundWorkCompleting.Set();
 
-            queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+            Assert.True(queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
             Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");


### PR DESCRIPTION
- This should significantly improve the performance of the LSP experiences. CPU will scale more drastically because instead of re-parsing every file when a document or project changes we'll only parse open documents.
- Added new `OpenDocumentGenerator` tests

Fixes dotnet/aspnetcore#31031