### PR TITLE
Remove spell check code action

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             RazorPredefinedCodeRefactoringProviderNames.UseExpressionBody,
             RazorPredefinedCodeFixProviderNames.ImplementAbstractClass,
             RazorPredefinedCodeFixProviderNames.ImplementInterface,
-            RazorPredefinedCodeFixProviderNames.SpellCheck,
             RazorPredefinedCodeFixProviderNames.RemoveUnusedVariable,
         };
 


### PR DESCRIPTION
This isn't working in the following case, so removing support for this code action.

![image](https://user-images.githubusercontent.com/14852843/114755123-29b89e00-9d0e-11eb-99a8-6e821d2e60f4.png)

Revert tracking issue: https://github.com/dotnet/aspnetcore/issues/31808
