### PR TITLE
Add Workspace Diagnostics NOOP Handler

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -254,6 +254,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<DocumentDiagnosticsParams, DiagnosticReport[]>(MSLSPMethods.DocumentPullDiagnosticName, documentDiagnosticsParams, _clientCapabilities, cancellationToken);
         }
 
+        [JsonRpcMethod(MSLSPMethods.WorkspacePullDiagnosticName, UseSingleObjectParameterDeserialization = true)]
+        public static Task<WorkspaceDiagnosticReport> WorkspacePullDiagnosticsAsync(WorkspaceDocumentDiagnosticsParams workspaceDiagnosticsParams, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<WorkspaceDiagnosticReport>(null);
+        }
+
         // Internal for testing
         internal Task<ResponseType> ExecuteRequestAsync<RequestType, ResponseType>(
             string methodName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorHtmlCSharpLanguageServer.cs
@@ -254,6 +254,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return ExecuteRequestAsync<DocumentDiagnosticsParams, DiagnosticReport[]>(MSLSPMethods.DocumentPullDiagnosticName, documentDiagnosticsParams, _clientCapabilities, cancellationToken);
         }
 
+        // Razor tooling doesn't utilize workspace pull diagnostics as it doesn't really make sense for our use case. 
+        // However, without the workspace pull diagnostics endpoint, a bunch of unnecessary exceptions are
+        // triggered. Thus we add the following no-op handler until a server capability is available.
+        // Having a server capability would reduce overhead of sending/receiving the request and the
+        // associated serialization/deserialization.
         [JsonRpcMethod(MSLSPMethods.WorkspacePullDiagnosticName, UseSingleObjectParameterDeserialization = true)]
         public static Task<WorkspaceDiagnosticReport> WorkspacePullDiagnosticsAsync(WorkspaceDocumentDiagnosticsParams workspaceDiagnosticsParams, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Razor tooling doesn't utilize workspace pull diagnostics as it doesn't really make sense for our use case. Consequently, we don't have a workspace pull diagnostics endpoint. This is resulting in a bunch of unnecessary exceptions being triggered. Purpose of this task is to add in a NOOP handler to mitigate the exception.

Ideally we'd have a server capability to reduce overhead of sending/receiving the request and the associated serialization/deserialization (under discussion).

Fixes: https://github.com/dotnet/aspnetcore/issues/31134

cc/ @dibarbet @veler 