### PR TITLE
Add support for CompletionList.CommitCharacters.

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/CompletionListSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/CompletionListSerializationBenchmark.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 using Microsoft.CodeAnalysis.Razor.Serialization;
 using Microsoft.VisualStudio.Editor.Razor;
@@ -81,7 +82,17 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks
 
             var completionQueryLocation = new SourceSpan(queryIndex, length: 0);
             var razorCompletionItems = componentCompletionProvider.GetCompletionItems(syntaxTree, tagHelperDocumentContext, completionQueryLocation);
-            var completionList = RazorCompletionEndpoint.CreateLSPCompletionList(razorCompletionItems, new CompletionListCache(), new[] { ExtendedCompletionItemKinds.TagHelper });
+            var completionList = RazorCompletionEndpoint.CreateLSPCompletionList(
+                razorCompletionItems,
+                new CompletionListCache(),
+                new[] { ExtendedCompletionItemKinds.TagHelper },
+                new PlatformAgnosticCompletionCapability()
+                {
+                    VSCompletionList = new VSCompletionListCapability()
+                    {
+                        CommitCharacters = true,
+                    }
+                });
             return completionList;
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
@@ -45,8 +45,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
                 writer.WriteStartObject();
 
-                writer.WritePropertyName("isIncomplete");
-                writer.WriteValue(completionList.IsIncomplete);
+                WriteCompletionListProperties(writer, completionList, serializer);
 
                 if (completionList.Items != null)
                 {
@@ -66,6 +65,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 }
 
                 writer.WriteEndObject();
+            }
+
+            protected virtual void WriteCompletionListProperties(JsonWriter writer, CompletionList completionList, JsonSerializer serializer)
+            {
+                writer.WritePropertyName("isIncomplete");
+                writer.WriteValue(completionList.IsIncomplete);
             }
 
             private void WriteCompletionItem(JsonWriter writer, CompletionItem completionItem, JsonSerializer serializer)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedVSCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedVSCompletionList.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    [JsonConverter(typeof(OptimizedVSCompletionListJsonConverter))]
