### PR TITLE
Add classifications for TagHelper element/attribute quick info tooltips in VS

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             if (tagHelperClassifiedTextTooltip != null)
             {
                 var vsCompletionItem = completionItem.ToVSCompletionItem();
-                vsCompletionItem.Documentation = "";
+                vsCompletionItem.Documentation = string.Empty;
                 vsCompletionItem.Description = tagHelperClassifiedTextTooltip;
                 return Task.FromResult<CompletionItem>(vsCompletionItem);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -200,11 +200,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 case RazorCompletionItemKind.TagHelperAttribute:
                     {
                         var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
-                        _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperMarkupTooltip);
-
                         if (useDescriptionProperty)
                         {
                             _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                        }
+                        else
+                        {
+                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperMarkupTooltip);
                         }
 
                         break;
@@ -212,11 +214,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 case RazorCompletionItemKind.TagHelperElement:
                     {
                         var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
-                        _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperMarkupTooltip);
-
                         if (useDescriptionProperty)
                         {
                             _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                        }
+                        else
+                        {
+                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperMarkupTooltip);
                         }
 
                         break;
@@ -232,6 +236,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             if (tagHelperClassifiedTextTooltip != null)
             {
                 var vsCompletionItem = completionItem.ToVSCompletionItem();
+                vsCompletionItem.Documentation = "";
                 vsCompletionItem.Description = tagHelperClassifiedTextTooltip;
                 return Task.FromResult<CompletionItem>(vsCompletionItem);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -24,11 +24,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly DocumentResolver _documentResolver;
         private readonly RazorHoverInfoService _hoverInfoService;
+        private readonly ClientNotifierServiceBase _languageServer;
 
         public RazorHoverEndpoint(
             ForegroundDispatcher foregroundDispatcher,
             DocumentResolver documentResolver,
             RazorHoverInfoService hoverInfoService,
+            ClientNotifierServiceBase languageServer,
             ILoggerFactory loggerFactory)
         {
             if (foregroundDispatcher is null)
@@ -46,6 +48,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 throw new ArgumentNullException(nameof(hoverInfoService));
             }
 
+            if (languageServer is null)
+            {
+                throw new ArgumentNullException(nameof(languageServer));
+            }
+
             if (loggerFactory is null)
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
@@ -54,6 +61,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
             _foregroundDispatcher = foregroundDispatcher;
             _documentResolver = documentResolver;
             _hoverInfoService = hoverInfoService;
+            _languageServer = languageServer;
             _logger = loggerFactory.CreateLogger<RazorHoverEndpoint>();
         }
 
@@ -86,8 +94,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
             var linePosition = new LinePosition((int)request.Position.Line, (int)request.Position.Character);
             var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
             var location = new SourceLocation(hostDocumentIndex, (int)request.Position.Line, (int)request.Position.Character);
+            var isVSClient = _languageServer.ClientSettings.Capabilities is PlatformAgnosticClientCapabilities clientCapabilities &&
+                clientCapabilities.SupportsVisualStudioExtensions;
 
-            var hoverItem = _hoverInfoService.GetHoverInfo(codeDocument, location);
+            var hoverItem = _hoverInfoService.GetHoverInfo(codeDocument, location, isVSClient);
 
             _logger.LogTrace($"Found hover info items.");
 
@@ -98,7 +108,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
         {
             _capability = capability;
         }
-
 
         public HoverRegistrationOptions GetRegistrationOptions()
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -94,10 +94,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
             var linePosition = new LinePosition((int)request.Position.Line, (int)request.Position.Character);
             var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
             var location = new SourceLocation(hostDocumentIndex, (int)request.Position.Line, (int)request.Position.Character);
-            var isVSClient = _languageServer.ClientSettings.Capabilities is PlatformAgnosticClientCapabilities clientCapabilities &&
-                clientCapabilities.SupportsVisualStudioExtensions;
+            var clientCapabilities = _languageServer.ClientSettings.Capabilities;
 
