### PR TITLE
Fix setting breakpoint on solution load = no logs.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // We initialize the logger here instead of the constructor as the projection provider is constructed
             // *before* the language server. Thus, the log hub has yet to be initialized, thus we would be unable to
             // create the logger at that time.
-            InitializeLogHubLogger();
+            await InitializeLogHubLoggerAsync(cancellationToken).ConfigureAwait(false);
 
             var languageQueryParams = new RazorLanguageQueryParams()
             {
@@ -139,10 +139,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return result;
         }
 
-        private void InitializeLogHubLogger()
+        private async Task InitializeLogHubLoggerAsync(CancellationToken cancellationToken)
         {
             if (_logHubLogger is null)
             {
+                await _loggerProvider.InitializeLoggerAsync(cancellationToken);
+
+                cancellationToken.ThrowIfCancellationRequested();
+
                 _logHubLogger = _loggerProvider.CreateLogger(nameof(DefaultLSPProjectionProvider));
             }
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // We initialize the logger here instead of the constructor as the projection provider is constructed
             // *before* the language server. Thus, the log hub has yet to be initialized, thus we would be unable to
             // create the logger at that time.
-            await InitializeLogHubLoggerAsync(cancellationToken).ConfigureAwait(false);
+            await InitializeLogHubAsync(cancellationToken).ConfigureAwait(false);
 
             var languageQueryParams = new RazorLanguageQueryParams()
             {
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return result;
         }
 
-        private async Task InitializeLogHubLoggerAsync(CancellationToken cancellationToken)
+        private async Task InitializeLogHubAsync(CancellationToken cancellationToken)
         {
             if (_logHubLogger is null)
             {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HandlerTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HandlerTestBase.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
 using Moq;
@@ -14,7 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             var logger = new TestLogger();
             LoggerProvider = Mock.Of<HTMLCSharpLanguageServerLogHubLoggerProvider>(l =>
-                l.CreateLogger(It.IsAny<string>()) == logger, MockBehavior.Strict);
+                l.CreateLogger(It.IsAny<string>()) == logger && l.InitializeLoggerAsync(It.IsAny<CancellationToken>()) == Task.CompletedTask,
+                MockBehavior.Strict);
         }
 
         internal HTMLCSharpLanguageServerLogHubLoggerProvider LoggerProvider { get; }


### PR DESCRIPTION
- Because projections can be requested from soooo many different pieces of the Razor sub-system (debugging being one of them) we need to initialize our logger whenever projections are attempted to be resolved. This may seem expensive but 99.9% of the time the async method will run synchronously resulting in no harm to perf.

Found because this Debug.Assert being hit:
![image](https://user-images.githubusercontent.com/2008729/115825105-d0133c00-a3bd-11eb-8423-1cf036622cc4.png)

Fixes dotnet/aspnetcore#32088

/cc @TanayParikh would you mind taking a look since this touches on the LogHub infrastructure you added.