### PR TITLE
Add support for CompletionList.Data.

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/CompletionListSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/CompletionListSerializationBenchmark.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 using Microsoft.CodeAnalysis.Razor.Serialization;
 using Microsoft.VisualStudio.Editor.Razor;
@@ -91,6 +90,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks
                     VSCompletionList = new VSCompletionListCapability()
                     {
                         CommitCharacters = true,
+                        Data = true,
                     }
                 });
             return completionList;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedVSCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedVSCompletionList.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public OptimizedVSCompletionList(VSCompletionList completionList) : base(completionList)
         {
             CommitCharacters = completionList.CommitCharacters;
+            Data = completionList.Data;
         }
 
         public class OptimizedVSCompletionListJsonConverter : OptimizedCompletionList.OptimizedCompletionListJsonConverter
@@ -30,6 +31,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 {
                     writer.WritePropertyName("_vsext_commitCharacters");
                     serializer.Serialize(writer, vsCompletionList.CommitCharacters);
+                }
+
+                if (vsCompletionList.Data != null)
+                {
+                    writer.WritePropertyName("_vsext_data");
+                    serializer.Serialize(writer, vsCompletionList.Data);
                 }
 
                 base.WriteCompletionListProperties(writer, completionList, serializer);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = new CompletionList(completionItems, isIncomplete: false);
 
             // We wrap the pre-existing completion list with an optimized completion list to better control serialization/deserialization
-            CompletionList optimizedCompletionList = null;
+            CompletionList optimizedCompletionList;
 
             if (completionCapability?.VSCompletionList != null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
@@ -7,14 +7,23 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
+    /// <summary>
+    /// A subclass of the LSP protocol <see cref="CompletionList"/> that contains extensions specific to Visual Studio.
+    /// </summary>
     internal class VSCompletionList : CompletionList
     {
         protected VSCompletionList(CompletionList innerCompletionList) : base (innerCompletionList.Items, innerCompletionList.IsIncomplete)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the default <see cref="CompletionItem.CommitCharacters"/> used for completion items.
+        /// </summary>
         public Container<string> CommitCharacters { get; set; }
 
+        /// <summary>
+        /// Gets or sets the default <see cref="CompletionItem.Data"/> used for completion items.
+        /// </summary>
         public object Data { get; set; }
 
         public static VSCompletionList Convert(CompletionList completionList, VSCompletionListCapability vsCompletionListCapability)
@@ -75,7 +84,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // This piece makes a massive assumption that all completion items will have a resultId associated with them and their
             // data properties will all be the same. Therefore, we can inspect the first item and empty out the rest.
             var commonDataItem = completionList.FirstOrDefault();
-            if (commonDataItem == null)
+            if (commonDataItem is null)
             {
                 // Empty list
                 return;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionListCapability.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionListCapability.cs
@@ -5,8 +5,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
     internal class VSCompletionListCapability
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether completion lists can have VSCommitCharacters. These commit characters get propagated
+        /// onto underlying valid completion items unless they have their own commit characters.
+        /// </summary>
         public bool CommitCharacters { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether completion lists can have Data bags. These data bags get propagated
+        /// onto underlying completion items unless they have their own data bags.
+        /// </summary>
         public bool Data { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionListCapability.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionListCapability.cs
@@ -6,5 +6,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
     internal class VSCompletionListCapability
     {
         public bool CommitCharacters { get; set; }
+
+        public bool Data { get; set; }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/VSCompletionListTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/VSCompletionListTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
@@ -8,6 +9,60 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
     public class VSCompletionListTest
     {
+        [Fact]
+        public void Convert_DataTrue_RemovesDataFromItems()
+        {
+            // Arrange
+            var dataObject = new JObject()
+            {
+                ["resultId"] = 123
+            };
+            var completionList = new CompletionList(
+                new CompletionItem()
+                {
+                    Label = "Test",
+                    Data = dataObject,
+                });
+            var capabilities = new VSCompletionListCapability()
+            {
+                Data = true,
+            };
+
+            // Act
+            var vsCompletionList = VSCompletionList.Convert(completionList, capabilities);
+
+            // Assert
+            Assert.Collection(vsCompletionList.Items, item => Assert.Null(item.Data));
+            Assert.Same(dataObject, vsCompletionList.Data);
+        }
+
+        [Fact]
+        public void Convert_DataFalse_DoesNotTouchData()
+        {
+            // Arrange
+            var dataObject = new JObject()
+            {
+                ["resultId"] = 123
+            };
+            var completionList = new CompletionList(
+                new CompletionItem()
+                {
+                    Label = "Test",
+                    Data = dataObject,
+                });
+            var capabilities = new VSCompletionListCapability()
+            {
+                Data = false,
+            };
+
+            // Act
+            var vsCompletionList = VSCompletionList.Convert(completionList, capabilities);
+
+            // Assert
+            Assert.Collection(vsCompletionList.Items, item => Assert.Same(dataObject, item.Data));
+            Assert.Null(vsCompletionList.Data);
+        }
+
         [Fact]
         public void Convert_CommitCharactersTrue_RemovesCommitCharactersFromItems()
         {


### PR DESCRIPTION
- `CompletionList.Data` serves as a way for completion items to not redundantly provide `Data`. Aka, all completion data objects serve as a default for underlying completion items.
- The LSP Platform hasn't yet inserted these changes into VS; however, our language server doesn't depend on the LSP platform directly anyhow. This changeset enables the data bag optimization of the LSP platform in a way that will automatically light up once it becomes available.
- Updated benchmarks to use new `Data` capability on the completion list.
- Updated our `VSCompletionListCapability` to include a `Data` property.
- Added tests

**Before:**
|                                              Method |     Mean |     Error |    StdDev |  Op/s |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|---------------------------------------------------- |---------:|----------:|----------:|------:|---------:|---------:|--------:|----------:|
| 'Component Completion List Roundtrip Serialization' | 7.434 ms | 0.1169 ms | 0.1036 ms | 134.5 | 585.9375 | 296.8750 |  7.8125 |  3,679 KB |
|           'Component Completion List Serialization' | 1.924 ms | 0.0257 ms | 0.0241 ms | 519.8 |  83.9844 |  37.1094 | 21.4844 |    523 KB |
|         'Component Completion List Deserialization' | 5.888 ms | 0.1090 ms | 0.1908 ms | 169.8 | 507.8125 | 242.1875 |       - |  3,156 KB |

**After:**
|                                              Method |       Mean |    Error |   StdDev |    Op/s |    Gen 0 |    Gen 1 | Gen 2 | Allocated |
|---------------------------------------------------- |-----------:|---------:|---------:|--------:|---------:|---------:|------:|----------:|
| 'Component Completion List Roundtrip Serialization' | 2,931.8 us | 43.66 us | 38.71 us |   341.1 | 304.6875 | 136.7188 |     - |  1,870 KB |
|           'Component Completion List Serialization' |   332.5 us |  6.04 us |  5.65 us | 3,007.8 |  26.8555 |   5.3711 |     - |    166 KB |
|         'Component Completion List Deserialization' | 2,836.9 us | 49.85 us | 46.63 us |   352.5 | 277.3438 | 121.0938 |     - |  1,704 KB |

**Results:**
Roundtrip: 2.5x faster
Serialization: 5.8x faster
Deserialization: 2.1x faster

Razor's language server part of dotnet/aspnetcore#31883