### PR TITLE
Add Razor client name to documents to mitigate race condition with C#

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -63,17 +63,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             documentContainer.SupportsDiagnostics = true;
 
             var filePath = documentUri.GetAbsoluteOrUNCPath().Replace('/', '\\');
-            KeyValuePair<Key, Entry>? associatedKvp = null;
-            foreach (var entry in _entries)
-            {
-                if (FilePathComparer.Instance.Equals(filePath, entry.Key.FilePath))
-                {
-                    associatedKvp = entry;
-                    break;
-                }
-            }
-
-            if (associatedKvp == null)
+            if (!TryGetKeyAndEntry(filePath, out var associatedKvp))
             {
                 return;
             }
@@ -121,6 +111,54 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
                 Updated?.Invoke(this, documentContainer.FilePath);
             }
+        }
+
+        // Called by us to promote a background document (i.e. assign to a client name). Promoting a background
+        // document will allow it to be recognized by the C# server.
+        public void PromoteBackgroundDocument(Uri documentUri, IRazorDocumentPropertiesService propertiesService)
+        {
+            var filePath = documentUri.GetAbsoluteOrUNCPath().Replace('/', '\\');
+            if (!TryGetKeyAndEntry(filePath, out var associatedKvp))
+            {
+                return;
+            }
+
+            var associatedKey = associatedKvp.Value.Key;
+            var associatedEntry = associatedKvp.Value.Value;
+
+            var filename = associatedKey.FilePath + ".g.cs";
+
+            // To promote the background document, we just need to add the passed in properties service to
+            // the dynamic file info. The properties service will contain the client name and will allow
+            // the C# server to recognize the document.
+            var documentServiceProvider = associatedEntry.Current.DocumentServiceProvider;
+            var excerptService = documentServiceProvider.GetService<IRazorDocumentExcerptService>();
+            var mappingService = documentServiceProvider.GetService<IRazorSpanMappingService>();
+            var emptyContainer = new AddedDynamicDocumentContainer(
+                documentUri, propertiesService, excerptService, mappingService, associatedEntry.Current.TextLoader);
+
+            lock (associatedEntry.Lock)
+            {
+                associatedEntry.Current = new RazorDynamicFileInfo(
+                    filename, associatedEntry.Current.SourceCodeKind, associatedEntry.Current.TextLoader, _factory.Create(emptyContainer));
+            }
+
+            Updated?.Invoke(this, filePath);
+        }
+
+        private bool TryGetKeyAndEntry(string filePath, out KeyValuePair<Key, Entry>? associatedKvp)
+        {
+            associatedKvp = null;
+            foreach (var entry in _entries)
+            {
+                if (FilePathComparer.Instance.Equals(filePath, entry.Key.FilePath))
+                {
+                    associatedKvp = entry;
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         // Called by us when a document opens in the editor
@@ -304,6 +342,39 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 // won't work for projects with Razor files.
                 return Task.FromResult(TextAndVersion.Create(SourceText.From("", Encoding.UTF8), _version, _filePath));
             }
+        }
+
+        private class AddedDynamicDocumentContainer : DynamicDocumentContainer
+        {
+            private readonly Uri _documentUri;
+            private readonly IRazorDocumentPropertiesService _documentPropertiesService;
+            private readonly IRazorDocumentExcerptService _documentExcerptService;
+            private readonly IRazorSpanMappingService _spanMappingService;
+            private readonly TextLoader _textLoader;
+
+            public AddedDynamicDocumentContainer(
+                Uri documentUri,
+                IRazorDocumentPropertiesService documentPropertiesService,
+                IRazorDocumentExcerptService documentExcerptService,
+                IRazorSpanMappingService spanMappingService,
+                TextLoader textLoader)
+            {
+                _documentUri = documentUri;
+                _documentPropertiesService = documentPropertiesService;
+                _documentExcerptService = documentExcerptService;
+                _spanMappingService = spanMappingService;
+                _textLoader = textLoader;
+            }
+
+            public override string FilePath => _documentUri.LocalPath;
+
+            public override IRazorDocumentPropertiesService GetDocumentPropertiesService() => _documentPropertiesService;
+
+            public override IRazorDocumentExcerptService GetExcerptService() => _documentExcerptService;
+
+            public override IRazorSpanMappingService GetMappingService() => _spanMappingService;
+
+            public override TextLoader GetTextLoader(string filePath) => _textLoader;
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -129,8 +129,8 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             var filename = associatedKey.FilePath + ".g.cs";
 
             // To promote the background document, we just need to add the passed in properties service to
-            // the dynamic file info. The properties service will contain the client name and will allow
-            // the C# server to recognize the document.
+            // the dynamic file info. The properties service contains the client name and allows the C#
+            // server to recognize the document.
             var documentServiceProvider = associatedEntry.Current.DocumentServiceProvider;
             var excerptService = documentServiceProvider.GetService<IRazorDocumentExcerptService>();
             var mappingService = documentServiceProvider.GetService<IRazorSpanMappingService>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             var documentServiceProvider = associatedEntry.Current.DocumentServiceProvider;
             var excerptService = documentServiceProvider.GetService<IRazorDocumentExcerptService>();
             var mappingService = documentServiceProvider.GetService<IRazorSpanMappingService>();
-            var emptyContainer = new AddedDynamicDocumentContainer(
+            var emptyContainer = new PromotedDynamicDocumentContainer(
                 documentUri, propertiesService, excerptService, mappingService, associatedEntry.Current.TextLoader);
 
             lock (associatedEntry.Lock)
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             }
         }
 
-        private class AddedDynamicDocumentContainer : DynamicDocumentContainer
+        private class PromotedDynamicDocumentContainer : DynamicDocumentContainer
         {
             private readonly Uri _documentUri;
             private readonly IRazorDocumentPropertiesService _documentPropertiesService;
@@ -352,7 +352,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             private readonly IRazorSpanMappingService _spanMappingService;
             private readonly TextLoader _textLoader;
 
-            public AddedDynamicDocumentContainer(
+            public PromotedDynamicDocumentContainer(
                 Uri documentUri,
                 IRazorDocumentPropertiesService documentPropertiesService,
                 IRazorDocumentExcerptService documentExcerptService,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -117,6 +117,16 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
         // document will allow it to be recognized by the C# server.
         public void PromoteBackgroundDocument(Uri documentUri, IRazorDocumentPropertiesService propertiesService)
         {
+            if (documentUri is null)
+            {
+                throw new ArgumentNullException(nameof(documentUri));
+            }
+
+            if (propertiesService is null)
+            {
+                throw new ArgumentNullException(nameof(propertiesService));
+            }
+
             var filePath = documentUri.GetAbsoluteOrUNCPath().Replace('/', '\\');
             if (!TryGetKeyAndEntry(filePath, out var associatedKvp))
             {
@@ -359,6 +369,24 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 IRazorSpanMappingService spanMappingService,
                 TextLoader textLoader)
             {
+                // It's valid for the excerpt service and span mapping service to be null in this class,
+                // so we purposefully don't null check them below.
+
+                if (documentUri is null)
+                {
+                    throw new ArgumentNullException(nameof(documentUri));
+                }
+
+                if (documentPropertiesService is null)
+                {
+                    throw new ArgumentNullException(nameof(documentPropertiesService));
+                }
+
+                if (textLoader is null)
+                {
+                    throw new ArgumentNullException(nameof(textLoader));
+                }
+
                 _documentUri = documentUri;
                 _documentPropertiesService = documentPropertiesService;
                 _documentExcerptService = documentExcerptService;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Razor
     // Given a DocumentSnapshot this class allows the retrieval of a TextLoader for the generated C#
     // and services to help map spans and excerpts to and from the top-level Razor document to behind
     // the scenes C#.
-    internal sealed class DefaultDynamicDocumentContainer : DynamicDocumentContainer
+    internal class DefaultDynamicDocumentContainer : DynamicDocumentContainer
     {
         private readonly DocumentSnapshot _documentSnapshot;
         private RazorDocumentExcerptService _excerptService;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Razor
     // Given a DocumentSnapshot this class allows the retrieval of a TextLoader for the generated C#
     // and services to help map spans and excerpts to and from the top-level Razor document to behind
     // the scenes C#.
-    internal class DefaultDynamicDocumentContainer : DynamicDocumentContainer
+    internal sealed class DefaultDynamicDocumentContainer : DynamicDocumentContainer
     {
         private readonly DocumentSnapshot _documentSnapshot;
         private RazorDocumentExcerptService _excerptService;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentPublisher.cs
@@ -13,6 +13,8 @@ using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
 using CodeAnalysisWorkspace = Microsoft.CodeAnalysis.Workspace;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
@@ -22,17 +24,32 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         private readonly RazorDynamicFileInfoProvider _dynamicFileInfoProvider;
         private readonly LSPDocumentMappingProvider _lspDocumentMappingProvider;
+        private readonly ProjectSnapshotManager _projectSnapshotManager;
 
         [ImportingConstructor]
-        public CSharpVirtualDocumentPublisher(RazorDynamicFileInfoProvider dynamicFileInfoProvider, LSPDocumentMappingProvider lspDocumentMappingProvider)
+        public CSharpVirtualDocumentPublisher(
+            RazorDynamicFileInfoProvider dynamicFileInfoProvider,
+            LSPDocumentMappingProvider lspDocumentMappingProvider,
+            ProjectSnapshotManager projectSnapshotManager)
         {
             if (dynamicFileInfoProvider is null)
             {
                 throw new ArgumentNullException(nameof(dynamicFileInfoProvider));
             }
 
+            if (lspDocumentMappingProvider is null)
+            {
+                throw new ArgumentNullException(nameof(lspDocumentMappingProvider));
+            }
+
+            if (projectSnapshotManager is null)
+            {
+                throw new ArgumentNullException(nameof(projectSnapshotManager));
+            }
+
             _dynamicFileInfoProvider = dynamicFileInfoProvider;
             _lspDocumentMappingProvider = lspDocumentMappingProvider;
+            _projectSnapshotManager = projectSnapshotManager;
         }
 
         public override void Initialize(LSPDocumentManager documentManager)
@@ -48,17 +65,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         // Internal for testing
         internal void DocumentManager_Changed(object sender, LSPDocumentChangeEventArgs args)
         {
-            // We need the below check to address a race condition between when a request is sent to the C# server
-            // and when the C# server receives a workspace/didOpen notification for the document. This race condition
-            // may occur when the Razor server finishes initializing before C# receives and processes the document open
-            // request.
-            // This workaround adds the Razor client name to the document so the C# server will recognize it, despite
-            // the document not being formally opened. Note this is meant to only be a temporary workaround until a
-            // longer-term solution is implemented in the future.
             if (args.Kind == LSPDocumentChangeKind.Added)
             {
-                var csharpContainer = new CSharpVirtualDocumentContainer(_lspDocumentMappingProvider, args.New, args.New.Snapshot);
-                _dynamicFileInfoProvider.UpdateLSPFileInfo(args.New.Uri, csharpContainer);
+                if (TryGetVirtualDocumentSnapshot(args.New.Uri, _projectSnapshotManager, out var documentSnapshot))
+                {
+                    var addedDocumentContainer = new CSharpAddedVirtualDocumentContainer(documentSnapshot);
+                    _dynamicFileInfoProvider.UpdateLSPFileInfo(args.New.Uri, addedDocumentContainer);
+                }
             }
 
             if (args.Kind != LSPDocumentChangeKind.VirtualDocumentChanged)
@@ -70,6 +83,37 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 var csharpContainer = new CSharpVirtualDocumentContainer(_lspDocumentMappingProvider, args.New, args.VirtualNew.Snapshot);
                 _dynamicFileInfoProvider.UpdateLSPFileInfo(args.New.Uri, csharpContainer);
+            }
+
+            static bool TryGetVirtualDocumentSnapshot(
+                Uri documentUri,
+                ProjectSnapshotManager projectSnapshotManager,
+                out DocumentSnapshot documentSnapshot)
+            {
+                documentSnapshot = null;
+                foreach (var project in projectSnapshotManager.Projects)
+                {
+                    var filePath = CodeAnalysis.Razor.UriExtensions.GetAbsoluteOrUNCPath(documentUri).Replace('/', '\\');
+                    documentSnapshot ??= project.GetDocument(filePath);
+                    if (documentSnapshot != null)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        private class CSharpAddedVirtualDocumentContainer : DefaultDynamicDocumentContainer
+        {
+            public CSharpAddedVirtualDocumentContainer(DocumentSnapshot documentSnapshot) : base(documentSnapshot)
+            {
+            }
+
+            public override IRazorDocumentPropertiesService GetDocumentPropertiesService()
+            {
+                return CSharpDocumentPropertiesService.Instance;
             }
         }
 


### PR DESCRIPTION
### Summary of the changes
 - This addresses the high-hitting semantic tokens issue https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1291116/. It appears the C# server isn't processing the textDocument/didOpen request before Razor is sending a semantic tokens request to the C# server, which is resulting in a Contract failure on the C# side.
 - I'm not sure this is the ideal fix but from testing it seems to resolve the problem? @NTaylorMullen please let me know if this wasn't the approach you were thinking of, or if my detailing of the issue isn't correct (this is just what I understand from the meeting yesterday but I definitely could have misunderstood something).