### PR TITLE
Update Benchmarking infrastructure for net6.0

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,6 +12,8 @@
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <!-- Used for the Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
+    <!-- Used for BenchmarkDotNet prerelease packages -->
+    <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,7 +92,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
-    <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
+    <BenchmarkDotNetPackageVersion>0.12.1.1466</BenchmarkDotNetPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>16.8.0</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.8.0</MicrosoftBuildPackageVersion>

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Properties/launchSettings.json
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "LanguageServer.Protocol.Extensions.Performance": {
+      "commandName": "Project",
+      "commandLineArgs": "--config profile"
+    }
+  }
+}

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/readme.md
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/readme.md
@@ -1,5 +1,13 @@
 Compile the solution in Release mode (so binaries are available in release)
 
+In Visual Studio:
+- Set the Microsoft.AspNetCore.Razor.Microbenchmarks project as the "Startup" project
+- Set the configuration to "Release"
+- Run without debugging (ctrl + F5)
+
+You can also debug your benchmark by using the Debug configuration and running normally; however, numbers generated in that way wont be valuable.
+
+Command Line:
 To run a specific benchmark add it as parameter.
 ```
 dotnet run --config profile -c Release <benchmark_name>

--- a/src/Shared/BenchmarkRunner/Program.cs
+++ b/src/Shared/BenchmarkRunner/Program.cs
@@ -62,19 +62,13 @@ namespace Microsoft.AspNetCore.BenchmarkDotNet.Runner
 
         private static IConfig GetConfig()
         {
-#if NET5_0 || NETCOREAPP5_0
+#if DEBUG
+            return new DebugInProcessConfig();
+#else
             return ManualConfig.CreateEmpty()
                 .AddJob(Job.Default
-                    .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings
-                    (
-                        // not using "net5.0", a workaround for https://github.com/dotnet/BenchmarkDotNet/pull/1479
-                        targetFrameworkMoniker: "netcoreapp5.0",
-                        runtimeFrameworkVersion: default,
-                        name: ".NET Core 5.0"
-                    )))
+                    .WithToolchain(CsProjCoreToolchain.From(NetCoreAppSettings.NetCoreApp60))
                     .AsDefault());
-#else
-            return ManualConfig.CreateEmpty();
 #endif
         }
 


### PR DESCRIPTION
- Added the ability to debug benchmarks in-proc.
- Added the ability to run benchmarks in VS.
- Updated README.md on how to run benchmarks in VS.
- Needed to add a feed to the BenchmarkDotNet pre-release feed.

Fixes dotnet/aspnetcore#31941