### PR TITLE
Fix directive attribute completions.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -212,9 +212,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 SetResolveData(resultId, completionList);
             }
 
-            completionList = completionList is VSCompletionList vsCompletionList
-                ? new OptimizedVSCompletionList(vsCompletionList)
-                : new OptimizedVSCompletionList(completionList);
+            if (completionList != null)
+            {
+                completionList = completionList is VSCompletionList vsCompletionList
+                    ? new OptimizedVSCompletionList(vsCompletionList)
+                    : new OptimizedVSCompletionList(completionList);
+            }
 
             _logger.LogInformation("Returning completion list.");
             return completionList;


### PR DESCRIPTION
- Turned out that our HmtlC# completion handler was null reffing when typing `@` in a directive attribute context because the returned completion list was empty. This in turn resulted in our delegated completion request returning `null` causing our optimized completion list wrapping to throw
- Added a test to cover the scenario

Fixes dotnet/aspnetcore#31984