### PR TITLE
Fix VSCode Code Actions

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -63,6 +63,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
             public const string AddUsing = "AddUsing";
 
+            public const string CodeActionFromVSCode = "CodeActionFromVSCode";
+
             /// <summary>
             /// Remaps without formatting the resolved code action edit
             /// </summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
                 foreach (var codeAction in codeActions)
                 {
-                    if (!codeAction.Name.Equals("CodeActionFromVSCode", StringComparison.Ordinal))
+                    if (!codeAction.Name.Equals(LanguageServerConstants.CodeActions.CodeActionFromVSCode, StringComparison.Ordinal))
                     {
                         continue;
                     }
@@ -166,8 +166,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     string action;
 
                     // The formatting pass of our Default code action resolver rejects
-                    // implicit/explicit expressions. So if we're in an implicit expression, 
-                    // we run the remapping resolver responsible for simply remapping 
+                    // implicit/explicit expressions. So if we're in an implicit expression,
+                    // we run the remapping resolver responsible for simply remapping
                     // (without formatting) the resolved code action. We do not support
                     // explicit expressions due to issues with the remapping methodology
                     // risking document corruption.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -205,8 +205,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
                 foreach (var tag in tags)
                 {
-                    if (_allAvailableCodeActionNames.Contains(tag) ||
-                        tag.Equals(LanguageServerConstants.CodeActions.CodeActionFromVSCode, StringComparison.Ordinal))
+                    if (_allAvailableCodeActionNames.Contains(tag))
                     {
                         codeAction.Name = tag;
                         break;
@@ -319,6 +318,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             availableCodeActionNames.UnionWith(refactoringProviderNames);
             availableCodeActionNames.UnionWith(codeFixProviderNames);
+            availableCodeActionNames.Add(LanguageServerConstants.CodeActions.CodeActionFromVSCode);
 
             return availableCodeActionNames;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -210,6 +210,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                         codeAction.Name = tag;
                         break;
                     }
+                    else if (tag.Equals(LanguageServerConstants.CodeActions.CodeActionFromVSCode, StringComparison.Ordinal))
+                    {
+                        codeAction.Name = tag;
+                        break;
+                    }
                 }
 
                 if (string.IsNullOrEmpty(codeAction.Name))
@@ -218,7 +223,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 }
 
                 return true;
-            });
+            }).ToArray();
         }
 
         private async Task<IEnumerable<RazorCodeAction>> FilterCSharpCodeActionsAsync(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -205,12 +205,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
                 foreach (var tag in tags)
                 {
-                    if (_allAvailableCodeActionNames.Contains(tag))
-                    {
-                        codeAction.Name = tag;
-                        break;
-                    }
-                    else if (tag.Equals(LanguageServerConstants.CodeActions.CodeActionFromVSCode, StringComparison.Ordinal))
+                    if (_allAvailableCodeActionNames.Contains(tag) ||
+                        tag.Equals(LanguageServerConstants.CodeActions.CodeActionFromVSCode, StringComparison.Ordinal))
                     {
                         codeAction.Name = tag;
                         break;


### PR DESCRIPTION
### Summary of the changes
 - This finishes up the additional items required to support the new code action identifiers in VSCode (wasn't able to test it properly before because of other issues). Note that PR was merged *after* the VSCode insertion was cut so there shouldn't be any issues with the new VSCode release.
 - In some scenarios, I'm getting [this](https://github.com/OmniSharp/omnisharp-roslyn/issues/2132) after invoking the code action. As far as I can tell this is a O# issue.
    - This is also preventing me for validating Razor add component using / fully qualify component (https://github.com/dotnet/aspnetcore/issues/31608)