### PR TITLE
Update Roslyn-Debugging.md

### DIFF
--- a/docs/contributing/Roslyn-Debugging.md
+++ b/docs/contributing/Roslyn-Debugging.md
@@ -8,7 +8,7 @@ Sometimes it may be necessary to make changes in [`dotnet/roslyn`](https://githu
 4. `./Build.cmd -pack`. The `-pack` option causes the creation of NuGet packages.
 5. You should see the generated packages in the `roslyn\artifacts\packages\Debug\Release` directory. Take note of the package versions (ie. `Microsoft.CodeAnalysis.Workspaces.Common.3.8.0.nupkg` => `3.8.0`).
 6. Open `aspnetcore-tooling/NuGet.config` and add the local package source `<add key="Roslyn Local Package source" value="<PATH_TO_ROSLYN_REPO>\artifacts\packages\Debug\Release" />`.
-7. Open `aspnetcore-tooling/eng/Versions.props` and update all the `Tooling_*` versions to the version noted in step 5, except for  `Tooling_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion`.
+7. Open `aspnetcore-tooling/eng/Versions.props` and update all the `Tooling_*` versions to the version noted in step 5.
 
 ## Notes:
 - If you're familiar with _Visual Studio Hives_ the `dotnet/roslyn` project uses the `RoslynDev` root suffix .


### PR DESCRIPTION
`Tooling_MicrosoftVisualStudioLanguageServicesRazorRemoteClientPackageVersion` no longer in `Versions.props`
