### PR TITLE
Don't provide "Create Component" light bulb if no tag.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -60,6 +60,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return EmptyResult;
             }
 
+            if (!IsApplicableTag(startTag))
+            {
+                return EmptyResult;
+            }
+
             if (IsTagUnknown(startTag, context))
             {
                 AddComponentAccessFromTag(context, startTag, codeActions);
@@ -67,6 +72,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             }
 
             return Task.FromResult(codeActions as IReadOnlyList<RazorCodeAction>);
+        }
+
+        private static bool IsApplicableTag(MarkupStartTagSyntax startTag)
+        {
+            if (startTag.Name.FullWidth == 0)
+            {
+                // Empty tag name, we shouldn't show a light bulb just to create an empty file.
+                return false;
+            }
+
+            return true;
         }
 
         private void AddCreateComponentFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<RazorCodeAction> container)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -21,6 +21,30 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
     public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBase
     {
         [Fact]
+        public async Task Handle_NoTagName_DoesNotProvideLightBulb()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var contents = "<";
+            var request = new RazorCodeActionParams()
+            {
+                TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
+                Range = new Range(new Position(0, 1), new Position(0, 1)),
+            };
+
+            var location = new SourceLocation(1, -1, -1);
+            var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(0, 1));
+
+            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService(), FilePathNormalizer);
+
+            // Act
+            var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
+
+            // Assert
+            Assert.Null(commandOrCodeActionContainer);
+        }
+
+        [Fact]
         public async Task Handle_InvalidSyntaxTree_NoStartNode()
         {
             // Arrange


### PR DESCRIPTION
- When typing you end up in scenarios where the document looks like: `<|` a lot. We should not be providing "Create Component from unknown tag" light bulbs in this scenario, there's no value.
- Added a test to validate that we no longer provide a light bulb.

Fixes dotnet/aspnetcore#31977