### PR TITLE
Update comment on contained language marker to mention roslyn usages

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VirtualDocumentFactoryBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VirtualDocumentFactoryBase.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
     {
         /// <summary>
         /// This marker is understood by LiveShare in order to ensure that virtual documents are not serialized to disk.
+        /// Also used in roslyn to filter out text buffer operations on virtual documents.
         /// </summary>
         private const string ContainedLanguageMarker = "ContainedLanguageMarker";
 


### PR DESCRIPTION
Dependency on this marker was added in https://github.com/dotnet/roslyn/pull/52609, updating comment.
