### PR TITLE
Fix up Blazor WASM debugging extension

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -2,7 +2,7 @@
   "name": "blazorwasm-companion",
   "displayName": "Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension",
   "description": "A companion extension for debugging Blazor WebAssembly applications in VS Code. Must be installed alongside the C# extension.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/dotnet/aspnetcore-tooling.git"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/src/acquireDotnetInstall.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/src/acquireDotnetInstall.ts
@@ -20,7 +20,7 @@ export async function acquireDotnetInstall(outputChannel: vscode.OutputChannel):
         if (!dotnetPath) {
             throw new Error('Install step returned an undefined path.');
         }
-        await vscode.commands.executeCommand('dotnet.ensureDotnetDependencies', { command: dotnetPath, arguments: '--info' });
+        await vscode.commands.executeCommand('dotnet.ensureDotnetDependencies', { command: dotnetPath, arguments: ['--info'] });
         return dotnetPath;
     } catch (err) {
         const message = err.msg;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/src/extension.ts
@@ -46,6 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
                     pidsByUrl.set(url, spawnedProxy.pid);
                     return {
                         url,
+                        inspectUri: `${url}{browserInspectUriPath}`,
                         debuggingPort,
                     };
                 }
@@ -53,6 +54,9 @@ export function activate(context: vscode.ExtensionContext) {
 
             for await (const error of spawnedProxy.stderr) {
                 outputChannel.appendLine(`ERROR: ${error}`);
+                return {
+                    inspectUri: '{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}',
+                };
             }
 
             return;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
@@ -25,10 +25,11 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
 
         const result = await vscode.commands.executeCommand<{
             url: string,
+            inspectUri: string,
             debuggingPort: number,
         } | undefined>('blazorwasm-companion.launchDebugProxy');
         if (result) {
-            await this.launchBrowser(folder, configuration, result.url, result.debuggingPort);
+            await this.launchBrowser(folder, configuration, result.inspectUri, result.debuggingPort);
         }
 
         const terminateDebugProxy = this.vscodeType.debug.onDidTerminateDebugSession(async event => {
@@ -87,8 +88,7 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
         }
     }
 
-    private async launchBrowser(folder: vscode.WorkspaceFolder | undefined, configuration: vscode.DebugConfiguration, wsAddress?: string, debuggingPort?: number) {
-        const inspectUri = `${wsAddress}{browserInspectUriPath}`;
+    private async launchBrowser(folder: vscode.WorkspaceFolder | undefined, configuration: vscode.DebugConfiguration, inspectUri?: string, debuggingPort?: number) {
         const browser = {
             name: JS_DEBUG_NAME,
             type: configuration.browser === 'edge' ? 'pwa-msedge' : 'pwa-chrome',


### PR DESCRIPTION
### Summary of the changes
 - Pass `arguments` to `dotnet.ensureDotnetDependencies` as list of strings
 - Fallback to debugging proxy launched via middleware if extension fails

Fixes: https://github.com/dotnet/aspnetcore/issues/31757
Provides a fallback for https://github.com/dotnet/aspnetcore/issues/31653