-            var hoverItem = _hoverInfoService.GetHoverInfo(codeDocument, location, isVSClient);
+            var hoverItem = _hoverInfoService.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             _logger.LogTrace($"Found hover info items.");
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverInfoService.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using HoverModel = OmniSharp.Extensions.LanguageServer.Protocol.Models.Hover;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
 {
     internal abstract class RazorHoverInfoService
     {
-        public abstract HoverModel GetHoverInfo(RazorCodeDocument codeDocument, SourceLocation location, bool isVSClient);
+        public abstract HoverModel GetHoverInfo(RazorCodeDocument codeDocument, SourceLocation location, ClientCapabilities clientCapabilities);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/VSHover.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/VSHover.cs
@@ -1,13 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language;
+#nullable enable
+
+using Newtonsoft.Json;
 using HoverModel = OmniSharp.Extensions.LanguageServer.Protocol.Models.Hover;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
 {
-    internal abstract class RazorHoverInfoService
+    internal class VSHover : HoverModel
     {
-        public abstract HoverModel GetHoverInfo(RazorCodeDocument codeDocument, SourceLocation location, bool isVSClient);
+        [JsonProperty("type")]
+        public readonly string Type = "VSHover";
+
+        public object? RawContent { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/VSHover.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/VSHover.cs
@@ -3,16 +3,12 @@
 
 #nullable enable
 
-using Newtonsoft.Json;
 using HoverModel = OmniSharp.Extensions.LanguageServer.Protocol.Models.Hover;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
 {
     internal class VSHover : HoverModel
     {
-        [JsonProperty("type")]
-        public readonly string Type = "VSHover";
-
         public object? RawContent { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 
         public ClientNotifierServiceBase LanguageServer;
 
-        public override bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, out MarkupContent tagHelperDescription)
+        public override bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, out MarkupContent tooltipContent)
         {
             if (elementDescriptionInfo is null)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
             var associatedTagHelperInfos = elementDescriptionInfo.AssociatedTagHelperDescriptions;
             if (associatedTagHelperInfos.Count == 0)
             {
-                tagHelperDescription = null;
+                tooltipContent = null;
                 return false;
             }
 
@@ -75,26 +75,26 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
                 descriptionBuilder.Append(finalSummaryContent);
             }
 
-            tagHelperDescription = new MarkupContent
+            tooltipContent = new MarkupContent
             {
                 Kind = GetMarkupKind()
             };
 
-            tagHelperDescription.Value = descriptionBuilder.ToString();
+            tooltipContent.Value = descriptionBuilder.ToString();
             return true;
         }
 
-        public override bool TryCreateTooltip(AggregateBoundAttributeDescription descriptionInfos, out MarkupContent tagHelperDescription)
+        public override bool TryCreateTooltip(AggregateBoundAttributeDescription attributeDescriptionInfo, out MarkupContent tooltipContent)
         {
-            if (descriptionInfos is null)
+            if (attributeDescriptionInfo is null)
             {
-                throw new ArgumentNullException(nameof(descriptionInfos));
+                throw new ArgumentNullException(nameof(attributeDescriptionInfo));
             }
 
-            var associatedAttributeInfos = descriptionInfos.DescriptionInfos;
+            var associatedAttributeInfos = attributeDescriptionInfo.DescriptionInfos;
             if (associatedAttributeInfos.Count == 0)
             {
-                tagHelperDescription = null;
+                tooltipContent = null;
                 return false;
             }
 
@@ -145,12 +145,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
                 descriptionBuilder.Append(finalSummaryContent);
             }
 
-            tagHelperDescription = new MarkupContent
+            tooltipContent = new MarkupContent
             {
                 Kind = GetMarkupKind()
             };
 
-            tagHelperDescription.Value = descriptionBuilder.ToString();
+            tooltipContent.Value = descriptionBuilder.ToString();
             return true;
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -147,9 +147,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
                 TryClassifySummary(documentationRuns, descriptionInfo.Documentation);
 
                 // 3. Combine type + summary information
-                descriptions.Add(new DescriptionClassification(new List<VSClassifiedTextRun>(typeRuns), new List<VSClassifiedTextRun>(documentationRuns)));
-                typeRuns.Clear();
-                documentationRuns.Clear();
+                descriptions.Add(new DescriptionClassification(typeRuns, documentationRuns));
             }
 
             descriptionClassifications = descriptions;
@@ -196,9 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
                 TryClassifySummary(documentationRuns, descriptionInfo.Documentation);
 
                 // 3. Combine type + summary information
-                descriptions.Add(new DescriptionClassification(new List<VSClassifiedTextRun>(typeRuns), new List<VSClassifiedTextRun>(documentationRuns)));
-                typeRuns.Clear();
-                documentationRuns.Clear();
+                descriptions.Add(new DescriptionClassification(typeRuns, documentationRuns));
             }
 
             descriptionClassifications = descriptions;
@@ -452,8 +448,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
             return new VSClassifiedTextElement(runs);
         }
 
-        private record DescriptionClassification(IReadOnlyList<VSClassifiedTextRun> Type, IReadOnlyList<VSClassifiedTextRun> Documentation);
-
         // Internal for testing
         // Adapted from VS' PredefinedClassificationTypeNames
         internal static class VSPredefinedClassificationTypeNames
@@ -470,5 +464,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 
             public const string WhiteSpace = "whitespace";
         }
+
+        private record DescriptionClassification(IReadOnlyList<VSClassifiedTextRun> Type, IReadOnlyList<VSClassifiedTextRun> Documentation);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -11,11 +11,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 {
     internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactory
     {
-        private static readonly Guid ImageCatalogGuid = new("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
-
-        private static readonly VSImageElement TagHelperGlyph = new(
+        // Internal for testing
+        internal static readonly VSImageElement TagHelperGlyph = new(
             new VSImageId(ImageCatalogGuid, 3564), // KnownImageIds.Type = 3564
             "Razor TagHelper Glyph");
+
+        private static readonly Guid ImageCatalogGuid = new("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
 
         private static readonly IReadOnlyList<string> CSharpPrimitiveTypes =
             new string[] { "bool", "byte", "sbyte", "char", "decimal", "double", "float", "int", "uint",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -11,12 +11,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 {
     internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactory
     {
+        private static readonly Guid ImageCatalogGuid = new("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
+
         // Internal for testing
         internal static readonly VSImageElement TagHelperGlyph = new(
             new VSImageId(ImageCatalogGuid, 3564), // KnownImageIds.Type = 3564
             "Razor TagHelper Glyph");
-
-        private static readonly Guid ImageCatalogGuid = new("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
 
         private static readonly IReadOnlyList<string> CSharpPrimitiveTypes =
             new string[] { "bool", "byte", "sbyte", "char", "decimal", "double", "float", "int", "uint",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/LSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/LSPTagHelperTooltipFactory.cs
@@ -8,8 +8,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 {
     internal abstract class LSPTagHelperTooltipFactory : TagHelperTooltipFactoryBase
     {
-        public abstract bool TryCreateTooltip(AggregateBoundElementDescription descriptionInfos, out MarkupContent tooltipContent);
+        public abstract bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, out MarkupContent tooltipContent);
 
-        public abstract bool TryCreateTooltip(AggregateBoundAttributeDescription descriptionInfos, out MarkupContent tooltipContent);
+        public abstract bool TryCreateTooltip(AggregateBoundAttributeDescription attributeDescriptionInfo, out MarkupContent tooltipContent);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSClassifiedTextElement.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSClassifiedTextElement.cs
@@ -15,6 +15,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
     /// </summary>
     internal sealed class VSClassifiedTextElement
     {
+        [JsonProperty("type")]
+        public static readonly string Type = "ClassifiedTextElement";
+
         public const string TextClassificationTypeName = "text";
 
         public VSClassifiedTextElement(params VSClassifiedTextRun[] runs)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSClassifiedTextRun.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSClassifiedTextRun.cs
@@ -13,6 +13,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
     /// </summary>
     internal sealed class VSClassifiedTextRun
     {
+        [JsonProperty("type")]
+        public static readonly string Type = "ClassifiedTextRun";
+
         public VSClassifiedTextRun(string classificationTypeName, string text)
             : this(classificationTypeName, text, VSClassifiedTextRunStyle.Plain)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSContainerElement.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSContainerElement.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
+{
+    /// <summary>
+    /// Equivalent to VS' ContainerElement. The class has been adapted here so we can
+    /// use it for LSP serialization since we don't have access to the VS version.
+    /// Refer to original class for additional details.
+    /// </summary>
+    internal sealed class VSContainerElement
+    {
+        [JsonProperty("type")]
+        public static readonly string Type = "ContainerElement";
+
+        public VSContainerElement(VSContainerElementStyle style, IEnumerable<object> elements)
+        {
+            Style = style;
+            Elements = elements?.ToImmutableList() ?? throw new ArgumentNullException(nameof(elements));
+        }
+
+        public VSContainerElement(VSContainerElementStyle style, params object[] elements)
+        {
+            Style = style;
+            Elements = elements?.ToImmutableList() ?? throw new ArgumentNullException(nameof(elements));
+        }
+
+        [JsonProperty("Elements")]
+        public IEnumerable<object> Elements { get; }
+
+        [JsonProperty("Style")]
+        public VSContainerElementStyle Style { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSContainerElementStyle.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSContainerElementStyle.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
+{
+    /// <summary>
+    /// Equivalent to VS' ContainerElementStyle. The class has been adapted here so we
+    /// can use it for LSP serialization since we don't have access to the VS version.
+    /// Refer to original class for additional details.
+    /// </summary>
+    [Flags]
+    internal enum VSContainerElementStyle
+    {
+        Wrapped = 0b_0000,
+        Stacked = 0b_0001,
+        VerticalPadding = 0b_0010
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSImageElement.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSImageElement.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
+{
+    /// <summary>
+    /// Equivalent to VS' ImageElement. The class has been adapted here so we can
+    /// use it for LSP serialization since we don't have access to the VS version.
+    /// Refer to original class for additional details.
+    /// </summary>
+    internal class VSImageElement
+    {
+        [JsonProperty("type")]
+        public static readonly string Type = "ImageElement";
+
+        public static readonly VSImageElement Empty = new(default, string.Empty);
+
+        public VSImageElement(VSImageId imageId)
+        {
+            ImageId = imageId;
+        }
+
+        public VSImageElement(VSImageId imageId, string automationName)
+            : this(imageId)
+        {
+            AutomationName = automationName ?? throw new ArgumentNullException(nameof(automationName));
+        }
+
+        [JsonProperty("ImageId")]
+        public VSImageId ImageId { get; }
+
+        [JsonProperty("AutomationName")]
+        public string AutomationName { get; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSImageId.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSImageId.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
+{
+    /// <summary>
+    /// Equivalent to VS' ContainerElementStyle. The class has been adapted here so we
+    /// can use it for LSP serialization since we don't have access to the VS version.
+    /// Refer to original class for additional details.
+    /// </summary>
+    internal class VSImageId : IEquatable<VSImageId>
+    {
+        [JsonProperty("type")]
+        public static readonly string Type = "ImageId";
+
+        [JsonProperty("Guid")]
+        public readonly Guid Guid;
+
+        [JsonProperty("Id")]
+        public readonly int Id;
+
+        public VSImageId(Guid guid, int id)
+        {
+            Guid = guid;
+            Id = id;
+        }
+        public override string ToString()
+        {
+            return this.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        public string ToString(IFormatProvider provider)
+        {
+            return string.Format(provider, @"{0} : {1}", Guid.ToString("D", provider), Id.ToString(provider));
+        }
+
+        bool IEquatable<VSImageId>.Equals(VSImageId other) => Id.Equals(other.Id) && Guid.Equals(other.Guid);
+
+        public override bool Equals(object other) => other is VSImageId otherImage && ((IEquatable<VSImageId>)this).Equals(otherImage);
+
+        public static bool operator ==(VSImageId left, VSImageId right) => left.Equals(right);
+
+        public static bool operator !=(VSImageId left, VSImageId right) => !(left == right);
+
+        public override int GetHashCode() => Guid.GetHashCode() ^ Id.GetHashCode();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSLSPTagHelperTooltipFactory.cs
@@ -7,8 +7,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 {
     internal abstract class VSLSPTagHelperTooltipFactory : TagHelperTooltipFactoryBase
     {
-        public abstract bool TryCreateTooltip(AggregateBoundElementDescription descriptionInfos, out VSClassifiedTextElement tooltipContent);
+        public abstract bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, out VSContainerElement tooltipContent);
 
-        public abstract bool TryCreateTooltip(AggregateBoundAttributeDescription descriptionInfos, out VSClassifiedTextElement tooltipContent);
+        public abstract bool TryCreateTooltip(AggregateBoundAttributeDescription attributeDescriptionInfo, out VSContainerElement tooltipContent);
+
+        public abstract bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, out VSClassifiedTextElement tooltipContent);
+
+        public abstract bool TryCreateTooltip(AggregateBoundAttributeDescription attributeDescriptionInfo, out VSClassifiedTextElement tooltipContent);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
             // Expected output:
             //     Accepts List<string>s
             Assert.Collection(runs,
-                run =>AssertExpectedClassification(run, "Accepts ", VSPredefinedClassificationTypeNames.Text),
+                run => AssertExpectedClassification(run, "Accepts ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "List", VSPredefinedClassificationTypeNames.Type),
                 run => AssertExpectedClassification(run, "<", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -444,19 +444,19 @@ End summary description.";
             var containerElements = container.Elements.ToList();
 
             // Expected output:
-            //     [TagHelper Glyph] Microsoft.AspNetCore.SomeTagHelper
+            //     [Class Glyph] Microsoft.AspNetCore.SomeTagHelper
             //     Uses List<string>s
             //
-            //     [TagHelper Glyph] Microsoft.AspNetCore.OtherTagHelper
+            //     [Class Glyph] Microsoft.AspNetCore.OtherTagHelper
             //     Also uses List<string>s
             Assert.Equal(VSContainerElementStyle.Stacked, container.Style);
             Assert.Equal(4, containerElements.Count);
 
-            // [TagHelper Glyph] Microsoft.AspNetCore.SomeTagHelper
+            // [Class Glyph] Microsoft.AspNetCore.SomeTagHelper
             var innerContainer = ((VSContainerElement)containerElements[0]).Elements.ToList();
             var classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
-            Assert.Equal(TagHelperGlyph, innerContainer[0]);
+            Assert.Equal(ClassGlyph, innerContainer[0]);
             Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "AspNetCore", VSPredefinedClassificationTypeNames.Text),
@@ -474,11 +474,11 @@ End summary description.";
                 run => AssertExpectedClassification(run, ">", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "s", VSPredefinedClassificationTypeNames.Text));
 
-            // [TagHelper Glyph] Microsoft.AspNetCore.OtherTagHelper
+            // [Class Glyph] Microsoft.AspNetCore.OtherTagHelper
             innerContainer = ((VSContainerElement)containerElements[2]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
-            Assert.Equal(TagHelperGlyph, innerContainer[0]);
+            Assert.Equal(ClassGlyph, innerContainer[0]);
             Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "AspNetCore", VSPredefinedClassificationTypeNames.Text),
@@ -540,10 +540,10 @@ End summary description.";
             var containerElements = container.Elements.ToList();
 
             // Expected output:
-            //     [TagHelper Glyph] string Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeProperty
+            //     [Property Glyph] string Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeProperty
             //     Uses List<string>s
             //
-            //     [TagHelper Glyph] bool? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty
+            //     [Property Glyph] bool? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty
             //     Uses List<string>s
             Assert.Equal(VSContainerElementStyle.Stacked, container.Style);
             Assert.Equal(4, containerElements.Count);
@@ -552,7 +552,7 @@ End summary description.";
             var innerContainer = ((VSContainerElement)containerElements[0]).Elements.ToList();
             var classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
-            Assert.Equal(TagHelperGlyph, innerContainer[0]);
+            Assert.Equal(PropertyGlyph, innerContainer[0]);
             Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
                 run => AssertExpectedClassification(run, " ", VSPredefinedClassificationTypeNames.WhiteSpace),
                 run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
@@ -580,7 +580,7 @@ End summary description.";
             innerContainer = ((VSContainerElement)containerElements[2]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
-            Assert.Equal(TagHelperGlyph, innerContainer[0]);
+            Assert.Equal(PropertyGlyph, innerContainer[0]);
             Assert.Collection(classifiedTextElement.Runs,run => AssertExpectedClassification(run, "bool", VSPredefinedClassificationTypeNames.Keyword),
                 run => AssertExpectedClassification(run, "?", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, " ", VSPredefinedClassificationTypeNames.WhiteSpace),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -437,11 +437,11 @@ End summary description.";
             var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos);
 
             // Act
-            var result = descriptionFactory.TryCreateTooltip(elementDescription, out VSContainerElement containerElement);
+            var result = descriptionFactory.TryCreateTooltip(elementDescription, out VSContainerElement container);
 
             // Assert
             Assert.True(result);
-            var container = containerElement.Elements.ToList();
+            var containerElements = container.Elements.ToList();
 
             // Expected output:
             //     [TagHelper Glyph] Microsoft.AspNetCore.SomeTagHelper
@@ -449,11 +449,11 @@ End summary description.";
             //
             //     [TagHelper Glyph] Microsoft.AspNetCore.OtherTagHelper
             //     Also uses List<string>s
-            Assert.Equal(VSContainerElementStyle.Stacked, containerElement.Style);
-            Assert.Equal(4, container.Count);
+            Assert.Equal(VSContainerElementStyle.Stacked, container.Style);
+            Assert.Equal(4, containerElements.Count);
 
             // [TagHelper Glyph] Microsoft.AspNetCore.SomeTagHelper
-            var innerContainer = ((VSContainerElement)container[0]).Elements.ToList();
+            var innerContainer = ((VSContainerElement)containerElements[0]).Elements.ToList();
             var classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
             Assert.Equal(TagHelperGlyph, innerContainer[0]);
@@ -464,7 +464,7 @@ End summary description.";
                 run => AssertExpectedClassification(run, "SomeTagHelper", VSPredefinedClassificationTypeNames.Type));
 
             // Uses List<string>s
-            innerContainer = ((VSContainerElement)container[1]).Elements.ToList();
+            innerContainer = ((VSContainerElement)containerElements[1]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[0];
             Assert.Single(innerContainer);
             Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
@@ -475,7 +475,7 @@ End summary description.";
                 run => AssertExpectedClassification(run, "s", VSPredefinedClassificationTypeNames.Text));
 
             // [TagHelper Glyph] Microsoft.AspNetCore.OtherTagHelper
-            innerContainer = ((VSContainerElement)container[2]).Elements.ToList();
+            innerContainer = ((VSContainerElement)containerElements[2]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
             Assert.Equal(TagHelperGlyph, innerContainer[0]);
@@ -486,7 +486,7 @@ End summary description.";
                 run => AssertExpectedClassification(run, "OtherTagHelper", VSPredefinedClassificationTypeNames.Type));
 
             // Also uses List<string>s
-            innerContainer = ((VSContainerElement)container[3]).Elements.ToList();
+            innerContainer = ((VSContainerElement)containerElements[3]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[0];
             Assert.Single(innerContainer);
             Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Also uses ", VSPredefinedClassificationTypeNames.Text),
@@ -533,11 +533,11 @@ End summary description.";
             var attributeDescription = new AggregateBoundAttributeDescription(associatedAttributeDescriptions);
 
             // Act
-            var result = descriptionFactory.TryCreateTooltip(attributeDescription, out VSContainerElement containerElement);
+            var result = descriptionFactory.TryCreateTooltip(attributeDescription, out VSContainerElement container);
 
             // Assert
             Assert.True(result);
-            var container = containerElement.Elements.ToList();
+            var containerElements = container.Elements.ToList();
 
             // Expected output:
             //     [TagHelper Glyph] string Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeProperty
@@ -545,11 +545,11 @@ End summary description.";
             //
             //     [TagHelper Glyph] bool? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty
             //     Uses List<string>s
-            Assert.Equal(VSContainerElementStyle.Stacked, containerElement.Style);
-            Assert.Equal(4, container.Count);
+            Assert.Equal(VSContainerElementStyle.Stacked, container.Style);
+            Assert.Equal(4, containerElements.Count);
 
             // [TagHelper Glyph] string Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeProperty
-            var innerContainer = ((VSContainerElement)container[0]).Elements.ToList();
+            var innerContainer = ((VSContainerElement)containerElements[0]).Elements.ToList();
             var classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
             Assert.Equal(TagHelperGlyph, innerContainer[0]);
@@ -566,7 +566,7 @@ End summary description.";
                 run => AssertExpectedClassification(run, "SomeProperty", VSPredefinedClassificationTypeNames.Identifier));
 
             // Uses List<string>s
-            innerContainer = ((VSContainerElement)container[1]).Elements.ToList();
+            innerContainer = ((VSContainerElement)containerElements[1]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[0];
             Assert.Single(innerContainer);
             Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
@@ -577,7 +577,7 @@ End summary description.";
                 run => AssertExpectedClassification(run, "s", VSPredefinedClassificationTypeNames.Text));
 
             // [TagHelper Glyph] bool? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty
-            innerContainer = ((VSContainerElement)container[2]).Elements.ToList();
+            innerContainer = ((VSContainerElement)containerElements[2]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
             Assert.Equal(TagHelperGlyph, innerContainer[0]);
@@ -595,7 +595,7 @@ End summary description.";
                 run => AssertExpectedClassification(run, "AnotherProperty", VSPredefinedClassificationTypeNames.Identifier));
 
             // Uses List<string>s
-            innerContainer = ((VSContainerElement)container[3]).Elements.ToList();
+            innerContainer = ((VSContainerElement)containerElements[3]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[0];
             Assert.Single(innerContainer);
             Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
@@ -606,7 +606,7 @@ End summary description.";
                 run => AssertExpectedClassification(run, "s", VSPredefinedClassificationTypeNames.Text));
         }
 
-        private static void AssertExpectedClassification(
+        internal static void AssertExpectedClassification(
             VSClassifiedTextRun run,
             string expectedText,
             string expectedClassificationType,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -26,7 +26,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 
             // Expected output:
             //     Accepts List<string>s
-            Assert.Collection(runs, run => AssertExpectedClassification(run, "Accepts ", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(runs,
+                run =>AssertExpectedClassification(run, "Accepts ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "List", VSPredefinedClassificationTypeNames.Type),
                 run => AssertExpectedClassification(run, "<", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
@@ -48,7 +49,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 
             // Expected output:
             //     Accepts List<string>s
-            Assert.Collection(runs, run => AssertExpectedClassification(run, "Accepts ", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(runs,
+                run => AssertExpectedClassification(run, "Accepts ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "List", VSPredefinedClassificationTypeNames.Type),
                 run => AssertExpectedClassification(run, "<", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
@@ -95,7 +97,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 
             // Expected output:
             //     code: This is code and This is some other code.
-            Assert.Collection(runs, run => AssertExpectedClassification(run, "code: ", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(runs,
+                run => AssertExpectedClassification(run, "code: ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "This is code", VSPredefinedClassificationTypeNames.Text, VSClassifiedTextRunStyle.UseClassificationFont),
                 run => AssertExpectedClassification(run, " and ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "This is some other code", VSPredefinedClassificationTypeNames.Text, VSClassifiedTextRunStyle.UseClassificationFont),
@@ -167,7 +170,8 @@ End summary description.";
             // Expected output:
             //     Microsoft.AspNetCore.SomeTagHelper
             //     Uses List<List<string>>s
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "AspNetCore", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
@@ -206,7 +210,8 @@ End summary description.";
             // Expected output:
             //     Microsoft.AspNetCore.SomeTagHelper.SomeTagHelper
             //     Uses C<B>s
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "AspNetCore", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
@@ -246,7 +251,8 @@ End summary description.";
             //
             //     Microsoft.AspNetCore.OtherTagHelper
             //     Also uses List<string>s
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "AspNetCore", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
@@ -313,7 +319,8 @@ End summary description.";
             // Expected output:
             //     string Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeProperty
             //     Uses List<List<string>>s
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
                 run => AssertExpectedClassification(run, " ", VSPredefinedClassificationTypeNames.WhiteSpace),
                 run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
@@ -368,7 +375,8 @@ End summary description.";
             //
             //     bool? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty
             //     Uses List<string>s
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
                 run => AssertExpectedClassification(run, " ", VSPredefinedClassificationTypeNames.WhiteSpace),
                 run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
@@ -457,7 +465,8 @@ End summary description.";
             var classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
             Assert.Equal(ClassGlyph, innerContainer[0]);
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "AspNetCore", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
@@ -467,7 +476,8 @@ End summary description.";
             innerContainer = ((VSContainerElement)containerElements[1]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[0];
             Assert.Single(innerContainer);
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "List", VSPredefinedClassificationTypeNames.Type),
                 run => AssertExpectedClassification(run, "<", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
@@ -479,7 +489,8 @@ End summary description.";
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
             Assert.Equal(ClassGlyph, innerContainer[0]);
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "AspNetCore", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
@@ -489,7 +500,8 @@ End summary description.";
             innerContainer = ((VSContainerElement)containerElements[3]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[0];
             Assert.Single(innerContainer);
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Also uses ", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Also uses ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "List", VSPredefinedClassificationTypeNames.Type),
                 run => AssertExpectedClassification(run, "<", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
@@ -553,7 +565,8 @@ End summary description.";
             var classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
             Assert.Equal(PropertyGlyph, innerContainer[0]);
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
                 run => AssertExpectedClassification(run, " ", VSPredefinedClassificationTypeNames.WhiteSpace),
                 run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Punctuation),
@@ -569,7 +582,8 @@ End summary description.";
             innerContainer = ((VSContainerElement)containerElements[1]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[0];
             Assert.Single(innerContainer);
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "List", VSPredefinedClassificationTypeNames.Type),
                 run => AssertExpectedClassification(run, "<", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),
@@ -581,7 +595,8 @@ End summary description.";
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
             Assert.Equal(PropertyGlyph, innerContainer[0]);
-            Assert.Collection(classifiedTextElement.Runs,run => AssertExpectedClassification(run, "bool", VSPredefinedClassificationTypeNames.Keyword),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "bool", VSPredefinedClassificationTypeNames.Keyword),
                 run => AssertExpectedClassification(run, "?", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, " ", VSPredefinedClassificationTypeNames.WhiteSpace),
                 run => AssertExpectedClassification(run, "Microsoft", VSPredefinedClassificationTypeNames.Text),
@@ -598,7 +613,8 @@ End summary description.";
             innerContainer = ((VSContainerElement)containerElements[3]).Elements.ToList();
             classifiedTextElement = (VSClassifiedTextElement)innerContainer[0];
             Assert.Single(innerContainer);
-            Assert.Collection(classifiedTextElement.Runs, run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
+            Assert.Collection(classifiedTextElement.Runs,
+                run => AssertExpectedClassification(run, "Uses ", VSPredefinedClassificationTypeNames.Text),
                 run => AssertExpectedClassification(run, "List", VSPredefinedClassificationTypeNames.Type),
                 run => AssertExpectedClassification(run, "<", VSPredefinedClassificationTypeNames.Punctuation),
                 run => AssertExpectedClassification(run, "string", VSPredefinedClassificationTypeNames.Keyword),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             {
                 var initializeParams = new InitializeParams
                 {
-                    Capabilities = new ClientCapabilities
+                    Capabilities = new PlatformAgnosticClientCapabilities
                     {
                         TextDocument = new TextDocumentClientCapabilities
                         {
@@ -56,9 +56,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("test1", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Contains("**Test1TagHelper**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -74,9 +75,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -94,9 +96,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var service = GetDefaultRazorHoverInfoService();
             var edgeLocation = txt.IndexOf("bool-val", StringComparison.Ordinal) + "bool-val".Length;
             var location = new SourceLocation(edgeLocation, 0, edgeLocation);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -113,9 +116,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("true", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Null(hover);
@@ -129,9 +133,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("=", StringComparison.Ordinal) + 1, -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Null(hover);
@@ -145,9 +150,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("true'", StringComparison.Ordinal) + 5, -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Null(hover);
@@ -161,9 +167,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -186,9 +193,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var service = GetDefaultRazorHoverInfoService();
             var charIndex = txt.IndexOf("@test", StringComparison.Ordinal) + 2;
             var location = new SourceLocation(charIndex, -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.NotNull(hover);
@@ -205,9 +213,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("test1", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Contains("**Test1TagHelper**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -223,9 +232,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -242,9 +252,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("strong", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Null(hover);
@@ -261,9 +272,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             languageServer.ClientSettings.Capabilities.TextDocument.Hover.Value.ContentFormat = new Container<MarkupKind>(MarkupKind.PlainText);
             var service = GetDefaultRazorHoverInfoService(languageServer);
             var location = new SourceLocation(txt.IndexOf("test1", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = languageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Contains("Test1TagHelper", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -283,9 +295,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             languageServer.ClientSettings.Capabilities.TextDocument.Hover.Value.ContentFormat = new Container<MarkupKind>(MarkupKind.PlainText);
             var service = GetDefaultRazorHoverInfoService(languageServer);
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = languageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Contains("BoolVal", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -306,9 +319,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             languageServer.ClientSettings.Capabilities.TextDocument.Hover.Value.ContentFormat = new Container<MarkupKind>(MarkupKind.PlainText);
             var service = GetDefaultRazorHoverInfoService(languageServer);
             var location = new SourceLocation(txt.IndexOf("strong", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = languageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Null(hover);
@@ -325,9 +339,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             languageServer.ClientSettings.Capabilities.TextDocument.Hover.Value.ContentFormat = new Container<MarkupKind>(MarkupKind.PlainText);
             var service = GetDefaultRazorHoverInfoService(languageServer);
             var location = new SourceLocation(txt.IndexOf("weak", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = languageServer.ClientSettings.Capabilities;
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
             Assert.Null(hover);
@@ -341,12 +356,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("test1", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
+            ((PlatformAgnosticClientCapabilities)clientCapabilities).SupportsVisualStudioExtensions = true;
 
             // Act
-            var vsHover = (VSHover)service.GetHoverInfo(codeDocument, location, isVSClient: true);
+            var vsHover = (VSHover)service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
-            Assert.Contains("**Test1TagHelper**", vsHover.Contents.MarkupContent.Value, StringComparison.Ordinal);
+            Assert.False(vsHover.Contents.HasMarkupContent);
+            Assert.True(vsHover.Contents.HasMarkedStrings && !vsHover.Contents.MarkedStrings.Any());
             var expectedRange = new RangeModel(new Position(1, 1), new Position(1, 6));
             Assert.Equal(expectedRange, vsHover.Range);
 
@@ -359,7 +377,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var innerContainer = ((VSContainerElement)containerElements[0]).Elements.ToList();
             var classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
-            Assert.Equal(TagHelperGlyph, innerContainer[0]);
+            Assert.Equal(ClassGlyph, innerContainer[0]);
             Assert.Collection(classifiedTextElement.Runs,
                 run => DefaultVSLSPTagHelperTooltipFactoryTest.AssertExpectedClassification(run, "Test1TagHelper", VSPredefinedClassificationTypeNames.Type));
         }
@@ -372,13 +390,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
             var service = GetDefaultRazorHoverInfoService();
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
+            ((PlatformAgnosticClientCapabilities)clientCapabilities).SupportsVisualStudioExtensions = true;
 
             // Act
-            var vsHover = (VSHover)service.GetHoverInfo(codeDocument, location, isVSClient: true);
+            var vsHover = (VSHover)service.GetHoverInfo(codeDocument, location, clientCapabilities);
 
             // Assert
-            Assert.Contains("**BoolVal**", vsHover.Contents.MarkupContent.Value, StringComparison.Ordinal);
-            Assert.DoesNotContain("**IntVal**", vsHover.Contents.MarkupContent.Value, StringComparison.Ordinal);
+            Assert.False(vsHover.Contents.HasMarkupContent);
+            Assert.True(vsHover.Contents.HasMarkedStrings && !vsHover.Contents.MarkedStrings.Any());
             var expectedRange = new RangeModel(new Position(1, 7), new Position(1, 15));
             Assert.Equal(expectedRange, vsHover.Range);
 
@@ -391,7 +411,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var innerContainer = ((VSContainerElement)containerElements[0]).Elements.ToList();
             var classifiedTextElement = (VSClassifiedTextElement)innerContainer[1];
             Assert.Equal(2, innerContainer.Count);
-            Assert.Equal(TagHelperGlyph, innerContainer[0]);
+            Assert.Equal(PropertyGlyph, innerContainer[0]);
             Assert.Collection(classifiedTextElement.Runs,
                 run => DefaultVSLSPTagHelperTooltipFactoryTest.AssertExpectedClassification(run, "bool", VSPredefinedClassificationTypeNames.Keyword),
                 run => DefaultVSLSPTagHelperTooltipFactoryTest.AssertExpectedClassification(run, " ", VSPredefinedClassificationTypeNames.WhiteSpace),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("test1", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Contains("**Test1TagHelper**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(edgeLocation, 0, edgeLocation);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("true", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Null(hover);
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("=", StringComparison.Ordinal) + 1, -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Null(hover);
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("true'", StringComparison.Ordinal) + 5, -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Null(hover);
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(charIndex, -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.NotNull(hover);
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("test1", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Contains("**Test1TagHelper**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Contains("**BoolVal**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -242,7 +242,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("strong", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Null(hover);
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("test1", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Contains("Test1TagHelper", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -283,7 +283,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("bool-val", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Contains("BoolVal", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("strong", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Null(hover);
@@ -325,7 +325,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             var location = new SourceLocation(txt.IndexOf("weak", StringComparison.Ordinal), -1, -1);
 
             // Act
-            var hover = service.GetHoverInfo(codeDocument, location);
+            var hover = service.GetHoverInfo(codeDocument, location, isVSClient: false);
 
             // Assert
             Assert.Null(hover);
@@ -338,8 +338,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
                 languageServer = LanguageServer;
             }
 
-            var tagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory(languageServer);
-            return new DefaultRazorHoverInfoService(TagHelperFactsService, tagHelperTooltipFactory, HtmlFactsService);
+            var lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory(languageServer);
+            var vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory();
+            return new DefaultRazorHoverInfoService(TagHelperFactsService, lspTagHelperTooltipFactory, vsLspTagHelperTooltipFactory, HtmlFactsService);
         }
     }
 }


### PR DESCRIPTION
### Summary of the changes
 - Adds classifications for Razor TagHelper element/attribute quick info tooltips.
 - Some of the logic here can be reduced once LSP VSCompletionItems support returning ContainerElements instead of just ClassifiedTextElements, tracked by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1319274.

Before:
![image](https://user-images.githubusercontent.com/16968319/116830809-c9748980-ab60-11eb-94f3-71b606fc1947.png)

After:
![image](https://user-images.githubusercontent.com/16968319/116830637-81edfd80-ab60-11eb-9de2-d16e2a396704.png)

Fixes: 
https://github.com/dotnet/aspnetcore/issues/30224