### PR TITLE
Only provide fully qualified Component completion if unimported.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
@@ -365,12 +365,12 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             public bool Equals(TagHelperDescriptor x, TagHelperDescriptor y)
             {
-                if (x == y)
+                if (object.ReferenceEquals(x, y))
                 {
                     return true;
                 }
 
-                if (x == null || y == null)
+                if (x is null || y is null)
                 {
                     return false;
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
@@ -178,6 +179,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var catchAllDescriptors = new HashSet<TagHelperDescriptor>();
             var prefix = completionContext.DocumentContext.Prefix ?? string.Empty;
             var possibleChildDescriptors = _tagHelperFactsService.GetTagHelpersGivenParent(completionContext.DocumentContext, completionContext.ContainingTagName);
+            possibleChildDescriptors = FilterFullyQualifiedCompletions(possibleChildDescriptors);
             foreach (var possibleDescriptor in possibleChildDescriptors)
             {
                 var addRuleCompletions = false;
@@ -315,6 +317,78 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     existingRuleDescriptors.UnionWith(descriptors);
                 }
             }
+        }
+
+        private static IReadOnlyList<TagHelperDescriptor> FilterFullyQualifiedCompletions(IReadOnlyList<TagHelperDescriptor> possibleChildDescriptors)
+        {
+            // Iterate once through the list to tease apart fully qualified and short name TagHelpers
+            var fullyQualifiedTagHelpers = new List<TagHelperDescriptor>();
+            var shortNameTagHelpers = new HashSet<TagHelperDescriptor>(ShortNameToFullyQualifiedComparer.Instance);
+            for (var i = 0; i < possibleChildDescriptors.Count; i++)
+            {
+                var descriptor = possibleChildDescriptors[i];
+
+                if (descriptor.IsComponentFullyQualifiedNameMatch())
+                {
+                    fullyQualifiedTagHelpers.Add(descriptor);
+                }
+                else
+                {
+                    shortNameTagHelpers.Add(descriptor);
+                }
+            }
+
+            // Re-combine the short named & fully qualified TagHelpers but filter out any fully qualified TagHelpers that have a short
+            // named representation already.
+            var filteredList = new List<TagHelperDescriptor>(shortNameTagHelpers);
+            for (var i = 0; i < fullyQualifiedTagHelpers.Count; i++)
+            {
+                var fullyQualifiedTagHelper = fullyQualifiedTagHelpers[i];
+
+                if (!shortNameTagHelpers.Contains(fullyQualifiedTagHelper))
+                {
+                    // Unimported completion item that isn't represented in a short named form.
+                    filteredList.Add(fullyQualifiedTagHelper);
+                }
+                else
+                {
+                    // There's already a shortname variant of this item, don't include it.
+                }
+            }
+
+            return filteredList;
+        }
+
+        private class ShortNameToFullyQualifiedComparer : IEqualityComparer<TagHelperDescriptor>
+        {
+            public static readonly ShortNameToFullyQualifiedComparer Instance = new ShortNameToFullyQualifiedComparer();
+
+            public bool Equals(TagHelperDescriptor x, TagHelperDescriptor y)
+            {
+                if (x == y)
+                {
+                    return true;
+                }
+
+                if (x == null || y == null)
+                {
+                    return false;
+                }
+
+                if (!string.Equals(x.Name, y.Name, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                if (!string.Equals(x.AssemblyName, y.AssemblyName, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            public int GetHashCode(TagHelperDescriptor obj) => obj.Name.GetHashCode();
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IsExternalInit.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IsExternalInit.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System.Runtime.CompilerServices
+{
+    // Used to compile against C# 9 in a netstandard2.0 app.
+    internal class IsExternalInit
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
@@ -6,6 +6,7 @@
     <EnableApiCheck>false</EnableApiCheck>
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- The intent of this change is to improve performance so our payloads are "less"
- Prior to this we'd always provide component completions for every listed component twice over. Meaning, if you had a `<Counter>` you'd get a `Counter` completion and a `MyNamespace.Counter` completion item. Now we remove the fully qualified variants if their non-fully qualified variant is in scope.
- Added a test to validate the new completion behavior.

**Before:**
|                                              Method |      Mean |     Error |    StdDev |   Op/s |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|---------------------------------------------------- |----------:|----------:|----------:|-------:|---------:|---------:|--------:|----------:|
| 'Component Completion List Roundtrip Serialization' | 11.219 ms | 0.0953 ms | 0.0744 ms |  89.13 | 718.7500 | 359.3750 |       - |  4,569 KB |
|           'Component Completion List Serialization' |  2.221 ms | 0.0442 ms | 0.1008 ms | 450.33 |  82.0313 |  27.3438 | 15.6250 |    555 KB |
|         'Component Completion List Deserialization' |  8.801 ms | 0.0836 ms | 0.0698 ms | 113.63 | 640.6250 | 312.5000 |       - |  4,013 KB |

**After:**
|                                              Method |     Mean |     Error |    StdDev |  Op/s |    Gen 0 |    Gen 1 | Gen 2 | Allocated |
|---------------------------------------------------- |---------:|----------:|----------:|------:|---------:|---------:|------:|----------:|
| 'Component Completion List Roundtrip Serialization' | 5.195 ms | 0.0605 ms | 0.0472 ms | 192.5 | 367.1875 | 179.6875 |     - |  2,294 KB |
|           'Component Completion List Serialization' | 1.071 ms | 0.0212 ms | 0.0236 ms | 934.0 |  44.9219 |   7.8125 |     - |    287 KB |
|         'Component Completion List Deserialization' | 4.127 ms | 0.0748 ms | 0.1049 ms | 242.3 | 320.3125 | 148.4375 |     - |  2,007 KB |

**Results:**
Roundtrip: 2.2x faster
Serialization: 2.1x faster
Deserialization: 2.5x faster

Fixes dotnet/aspnetcore#31939