+    internal class OptimizedVSCompletionList : VSCompletionList
+    {
+        public OptimizedVSCompletionList(VSCompletionList completionList) : base(completionList)
+        {
+            CommitCharacters = completionList.CommitCharacters;
+        }
+
+        public class OptimizedVSCompletionListJsonConverter : OptimizedCompletionList.OptimizedCompletionListJsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return typeof(OptimizedVSCompletionList) == objectType;
+            }
+
+            protected override void WriteCompletionListProperties(JsonWriter writer, CompletionList completionList, JsonSerializer serializer)
+            {
+                var vsCompletionList = (OptimizedVSCompletionList)completionList;
+
+                if (vsCompletionList.CommitCharacters != null)
+                {
+                    writer.WritePropertyName("_vsext_commitCharacters");
+                    serializer.Serialize(writer, vsCompletionList.CommitCharacters);
+                }
+
+                base.WriteCompletionListProperties(writer, completionList, serializer);
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/PlatformAgnosticCompletionCapability.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/PlatformAgnosticCompletionCapability.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal class PlatformAgnosticCompletionCapability : CompletionCapability
+    {
+        public static readonly PlatformExtensionConverter<CompletionCapability, PlatformAgnosticCompletionCapability> JsonConverter = new PlatformExtensionConverter<CompletionCapability, PlatformAgnosticCompletionCapability>();
+
+        [JsonProperty("_ms_completionList")]
+        public VSCompletionListCapability VSCompletionList { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
     internal class RazorCompletionEndpoint : ICompletionHandler, ICompletionResolveHandler
     {
-        private CompletionCapability _capability;
+        private PlatformAgnosticCompletionCapability _capability;
         private readonly ILogger _logger;
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentResolver _documentResolver;
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         public void SetCapability(CompletionCapability capability)
         {
-            _capability = capability;
+            _capability = (PlatformAgnosticCompletionCapability)capability;
             _supportedItemKinds = _capability.CompletionItemKind.ValueSet.Cast<ExtendedCompletionItemKinds>().ToList();
         }
 
@@ -200,13 +200,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         // Internal for testing
-        internal CompletionList CreateLSPCompletionList(IReadOnlyList<RazorCompletionItem> razorCompletionItems) => CreateLSPCompletionList(razorCompletionItems, _completionListCache, _supportedItemKinds);
+        internal CompletionList CreateLSPCompletionList(IReadOnlyList<RazorCompletionItem> razorCompletionItems) => CreateLSPCompletionList(razorCompletionItems, _completionListCache, _supportedItemKinds, _capability);
 
         // Internal for benchmarking and testing
         internal static CompletionList CreateLSPCompletionList(
             IReadOnlyList<RazorCompletionItem> razorCompletionItems,
             CompletionListCache completionListCache,
-            IReadOnlyList<ExtendedCompletionItemKinds> supportedItemKinds)
+            IReadOnlyList<ExtendedCompletionItemKinds> supportedItemKinds,
+            PlatformAgnosticCompletionCapability completionCapability)
         {
             var resultId = completionListCache.Set(razorCompletionItems);
             var completionItems = new List<CompletionItem>();
@@ -223,7 +224,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = new CompletionList(completionItems, isIncomplete: false);
 
             // We wrap the pre-existing completion list with an optimized completion list to better control serialization/deserialization
-            var optimizedCompletionList = new OptimizedCompletionList(completionList);
+            CompletionList optimizedCompletionList = null;
+
+            if (completionCapability.VSCompletionList != null)
+            {
+                // We're operating in VS, lets make a VS specific optimized completion list
+
+                var vsCompletionList = VSCompletionList.Convert(completionList, completionCapability.VSCompletionList);
+                optimizedCompletionList = new OptimizedVSCompletionList(vsCompletionList);
+            }
+            else
+            {
+                optimizedCompletionList = new OptimizedCompletionList(completionList);
+            }
+
             return optimizedCompletionList;
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // We wrap the pre-existing completion list with an optimized completion list to better control serialization/deserialization
             CompletionList optimizedCompletionList = null;
 
-            if (completionCapability.VSCompletionList != null)
+            if (completionCapability?.VSCompletionList != null)
             {
                 // We're operating in VS, lets make a VS specific optimized completion list
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
@@ -8,10 +8,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
     internal class VSCompletionList : CompletionList
     {
-        public VSCompletionList()
-        {
-        }
-
         protected VSCompletionList(CompletionList innerCompletionList) : base (innerCompletionList.Items, innerCompletionList.IsIncomplete)
         {
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal class VSCompletionList : CompletionList
+    {
+        public VSCompletionList()
+        {
+        }
+
+        protected VSCompletionList(CompletionList innerCompletionList) : base (innerCompletionList.Items, innerCompletionList.IsIncomplete)
+        {
+        }
+
+        public Container<string> CommitCharacters { get; set; }
+
+        public static VSCompletionList Convert(CompletionList completionList, VSCompletionListCapability vsCompletionListCapability)
+        {
+            var vsCompletionList = new VSCompletionList(completionList);
+            if (vsCompletionListCapability.CommitCharacters)
+            {
+                PromoteCommonCommitCharactersOntoList(vsCompletionList);
+            }
+
+            return vsCompletionList;
+        }
+
+        private static void PromoteCommonCommitCharactersOntoList(VSCompletionList completionList)
+        {
+            var commitCharacterReferences = new Dictionary<object, int>();
+            var highestUsedCount = 0;
+            Container<string> mostUsedCommitCharacters = null;
+            foreach (var completionItem in completionList.Items)
+            {
+                var commitCharacters = completionItem.CommitCharacters;
+                if (commitCharacters == null)
+                {
+                    continue;
+                }
+
+                commitCharacterReferences.TryGetValue(commitCharacters, out var existingCount);
+                existingCount++;
+
+                if (existingCount > highestUsedCount)
+                {
+                    // Capture the most used commit character counts so we don't need to re-iterate the array later
+                    mostUsedCommitCharacters = commitCharacters;
+                    highestUsedCount = existingCount;
+                }
+
+                commitCharacterReferences[commitCharacters] = existingCount;
+            }
+
+            // Promoted the most used commit characters onto the list and then remove these from child items.
+            completionList.CommitCharacters = mostUsedCommitCharacters;
+            foreach (var completionItem in completionList.Items)
+            {
+                if (completionItem.CommitCharacters == completionList.CommitCharacters)
+                {
+                    completionItem.CommitCharacters = null;
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionListCapability.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionListCapability.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal class VSCompletionListCapability
+    {
+        public bool CommitCharacters { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -29,7 +29,6 @@ using OmniSharp.Extensions.LanguageServer.Server;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.LanguageServer.Refactoring;
 using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
-using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
@@ -63,8 +62,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             Serializer.Instance.JsonSerializer.Converters.RegisterRazorConverters();
 
-            // Custom ClientCapabilities deserializer to extract experimental capabilities
+            // Custom ClientCapabilities deserializer to extract platform specific capabilities
             Serializer.Instance.JsonSerializer.Converters.Add(PlatformAgnosticClientCapabilities.JsonConverter);
+            Serializer.Instance.JsonSerializer.Converters.Add(PlatformAgnosticCompletionCapability.JsonConverter);
 
             ILanguageServer server = null;
             var logLevel = RazorLSPOptions.GetLogLevelForTrace(trace);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/VSCompletionListTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/VSCompletionListTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    public class VSCompletionListTest
+    {
+        [Fact]
+        public void Convert_CommitCharactersTrue_RemovesCommitCharactersFromItems()
+        {
+            // Arrange
+            var commitCharacters = new Container<string>("<");
+            var completionList = new CompletionList(
+                new CompletionItem()
+                {
+                    Label = "Test",
+                    CommitCharacters = commitCharacters
+                });
+            var capabilities = new VSCompletionListCapability()
+            {
+                CommitCharacters = true,
+            };
+
+            // Act
+            var vsCompletionList = VSCompletionList.Convert(completionList, capabilities);
+
+            // Assert
+            Assert.Collection(vsCompletionList.Items, item => Assert.Null(item.CommitCharacters));
+            Assert.Equal(commitCharacters, vsCompletionList.CommitCharacters);
+        }
+
+        [Fact]
+        public void Convert_CommitCharactersFalse_DoesNotTouchCommitCharacters()
+        {
+            // Arrange
+            var commitCharacters = new Container<string>("<");
+            var completionList = new CompletionList(
+                new CompletionItem()
+                {
+                    Label = "Test",
+                    CommitCharacters = commitCharacters
+                });
+            var capabilities = new VSCompletionListCapability()
+            {
+                CommitCharacters = false,
+            };
+
+            // Act
+            var vsCompletionList = VSCompletionList.Convert(completionList, capabilities);
+
+            // Assert
+            Assert.Collection(vsCompletionList.Items, item => Assert.Equal(commitCharacters, item.CommitCharacters));
+            Assert.Null(vsCompletionList.CommitCharacters);
+        }
+    }
+}


### PR DESCRIPTION
- `CompletionList.CommitCharacters` serves as a way for completion items to not redundantly provide commit characters. Aka, all completion list commit characters serve as a default for underlying completion items.
- The LSP Platform hasn't yet inserted these changes into VS; however, our language server doesn't depend on the LSP platform directly anyhow. This changeset enables the commit character optimization of the LSP platform in a way that will automatically light up once it becomes available.
- Updated benchmarks to use new CommitCharacters on the completion list.
- Expanded our language server client capabilities to track VS' completion list capabilities that identify whether or not the CommitCharacters. This manifests as `PlatformAgnosticCompletionCapability` and `VSCompletionListCapability`.
 - Added a new `VSCompletionList` and `OptimizedVSCompletionList` set of types with their optimized forms.

**Before:**
|                                              Method |      Mean |     Error |    StdDev |   Op/s |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|---------------------------------------------------- |----------:|----------:|----------:|-------:|---------:|---------:|--------:|----------:|
| 'Component Completion List Roundtrip Serialization' | 12.302 ms | 0.2425 ms | 0.4786 ms |  81.29 | 718.7500 | 359.3750 |       - |  4,569 KB |
|           'Component Completion List Serialization' |  2.152 ms | 0.0319 ms | 0.0283 ms | 464.75 |  82.0313 |  31.2500 | 15.6250 |    555 KB |
|         'Component Completion List Deserialization' |  9.409 ms | 0.1797 ms | 0.2399 ms | 106.28 | 640.6250 | 312.5000 |       - |  4,013 KB |

**After:**
|                                              Method |     Mean |     Error |    StdDev |  Op/s |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|---------------------------------------------------- |---------:|----------:|----------:|------:|---------:|---------:|--------:|----------:|
| 'Component Completion List Roundtrip Serialization' | 7.434 ms | 0.1169 ms | 0.1036 ms | 134.5 | 585.9375 | 296.8750 |  7.8125 |  3,679 KB |
|           'Component Completion List Serialization' | 1.924 ms | 0.0257 ms | 0.0241 ms | 519.8 |  83.9844 |  37.1094 | 21.4844 |    523 KB |
|         'Component Completion List Deserialization' | 5.888 ms | 0.1090 ms | 0.1908 ms | 169.8 | 507.8125 | 242.1875 |       - |  3,156 KB |

**Results:**
Roundtrip: 1.7x faster
Serialization: 1.1x faster
Deserialization: 1.6x faster

Razor's part of dotnet/aspnetcore#31886