### PR TITLE
Fix HTML formatting when using tabs

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -267,6 +267,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 // Get first non-whitespace character position
                 var nonWsPos = sourceText.Lines[i].GetFirstNonWhitespacePosition();
                 var existingIndentation = (nonWsPos ?? sourceText.Lines[i].End) - sourceText.Lines[i].Start;
+
+                // The existingIndentation above is measured in characters, and is used to create text edits
+                // The below is measured in columns, so takes into account tab size. This is useful for creating
+                // new indentation strings
+                var existingIndentationSize = sourceText.Lines[i].GetIndentationSize(options.TabSize);
+
                 var emptyOrWhitespaceLine = false;
                 if (nonWsPos == null)
                 {
@@ -284,6 +290,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                         HtmlIndentationLevel = span.HtmlIndentationLevel,
                         RelativeIndentationLevel = span.IndentationLevel - previousIndentationLevel,
                         ExistingIndentation = existingIndentation,
+                        ExistingIndentationSize = existingIndentationSize,
                         FirstSpan = span,
                         EmptyOrWhitespaceLine = emptyOrWhitespaceLine,
                     };
@@ -310,6 +317,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                         HtmlIndentationLevel = 0,
                         RelativeIndentationLevel = previousIndentationLevel,
                         ExistingIndentation = existingIndentation,
+                        ExistingIndentationSize = existingIndentation,
                         FirstSpan = placeholderSpan,
                         EmptyOrWhitespaceLine = emptyOrWhitespaceLine,
                     };

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
@@ -336,7 +336,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     {
                         // Given that the HTML formatter ran before this, we can assume
                         // HTML is already correctly formatted. So we can use the existing indentation as is.
-                        razorDesiredIndentation = context.Indentations[i].ExistingIndentation;
+                        // We need to make sure to use the indentation size, as this will get passed to
+                        // GetIndentationString eventually.
+                        razorDesiredIndentation = context.Indentations[i].ExistingIndentationSize;
                     }
                 }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     // Instead, we should just add to the existing indentation.
                     //
                     var razorDesiredIndentationString = context.GetIndentationLevelString(razorDesiredIndentationLevel);
-                    var existingIndentationString = context.GetIndentationString(context.Indentations[i].ExistingIndentation);
+                    var existingIndentationString = context.GetIndentationString(context.Indentations[i].ExistingIndentationSize);
                     var desiredIndentationString = existingIndentationString + razorDesiredIndentationString;
                     var spanToReplace = new TextSpan(line.Start, context.Indentations[i].ExistingIndentation);
                     var change = new TextChange(spanToReplace, desiredIndentationString);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IndentationContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IndentationContext.cs
@@ -15,6 +15,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public int RelativeIndentationLevel { get; set; }
 
+        /// <summary>
+        /// The number of characters of indentation there are on this line
+        /// </summary>
         public int ExistingIndentation { get; set; }
 
         public FormattingSpan FirstSpan { get; set; }
@@ -28,6 +31,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public bool StartsInRazorContext => !StartsInHtmlContext && !StartsInCSharpContext;
 
         public int MinCSharpIndentLevel => FirstSpan.MinCSharpIndentLevel;
+
+        /// <summary>
+        /// The amount of visual indentation there is on this line, taking into account tab size
+        /// </summary>
+        public int ExistingIndentationSize { get; internal set; }
 
         public override string ToString()
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextLineExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/TextLineExtensions.cs
@@ -14,6 +14,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return line.ToString().GetLeadingWhitespace();
         }
 
+        public static int GetIndentationSize(this TextLine line, long tabSize)
+        {
+            var text = line.Text;
+
+            var indentation = 0;
+            for (var i = line.Start; i < line.End; i++)
+            {
+                var c = text[i];
+                if (c == '\t')
+                {
+                    indentation += (int)tabSize;
+                }
+                else if (char.IsWhiteSpace(c))
+                {
+                    indentation++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return indentation;
+        }
+
         public static int? GetFirstNonWhitespacePosition(this TextLine line)
         {
             var firstNonWhitespaceOffset = line.GetFirstNonWhitespaceOffset();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -40,7 +40,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 TextDocument = new TextDocumentIdentifier(uri),
                 Character = ">",
-                Options = new FormattingOptions(),
+                Options = new FormattingOptions
+                {
+                    TabSize = 4,
+                    InsertSpaces = true
+                },
             };
 
             // Act
@@ -71,7 +75,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 TextDocument = new TextDocumentIdentifier(uri),
                 Character = ">",
-                Options = new FormattingOptions(),
+                Options = new FormattingOptions
+                {
+                    TabSize = 4,
+                    InsertSpaces = true
+                },
             };
 
             // Act
@@ -104,7 +112,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 TextDocument = new TextDocumentIdentifier(uri),
                 Character = ">",
-                Options = new FormattingOptions(),
+                Options = new FormattingOptions
+                {
+                    TabSize = 4,
+                    InsertSpaces = true
+                },
             };
 
             // Act
