### PR TITLE
Workaround VS completion soft-selection issue.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -20,7 +20,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             {
                 if (_transitionCompletionItem == null)
                 {
-                    _transitionCompletionItem = new RazorCompletionItem("@...", "@", RazorCompletionItemKind.Directive);
+                    _transitionCompletionItem = new RazorCompletionItem(
+                        displayText: "@...",
+                        insertText: "@",
+                        kind: RazorCompletionItemKind.Directive,
+
+                        // We specify these two commit characters to work around a Visual Studio interaction where
+                        // completion items that get "soft selected" will cause completion to re-trigger if a user
+                        // types one of the soft-selected completion item's commit characters.
+                        // In practice this happens in the `<button |` scenario where the "space" results in completions
+                        // where this directive attribute transition character ("@...") gets provided and then typing
+                        // `@` should re-trigger OR typing `/` should re-trigger.
+                        commitCharacters: new[] { "@", "/", ">" });
                     _transitionCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription("Blazor directive attributes"));
                 }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                         insertText: "@",
                         kind: RazorCompletionItemKind.Directive,
 
-                        // We specify these two commit characters to work around a Visual Studio interaction where
+                        // We specify these three commit characters to work around a Visual Studio interaction where
                         // completion items that get "soft selected" will cause completion to re-trigger if a user
                         // types one of the soft-selected completion item's commit characters.
                         // In practice this happens in the `<button |` scenario where the "space" results in completions


### PR DESCRIPTION
- VisualStudio looks at a "soft selected" item and inspects its available commit characters when deciding whether or not to re-trigger completion. If you happen to type a commit character of that soft selected item VS would re-trigger completion. Pre-client refactor Visual Studio didn't differentiate language servers commit characters so when it saw the `@...` item it saw the `AllCommitCharacter` server capabilities for both our Razor and HTMLC# language servers. Because the HTMLC# language server had `@` in its all commit character list the `@...` item would re-trigger completion when you typed `@`. Post-refactor they're smarter and only look at the corresponding language server that provided the completion item, in this case Razor which does not have an `@` as a trigger character.
- This changeset works around the funky VS behavior mentioned above by adding common commit characters to the `@...` completion item so that when its soft-selected completion is re-triggered. Unfortunately this also has the consequence of a user selecting that item and typing one of these mew commit characters and getting an unexpected result like `@@` or `@/` etc. Thankfully these scenarios don't typically come into play.
- We'll be able to remove this quirk once VisualStudio starts not pre-inspecting soft-selected items and making the odd choice to re-trigger completion.

Fixes dotnet/aspnetcore#31469
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1305289
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1302311