### PR TITLE
Keep alive latest Razor document parse output.  (6 parses per-character -> 1)

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentOutputReferenceCapturer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentOutputReferenceCapturer.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DocumentOutputReferenceCapturer : ProjectSnapshotChangeTrigger
+    {
+        private readonly Dictionary<string, Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)>> _referencedOutputTasks;
+        private ProjectSnapshotManagerBase _projectManager;
+
+        public DocumentOutputReferenceCapturer()
+        {
+            _referencedOutputTasks = new Dictionary<string, Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)>>(FilePathComparer.Instance);
+        }
+
+        public override void Initialize(ProjectSnapshotManagerBase projectManager)
+        {
+            _projectManager = projectManager;
+            _projectManager.Changed += ProjectManager_Changed;
+        }
+
+        private void ProjectManager_Changed(object sender, ProjectChangeEventArgs args)
+        {
+            if (args is null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
+
+            switch (args.Kind)
+            {
+                case ProjectChangeKind.DocumentChanged:
+                    if (_projectManager.IsDocumentOpen(args.DocumentFilePath))
+                    {
+                        var document = args.Newer.GetDocument(args.DocumentFilePath);
+                        KeepAlive(document);
+                    }
+                    else
+                    {
+                        Release(args.DocumentFilePath);
+                    }
+                    break;
+                case ProjectChangeKind.DocumentRemoved:
+                    Release(args.DocumentFilePath);
+                    break;
+                case ProjectChangeKind.ProjectRemoved:
+                    foreach (var filePath in args.Older.DocumentFilePaths)
+                    {
+                        Release(filePath);
+                    }
+                    break;
+            }
+        }
+
+        private void KeepAlive(DocumentSnapshot snapshot)
+        {
+            var defaultSnapshot = snapshot as DefaultDocumentSnapshot;
+            if (defaultSnapshot == null)
+            {
+                return;
+            }
+
+            // References the task that's responsible for calculating document output. DocumentSnapshot's don't know about
+            // other documents (they shouldn't) so because of this we do the work of referencing generated output for the
+            // latest versions of documents that are open so that those documents don't have to re-compute their output.
+            // This way those syntax trees will be instantly available.
+            _referencedOutputTasks[defaultSnapshot.FilePath] = defaultSnapshot.State.GetGeneratedOutputAndVersionAsync(defaultSnapshot.ProjectInternal, defaultSnapshot);
+        }
+
+        private void Release(string filePath)
+        {
+            // We don't want to reference documents forever, if a document gets removed or closed we release to ensure that the
+            // output of the document can get garbage collected.
+            _referencedOutputTasks.Remove(filePath);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -154,6 +154,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RazorFileChangeDetectorManager>();
 
                         services.AddSingleton<ProjectSnapshotChangeTrigger, RazorServerReadyPublisher>();
+                        services.AddSingleton<ProjectSnapshotChangeTrigger, DocumentOutputReferenceCapturer>();
 
                         services.AddSingleton<ClientNotifierServiceBase, DefaultClientNotifierService>();
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentOutputReferenceCapturerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentOutputReferenceCapturerTest.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class DocumentOutputReferenceCapturerTest : LanguageServerTestBase
+    {
+        public DocumentOutputReferenceCapturerTest()
+        {
+            ProjectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            ProjectManager.AllowNotifyListeners = true;
+
+            HostProject = new HostProject("C:/path/to/project.csproj", RazorConfiguration.Default, "TestNamespace");
+            ProjectManager.ProjectAdded(HostProject);
+            HostDocument = new HostDocument("C:/path/to/file.razor", "file.razor");
+            ProjectManager.DocumentAdded(HostProject, HostDocument, new EmptyTextLoader(HostDocument.FilePath));
+
+            DocumentOutputReferenceCapturer = new DocumentOutputReferenceCapturer();
+            DocumentOutputReferenceCapturer.Initialize(ProjectManager);
+        }
+
+        private TestProjectSnapshotManager ProjectManager { get; }
+
+        private DocumentOutputReferenceCapturer DocumentOutputReferenceCapturer { get; }
+
+        private HostProject HostProject { get; }
+
+        private HostDocument HostDocument { get; }
+
+        private DocumentSnapshot CurrentDocumentSnapshot => ProjectManager.GetLoadedProject(HostProject.FilePath).GetDocument(HostDocument.FilePath);
+
+        [Fact]
+        public async Task DocumentOpened_CapturesOnlyLatestDocumentVersion()
+        {
+            // Arrange
+            var originalDocument = CurrentDocumentSnapshot;
+            await originalDocument.GetGeneratedOutputAsync();
+
+            // Act
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, SourceText.From(string.Empty));
+
+            await CurrentDocumentSnapshot.GetGeneratedOutputAsync();
+
+            GC.GetTotalMemory(forceFullCollection: true);
+
+            // Assert
+            Assert.False(originalDocument.TryGetGeneratedOutput(out _));
+            Assert.True(CurrentDocumentSnapshot.TryGetGeneratedOutput(out _));
+        }
+
+        [Fact]
+        public async Task DocumentClosed_ReleasesAllDocumentVersions()
+        {
+            // Arrange
+            await CurrentDocumentSnapshot.GetGeneratedOutputAsync();
+
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, SourceText.From(string.Empty));
+
+            var originalDocument = CurrentDocumentSnapshot;
+            await originalDocument.GetGeneratedOutputAsync();
+
+            // Act
+            ProjectManager.DocumentClosed(HostProject.FilePath, HostDocument.FilePath, new EmptyTextLoader(HostDocument.FilePath));
+
+            await CurrentDocumentSnapshot.GetGeneratedOutputAsync();
+
+            GC.GetTotalMemory(forceFullCollection: true);
+
+            // Assert
+            Assert.False(originalDocument.TryGetGeneratedOutput(out _));
+            Assert.False(CurrentDocumentSnapshot.TryGetGeneratedOutput(out _));
+        }
+
+        [Fact]
+        public async Task DocumentRemoved_ReleasesAllDocumentVersions()
+        {
+            // Arrange
+            await CurrentDocumentSnapshot.GetGeneratedOutputAsync();
+
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, SourceText.From(string.Empty));
+
+            var originallyPinnedDocument = CurrentDocumentSnapshot;
+            await originallyPinnedDocument.GetGeneratedOutputAsync();
+
+            // Act
+            ProjectManager.DocumentRemoved(HostProject, HostDocument);
+
+            GC.GetTotalMemory(forceFullCollection: true);
+
+            // Assert
+            Assert.False(originallyPinnedDocument.TryGetGeneratedOutput(out _));
+        }
+
+        [Fact]
+        public async Task ProjectRemoved_ReleasesAllDocumentVersions()
+        {
+            // Arrange
+            await CurrentDocumentSnapshot.GetGeneratedOutputAsync();
+
+            ProjectManager.DocumentOpened(HostProject.FilePath, HostDocument.FilePath, SourceText.From(string.Empty));
+
+            var originallyPinnedDocument = CurrentDocumentSnapshot;
+            await originallyPinnedDocument.GetGeneratedOutputAsync();
+
+            // Act
+            ProjectManager.ProjectRemoved(HostProject);
+
+            GC.GetTotalMemory(forceFullCollection: true);
+
+            // Assert
+            Assert.False(originallyPinnedDocument.TryGetGeneratedOutput(out _));
+        }
+    }
+}


### PR DESCRIPTION
- Added logic to capture/keep alive the latest document output. I added some logging to see how much of an impact this would have and after typing out `<strong>` you'd result in roughly 6 different Razor parses on the final version of the document because the underlying `DefaultDocumentSnapshot` state held a `WeakReference` to the underlying document output and that `WeakReference` would be collected inbetween all of the requests during that flow. With this change we now only have 1 parsed representation at the end because we keep a reference to the latest open document version's output.
- Added tests to validate the capturing/releasing behavior.

Fixes dotnet/aspnetcore#30953