### PR TITLE
Add provisional completion -> resolve support.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -101,6 +101,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 request,
                 cancellationToken).ConfigureAwait(false);
 
+            if (result == null)
+            {
+                // Could not resolve any additional information about the completion item, return early.
+                return request;
+            }
+
             _logger.LogInformation("Received result, post-processing.");
 
             result = await PostProcessCompletionItemAsync(request, result, requestContext, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ITextSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ITextSnapshotExtensions.cs
@@ -47,10 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             // the word we care about and not whitespace following it. For instance:
             //
             //      @Date|\r\n
-            //
-            // Will return the \r\n as the "word" which is incorrect; however, this is actually fixed in newer VS CoreEditor builds but is behind
-            // the "Use word pattern in LSP completion" preview feature. Once this preview feature flag is the default we can remove this -1.
-            var completionCharacterIndex = Math.Max(0, absoluteIndex - 1);
+            var completionCharacterIndex = Math.Max(0, absoluteIndex);
             var completionSnapshotPoint = new SnapshotPoint(snapshot, completionCharacterIndex);
             var wordExtent = navigator.GetExtentOfWord(completionSnapshotPoint);
 


### PR DESCRIPTION
- With how provisional completions work (they require two projections) we weren't updating the projection kind to be C# so the completion items that were returned were getting associated with the HTML server kind.
- Added a new test to validate that provisional completion works as expected in a resolveable way.

Fixes dotnet/aspnetcore#31209