### PR TITLE
Don't throw exception if null configuration options returned

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
@@ -137,6 +137,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             out int tabSize)
         {
             var vsEditor = result[2];
+
             insertSpaces = RazorLSPOptions.Default.InsertSpaces;
             tabSize = RazorLSPOptions.Default.TabSize;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
@@ -102,25 +102,32 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var html = result[1];
 
             trace = RazorLSPOptions.Default.Trace;
-            if (razor.TryGetValue("trace", out var parsedTrace))
-            {
-                trace = GetObjectOrDefault(parsedTrace, trace);
-            }
-
             enableFormatting = RazorLSPOptions.Default.EnableFormatting;
-            if (razor.TryGetValue("format", out var parsedFormat))
+            autoClosingTags = RazorLSPOptions.Default.AutoClosingTags;
+
+            if (razor != null)
             {
-                if (parsedFormat is JObject jObject &&
-                    jObject.TryGetValue("enable", out var parsedEnableFormatting))
+                if (razor.TryGetValue("trace", out var parsedTrace))
                 {
-                    enableFormatting = GetObjectOrDefault(parsedEnableFormatting, enableFormatting);
+                    trace = GetObjectOrDefault(parsedTrace, trace);
+                }
+
+                if (razor.TryGetValue("format", out var parsedFormat))
+                {
+                    if (parsedFormat is JObject jObject &&
+                        jObject.TryGetValue("enable", out var parsedEnableFormatting))
+                    {
+                        enableFormatting = GetObjectOrDefault(parsedEnableFormatting, enableFormatting);
+                    }
                 }
             }
 
-            autoClosingTags = RazorLSPOptions.Default.AutoClosingTags;
-            if (html.TryGetValue("autoClosingTags", out var parsedAutoClosingTags))
+            if (html != null)
             {
-                autoClosingTags = GetObjectOrDefault(parsedAutoClosingTags, autoClosingTags);
+                if (html.TryGetValue("autoClosingTags", out var parsedAutoClosingTags))
+                {
+                    autoClosingTags = GetObjectOrDefault(parsedAutoClosingTags, autoClosingTags);
+                }
             }
         }
 
@@ -130,14 +137,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             out int tabSize)
         {
             var vsEditor = result[2];
-
             insertSpaces = RazorLSPOptions.Default.InsertSpaces;
+            tabSize = RazorLSPOptions.Default.TabSize;
+
+            if (vsEditor == null)
+            {
+                return;
+            }
+
             if (vsEditor.TryGetValue(nameof(EditorSettings.IndentWithTabs), out var parsedInsertTabs))
             {
                 insertSpaces = !GetObjectOrDefault(parsedInsertTabs, insertSpaces);
             }
 
-            tabSize = RazorLSPOptions.Default.TabSize;
             if (vsEditor.TryGetValue(nameof(EditorSettings.IndentSize), out var parsedTabSize))
             {
                 tabSize = GetObjectOrDefault(parsedTabSize, tabSize);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -157,6 +157,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Equal(expectedOptions, options);
         }
 
+        [Fact]
+        public void BuildOptions_NullOptions()
+        {
+            // Arrange
+            var expectedOptions = RazorLSPOptions.Default;
+
+            // Act
+            var result = new JObject[] { null, null, null };
+            var languageServer = GetLanguageServer(new ResponseRouterReturns(result));
+            var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
+            var options = configurationService.BuildOptions(result);
+
+            // Assert
+            Assert.Equal(expectedOptions, options);
+        }
+
         private ClientNotifierServiceBase GetLanguageServer(IResponseRouterReturns result, bool shouldThrow = false)
         {
             var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);


### PR DESCRIPTION
### Summary of the changes
 - @TanayParikh reported seeing the following exception when loading the Razor extension in VSCode:
 ```
Microsoft.AspNetCore.Razor.LanguageServer.DefaultRazorConfigurationService: Failed to sync client configuration on the server: System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.AspNetCore.Razor.LanguageServer.DefaultRazorConfigurationService.ExtractVSOptions(JObject[] result, Boolean& insertSpaces, Int32& tabSize) in C:\Users\taparik\dev\aspnetcore-tooling\src\Razor\src\Microsoft.AspNetCore.Razor.LanguageServer\DefaultRazorConfigurationService.cs:line 135
   at Microsoft.AspNetCore.Razor.LanguageServer.DefaultRazorConfigurationService.BuildOptions(JObject[] result) in C:\Users\taparik\dev\aspnetcore-tooling\src\Razor\src\Microsoft.AspNetCore.Razor.LanguageServer\DefaultRazorConfigurationService.cs:line 90
   at Microsoft.AspNetCore.Razor.LanguageServer.DefaultRazorConfigurationService.GetLatestOptionsAsync(CancellationToken cancellationToken) in C:\Users\taparik\dev\aspnetcore-tooling\src\Razor\src\Microsoft.AspNetCore.Razor.LanguageServer\DefaultRazorConfigurationService.cs:line 52 | 
```
- This looks to be because VSCode [can return null](https://github.com/microsoft/vscode-languageserver-node/blob/d58c00bbf8837b9fd0144924db5e7b1c543d839e/client/src/common/configuration.ts#L34) JObjects.
- This PR adds better error handling so that we won't crash when returned null.
