### PR TITLE
Add support for C#/HTML CompletionList.Data and CommitCharacters

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -110,7 +110,7 @@
     <MicrosoftVisualStudioEditorPackageVersion>16.10.8</MicrosoftVisualStudioEditorPackageVersion>
     <MicrosoftVisualStudioLanguagePackageVersion>16.10.8</MicrosoftVisualStudioLanguagePackageVersion>
     <MicrosoftVisualStudioLanguageIntellisensePackageVersion>16.10.8</MicrosoftVisualStudioLanguageIntellisensePackageVersion>
-    <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>16.10.170-g435581052d</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
+    <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>16.10.1202</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
     <MicrosoftVisualStudioPackageLanguageService150PackageVersion>16.7.30204.53-pre</MicrosoftVisualStudioPackageLanguageService150PackageVersion>
     <MicrosoftVisualStudioLiveSharePackageVersion>0.3.1074</MicrosoftVisualStudioLiveSharePackageVersion>
     <MicrosoftVisualStudioOLEInteropPackageVersion>7.10.6071</MicrosoftVisualStudioOLEInteropPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -584,15 +584,29 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         internal static void SetResolveData(long resultId, CompletionList completionList)
         {
-            for (var i = 0; i < completionList.Items.Length; i++)
+            if (completionList is VSCompletionList vsCompletionList && vsCompletionList.Data != null)
             {
-                var item = completionList.Items[i];
+                // Provided completion list is already wrapping completion list data, lets wrap that instead of each completion item.
+
                 var data = new CompletionResolveData()
                 {
                     ResultId = resultId,
-                    OriginalData = item.Data,
+                    OriginalData = vsCompletionList.Data,
                 };
-                item.Data = data;
+                vsCompletionList.Data = data;
+            }
+            else
+            {
+                for (var i = 0; i < completionList.Items.Length; i++)
+                {
+                    var item = completionList.Items[i];
+                    var data = new CompletionResolveData()
+                    {
+                        ResultId = resultId,
+                        OriginalData = item.Data,
+                    };
+                    item.Data = data;
+                }
             }
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -997,6 +997,31 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         }
 
         [Fact]
+        public void SetResolveData_RewritesCompletionListData()
+        {
+            // Arrange
+            var originalData = new object();
+            var completionList = new VSCompletionList()
+            {
+                Items = new[]
+                {
+                    new CompletionItem() { InsertText = "Hello" }
+                },
+                Data = originalData
+            };
+            _ = new TestDocumentManager();
+            _ = new Mock<LSPRequestInvoker>(MockBehavior.Strict).Object;
+            _ = new Mock<LSPProjectionProvider>(MockBehavior.Strict).Object;
+
+            // Act
+            CompletionHandler.SetResolveData(123, completionList);
+
+            // Assert
+            var newData = Assert.IsType<CompletionResolveData>(completionList.Data);
+            Assert.Same(originalData, newData.OriginalData);
+        }
+
+        [Fact]
         public async Task HandleRequestAsync_ProvisionalCompletion()
         {
             // Arrange


### PR DESCRIPTION
- Update LSP protocol version and add support for `CompletionList.Data` wrapping in our HTMLC# completion handler.

Part of dotnet/aspnetcore#31852
Part of dotnet/aspnetcore#31883
Part of dotnet/aspnetcore#31886

/cc @ToddGrun @jimmylewis Down for another dual insertion to consume the SumType/CompletionList optimizations?