### PR TITLE
Make typing around C# breakpoints in Razor instant.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Debugging/DefaultRazorProximityExpressionResolver.cs
@@ -90,6 +90,21 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
                 return null;
             }
 
+            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var virtualDocument))
+            {
+                Debug.Fail($"Some how there's no C# document associated with the host Razor document {documentUri.OriginalString} when validating breakpoint locations.");
+                return null;
+            }
+
+            if (virtualDocument.HostDocumentSyncVersion != documentSnapshot.Version)
+            {
+                // C# document isn't up-to-date with the Razor document. Because VS' debugging tech is synchronous on the UI thread we have to bail. Ideally we'd wait
+                // for the C# document to become "updated"; however, that'd require the UI thread to see that the C# buffer is updated. Because this call path blocks
+                // the UI thread the C# document will never update until this path has exited. This means as a user types around the point of interest data may get stale
+                // but will re-adjust later.
+                return null;
+            }
+
             var cacheKey = new CacheKey(documentSnapshot.Uri, documentSnapshot.Version, lineIndex, characterIndex);
             if (_cache.TryGetValue(cacheKey, out var cachedExpressions))
             {
@@ -110,12 +125,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
             if (projectionResult.LanguageKind != RazorLanguageKind.CSharp)
             {
                 // We only allow proximity expressions in C#
-                return null;
-            }
-
-            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var virtualDocument))
-            {
-                Debug.Fail($"Somehow there's no C# document associated with the host Razor document {documentUri.OriginalString} when retrieving proximity expressions.");
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLanguageDebugInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLanguageDebugInfo.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 message: "Razor Debugger",
                 async (context) =>
                 {
-                    var proximityExpressions = await _proximityExpressionResolver.TryResolveProximityExpressionsAsync(textBuffer, iLine, iCol, context.CancellationToken);
+                    var proximityExpressions = await _proximityExpressionResolver.TryResolveProximityExpressionsAsync(textBuffer, iLine, iCol, context.CancellationToken).ConfigureAwait(false);
                     return proximityExpressions;
                 });
 
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 message: "Razor Debugger",
                 async (context) =>
                 {
-                    var breakpointRange = await _breakpointResolver.TryResolveBreakpointRangeAsync(textBuffer, iLine, iCol, context.CancellationToken);
+                    var breakpointRange = await _breakpointResolver.TryResolveBreakpointRangeAsync(textBuffer, iLine, iCol, context.CancellationToken).ConfigureAwait(false);
                     if (breakpointRange == null)
                     {
                         // No applicable breakpoint location.

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
         public DefaultRazorBreakpointResolverTest()
         {
             DocumentUri = new Uri("file://C:/path/to/file.razor", UriKind.Absolute);
+            CSharpDocumentUri = new Uri(DocumentUri.OriginalString + ".g.cs", UriKind.Absolute);
 
             ValidBreakpointCSharp = "private int foo = 123;";
             InvalidBreakpointCSharp = "private int bar;";
@@ -45,6 +46,8 @@ $@"public class SomeRazorFile
         private ITextBuffer CSharpTextBuffer { get; }
 
         private Uri DocumentUri { get; }
+
+        private Uri CSharpDocumentUri { get; }
 
         private ITextBuffer HostTextbuffer { get; }
 
@@ -75,6 +78,23 @@ $@"public class SomeRazorFile
 
             // Assert
             Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task TryResolveBreakpointRangeAsync_UnsynchronizedCSharpDocument_ReturnsNull()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var testCSharpDocument = new CSharpVirtualDocumentSnapshot(CSharpDocumentUri, CSharpTextBuffer.CurrentSnapshot, hostDocumentSyncVersion: 1);
+            var document = new TestLSPDocumentSnapshot(DocumentUri, version: (int)(testCSharpDocument.HostDocumentSyncVersion.Value + 1), testCSharpDocument);
+            documentManager.AddDocument(document.Uri, document);
+            var resolver = CreateResolverWith(documentManager: documentManager);
+
+            // Act
+            var expressions = await resolver.TryResolveBreakpointRangeAsync(HostTextbuffer, lineIndex: 0, characterIndex: 1, CancellationToken.None);
+
+            // Assert
+            Assert.Null(expressions);
         }
 
         [Fact]
@@ -229,8 +249,7 @@ $@"public class SomeRazorFile
         {
             var documentUri = DocumentUri;
             uriProvider ??= Mock.Of<FileUriProvider>(provider => provider.TryGet(HostTextbuffer, out documentUri) == true && provider.TryGet(It.IsNotIn(HostTextbuffer), out It.Ref<Uri>.IsAny) == false, MockBehavior.Strict);
-            var csharpDocumentUri = new Uri(DocumentUri.OriginalString + ".g.cs", UriKind.Absolute);
-            var csharpVirtualDocumentSnapshot = new CSharpVirtualDocumentSnapshot(csharpDocumentUri, CSharpTextBuffer.CurrentSnapshot, hostDocumentSyncVersion: 0);
+            var csharpVirtualDocumentSnapshot = new CSharpVirtualDocumentSnapshot(CSharpDocumentUri, CSharpTextBuffer.CurrentSnapshot, hostDocumentSyncVersion: 0);
             LSPDocumentSnapshot documentSnapshot = new TestLSPDocumentSnapshot(DocumentUri, 0, csharpVirtualDocumentSnapshot);
             documentManager ??= Mock.Of<LSPDocumentManager>(manager => manager.TryGetDocument(DocumentUri, out documentSnapshot) == true, MockBehavior.Strict);
             if (projectionProvider is null)


### PR DESCRIPTION
- Found that when you type near a breakpoint in Razor we would request projections from our language srever and wait for the document to be synchronized. Turns out due to VS' debugging tech being synchronous on the UI thread that was an impossible thing to do. Basically as you'd type we're try to synchronize the C# document and continually timeout during synchronization if you were typing. To address this I added a stop-gap where if the C# document is of a different host document sync version then the top level document we let the breakpoint grow on its own. This will result in some unexpected behaviors for customers as their breakpoint highlight may grow unexpectedly but replacing it will fix it or it will just inherently be fixed later when the editor re-verifies breakpoints (running). Sadly there's no workaround given the synchronous nature of VS' debugging hooks so we have to commit a crime here.
- Did the same fix for proximity expressions
- Just to note: If you place a breakpoint nothing has changed because 99.9% of the time the C# document will be up-to-date so things will work as you'd expect.
- Sprinkled a few ConfigureAwait(false)'s
- Added tests

![9eMTivgVFT](https://user-images.githubusercontent.com/2008729/115824056-38611e00-a3bc-11eb-8e98-6815781b0327.gif)

Got you @TanayParikh 😉 

Fixes dotnet/aspnetcore#32079