@@ -131,7 +143,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 TextDocument = new TextDocumentIdentifier(uri),
                 Character = "!",
-                Options = new FormattingOptions(),
+                Options = new FormattingOptions
+                {
+                    TabSize = 4,
+                    InsertSpaces = true
+                },
             };
 
             // Act
@@ -154,7 +170,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 TextDocument = new TextDocumentIdentifier(uri),
                 Character = ">",
-                Options = new FormattingOptions(),
+                Options = new FormattingOptions
+                {
+                    TabSize = 4,
+                    InsertSpaces = true
+                },
             };
 
             // Act
@@ -179,7 +199,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 TextDocument = new TextDocumentIdentifier(uri),
                 Character = ">",
-                Options = new FormattingOptions(),
+                Options = new FormattingOptions
+                {
+                    TabSize = 4,
+                    InsertSpaces = true
+                },
             };
 
             // Act
@@ -203,7 +227,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 TextDocument = new TextDocumentIdentifier(uri),
                 Character = ">",
-                Options = new FormattingOptions(),
+                Options = new FormattingOptions
+                {
+                    TabSize = 4,
+                    InsertSpaces = true
+                },
             };
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -416,6 +416,123 @@ expected: @"@code {
 ");
         }
 
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/26836")]
+        public async Task FormatNestedBlock_Tabs()
+        {
+            await RunFormattingTestAsync(
+input: @"@code {
+    public string DoSomething()
+    {
+        <strong>
+            @DateTime.Now.ToString()
+        </strong>
+
+        return String.Empty;
+    }
+}
+",
+expected: @"@code {
+	public string DoSomething()
+	{
+		<strong>
+			@DateTime.Now.ToString()
+		</strong>
+
+		return String.Empty;
+	}
+}
+",
+tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
+insertSpaces: false);
+        }
+
+        [Fact]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1273468/")]
+        public async Task FormatHtmlWithTabs1()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@page ""/""  
+@{
+ ViewData[""Title""] = ""Create"";
+ <hr />
+ <div class=""row"">
+  <div class=""col-md-4"">
+   <form method=""post"">
+    <div class=""form-group"">
+     <label asp-for=""Movie.Title"" class=""control-label""></label>
+     <input asp-for=""Movie.Title"" class=""form-control"" />
+     <span asp-validation-for=""Movie.Title"" class=""text-danger""></span>
+    </div>
+   </form>
+  </div>
+ </div>
+}
+",
+expected: @"@page ""/""
+@{
+	ViewData[""Title""] = ""Create"";
+	<hr />
+	<div class=""row"">
+		<div class=""col-md-4"">
+			<form method=""post"">
+				<div class=""form-group"">
+					<label asp-for=""Movie.Title"" class=""control-label""></label>
+					<input asp-for=""Movie.Title"" class=""form-control"" />
+					<span asp-validation-for=""Movie.Title"" class=""text-danger""></span>
+				</div>
+			</form>
+		</div>
+	</div>
+}
+",
+tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
+insertSpaces: false,
+fileKind: FileKinds.Legacy);
+        }
+
+        [Fact]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1273468/")]
+        public async Task FormatHtmlWithTabs2()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@page ""/""  
+
+ <hr />
+ <div class=""row"">
+  <div class=""col-md-4"">
+   <form method=""post"">
+    <div class=""form-group"">
+     <label asp-for=""Movie.Title"" class=""control-label""></label>
+     <input asp-for=""Movie.Title"" class=""form-control"" />
+     <span asp-validation-for=""Movie.Title"" class=""text-danger""></span>
+    </div>
+   </form>
+  </div>
+ </div>
+",
+expected: @"@page ""/""
+
+<hr />
+<div class=""row"">
+	<div class=""col-md-4"">
+		<form method=""post"">
+			<div class=""form-group"">
+				<label asp-for=""Movie.Title"" class=""control-label""></label>
+				<input asp-for=""Movie.Title"" class=""form-control"" />
+				<span asp-validation-for=""Movie.Title"" class=""text-danger""></span>
+			</div>
+		</form>
+	</div>
+</div>
+",
+tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
+insertSpaces: false,
+fileKind: FileKinds.Legacy);
+        }
+
         private IReadOnlyList<TagHelperDescriptor> GetComponents()
         {
             AdditionalSyntaxTrees.Add(Parse(@"


### PR DESCRIPTION
Fixes AB#1273468

(and in case that doesn't work, Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1273468/)

When reformatting we used to look at the existing formatting and base changes on that. When formatting things with tabs, that fell down because we'd see `\t\t` and think "oh, they want two spaces of indentation". This PR adds a new field so that we can think "oh, they want 8 columns of indentation" instead.