### PR TITLE
Merge interop branch into vs17.0 branch

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,9 +14,6 @@
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
     <!-- Used for BenchmarkDotNet prerelease packages -->
     <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
-    <!-- Dev17 Package sources -->
-    <add key="azure-public/vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <add key="azure-public/vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,7 +90,7 @@
     <!-- Several packages share the MS.CA.Testing version -->
     <Tooling_MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.21103.2</Tooling_MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.0.0-preview-2-31228-438</MicrosoftVisualStudioShellPackagesVersion>
-    <MicrosoftVisualStudioPackagesVersion>17.0.28-g439d20ddd3</MicrosoftVisualStudioPackagesVersion>
+    <MicrosoftVisualStudioPackagesVersion>17.0.35-gdeb9415fdc</MicrosoftVisualStudioPackagesVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
@@ -162,5 +162,6 @@
 
     <!-- Temporary hack to workaround package restrictions for dev17 -->
     <MicrosoftInternalVisualStudioShellFrameworkPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkPackageVersion>
+    <MicrosoftIORedistPackageVersion>4.7.1</MicrosoftIORedistPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -91,11 +91,11 @@
     <Tooling_MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.21103.2</Tooling_MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.0.0-preview-2-31228-438</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.0.35-gdeb9415fdc</MicrosoftVisualStudioPackagesVersion>
+    <RoslynPackageVersion>3.10.0-2.21179.6</RoslynPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <BenchmarkDotNetPackageVersion>0.12.1.1466</BenchmarkDotNetPackageVersion>
-    <MicrosoftBuildFrameworkPackageVersion>16.8.0</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.8.0</MicrosoftBuildPackageVersion>
     <MicrosoftNETCoreApp50PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp50PackageVersion>
@@ -103,17 +103,12 @@
     <MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>
     <MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>3.9.0-2.20573.10</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftServiceHubFrameworkPackageVersion>2.7.2466</MicrosoftServiceHubFrameworkPackageVersion>
-    <MicrosoftVisualStudioComponentModelHostPackageVersion>17.0.32-g9d6b2c6f26</MicrosoftVisualStudioComponentModelHostPackageVersion>
-    <MicrosoftVisualStudioImageCatalogPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImageCatalogPackageVersion>
     <MicrosoftVisualStudioEditorPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioEditorPackageVersion>
     <MicrosoftVisualStudioLanguagePackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioLanguagePackageVersion>
     <MicrosoftVisualStudioLanguageIntellisensePackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioLanguageIntellisensePackageVersion>
     <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>17.0.1023-g6bffc2ffdf</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
-    <MicrosoftVisualStudioUtilitiesPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioUtilitiesPackageVersion>
     <MicrosoftVisualStudioLiveSharePackageVersion>0.3.1074</MicrosoftVisualStudioLiveSharePackageVersion>
     <MicrosoftVisualStudioProjectSystemSDKPackageVersion>16.10.81-pre</MicrosoftVisualStudioProjectSystemSDKPackageVersion>
-    <MicrosoftVisualStudioRpcContractsPackageVersion>16.10.14-alpha</MicrosoftVisualStudioRpcContractsPackageVersion>
     <MicrosoftVisualStudioShell150PackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShell150PackageVersion>
     <MicrosoftVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropPackageVersion>
     <MicrosoftVisualStudioTextDataPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextDataPackageVersion>
@@ -130,32 +125,21 @@
     <MonoAddinsPackageVersion>1.3.8</MonoAddinsPackageVersion>
     <MonoDevelopSdkPackageVersion>1.0.15</MonoDevelopSdkPackageVersion>
     <MoqPackageVersion>4.16.0</MoqPackageVersion>
-    <!-- STOP!!! We need to reference the version of JSON that our HOSTS support. -->
-    <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
     <OmniSharpExtensionsLanguageServerPackageVersion>0.18.1</OmniSharpExtensionsLanguageServerPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.33.0</OmniSharpMSBuildPackageVersion>
-    <StreamJsonRpcPackageVersion>2.8.21</StreamJsonRpcPackageVersion>
-    <SystemPrivateUriPackageVersion>4.3.2</SystemPrivateUriPackageVersion>
-    <SystemCompositionPackageVersion>1.0.31.0</SystemCompositionPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>5.0.0</SystemCollectionsImmutablePackageVersion>
-    <SystemIOPipelinesPackageVersion>5.0.1</SystemIOPipelinesPackageVersion>
-    <VSMAC_NewtonsoftJsonPackageVersion>12.0.2</VSMAC_NewtonsoftJsonPackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.3.2</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>6.0.0-preview3.21158.1</Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCommonPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisCommonPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)</Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>
     <Tooling_RoslynDiagnosticsAnalyzersPackageVersion>$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)</Tooling_RoslynDiagnosticsAnalyzersPackageVersion>
-    <Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>3.10.0-2.21179.6</Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitCombinatorialPackageVersion>1.4.1</XunitCombinatorialPackageVersion>
     <XunitVersion>2.4.1</XunitVersion>

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
@@ -41,7 +41,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
   </ItemGroup>
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/Microsoft.AspNetCore.Razor.LanguageServer.Common.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion)"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion)"/>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -14,7 +14,6 @@
     
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="$(OmniSharpExtensionsLanguageServerPackageVersion)" />
-    <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
@@ -15,8 +15,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="$(Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.NonCapturingTimer.Sources" Version="$(MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion)" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
@@ -24,12 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguagePackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(Tooling_MicrosoftCodeAnalysisCSharpPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(Tooling_MicrosoftCodeAnalysisCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="$(Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="$(Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Microsoft.VisualStudio.Editor.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Microsoft.VisualStudio.Editor.Razor.csproj
@@ -9,14 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="$(Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisensePackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language" Version="$(MicrosoftVisualStudioLanguagePackageVersion)" />
-    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
-    <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Composition" Version="$(SystemCompositionPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client.Implementation" Version="$(MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion)" />
   </ItemGroup>
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -17,24 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
-    <PackageReference Include="System.Composition" Version="$(SystemCompositionPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
-    <PackageReference Include="Microsoft.ServiceHub.Framework" Version="$(MicrosoftServiceHubFrameworkPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropPackageVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkPackageVersion)" />
   </ItemGroup>
-
-    <!-- Workaround for Microsoft.VisualStudio.SDK.EmbedInteropTypes not working correctly-->
-  <Target Name="_EmbeddedAssemblyWorkaround" DependsOnTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)'=='Microsoft.VisualStudio.Shell.Interop.11.0'">
-        <EmbedInteropTypes>false</EmbedInteropTypes>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -25,12 +25,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Package changes to enable dev17 builds that have incoherent versions -->
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
   </ItemGroup>
 
     <!-- Workaround for Microsoft.VisualStudio.SDK.EmbedInteropTypes not working correctly-->

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
@@ -10,21 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(Tooling_MicrosoftCodeAnalysisPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(Tooling_MicrosoftCodeAnalysisCommonPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="$(Tooling_MicrosoftCodeAnalysisFeaturesPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="$(MicrosoftNETSdkRazorPackageVersion)" IncludeAssets="None" PrivateAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisensePackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
-    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
-    <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropPackageVersion)" />
   </ItemGroup>
 
@@ -35,15 +24,6 @@
   <ItemGroup>
     <Reference Include="System.Xaml" />
   </ItemGroup>
-
-  <!-- Workaround for Microsoft.VisualStudio.SDK.EmbedInteropTypes not working correctly-->
-  <Target Name="_EmbeddedAssemblyWorkaround" DependsOnTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)'=='Microsoft.VisualStudio.Shell.Interop.11.0'">
-        <EmbedInteropTypes>false</EmbedInteropTypes>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 
   <!--
     The ProjectSystem.SDK tasks that handle XamlPropertyRule don't work on the dotnet core version

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
@@ -21,17 +21,11 @@
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisensePackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" Version="$(MicrosoftVisualStudioRpcContractsPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Package changes to enable dev17 builds that have incoherent versions -->
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="MonoDevelop.Sdk" Version="$(MonoDevelopSdkPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(VSMAC_NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguagePackageVersion)"/>
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(Tooling_MicrosoftCodeAnalysisCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(Tooling_MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="$(MicrosoftCodeAnalysisRazorPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.XUnit" Version="$(MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion)" />

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
@@ -17,10 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
   </ItemGroup>
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/Microsoft.CodeAnalysis.Remote.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/Microsoft.CodeAnalysis.Remote.Razor.Test.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
-    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Microsoft.VisualStudio.Editor.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Microsoft.VisualStudio.Editor.Razor.Test.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion)"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion)"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(Tooling_MicrosoftCodeAnalysisCommonPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
   </ItemGroup>
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Documents/VisualStudioFileChangeTrackerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Documents/VisualStudioFileChangeTrackerTest.cs
@@ -15,124 +15,124 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
 {
     public class VisualStudioFileChangeTrackerTest : ForegroundDispatcherTestBase
     {
-        // public VisualStudioFileChangeTrackerTest()
-        // {
-        //     var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
-        //     JoinableTaskFactory = new JoinableTaskFactory(joinableTaskContext.Context);
-        // }
+        public VisualStudioFileChangeTrackerTest()
+        {
+            var joinableTaskContext = new JoinableTaskContextNode(new JoinableTaskContext());
+            JoinableTaskFactory = new JoinableTaskFactory(joinableTaskContext.Context);
+        }
 
-        // private ErrorReporter ErrorReporter { get; } = new DefaultErrorReporter();
+        private ErrorReporter ErrorReporter { get; } = new DefaultErrorReporter();
 
-        // private JoinableTaskFactory JoinableTaskFactory { get; }
+        private JoinableTaskFactory JoinableTaskFactory { get; }
 
-        // [ForegroundFact]
-        // public async Task StartListening_AdvisesForFileChange()
-        // {
-        //     // Arrange
-        //     var fileChangeService = new Mock<IVsAsyncFileChangeEx>(MockBehavior.Strict);
-        //     fileChangeService
-        //         .Setup(f => f.AdviseFileChangeAsync(It.IsAny<string>(), It.IsAny<_VSFILECHANGEFLAGS>(), It.IsAny<IVsFreeThreadedFileChangeEvents2>(), It.IsAny<CancellationToken>()))
-        //         .Returns(Task.FromResult<uint>(123))
-        //         .Verifiable();
-        //     var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object, JoinableTaskFactory);
+        [ForegroundFact]
+        public async Task StartListening_AdvisesForFileChange()
+        {
+            // Arrange
+            var fileChangeService = new Mock<IVsAsyncFileChangeEx>(MockBehavior.Strict);
+            fileChangeService
+                .Setup(f => f.AdviseFileChangeAsync(It.IsAny<string>(), It.IsAny<_VSFILECHANGEFLAGS>(), It.IsAny<IVsFreeThreadedFileChangeEvents2>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<uint>(123))
+                .Verifiable();
+            var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object, JoinableTaskFactory);
 
-        //     // Act
-        //     tracker.StartListening();
-        //     await tracker._fileChangeAdviseTask;
+            // Act
+            tracker.StartListening();
+            await tracker._fileChangeAdviseTask;
 
-        //     // Assert
-        //     fileChangeService.Verify();
-        // }
+            // Assert
+            fileChangeService.Verify();
+        }
 
-        // [ForegroundFact]
-        // public async Task StartListening_AlreadyListening_DoesNothing()
-        // {
-        //     // Arrange
-        //     var callCount = 0;
-        //     var fileChangeService = new Mock<IVsAsyncFileChangeEx>(MockBehavior.Strict);
-        //     fileChangeService
-        //         .Setup(f => f.AdviseFileChangeAsync(It.IsAny<string>(), It.IsAny<_VSFILECHANGEFLAGS>(), It.IsAny<IVsFreeThreadedFileChangeEvents2>(), It.IsAny<CancellationToken>()))
-        //         .Returns(Task.FromResult<uint>(123))
-        //         .Callback(() => callCount++);
-        //     var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object, JoinableTaskFactory);
-        //     tracker.StartListening();
+        [ForegroundFact]
+        public async Task StartListening_AlreadyListening_DoesNothing()
+        {
+            // Arrange
+            var callCount = 0;
+            var fileChangeService = new Mock<IVsAsyncFileChangeEx>(MockBehavior.Strict);
+            fileChangeService
+                .Setup(f => f.AdviseFileChangeAsync(It.IsAny<string>(), It.IsAny<_VSFILECHANGEFLAGS>(), It.IsAny<IVsFreeThreadedFileChangeEvents2>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<uint>(123))
+                .Callback(() => callCount++);
+            var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object, JoinableTaskFactory);
+            tracker.StartListening();
 
-        //     // Act
-        //     tracker.StartListening();
-        //     await tracker._fileChangeAdviseTask;
+            // Act
+            tracker.StartListening();
+            await tracker._fileChangeAdviseTask;
 
-        //     // Assert
-        //     Assert.Equal(1, callCount);
-        // }
+            // Assert
+            Assert.Equal(1, callCount);
+        }
 
-        // [ForegroundFact]
-        // public async Task StopListening_UnadvisesForFileChange()
-        // {
-        //     // Arrange
-        //     var fileChangeService = new Mock<IVsAsyncFileChangeEx>(MockBehavior.Strict);
-        //     fileChangeService
-        //         .Setup(f => f.AdviseFileChangeAsync(It.IsAny<string>(), It.IsAny<_VSFILECHANGEFLAGS>(), It.IsAny<IVsFreeThreadedFileChangeEvents2>(), It.IsAny<CancellationToken>()))
-        //         .Returns(Task.FromResult<uint>(123))
-        //         .Verifiable();
-        //     fileChangeService
-        //         .Setup(f => f.UnadviseFileChangeAsync(123, It.IsAny<CancellationToken>()))
-        //         .Verifiable();
-        //     var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object, JoinableTaskFactory);
-        //     tracker.StartListening(); // Start listening for changes.
-        //     await tracker._fileChangeAdviseTask;
+        [ForegroundFact]
+        public async Task StopListening_UnadvisesForFileChange()
+        {
+            // Arrange
+            var fileChangeService = new Mock<IVsAsyncFileChangeEx>(MockBehavior.Strict);
+            fileChangeService
+                .Setup(f => f.AdviseFileChangeAsync(It.IsAny<string>(), It.IsAny<_VSFILECHANGEFLAGS>(), It.IsAny<IVsFreeThreadedFileChangeEvents2>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<uint>(123))
+                .Verifiable();
+            fileChangeService
+                .Setup(f => f.UnadviseFileChangeAsync(123, It.IsAny<CancellationToken>()))
+                .Verifiable();
+            var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object, JoinableTaskFactory);
+            tracker.StartListening(); // Start listening for changes.
+            await tracker._fileChangeAdviseTask;
 
-        //     // Act
-        //     tracker.StopListening();
-        //     await tracker._fileChangeUnadviseTask;
+            // Act
+            tracker.StopListening();
+            await tracker._fileChangeUnadviseTask;
 
-        //     // Assert
-        //     fileChangeService.Verify();
-        // }
+            // Assert
+            fileChangeService.Verify();
+        }
 
-        // [ForegroundFact]
-        // public void StopListening_NotListening_DoesNothing()
-        // {
-        //     // Arrange
-        //     var fileChangeService = new Mock<IVsAsyncFileChangeEx>(MockBehavior.Strict);
-        //     fileChangeService
-        //         .Setup(f => f.UnadviseFileChangeAsync(123, It.IsAny<CancellationToken>()))
-        //         .Throws(new InvalidOperationException());
-        //     var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object, JoinableTaskFactory);
+        [ForegroundFact]
+        public void StopListening_NotListening_DoesNothing()
+        {
+            // Arrange
+            var fileChangeService = new Mock<IVsAsyncFileChangeEx>(MockBehavior.Strict);
+            fileChangeService
+                .Setup(f => f.UnadviseFileChangeAsync(123, It.IsAny<CancellationToken>()))
+                .Throws(new InvalidOperationException());
+            var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object, JoinableTaskFactory);
 
-        //     // Act
-        //     tracker.StopListening();
+            // Act
+            tracker.StopListening();
 
-        //     // Assert
-        //     Assert.Null(tracker._fileChangeUnadviseTask);
-        // }
+            // Assert
+            Assert.Null(tracker._fileChangeUnadviseTask);
+        }
 
-        // [ForegroundTheory]
-        // [InlineData((uint)_VSFILECHANGEFLAGS.VSFILECHG_Size, (int)FileChangeKind.Changed)]
-        // [InlineData((uint)_VSFILECHANGEFLAGS.VSFILECHG_Time, (int)FileChangeKind.Changed)]
-        // [InlineData((uint)_VSFILECHANGEFLAGS.VSFILECHG_Add, (int)FileChangeKind.Added)]
-        // [InlineData((uint)_VSFILECHANGEFLAGS.VSFILECHG_Del, (int)FileChangeKind.Removed)]
-        // public async Task FilesChanged_WithSpecificFlags_InvokesChangedHandler_WithExpectedArguments(uint fileChangeFlag, int expectedKind)
-        // {
-        //     // Arrange
-        //     var filePath = TestProjectData.SomeProjectImportFile.FilePath;
-        //     var fileChangeService = Mock.Of<IVsAsyncFileChangeEx>(MockBehavior.Strict);
-        //     var tracker = new VisualStudioFileChangeTracker(filePath, Dispatcher, ErrorReporter, fileChangeService, JoinableTaskFactory);
+        [ForegroundTheory]
+        [InlineData((uint)_VSFILECHANGEFLAGS.VSFILECHG_Size, (int)FileChangeKind.Changed)]
+        [InlineData((uint)_VSFILECHANGEFLAGS.VSFILECHG_Time, (int)FileChangeKind.Changed)]
+        [InlineData((uint)_VSFILECHANGEFLAGS.VSFILECHG_Add, (int)FileChangeKind.Added)]
+        [InlineData((uint)_VSFILECHANGEFLAGS.VSFILECHG_Del, (int)FileChangeKind.Removed)]
+        public async Task FilesChanged_WithSpecificFlags_InvokesChangedHandler_WithExpectedArguments(uint fileChangeFlag, int expectedKind)
+        {
+            // Arrange
+            var filePath = TestProjectData.SomeProjectImportFile.FilePath;
+            var fileChangeService = Mock.Of<IVsAsyncFileChangeEx>(MockBehavior.Strict);
+            var tracker = new VisualStudioFileChangeTracker(filePath, Dispatcher, ErrorReporter, fileChangeService, JoinableTaskFactory);
 
-        //     var called = false;
-        //     tracker.Changed += (sender, args) =>
-        //     {
-        //         called = true;
-        //         Assert.Same(sender, tracker);
-        //         Assert.Equal(filePath, args.FilePath);
-        //         Assert.Equal((FileChangeKind)expectedKind, args.Kind);
-        //     };
+            var called = false;
+            tracker.Changed += (sender, args) =>
+            {
+                called = true;
+                Assert.Same(sender, tracker);
+                Assert.Equal(filePath, args.FilePath);
+                Assert.Equal((FileChangeKind)expectedKind, args.Kind);
+            };
 
-        //     // Act
-        //     tracker.FilesChanged(fileCount: 1, filePaths: new[] { filePath }, fileChangeFlags: new[] { fileChangeFlag });
-        //     await tracker._fileChangedTask;
+            // Act
+            tracker.FilesChanged(fileCount: 1, filePaths: new[] { filePath }, fileChangeFlags: new[] { fileChangeFlag });
+            await tracker._fileChangedTask;
 
-        //     // Assert
-        //     Assert.True(called);
-        // }
+            // Assert
+            Assert.True(called);
+        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -42,8 +42,12 @@
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="$(Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisensePackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" Version="$(MicrosoftVisualStudioRpcContractsPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Package changes to enable dev17 builds that have incoherent versions -->
+    <PackageReference Include="Microsoft.IO.Redist" Version="4.7.1"/>
   </ItemGroup>
 </Project>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -34,16 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(Tooling_MicrosoftCodeAnalysisCommonPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(Tooling_MicrosoftCodeAnalysisCSharpPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="$(Tooling_MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisensePackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
@@ -19,765 +19,656 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     public class DefaultRazorProjectHostTest : ForegroundDispatcherWorkspaceTestBase
     {
-        // public DefaultRazorProjectHostTest()
-        // {
-        //     ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace);
-
-        //     var projectConfigurationFilePathStore = new Mock<ProjectConfigurationFilePathStore>(MockBehavior.Strict);
-        //     projectConfigurationFilePathStore.Setup(s => s.Remove(It.IsAny<string>())).Verifiable();
-        //     ProjectConfigurationFilePathStore = projectConfigurationFilePathStore.Object;
-
-        //     ConfigurationItems = new ItemCollection(Rules.RazorConfiguration.SchemaName);
-        //     ExtensionItems = new ItemCollection(Rules.RazorExtension.SchemaName);
-        //     RazorComponentWithTargetPathItems = new ItemCollection(Rules.RazorComponentWithTargetPath.SchemaName);
-        //     RazorGenerateWithTargetPathItems = new ItemCollection(Rules.RazorGenerateWithTargetPath.SchemaName);
-        //     RazorGeneralProperties = new PropertyCollection(Rules.RazorGeneral.SchemaName);
-
-        //     JoinableTaskContext = new JoinableTaskContext();
-        // }
-
-        // private ItemCollection ConfigurationItems { get; }
-
-        // private ItemCollection ExtensionItems { get; }
-
-        // private ProjectConfigurationFilePathStore ProjectConfigurationFilePathStore { get; }
-
-        // private ItemCollection RazorComponentWithTargetPathItems { get; }
-
-        // private ItemCollection RazorGenerateWithTargetPathItems { get; }
-
-        // private PropertyCollection RazorGeneralProperties { get; }
-
-        // private TestProjectSnapshotManager ProjectManager { get; }
-
-        // private JoinableTaskContext JoinableTaskContext { get; }
-
-        // [Fact]
-        // public void TryGetDefaultConfiguration_FailsIfNoRule()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(defaultConfiguration);
-        // }
-
-        // [Fact]
-        // public void TryGetDefaultConfiguration_FailsIfNoConfiguration()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(Rules.RazorGeneral.SchemaName, new Dictionary<string, string>())
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(defaultConfiguration);
-        // }
-
-        // [Fact]
-        // public void TryGetDefaultConfiguration_FailsIfEmptyConfiguration()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = string.Empty
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(defaultConfiguration);
-        // }
-
-        // [Fact]
-        // public void TryGetDefaultConfiguration_SucceedsWithValidConfiguration()
-        // {
-        //     // Arrange
-        //     var expectedConfiguration = "Razor-13.37";
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = expectedConfiguration
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Equal(expectedConfiguration, defaultConfiguration);
-        // }
-
-        // [Fact]
-        // public void TryGetLanguageVersion_FailsIfNoRule()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(languageVersion);
-        // }
-
-        // [Fact]
-        // public void TryGetLanguageVersion_FailsIfNoLanguageVersion()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(Rules.RazorGeneral.SchemaName, new Dictionary<string, string>())
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(languageVersion);
-        // }
-
-        // [Fact]
-        // public void TryGetLanguageVersion_FailsIfEmptyLanguageVersion()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorLangVersionProperty] = string.Empty
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(languageVersion);
-        // }
-
-        // [Fact]
-        // public void TryGetLanguageVersion_SucceedsWithValidLanguageVersion()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0"
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Same(RazorLanguageVersion.Version_1_0, languageVersion);
-        // }
-
-        // [Fact]
-        // public void TryGetLanguageVersion_SucceedsWithUnknownLanguageVersion_DefaultsToLatest()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorLangVersionProperty] = "13.37"
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Same(RazorLanguageVersion.Latest, languageVersion);
-        // }
-
-        // [Fact]
-        // public void TryGetConfigurationItem_FailsNoRazorConfigurationRule()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
-
-        //     // Assert
-        //     Assert.False(result);
-        // }
-
-        // [Fact]
-        // public void TryGetConfigurationItem_FailsNoRazorConfigurationItems()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorConfiguration.SchemaName,
-        //             new Dictionary<string, Dictionary<string, string>>())
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
-
-        //     // Assert
-        //     Assert.False(result);
-        // }
-
-        // [Fact]
-        // public void TryGetConfigurationItem_FailsNoMatchingRazorConfigurationItems()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorConfiguration.SchemaName,
-        //             new Dictionary<string, Dictionary<string, string>>()
-        //             {
-        //                 ["Razor-10.0"] = new Dictionary<string, string>(),
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
-
-        //     // Assert
-        //     Assert.False(result);
-        // }
-
-        // [Fact]
-        // public void TryGetConfigurationItem_SucceedsForMatchingConfigurationItem()
-        // {
-        //     // Arrange
-        //     var expectedConfiguration = "Razor-13.37";
-        //     var expectedConfigurationValue = new Dictionary<string, string>()
-        //     {
-        //         [Rules.RazorConfiguration.ExtensionsProperty] = "SomeExtension"
-        //     };
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorConfiguration.SchemaName,
-        //             new Dictionary<string, Dictionary<string, string>>()
-        //         {
-        //             [expectedConfiguration] = expectedConfigurationValue
-        //         })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfigurationItem(expectedConfiguration, projectState, out var configurationItem);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Equal(expectedConfiguration, configurationItem.Key);
-        //     Assert.True(Enumerable.SequenceEqual(expectedConfigurationValue, configurationItem.Value));
-        // }
-
-        // [Fact]
-        // public void GetExtensionNames_SucceedsWithNoExtensions()
-        // {
-        //     // Arrange
-        //     var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
-        //     items.Item("Test");
-
-        //     var item = items.ToSnapshot().Items.Single();
-
-        //     // Act
-        //     var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
-
-        //     // Assert
-        //     Assert.Empty(extensionNames);
-        // }
-
-        // [Fact]
-        // public void GetExtensionNames_SucceedsWithEmptyExtensions()
-        // {
-        //     // Arrange
-        //     var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
-        //     items.Item("Test");
-        //     items.Property("Test", Rules.RazorConfiguration.ExtensionsProperty, string.Empty);
-
-        //     var item = items.ToSnapshot().Items.Single();
-
-        //     // Act
-        //     var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
-
-        //     // Assert
-        //     Assert.Empty(extensionNames);
-        // }
-
-        // [Fact]
-        // public void GetExtensionNames_SucceedsIfSingleExtension()
-        // {
-        //     // Arrange
-        //     var expectedExtensionName = "SomeExtensionName";
-
-        //     var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
-        //     items.Item("Test");
-        //     items.Property("Test", Rules.RazorConfiguration.ExtensionsProperty, "SomeExtensionName");
-
-        //     var item = items.ToSnapshot().Items.Single();
-
-        //     // Act
-        //     var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
-
-        //     // Assert
-        //     var extensionName = Assert.Single(extensionNames);
-        //     Assert.Equal(expectedExtensionName, extensionName);
-        // }
-
-        // [Fact]
-        // public void GetExtensionNames_SucceedsIfMultipleExtensions()
-        // {
-        //     // Arrange
-        //     var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
-        //     items.Item("Test");
-        //     items.Property("Test", Rules.RazorConfiguration.ExtensionsProperty, "SomeExtensionName;SomeOtherExtensionName");
-
-        //     var item = items.ToSnapshot().Items.Single();
-
-        //     // Act
-        //     var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
-
-        //     // Assert
-        //     Assert.Collection(
-        //         extensionNames,
-        //         name => Assert.Equal("SomeExtensionName", name),
-        //         name => Assert.Equal("SomeOtherExtensionName", name));
-        // }
-
-        // [Fact]
-        // public void TryGetExtensions_SucceedsWhenExtensionsNotFound()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Empty(extensions);
-        // }
-
-        // [Fact]
-        // public void TryGetExtensions_SucceedsWithUnConfiguredExtensionTypes()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorExtension.PrimaryDataSourceItemType] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorExtension.PrimaryDataSourceItemType,
-        //             new Dictionary<string, Dictionary<string, string>>()
-        //             {
-        //                 ["UnconfiguredExtensionName"] = new Dictionary<string, string>()
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Empty(extensions);
-        // }
-
-        // [Fact]
-        // public void TryGetExtensions_SucceedsWithSomeConfiguredExtensions()
-        // {
-        //     // Arrange
-        //     var expectedExtension1Name = "Extension1";
-        //     var expectedExtension2Name = "Extension2";
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorExtension.PrimaryDataSourceItemType] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorExtension.PrimaryDataSourceItemType,
-        //             new Dictionary<string, Dictionary<string, string>>()
-        //             {
-        //                 ["UnconfiguredExtensionName"] = new Dictionary<string, string>(),
-        //                 [expectedExtension1Name] = new Dictionary<string, string>(),
-        //                 [expectedExtension2Name] = new Dictionary<string, string>(),
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetExtensions(new[] { expectedExtension1Name, expectedExtension2Name }, projectState, out var extensions);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Collection(
-        //         extensions,
-        //         extension => Assert.Equal(expectedExtension2Name, extension.ExtensionName),
-        //         extension => Assert.Equal(expectedExtension1Name, extension.ExtensionName));
-        // }
-
-        // [Fact]
-        // public void TryGetConfiguration_FailsIfNoDefaultConfiguration()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(configuration);
-        // }
-
-        // [Fact]
-        // public void TryGetConfiguration_FailsIfNoLanguageVersion()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "13.37"
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(configuration);
-        // }
-
-        // [Fact]
-        // public void TryGetConfiguration_FailsIfNoConfigurationItems()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "13.37",
-        //                 [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(configuration);
-        // }
-
-        // [Fact]
-        // public void TryGetConfiguration_SucceedsWithNoConfiguredExtensionNames()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "Razor-13.37",
-        //                 [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
-        //             }),
-        //         [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorConfiguration.SchemaName,
-        //             new Dictionary<string, Dictionary<string, string>>()
-        //             {
-        //                 ["Razor-13.37"] = new Dictionary<string, string>()
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Equal(RazorLanguageVersion.Version_1_0, configuration.LanguageVersion);
-        //     Assert.Equal("Razor-13.37", configuration.ConfigurationName);
-        //     Assert.Empty(configuration.Extensions);
-        // }
-
-        // [Fact]
-        // public void TryGetConfiguration_IgnoresMissingExtension()
-        // {
-        //     // Arrange
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "13.37",
-        //                 [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
-        //             }),
-        //         [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorConfiguration.SchemaName,
-        //             new Dictionary<string, Dictionary<string, string>>()
-        //             {
-        //                 ["13.37"] = new Dictionary<string, string>()
-        //                 {
-        //                     ["Extensions"] = "Razor-13.37"
-        //                 }
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Empty(configuration.Extensions);
-        // }
-
-        // // This is more of an integration test but is here to test the overall flow/functionality
-        // [Fact]
-        // public void TryGetConfiguration_SucceedsWithAllPreRequisites()
-        // {
-        //     // Arrange
-        //     var expectedLanguageVersion = RazorLanguageVersion.Version_1_0;
-        //     var expectedConfigurationName = "Razor-Test";
-        //     var expectedExtension1Name = "Extension1";
-        //     var expectedExtension2Name = "Extension2";
-        //     var projectState = new Dictionary<string, IProjectRuleSnapshot>()
-        //     {
-        //         [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
-        //             Rules.RazorGeneral.SchemaName,
-        //             new Dictionary<string, string>()
-        //             {
-        //                 [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = expectedConfigurationName,
-        //                 [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
-        //             }),
-        //         [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorConfiguration.SchemaName,
-        //             new Dictionary<string, Dictionary<string, string>>()
-        //             {
-        //                 ["UnconfiguredRazorConfiguration"] = new Dictionary<string, string>()
-        //                 {
-        //                     ["Extensions"] = "Razor-9.0"
-        //                 },
-        //                 [expectedConfigurationName] = new Dictionary<string, string>()
-        //                 {
-        //                     ["Extensions"] = expectedExtension1Name + ";" + expectedExtension2Name
-        //                 }
-        //             }),
-        //         [Rules.RazorExtension.PrimaryDataSourceItemType] = TestProjectRuleSnapshot.CreateItems(
-        //             Rules.RazorExtension.PrimaryDataSourceItemType,
-        //             new Dictionary<string, Dictionary<string, string>>()
-        //             {
-        //                 [expectedExtension1Name] = new Dictionary<string, string>(),
-        //                 [expectedExtension2Name] = new Dictionary<string, string>(),
-        //             })
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Equal(expectedLanguageVersion, configuration.LanguageVersion);
-        //     Assert.Equal(expectedConfigurationName, configuration.ConfigurationName);
-        //     Assert.Collection(
-        //         configuration.Extensions.OrderBy(e => e.ExtensionName),
-        //         extension => Assert.Equal(expectedExtension1Name, extension.ExtensionName),
-        //         extension => Assert.Equal(expectedExtension2Name, extension.ExtensionName));
-        // }
+        public DefaultRazorProjectHostTest()
+        {
+            ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace);
+
+            var projectConfigurationFilePathStore = new Mock<ProjectConfigurationFilePathStore>(MockBehavior.Strict);
+            projectConfigurationFilePathStore.Setup(s => s.Remove(It.IsAny<string>())).Verifiable();
+            ProjectConfigurationFilePathStore = projectConfigurationFilePathStore.Object;
+
+            ConfigurationItems = new ItemCollection(Rules.RazorConfiguration.SchemaName);
+            ExtensionItems = new ItemCollection(Rules.RazorExtension.SchemaName);
+            RazorComponentWithTargetPathItems = new ItemCollection(Rules.RazorComponentWithTargetPath.SchemaName);
+            RazorGenerateWithTargetPathItems = new ItemCollection(Rules.RazorGenerateWithTargetPath.SchemaName);
+            RazorGeneralProperties = new PropertyCollection(Rules.RazorGeneral.SchemaName);
+
+            JoinableTaskContext = new JoinableTaskContext();
+        }
+
+        private ItemCollection ConfigurationItems { get; }
+
+        private ItemCollection ExtensionItems { get; }
+
+        private ProjectConfigurationFilePathStore ProjectConfigurationFilePathStore { get; }
+
+        private ItemCollection RazorComponentWithTargetPathItems { get; }
+
+        private ItemCollection RazorGenerateWithTargetPathItems { get; }
+
+        private PropertyCollection RazorGeneralProperties { get; }
+
+        private TestProjectSnapshotManager ProjectManager { get; }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        [Fact]
+        public void TryGetDefaultConfiguration_FailsIfNoRule()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(defaultConfiguration);
+        }
+
+        [Fact]
+        public void TryGetDefaultConfiguration_FailsIfNoConfiguration()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(Rules.RazorGeneral.SchemaName, new Dictionary<string, string>())
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(defaultConfiguration);
+        }
+
+        [Fact]
+        public void TryGetDefaultConfiguration_FailsIfEmptyConfiguration()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = string.Empty
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(defaultConfiguration);
+        }
+
+        [Fact]
+        public void TryGetDefaultConfiguration_SucceedsWithValidConfiguration()
+        {
+            // Arrange
+            var expectedConfiguration = "Razor-13.37";
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = expectedConfiguration
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedConfiguration, defaultConfiguration);
+        }
+
+        [Fact]
+        public void TryGetLanguageVersion_FailsIfNoRule()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(languageVersion);
+        }
+
+        [Fact]
+        public void TryGetLanguageVersion_FailsIfNoLanguageVersion()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(Rules.RazorGeneral.SchemaName, new Dictionary<string, string>())
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(languageVersion);
+        }
+
+        [Fact]
+        public void TryGetLanguageVersion_FailsIfEmptyLanguageVersion()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorLangVersionProperty] = string.Empty
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(languageVersion);
+        }
+
+        [Fact]
+        public void TryGetLanguageVersion_SucceedsWithValidLanguageVersion()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0"
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(RazorLanguageVersion.Version_1_0, languageVersion);
+        }
+
+        [Fact]
+        public void TryGetLanguageVersion_SucceedsWithUnknownLanguageVersion_DefaultsToLatest()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorLangVersionProperty] = "13.37"
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(RazorLanguageVersion.Latest, languageVersion);
+        }
+
+        [Fact]
+        public void TryGetConfigurationItem_FailsNoRazorConfigurationRule()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryGetConfigurationItem_FailsNoRazorConfigurationItems()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorConfiguration.SchemaName,
+                    new Dictionary<string, Dictionary<string, string>>())
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryGetConfigurationItem_FailsNoMatchingRazorConfigurationItems()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorConfiguration.SchemaName,
+                    new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        ["Razor-10.0"] = new Dictionary<string, string>(),
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryGetConfigurationItem_SucceedsForMatchingConfigurationItem()
+        {
+            // Arrange
+            var expectedConfiguration = "Razor-13.37";
+            var expectedConfigurationValue = new Dictionary<string, string>()
+            {
+                [Rules.RazorConfiguration.ExtensionsProperty] = "SomeExtension"
+            };
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorConfiguration.SchemaName,
+                    new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        [expectedConfiguration] = expectedConfigurationValue
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfigurationItem(expectedConfiguration, projectState, out var configurationItem);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedConfiguration, configurationItem.Key);
+            Assert.True(Enumerable.SequenceEqual(expectedConfigurationValue, configurationItem.Value));
+        }
+
+        [Fact]
+        public void GetExtensionNames_SucceedsWithNoExtensions()
+        {
+            // Arrange
+            var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
+            items.Item("Test");
+
+            var item = items.ToSnapshot().Items.Single();
+
+            // Act
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
+
+            // Assert
+            Assert.Empty(extensionNames);
+        }
+
+        [Fact]
+        public void GetExtensionNames_SucceedsWithEmptyExtensions()
+        {
+            // Arrange
+            var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
+            items.Item("Test");
+            items.Property("Test", Rules.RazorConfiguration.ExtensionsProperty, string.Empty);
+
+            var item = items.ToSnapshot().Items.Single();
+
+            // Act
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
+
+            // Assert
+            Assert.Empty(extensionNames);
+        }
+
+        [Fact]
+        public void GetExtensionNames_SucceedsIfSingleExtension()
+        {
+            // Arrange
+            var expectedExtensionName = "SomeExtensionName";
+
+            var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
+            items.Item("Test");
+            items.Property("Test", Rules.RazorConfiguration.ExtensionsProperty, "SomeExtensionName");
+
+            var item = items.ToSnapshot().Items.Single();
+
+            // Act
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
+
+            // Assert
+            var extensionName = Assert.Single(extensionNames);
+            Assert.Equal(expectedExtensionName, extensionName);
+        }
+
+        [Fact]
+        public void GetExtensionNames_SucceedsIfMultipleExtensions()
+        {
+            // Arrange
+            var items = new ItemCollection(Rules.RazorConfiguration.SchemaName);
+            items.Item("Test");
+            items.Property("Test", Rules.RazorConfiguration.ExtensionsProperty, "SomeExtensionName;SomeOtherExtensionName");
+
+            var item = items.ToSnapshot().Items.Single();
+
+            // Act
+            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
+
+            // Assert
+            Assert.Collection(
+                extensionNames,
+                name => Assert.Equal("SomeExtensionName", name),
+                name => Assert.Equal("SomeOtherExtensionName", name));
+        }
+
+        [Fact]
+        public void TryGetExtensions_SucceedsWhenExtensionsNotFound()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(extensions);
+        }
+
+        [Fact]
+        public void TryGetExtensions_SucceedsWithUnConfiguredExtensionTypes()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorExtension.PrimaryDataSourceItemType] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorExtension.PrimaryDataSourceItemType,
+                    new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        ["UnconfiguredExtensionName"] = new Dictionary<string, string>()
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(extensions);
+        }
+
+        [Fact]
+        public void TryGetExtensions_SucceedsWithSomeConfiguredExtensions()
+        {
+            // Arrange
+            var expectedExtension1Name = "Extension1";
+            var expectedExtension2Name = "Extension2";
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorExtension.PrimaryDataSourceItemType] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorExtension.PrimaryDataSourceItemType,
+                    new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        ["UnconfiguredExtensionName"] = new Dictionary<string, string>(),
+                        [expectedExtension1Name] = new Dictionary<string, string>(),
+                        [expectedExtension2Name] = new Dictionary<string, string>(),
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetExtensions(new[] { expectedExtension1Name, expectedExtension2Name }, projectState, out var extensions);
+
+            // Assert
+            Assert.True(result);
+            Assert.Collection(
+                extensions,
+                extension => Assert.Equal(expectedExtension2Name, extension.ExtensionName),
+                extension => Assert.Equal(expectedExtension1Name, extension.ExtensionName));
+        }
+
+        [Fact]
+        public void TryGetConfiguration_FailsIfNoDefaultConfiguration()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(configuration);
+        }
+
+        [Fact]
+        public void TryGetConfiguration_FailsIfNoLanguageVersion()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "13.37"
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(configuration);
+        }
+
+        [Fact]
+        public void TryGetConfiguration_FailsIfNoConfigurationItems()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "13.37",
+                        [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(configuration);
+        }
+
+        [Fact]
+        public void TryGetConfiguration_SucceedsWithNoConfiguredExtensionNames()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "Razor-13.37",
+                        [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
+                    }),
+                [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorConfiguration.SchemaName,
+                    new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        ["Razor-13.37"] = new Dictionary<string, string>()
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(RazorLanguageVersion.Version_1_0, configuration.LanguageVersion);
+            Assert.Equal("Razor-13.37", configuration.ConfigurationName);
+            Assert.Empty(configuration.Extensions);
+        }
+
+        [Fact]
+        public void TryGetConfiguration_IgnoresMissingExtension()
+        {
+            // Arrange
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = "13.37",
+                        [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
+                    }),
+                [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorConfiguration.SchemaName,
+                    new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        ["13.37"] = new Dictionary<string, string>()
+                        {
+                            ["Extensions"] = "Razor-13.37"
+                        }
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(configuration.Extensions);
+        }
+
+        // This is more of an integration test but is here to test the overall flow/functionality
+        [Fact]
+        public void TryGetConfiguration_SucceedsWithAllPreRequisites()
+        {
+            // Arrange
+            var expectedLanguageVersion = RazorLanguageVersion.Version_1_0;
+            var expectedConfigurationName = "Razor-Test";
+            var expectedExtension1Name = "Extension1";
+            var expectedExtension2Name = "Extension2";
+            var projectState = new Dictionary<string, IProjectRuleSnapshot>()
+            {
+                [Rules.RazorGeneral.SchemaName] = TestProjectRuleSnapshot.CreateProperties(
+                    Rules.RazorGeneral.SchemaName,
+                    new Dictionary<string, string>()
+                    {
+                        [Rules.RazorGeneral.RazorDefaultConfigurationProperty] = expectedConfigurationName,
+                        [Rules.RazorGeneral.RazorLangVersionProperty] = "1.0",
+                    }),
+                [Rules.RazorConfiguration.SchemaName] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorConfiguration.SchemaName,
+                    new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        ["UnconfiguredRazorConfiguration"] = new Dictionary<string, string>()
+                        {
+                            ["Extensions"] = "Razor-9.0"
+                        },
+                        [expectedConfigurationName] = new Dictionary<string, string>()
+                        {
+                            ["Extensions"] = expectedExtension1Name + ";" + expectedExtension2Name
+                        }
+                    }),
+                [Rules.RazorExtension.PrimaryDataSourceItemType] = TestProjectRuleSnapshot.CreateItems(
+                    Rules.RazorExtension.PrimaryDataSourceItemType,
+                    new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        [expectedExtension1Name] = new Dictionary<string, string>(),
+                        [expectedExtension2Name] = new Dictionary<string, string>(),
+                    })
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedLanguageVersion, configuration.LanguageVersion);
+            Assert.Equal(expectedConfigurationName, configuration.ConfigurationName);
+            Assert.Collection(
+                configuration.Extensions.OrderBy(e => e.ExtensionName),
+                extension => Assert.Equal(expectedExtension1Name, extension.ExtensionName),
+                extension => Assert.Equal(expectedExtension2Name, extension.ExtensionName));
+        }
+
+        [ForegroundFact]
+        public async Task DefaultRazorProjectHost_ForegroundThread_CreateAndDispose_Succeeds()
+        {
+            // Arrange
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+            var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            // Act & Assert
+            await host.LoadAsync();
+            Assert.Empty(ProjectManager.Projects);
+
+            await host.DisposeAsync();
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task DefaultRazorProjectHost_BackgroundThread_CreateAndDispose_Succeeds()
+        {
+            // Arrange
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+            var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            // Act & Assert
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact] // This can happen if the .xaml files aren't included correctly.
+        public async Task DefaultRazorProjectHost_OnProjectChanged_NoRulesDefined()
+        {
+            // Arrange
+            var changes = new TestProjectChangeDescription[]
+            {
+            };
+
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+            var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            // Act & Assert
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+            Assert.Empty(ProjectManager.Projects);
+        }
 
         // [ForegroundFact]
-        // public async Task DefaultRazorProjectHost_ForegroundThread_CreateAndDispose_Succeeds()
-        // {
-        //     // Arrange
-        //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        //     // Act & Assert
-        //     await host.LoadAsync();
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await host.DisposeAsync();
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task DefaultRazorProjectHost_BackgroundThread_CreateAndDispose_Succeeds()
-        // {
-        //     // Arrange
-        //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        //     // Act & Assert
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact] // This can happen if the .xaml files aren't included correctly.
-        // public async Task DefaultRazorProjectHost_OnProjectChanged_NoRulesDefined()
-        // {
-        //     // Arrange
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //     };
-
-        //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        //     // Act & Assert
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // // [ForegroundFact]
-        // // public async Task OnProjectChanged_ReadsProperties_InitializesProject()
-        // // {
-        // //     // Arrange
-        // //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
-        // //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
-
-        // //     ConfigurationItems.Item("MVC-2.1");
-        // //     ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
-
-        // //     ExtensionItems.Item("MVC-2.1");
-        // //     ExtensionItems.Item("Another-Thing");
-
-        // //     RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
-        // //     RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
-
-        // //     RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
-        // //     RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
-
-        // //     var changes = new TestProjectChangeDescription[]
-        // //     {
-        // //         RazorGeneralProperties.ToChange(),
-        // //         ConfigurationItems.ToChange(),
-        // //         ExtensionItems.ToChange(),
-        // //         RazorComponentWithTargetPathItems.ToChange(),
-        // //         RazorGenerateWithTargetPathItems.ToChange(),
-        // //     };
-
-        // //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-
-        // //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        // //     await Task.Run(async () => await host.LoadAsync());
-        // //     Assert.Empty(ProjectManager.Projects);
-
-        // //     // Act
-        // //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        // //     // Assert
-        // //     var snapshot = Assert.Single(ProjectManager.Projects);
-        // //     Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
-
-        // //     Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
-        // //     Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
-        // //     Assert.Collection(
-        // //         snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
-        // //         e => Assert.Equal("Another-Thing", e.ExtensionName),
-        // //         e => Assert.Equal("MVC-2.1", e.ExtensionName));
-
-        // //     Assert.Collection(
-        // //         snapshot.DocumentFilePaths.OrderBy(d => d),
-        // //         d =>
-        // //         {
-        // //             var document = snapshot.GetDocument(d);
-        // //             Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
-        // //             Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
-        // //             Assert.Equal(FileKinds.Legacy, document.FileKind);
-        // //         },
-        // //         d =>
-        // //         {
-        // //             var document = snapshot.GetDocument(d);
-        // //             Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
-        // //             Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
-        // //             Assert.Equal(FileKinds.Component, document.FileKind);
-        // //         });
-
-        // //     await Task.Run(async () => await host.DisposeAsync());
-        // //     Assert.Empty(ProjectManager.Projects);
-        // // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_NoVersionFound_DoesNotIniatializeProject()
-        // {
-        //     // Arrange
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "");
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "");
-
-        //     ConfigurationItems.Item("TestConfiguration");
-
-        //     ExtensionItems.Item("TestExtension");
-
-        //     RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
-
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         RazorGeneralProperties.ToChange(),
-        //         ConfigurationItems.ToChange(),
-        //         ExtensionItems.ToChange(),
-        //         RazorComponentWithTargetPathItems.ToChange(),
-        //         RazorGenerateWithTargetPathItems.ToChange(),
-        //     };
-
-        //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-
-        //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_UpdateProject_Succeeds()
+        // public async Task OnProjectChanged_ReadsProperties_InitializesProject()
         // {
         //     // Arrange
         //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
@@ -790,10 +681,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         //     ExtensionItems.Item("Another-Thing");
 
         //     RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
-        //     RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorComponentWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
-
-        //     RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentImportFile1.FilePath));
-        //     RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentImportFile1.FilePath), Rules.RazorComponentWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentImportFile1.TargetPath);
+        //     RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
 
         //     RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
         //     RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
@@ -814,10 +702,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         //     await Task.Run(async () => await host.LoadAsync());
         //     Assert.Empty(ProjectManager.Projects);
 
-        //     // Act - 1
+        //     // Act
         //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
 
-        //     // Assert - 1
+        //     // Assert
         //     var snapshot = Assert.Single(ProjectManager.Projects);
         //     Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
@@ -830,87 +718,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         //     Assert.Collection(
         //         snapshot.DocumentFilePaths.OrderBy(d => d),
-        //         d =>
-        //         {
-        //             var document = snapshot.GetDocument(d);
-        //             Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
-        //             Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
-        //             Assert.Equal(FileKinds.ComponentImport, document.FileKind);
-        //         },
-        //         d =>
-        //         {
-        //             var document = snapshot.GetDocument(d);
-        //             Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
-        //             Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
-        //         },
-        //         d =>
-        //         {
-        //             var document = snapshot.GetDocument(d);
-        //             Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
-        //             Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
-        //             Assert.Equal(FileKinds.Component, document.FileKind);
-        //         });
-
-        //     // Act - 2
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.0");
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.0");
-        //     ConfigurationItems.RemoveItem("MVC-2.1");
-        //     ConfigurationItems.Item("MVC-2.0", new Dictionary<string, string>() { { "Extensions", "MVC-2.0;Another-Thing" }, });
-        //     ExtensionItems.Item("MVC-2.0");
-        //     RazorComponentWithTargetPathItems.Item(TestProjectData.AnotherProjectNestedComponentFile3.FilePath, new Dictionary<string, string>()
-        //     {
-        //         { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedComponentFile3.TargetPath },
-        //     });
-        //     RazorGenerateWithTargetPathItems.Item(TestProjectData.AnotherProjectNestedFile3.FilePath, new Dictionary<string, string>()
-        //     {
-        //         { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedFile3.TargetPath },
-        //     });
-
-        //     changes = new TestProjectChangeDescription[]
-        //     {
-        //         RazorGeneralProperties.ToChange(changes[0].After),
-        //         ConfigurationItems.ToChange(changes[1].After),
-        //         ExtensionItems.ToChange(changes[2].After),
-        //         RazorComponentWithTargetPathItems.ToChange(changes[3].After),
-        //         RazorGenerateWithTargetPathItems.ToChange(changes[4].After),
-        //     };
-
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert - 2
-        //     snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
-
-        //     Assert.Equal(RazorLanguageVersion.Version_2_0, snapshot.Configuration.LanguageVersion);
-        //     Assert.Equal("MVC-2.0", snapshot.Configuration.ConfigurationName);
-        //     Assert.Collection(
-        //         snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
-        //         e => Assert.Equal("Another-Thing", e.ExtensionName),
-        //         e => Assert.Equal("MVC-2.0", e.ExtensionName));
-
-        //     Assert.Collection(
-        //         snapshot.DocumentFilePaths.OrderBy(d => d),
-        //         d =>
-        //         {
-        //             var document = snapshot.GetDocument(d);
-        //             Assert.Equal(TestProjectData.AnotherProjectNestedFile3.FilePath, document.FilePath);
-        //             Assert.Equal(TestProjectData.AnotherProjectNestedFile3.TargetPath, document.TargetPath);
-        //             Assert.Equal(FileKinds.Legacy, document.FileKind);
-        //         },
-        //         d =>
-        //         {
-        //             var document = snapshot.GetDocument(d);
-        //             Assert.Equal(TestProjectData.AnotherProjectNestedComponentFile3.FilePath, document.FilePath);
-        //             Assert.Equal(TestProjectData.AnotherProjectNestedComponentFile3.TargetPath, document.TargetPath);
-        //             Assert.Equal(FileKinds.Component, document.FileKind);
-        //         },
-        //         d =>
-        //         {
-        //             var document = snapshot.GetDocument(d);
-        //             Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
-        //             Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
-        //             Assert.Equal(FileKinds.ComponentImport, document.FileKind);
-        //         },
         //         d =>
         //         {
         //             var document = snapshot.GetDocument(d);
@@ -930,207 +737,400 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         //     Assert.Empty(ProjectManager.Projects);
         // }
 
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_VersionRemoved_DeinitializesProject()
-        // {
-        //     // Arrange
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
+        [ForegroundFact]
+        public async Task OnProjectChanged_NoVersionFound_DoesNotIniatializeProject()
+        {
+            // Arrange
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "");
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "");
 
-        //     ConfigurationItems.Item("MVC-2.1");
-        //     ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
+            ConfigurationItems.Item("TestConfiguration");
 
-        //     ExtensionItems.Item("MVC-2.1");
-        //     ExtensionItems.Item("Another-Thing");
+            ExtensionItems.Item("TestExtension");
 
-        //     RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
-        //     RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
+            RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
 
-        //     RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
-        //     RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
+            var changes = new TestProjectChangeDescription[]
+            {
+                 RazorGeneralProperties.ToChange(),
+                 ConfigurationItems.ToChange(),
+                 ExtensionItems.ToChange(),
+                 RazorComponentWithTargetPathItems.ToChange(),
+                 RazorGenerateWithTargetPathItems.ToChange(),
+            };
 
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         RazorGeneralProperties.ToChange(),
-        //         ConfigurationItems.ToChange(),
-        //         ExtensionItems.ToChange(),
-        //         RazorComponentWithTargetPathItems.ToChange(),
-        //         RazorGenerateWithTargetPathItems.ToChange(),
-        //     };
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
-        //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+            var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
 
-        //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
 
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
+            // Act
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
 
-        //     // Act - 1
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+            // Assert
+            Assert.Empty(ProjectManager.Projects);
 
-        //     // Assert - 1
-        //     var snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
 
-        //     Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
-        //     Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
-        //     Assert.Collection(
-        //         snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
-        //         e => Assert.Equal("Another-Thing", e.ExtensionName),
-        //         e => Assert.Equal("MVC-2.1", e.ExtensionName));
+        [ForegroundFact]
+        public async Task OnProjectChanged_UpdateProject_Succeeds()
+        {
+            // Arrange
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
 
-        //     // Act - 2
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "");
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "");
+            ConfigurationItems.Item("MVC-2.1");
+            ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
 
-        //     changes = new TestProjectChangeDescription[]
-        //     {
-        //         RazorGeneralProperties.ToChange(changes[0].After),
-        //         ConfigurationItems.ToChange(changes[1].After),
-        //         ExtensionItems.ToChange(changes[2].After),
-        //         RazorComponentWithTargetPathItems.ToChange(changes[3].After),
-        //         RazorGenerateWithTargetPathItems.ToChange(changes[4].After),
-        //     };
+            ExtensionItems.Item("MVC-2.1");
+            ExtensionItems.Item("Another-Thing");
 
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+            RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
+            RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorComponentWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
 
-        //     // Assert - 2
-        //     Assert.Empty(ProjectManager.Projects);
+            RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentImportFile1.FilePath));
+            RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentImportFile1.FilePath), Rules.RazorComponentWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentImportFile1.TargetPath);
 
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
+            RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
 
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_AfterDispose_IgnoresUpdate()
-        // {
-        //     // Arrange
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
+            var changes = new TestProjectChangeDescription[]
+            {
+                 RazorGeneralProperties.ToChange(),
+                 ConfigurationItems.ToChange(),
+                 ExtensionItems.ToChange(),
+                 RazorComponentWithTargetPathItems.ToChange(),
+                 RazorGenerateWithTargetPathItems.ToChange(),
+            };
 
-        //     ConfigurationItems.Item("MVC-2.1");
-        //     ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
-        //     ExtensionItems.Item("MVC-2.1");
-        //     ExtensionItems.Item("Another-Thing");
+            var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
 
-        //     RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
-        //     RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
 
-        //     RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
-        //     RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
+            // Act - 1
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
 
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         RazorGeneralProperties.ToChange(),
-        //         ConfigurationItems.ToChange(),
-        //         ExtensionItems.ToChange(),
-        //         RazorComponentWithTargetPathItems.ToChange(),
-        //         RazorGenerateWithTargetPathItems.ToChange(),
-        //     };
+            // Assert - 1
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
-        //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+            Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
+            Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
+            Assert.Collection(
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+                e => Assert.Equal("Another-Thing", e.ExtensionName),
+                e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
-        //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            Assert.Collection(
+                snapshot.DocumentFilePaths.OrderBy(d => d),
+                d =>
+                {
+                    var document = snapshot.GetDocument(d);
+                    Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
+                    Assert.Equal(FileKinds.ComponentImport, document.FileKind);
+                },
+                d =>
+                {
+                    var document = snapshot.GetDocument(d);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
+                },
+                d =>
+                {
+                    var document = snapshot.GetDocument(d);
+                    Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
+                    Assert.Equal(FileKinds.Component, document.FileKind);
+                });
 
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
+            // Act - 2
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.0");
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.0");
+            ConfigurationItems.RemoveItem("MVC-2.1");
+            ConfigurationItems.Item("MVC-2.0", new Dictionary<string, string>() { { "Extensions", "MVC-2.0;Another-Thing" }, });
+            ExtensionItems.Item("MVC-2.0");
+            RazorComponentWithTargetPathItems.Item(TestProjectData.AnotherProjectNestedComponentFile3.FilePath, new Dictionary<string, string>()
+             {
+                 { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedComponentFile3.TargetPath },
+             });
+            RazorGenerateWithTargetPathItems.Item(TestProjectData.AnotherProjectNestedFile3.FilePath, new Dictionary<string, string>()
+             {
+                 { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedFile3.TargetPath },
+             });
 
-        //     // Act - 1
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+            changes = new TestProjectChangeDescription[]
+            {
+                 RazorGeneralProperties.ToChange(changes[0].After),
+                 ConfigurationItems.ToChange(changes[1].After),
+                 ExtensionItems.ToChange(changes[2].After),
+                 RazorComponentWithTargetPathItems.ToChange(changes[3].After),
+                 RazorGenerateWithTargetPathItems.ToChange(changes[4].After),
+            };
 
-        //     // Assert - 1
-        //     var snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
 
-        //     Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
-        //     Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
-        //     Assert.Collection(
-        //         snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
-        //         e => Assert.Equal("Another-Thing", e.ExtensionName),
-        //         e => Assert.Equal("MVC-2.1", e.ExtensionName));
+            // Assert - 2
+            snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
-        //     // Act - 2
-        //     await Task.Run(async () => await host.DisposeAsync());
+            Assert.Equal(RazorLanguageVersion.Version_2_0, snapshot.Configuration.LanguageVersion);
+            Assert.Equal("MVC-2.0", snapshot.Configuration.ConfigurationName);
+            Assert.Collection(
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+                e => Assert.Equal("Another-Thing", e.ExtensionName),
+                e => Assert.Equal("MVC-2.0", e.ExtensionName));
 
-        //     // Assert - 2
-        //     Assert.Empty(ProjectManager.Projects);
+            Assert.Collection(
+                snapshot.DocumentFilePaths.OrderBy(d => d),
+                d =>
+                {
+                    var document = snapshot.GetDocument(d);
+                    Assert.Equal(TestProjectData.AnotherProjectNestedFile3.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.AnotherProjectNestedFile3.TargetPath, document.TargetPath);
+                    Assert.Equal(FileKinds.Legacy, document.FileKind);
+                },
+                d =>
+                {
+                    var document = snapshot.GetDocument(d);
+                    Assert.Equal(TestProjectData.AnotherProjectNestedComponentFile3.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.AnotherProjectNestedComponentFile3.TargetPath, document.TargetPath);
+                    Assert.Equal(FileKinds.Component, document.FileKind);
+                },
+                d =>
+                {
+                    var document = snapshot.GetDocument(d);
+                    Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
+                    Assert.Equal(FileKinds.ComponentImport, document.FileKind);
+                },
+                d =>
+                {
+                    var document = snapshot.GetDocument(d);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
+                    Assert.Equal(FileKinds.Legacy, document.FileKind);
+                },
+                d =>
+                {
+                    var document = snapshot.GetDocument(d);
+                    Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
+                    Assert.Equal(FileKinds.Component, document.FileKind);
+                });
 
-        //     // Act - 3
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.0");
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.0");
-        //     ConfigurationItems.Item("MVC-2.0", new Dictionary<string, string>() { { "Extensions", "MVC-2.0;Another-Thing" }, });
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
 
-        //     changes = new TestProjectChangeDescription[]
-        //     {
-        //         RazorGeneralProperties.ToChange(changes[0].After),
-        //         ConfigurationItems.ToChange(changes[1].After),
-        //         ExtensionItems.ToChange(changes[2].After),
-        //         RazorComponentWithTargetPathItems.ToChange(changes[3].After),
-        //         RazorGenerateWithTargetPathItems.ToChange(changes[4].After),
-        //     };
+        [ForegroundFact]
+        public async Task OnProjectChanged_VersionRemoved_DeinitializesProject()
+        {
+            // Arrange
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
 
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+            ConfigurationItems.Item("MVC-2.1");
+            ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
 
-        //     // Assert - 3
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
+            ExtensionItems.Item("MVC-2.1");
+            ExtensionItems.Item("Another-Thing");
 
-        // [ForegroundFact]
-        // public async Task OnProjectRenamed_RemovesHostProject_CopiesConfiguration()
-        // {
-        //     // Arrange
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
-        //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
+            RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
+            RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
 
-        //     ConfigurationItems.Item("MVC-2.1");
-        //     ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
+            RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
 
-        //     ExtensionItems.Item("MVC-2.1");
-        //     ExtensionItems.Item("Another-Thing");
+            var changes = new TestProjectChangeDescription[]
+            {
+                 RazorGeneralProperties.ToChange(),
+                 ConfigurationItems.ToChange(),
+                 ExtensionItems.ToChange(),
+                 RazorComponentWithTargetPathItems.ToChange(),
+                 RazorGenerateWithTargetPathItems.ToChange(),
+            };
 
-        //     RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
-        //     RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
-        //     RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
-        //     RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
+            var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
 
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         RazorGeneralProperties.ToChange(),
-        //         ConfigurationItems.ToChange(),
-        //         ExtensionItems.ToChange(),
-        //         RazorComponentWithTargetPathItems.ToChange(),
-        //         RazorGenerateWithTargetPathItems.ToChange(),
-        //     };
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
 
-        //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+            // Act - 1
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
 
-        //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            // Assert - 1
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
+            Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
+            Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
+            Assert.Collection(
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+                e => Assert.Equal("Another-Thing", e.ExtensionName),
+                e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
-        //     // Act - 1
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+            // Act - 2
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "");
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "");
 
-        //     // Assert - 1
-        //     var snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
-        //     Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
+            changes = new TestProjectChangeDescription[]
+            {
+                 RazorGeneralProperties.ToChange(changes[0].After),
+                 ConfigurationItems.ToChange(changes[1].After),
+                 ExtensionItems.ToChange(changes[2].After),
+                 RazorComponentWithTargetPathItems.ToChange(changes[3].After),
+                 RazorGenerateWithTargetPathItems.ToChange(changes[4].After),
+            };
 
-        //     // Act - 2
-        //     services.UnconfiguredProject.FullPath = TestProjectData.AnotherProject.FilePath;
-        //     await Task.Run(async () => await host.OnProjectRenamingAsync());
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
 
-        //     // Assert - 1
-        //     snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal(TestProjectData.AnotherProject.FilePath, snapshot.FilePath);
-        //     Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
+            // Assert - 2
+            Assert.Empty(ProjectManager.Projects);
 
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectChanged_AfterDispose_IgnoresUpdate()
+        {
+            // Arrange
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
+
+            ConfigurationItems.Item("MVC-2.1");
+            ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
+
+            ExtensionItems.Item("MVC-2.1");
+            ExtensionItems.Item("Another-Thing");
+
+            RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
+            RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
+
+            RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
+
+            var changes = new TestProjectChangeDescription[]
+            {
+                 RazorGeneralProperties.ToChange(),
+                 ConfigurationItems.ToChange(),
+                 ExtensionItems.ToChange(),
+                 RazorComponentWithTargetPathItems.ToChange(),
+                 RazorGenerateWithTargetPathItems.ToChange(),
+            };
+
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+
+            var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act - 1
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 1
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+
+            Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
+            Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
+            Assert.Collection(
+                snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+                e => Assert.Equal("Another-Thing", e.ExtensionName),
+                e => Assert.Equal("MVC-2.1", e.ExtensionName));
+
+            // Act - 2
+            await Task.Run(async () => await host.DisposeAsync());
+
+            // Assert - 2
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act - 3
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.0");
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.0");
+            ConfigurationItems.Item("MVC-2.0", new Dictionary<string, string>() { { "Extensions", "MVC-2.0;Another-Thing" }, });
+
+            changes = new TestProjectChangeDescription[]
+            {
+                 RazorGeneralProperties.ToChange(changes[0].After),
+                 ConfigurationItems.ToChange(changes[1].After),
+                 ExtensionItems.ToChange(changes[2].After),
+                 RazorComponentWithTargetPathItems.ToChange(changes[3].After),
+                 RazorGenerateWithTargetPathItems.ToChange(changes[4].After),
+            };
+
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 3
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectRenamed_RemovesHostProject_CopiesConfiguration()
+        {
+            // Arrange
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
+            RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
+
+            ConfigurationItems.Item("MVC-2.1");
+            ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
+
+            ExtensionItems.Item("MVC-2.1");
+            ExtensionItems.Item("Another-Thing");
+
+            RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
+            RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
+
+            RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
+
+            var changes = new TestProjectChangeDescription[]
+            {
+                 RazorGeneralProperties.ToChange(),
+                 ConfigurationItems.ToChange(),
+                 ExtensionItems.ToChange(),
+                 RazorComponentWithTargetPathItems.ToChange(),
+                 RazorGenerateWithTargetPathItems.ToChange(),
+            };
+
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+
+            var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act - 1
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 1
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+            Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
+
+            // Act - 2
+            services.UnconfiguredProject.FullPath = TestProjectData.AnotherProject.FilePath;
+            await Task.Run(async () => await host.OnProjectRenamingAsync());
+
+            // Assert - 1
+            snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal(TestProjectData.AnotherProject.FilePath, snapshot.FilePath);
+            Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
 
         private class TestProjectSnapshotManager : DefaultProjectSnapshotManager
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackRazorProjectHostTest.cs
@@ -17,648 +17,648 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     public class FallbackRazorProjectHostTest : ForegroundDispatcherWorkspaceTestBase
     {
-        // public FallbackRazorProjectHostTest()
-        // {
-        //     ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace);
-
-        //     var projectConfigurationFilePathStore = new Mock<ProjectConfigurationFilePathStore>(MockBehavior.Strict);
-        //     projectConfigurationFilePathStore.Setup(s => s.Remove(It.IsAny<string>())).Verifiable();
-        //     ProjectConfigurationFilePathStore = projectConfigurationFilePathStore.Object;
-
-        //     ReferenceItems = new ItemCollection(ManagedProjectSystemSchema.ResolvedCompilationReference.SchemaName);
-        //     ContentItems = new ItemCollection(ManagedProjectSystemSchema.ContentItem.SchemaName);
-        //     NoneItems = new ItemCollection(ManagedProjectSystemSchema.NoneItem.SchemaName);
-
-        //     JoinableTaskContext = new JoinableTaskContext();
-        // }
-
-        // private ItemCollection ReferenceItems { get; }
-
-        // private TestProjectSnapshotManager ProjectManager { get; }
-
-        // private ProjectConfigurationFilePathStore ProjectConfigurationFilePathStore { get; }
-
-        // private ItemCollection ContentItems { get; }
-
-        // private ItemCollection NoneItems { get; }
-
-        // private JoinableTaskContext JoinableTaskContext { get; }
-
-        // [Fact]
-        // public void GetChangedAndRemovedDocuments_ReturnsChangedContentAndNoneItems()
-        // {
-        //     // Arrange
-        //     var afterChangeContentItems = new ItemCollection(ManagedProjectSystemSchema.ContentItem.SchemaName);
-        //     ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "NewIndex.cshtml",
-        //         [ItemReference.FullPathPropertyName] = "C:\\From\\Index.cshtml",
-        //     });
-        //     var afterChangeNoneItems = new ItemCollection(ManagedProjectSystemSchema.NoneItem.SchemaName);
-        //     NoneItems.Item("About.cshtml", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "NewAbout.cshtml",
-        //         [ItemReference.FullPathPropertyName] = "C:\\From\\About.cshtml",
-        //     });
-        //     var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         afterChangeContentItems.ToChange(ContentItems.ToSnapshot()),
-        //         afterChangeNoneItems.ToChange(NoneItems.ToSnapshot()),
-        //     };
-        //     var update = services.CreateUpdate(changes).Value;
-
-        //     // Act
-        //     var result = host.GetChangedAndRemovedDocuments(update);
-
-        //     // Assert
-        //     Assert.Collection(
-        //         result,
-        //         document =>
-        //         {
-        //             Assert.Equal("C:\\From\\Index.cshtml", document.FilePath);
-        //             Assert.Equal("C:\\To\\NewIndex.cshtml", document.TargetPath);
-        //         },
-        //         document =>
-        //         {
-        //             Assert.Equal("C:\\From\\About.cshtml", document.FilePath);
-        //             Assert.Equal("C:\\To\\NewAbout.cshtml", document.TargetPath);
-        //         });
-        // }
-
-        // [Fact]
-        // public void GetCurrentDocuments_ReturnsContentAndNoneItems()
-        // {
-        //     // Arrange
-        //     ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "NewIndex.cshtml",
-        //         [ItemReference.FullPathPropertyName] = "C:\\From\\Index.cshtml",
-        //     });
-        //     NoneItems.Item("About.cshtml", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "NewAbout.cshtml",
-        //         [ItemReference.FullPathPropertyName] = "C:\\From\\About.cshtml",
-        //     });
-        //     var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ContentItems.ToChange(),
-        //         NoneItems.ToChange(),
-        //     };
-        //     var update = services.CreateUpdate(changes).Value;
-
-        //     // Act
-        //     var result = host.GetCurrentDocuments(update);
-
-        //     // Assert
-        //     Assert.Collection(
-        //         result,
-        //         document =>
-        //         {
-        //             Assert.Equal("C:\\From\\Index.cshtml", document.FilePath);
-        //             Assert.Equal("C:\\To\\NewIndex.cshtml", document.TargetPath);
-        //         },
-        //         document =>
-        //         {
-        //             Assert.Equal("C:\\From\\About.cshtml", document.FilePath);
-        //             Assert.Equal("C:\\To\\NewAbout.cshtml", document.TargetPath);
-        //         });
-        // }
-
-        // // This is for the legacy SDK case, we don't support components.
-        // [Fact]
-        // public void GetCurrentDocuments_IgnoresDotRazorFiles()
-        // {
-        //     // Arrange
-        //     ContentItems.Item("Index.razor", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "NewIndex.razor",
-        //         [ItemReference.FullPathPropertyName] = "C:\\From\\Index.razor",
-        //     });
-        //     NoneItems.Item("About.razor", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "NewAbout.razor",
-        //         [ItemReference.FullPathPropertyName] = "C:\\From\\About.razor",
-        //     });
-        //     var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ContentItems.ToChange(),
-        //         NoneItems.ToChange(),
-        //     };
-        //     var update = services.CreateUpdate(changes).Value;
-
-        //     // Act
-        //     var result = host.GetCurrentDocuments(update);
-
-        //     // Assert
-        //     Assert.Empty(result);
-        // }
-
-        // [Fact]
-        // public void TryGetRazorDocument_NoFilePath_ReturnsFalse()
-        // {
-        //     // Arrange
-        //     var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var itemState = new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "Index.cshtml",
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = host.TryGetRazorDocument(itemState, out var document);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(document);
-        // }
-
-        // [Fact]
-        // public void TryGetRazorDocument_NonRazorFilePath_ReturnsFalse()
-        // {
-        //     // Arrange
-        //     var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var itemState = new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.FullPathPropertyName] = "C:\\Path\\site.css",
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = host.TryGetRazorDocument(itemState, out var document);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(document);
-        // }
-
-        // [Fact]
-        // public void TryGetRazorDocument_NonRazorTargetPath_ReturnsFalse()
-        // {
-        //     // Arrange
-        //     var services = new TestProjectSystemServices("C:\\Path\\To\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var itemState = new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "site.html",
-        //         [ItemReference.FullPathPropertyName] = "C:\\Path\\From\\Index.cshtml",
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = host.TryGetRazorDocument(itemState, out var document);
-
-        //     // Assert
-        //     Assert.False(result);
-        //     Assert.Null(document);
-        // }
-
-        // [Fact]
-        // public void TryGetRazorDocument_JustFilePath_ReturnsTrue()
-        // {
-        //     // Arrange
-        //     var expectedPath = "C:\\Path\\Index.cshtml";
-        //     var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var itemState = new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.FullPathPropertyName] = expectedPath,
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = host.TryGetRazorDocument(itemState, out var document);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Equal(expectedPath, document.FilePath);
-        //     Assert.Equal(expectedPath, document.TargetPath);
-        // }
-
-        // [Fact]
-        // public void TryGetRazorDocument_LinkedFilepath_ReturnsTrue()
-        // {
-        //     // Arrange
-        //     var expectedFullPath = "C:\\Path\\From\\Index.cshtml";
-        //     var expectedTargetPath = "C:\\Path\\To\\Index.cshtml";
-        //     var services = new TestProjectSystemServices("C:\\Path\\To\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var itemState = new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "Index.cshtml",
-        //         [ItemReference.FullPathPropertyName] = expectedFullPath,
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = host.TryGetRazorDocument(itemState, out var document);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Equal(expectedFullPath, document.FilePath);
-        //     Assert.Equal(expectedTargetPath, document.TargetPath);
-        // }
-
-        // [Fact]
-        // public void TryGetRazorDocument_SetsLegacyFileKind()
-        // {
-        //     // Arrange
-        //     var expectedFullPath = "C:\\Path\\From\\Index.cshtml";
-        //     var expectedTargetPath = "C:\\Path\\To\\Index.cshtml";
-        //     var services = new TestProjectSystemServices("C:\\Path\\To\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-        //     var itemState = new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.LinkPropertyName] = "Index.cshtml",
-        //         [ItemReference.FullPathPropertyName] = expectedFullPath,
-        //     }.ToImmutableDictionary();
-
-        //     // Act
-        //     var result = host.TryGetRazorDocument(itemState, out var document);
-
-        //     // Assert
-        //     Assert.True(result);
-        //     Assert.Equal(expectedFullPath, document.FilePath);
-        //     Assert.Equal(expectedTargetPath, document.TargetPath);
-        //     Assert.Equal(FileKinds.Legacy, document.FileKind);
-        // }
-
-        // [ForegroundFact]
-        // public async Task FallbackRazorProjectHost_ForegroundThread_CreateAndDispose_Succeeds()
-        // {
-        //     // Arrange
-        //     var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        //     // Act & Assert
-        //     await host.LoadAsync();
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await host.DisposeAsync();
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task FallbackRazorProjectHost_BackgroundThread_CreateAndDispose_Succeeds()
-        // {
-        //     // Arrange
-        //     var services = new TestProjectSystemServices("Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        //     // Act & Assert
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact] // This can happen if the .xaml files aren't included correctly.
-        // public async Task OnProjectChanged_NoRulesDefined()
-        // {
-        //     // Arrange
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //     };
-
-        //     var services = new TestProjectSystemServices("Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
-        //     {
-        //         AssemblyVersion = new Version(2, 0),
-        //     };
-
-        //     // Act & Assert
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_ReadsProperties_InitializesProject()
-        // {
-        //     // Arrange
-        //     ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
-        //     ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.FullPathPropertyName] = "C:\\Path\\Index.cshtml",
-        //     });
-        //     NoneItems.Item("About.cshtml", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.FullPathPropertyName] = "C:\\Path\\About.cshtml",
-        //     });
-
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ReferenceItems.ToChange(),
-        //         ContentItems.ToChange(),
-        //         NoneItems.ToChange(),
-        //     };
-
-        //     var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
-        //     {
-        //         AssemblyVersion = new Version(2, 0), // Mock for reading the assembly's version
-        //     };
-
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert
-        //     var snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal("C:\\Path\\Test.csproj", snapshot.FilePath);
-        //     Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
-
-        //     Assert.Collection(
-        //         snapshot.DocumentFilePaths,
-        //         filePath => Assert.Equal("C:\\Path\\Index.cshtml", filePath),
-        //         filePath => Assert.Equal("C:\\Path\\About.cshtml", filePath));
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_NoAssemblyFound_DoesNotIniatializeProject()
-        // {
-        //     // Arrange
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ReferenceItems.ToChange(),
-        //     };
-        //     var services = new TestProjectSystemServices("Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_AssemblyFoundButCannotReadVersion_DoesNotIniatializeProject()
-        // {
-        //     // Arrange
-        //     ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
-
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ReferenceItems.ToChange(),
-        //     };
-
-        //     var services = new TestProjectSystemServices("Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
-
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_UpdateProject_Succeeds()
-        // {
-        //     // Arrange
-        //     ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
-        //     var afterChangeContentItems = new ItemCollection(ManagedProjectSystemSchema.ContentItem.SchemaName);
-        //     ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.FullPathPropertyName] = "C:\\Path\\Index.cshtml",
-        //     });
-
-        //     var initialChanges = new TestProjectChangeDescription[]
-        //     {
-        //         ReferenceItems.ToChange(),
-        //         ContentItems.ToChange(),
-        //     };
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ReferenceItems.ToChange(),
-        //         afterChangeContentItems.ToChange(ContentItems.ToSnapshot()),
-        //     };
-
-        //     var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
-        //     {
-        //         AssemblyVersion = new Version(2, 0),
-        //     };
-
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act - 1
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(initialChanges)));
-
-        //     // Assert - 1
-        //     var snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal("C:\\Path\\Test.csproj", snapshot.FilePath);
-        //     Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
-        //     var filePath = Assert.Single(snapshot.DocumentFilePaths);
-        //     Assert.Equal("C:\\Path\\Index.cshtml", filePath);
-
-        //     // Act - 2
-        //     host.AssemblyVersion = new Version(1, 0);
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert - 2
-        //     snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal("C:\\Path\\Test.csproj", snapshot.FilePath);
-        //     Assert.Same(FallbackRazorConfiguration.MVC_1_0, snapshot.Configuration);
-        //     Assert.Empty(snapshot.DocumentFilePaths);
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_VersionRemoved_DeinitializesProject()
-        // {
-        //     // Arrange
-        //     ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
-
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ReferenceItems.ToChange(),
-        //     };
-
-        //     var services = new TestProjectSystemServices("Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
-        //     {
-        //         AssemblyVersion = new Version(2, 0),
-        //     };
-
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act - 1
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert - 1
-        //     var snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal("Test.csproj", snapshot.FilePath);
-        //     Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
-
-        //     // Act - 2
-        //     host.AssemblyVersion = null;
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert - 2
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectChanged_AfterDispose_IgnoresUpdate()
-        // {
-        //     // Arrange
-        //     ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
-        //     ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
-        //     {
-        //         [ItemReference.FullPathPropertyName] = "C:\\Path\\Index.cshtml",
-        //     });
-
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ReferenceItems.ToChange(),
-        //         ContentItems.ToChange(),
-        //     };
-
-        //     var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
-        //     {
-        //         AssemblyVersion = new Version(2, 0),
-        //     };
-
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act - 1
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert - 1
-        //     var snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal("C:\\Path\\Test.csproj", snapshot.FilePath);
-        //     Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
-        //     var filePath = Assert.Single(snapshot.DocumentFilePaths);
-        //     Assert.Equal("C:\\Path\\Index.cshtml", filePath);
-
-        //     // Act - 2
-        //     await Task.Run(async () => await host.DisposeAsync());
-
-        //     // Assert - 2
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act - 3
-        //     host.AssemblyVersion = new Version(1, 1);
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert - 3
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // [ForegroundFact]
-        // public async Task OnProjectRenamed_RemovesHostProject_CopiesConfiguration()
-        // {
-        //     // Arrange
-        //     ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
-
-        //     var changes = new TestProjectChangeDescription[]
-        //     {
-        //         ReferenceItems.ToChange(),
-        //     };
-
-        //     var services = new TestProjectSystemServices("Test.csproj");
-
-        //     var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
-        //     {
-        //         AssemblyVersion = new Version(2, 0), // Mock for reading the assembly's version
-        //     };
-
-        //     await Task.Run(async () => await host.LoadAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-
-        //     // Act - 1
-        //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
-
-        //     // Assert - 1
-        //     var snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal("Test.csproj", snapshot.FilePath);
-        //     Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
-
-        //     // Act - 2
-        //     services.UnconfiguredProject.FullPath = "Test2.csproj";
-        //     await Task.Run(async () => await host.OnProjectRenamingAsync());
-
-        //     // Assert - 1
-        //     snapshot = Assert.Single(ProjectManager.Projects);
-        //     Assert.Equal("Test2.csproj", snapshot.FilePath);
-        //     Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
-
-        //     await Task.Run(async () => await host.DisposeAsync());
-        //     Assert.Empty(ProjectManager.Projects);
-        // }
-
-        // private class TestFallbackRazorProjectHost : FallbackRazorProjectHost
-        // {
-        //     internal TestFallbackRazorProjectHost(IUnconfiguredProjectCommonServices commonServices, Workspace workspace, ProjectConfigurationFilePathStore projectConfigurationFilePathStore, ProjectSnapshotManagerBase projectManager)
-        //         : base(commonServices, workspace, projectConfigurationFilePathStore, projectManager)
-        //     {
-        //     }
-
-        //     public Version AssemblyVersion { get; set; }
-
-        //     protected override Version GetAssemblyVersion(string filePath)
-        //     {
-        //         return AssemblyVersion;
-        //     }
-        // }
-
-        // private class TestProjectSnapshotManager : DefaultProjectSnapshotManager
-        // {
-        //     public TestProjectSnapshotManager(ForegroundDispatcher dispatcher, Workspace workspace)
-        //         : base(dispatcher, Mock.Of<ErrorReporter>(MockBehavior.Strict), Array.Empty<ProjectSnapshotChangeTrigger>(), workspace)
-        //     {
-        //     }
-        // }
+        public FallbackRazorProjectHostTest()
+        {
+            ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace);
+
+            var projectConfigurationFilePathStore = new Mock<ProjectConfigurationFilePathStore>(MockBehavior.Strict);
+            projectConfigurationFilePathStore.Setup(s => s.Remove(It.IsAny<string>())).Verifiable();
+            ProjectConfigurationFilePathStore = projectConfigurationFilePathStore.Object;
+
+            ReferenceItems = new ItemCollection(ManagedProjectSystemSchema.ResolvedCompilationReference.SchemaName);
+            ContentItems = new ItemCollection(ManagedProjectSystemSchema.ContentItem.SchemaName);
+            NoneItems = new ItemCollection(ManagedProjectSystemSchema.NoneItem.SchemaName);
+
+            JoinableTaskContext = new JoinableTaskContext();
+        }
+
+        private ItemCollection ReferenceItems { get; }
+
+        private TestProjectSnapshotManager ProjectManager { get; }
+
+        private ProjectConfigurationFilePathStore ProjectConfigurationFilePathStore { get; }
+
+        private ItemCollection ContentItems { get; }
+
+        private ItemCollection NoneItems { get; }
+
+        private JoinableTaskContext JoinableTaskContext { get; }
+
+        [Fact]
+        public void GetChangedAndRemovedDocuments_ReturnsChangedContentAndNoneItems()
+        {
+            // Arrange
+            var afterChangeContentItems = new ItemCollection(ManagedProjectSystemSchema.ContentItem.SchemaName);
+            ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "NewIndex.cshtml",
+                [ItemReference.FullPathPropertyName] = "C:\\From\\Index.cshtml",
+            });
+            var afterChangeNoneItems = new ItemCollection(ManagedProjectSystemSchema.NoneItem.SchemaName);
+            NoneItems.Item("About.cshtml", new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "NewAbout.cshtml",
+                [ItemReference.FullPathPropertyName] = "C:\\From\\About.cshtml",
+            });
+            var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var changes = new TestProjectChangeDescription[]
+            {
+                 afterChangeContentItems.ToChange(ContentItems.ToSnapshot()),
+                 afterChangeNoneItems.ToChange(NoneItems.ToSnapshot()),
+            };
+            var update = services.CreateUpdate(changes).Value;
+
+            // Act
+            var result = host.GetChangedAndRemovedDocuments(update);
+
+            // Assert
+            Assert.Collection(
+                result,
+                document =>
+                {
+                    Assert.Equal("C:\\From\\Index.cshtml", document.FilePath);
+                    Assert.Equal("C:\\To\\NewIndex.cshtml", document.TargetPath);
+                },
+                document =>
+                {
+                    Assert.Equal("C:\\From\\About.cshtml", document.FilePath);
+                    Assert.Equal("C:\\To\\NewAbout.cshtml", document.TargetPath);
+                });
+        }
+
+        [Fact]
+        public void GetCurrentDocuments_ReturnsContentAndNoneItems()
+        {
+            // Arrange
+            ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "NewIndex.cshtml",
+                [ItemReference.FullPathPropertyName] = "C:\\From\\Index.cshtml",
+            });
+            NoneItems.Item("About.cshtml", new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "NewAbout.cshtml",
+                [ItemReference.FullPathPropertyName] = "C:\\From\\About.cshtml",
+            });
+            var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ContentItems.ToChange(),
+                 NoneItems.ToChange(),
+            };
+            var update = services.CreateUpdate(changes).Value;
+
+            // Act
+            var result = host.GetCurrentDocuments(update);
+
+            // Assert
+            Assert.Collection(
+                result,
+                document =>
+                {
+                    Assert.Equal("C:\\From\\Index.cshtml", document.FilePath);
+                    Assert.Equal("C:\\To\\NewIndex.cshtml", document.TargetPath);
+                },
+                document =>
+                {
+                    Assert.Equal("C:\\From\\About.cshtml", document.FilePath);
+                    Assert.Equal("C:\\To\\NewAbout.cshtml", document.TargetPath);
+                });
+        }
+
+        // This is for the legacy SDK case, we don't support components.
+        [Fact]
+        public void GetCurrentDocuments_IgnoresDotRazorFiles()
+        {
+            // Arrange
+            ContentItems.Item("Index.razor", new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "NewIndex.razor",
+                [ItemReference.FullPathPropertyName] = "C:\\From\\Index.razor",
+            });
+            NoneItems.Item("About.razor", new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "NewAbout.razor",
+                [ItemReference.FullPathPropertyName] = "C:\\From\\About.razor",
+            });
+            var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ContentItems.ToChange(),
+                 NoneItems.ToChange(),
+            };
+            var update = services.CreateUpdate(changes).Value;
+
+            // Act
+            var result = host.GetCurrentDocuments(update);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void TryGetRazorDocument_NoFilePath_ReturnsFalse()
+        {
+            // Arrange
+            var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var itemState = new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "Index.cshtml",
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = host.TryGetRazorDocument(itemState, out var document);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(document);
+        }
+
+        [Fact]
+        public void TryGetRazorDocument_NonRazorFilePath_ReturnsFalse()
+        {
+            // Arrange
+            var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var itemState = new Dictionary<string, string>()
+            {
+                [ItemReference.FullPathPropertyName] = "C:\\Path\\site.css",
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = host.TryGetRazorDocument(itemState, out var document);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(document);
+        }
+
+        [Fact]
+        public void TryGetRazorDocument_NonRazorTargetPath_ReturnsFalse()
+        {
+            // Arrange
+            var services = new TestProjectSystemServices("C:\\Path\\To\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var itemState = new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "site.html",
+                [ItemReference.FullPathPropertyName] = "C:\\Path\\From\\Index.cshtml",
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = host.TryGetRazorDocument(itemState, out var document);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(document);
+        }
+
+        [Fact]
+        public void TryGetRazorDocument_JustFilePath_ReturnsTrue()
+        {
+            // Arrange
+            var expectedPath = "C:\\Path\\Index.cshtml";
+            var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var itemState = new Dictionary<string, string>()
+            {
+                [ItemReference.FullPathPropertyName] = expectedPath,
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = host.TryGetRazorDocument(itemState, out var document);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedPath, document.FilePath);
+            Assert.Equal(expectedPath, document.TargetPath);
+        }
+
+        [Fact]
+        public void TryGetRazorDocument_LinkedFilepath_ReturnsTrue()
+        {
+            // Arrange
+            var expectedFullPath = "C:\\Path\\From\\Index.cshtml";
+            var expectedTargetPath = "C:\\Path\\To\\Index.cshtml";
+            var services = new TestProjectSystemServices("C:\\Path\\To\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var itemState = new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "Index.cshtml",
+                [ItemReference.FullPathPropertyName] = expectedFullPath,
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = host.TryGetRazorDocument(itemState, out var document);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedFullPath, document.FilePath);
+            Assert.Equal(expectedTargetPath, document.TargetPath);
+        }
+
+        [Fact]
+        public void TryGetRazorDocument_SetsLegacyFileKind()
+        {
+            // Arrange
+            var expectedFullPath = "C:\\Path\\From\\Index.cshtml";
+            var expectedTargetPath = "C:\\Path\\To\\Index.cshtml";
+            var services = new TestProjectSystemServices("C:\\Path\\To\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+            var itemState = new Dictionary<string, string>()
+            {
+                [ItemReference.LinkPropertyName] = "Index.cshtml",
+                [ItemReference.FullPathPropertyName] = expectedFullPath,
+            }.ToImmutableDictionary();
+
+            // Act
+            var result = host.TryGetRazorDocument(itemState, out var document);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedFullPath, document.FilePath);
+            Assert.Equal(expectedTargetPath, document.TargetPath);
+            Assert.Equal(FileKinds.Legacy, document.FileKind);
+        }
+
+        [ForegroundFact]
+        public async Task FallbackRazorProjectHost_ForegroundThread_CreateAndDispose_Succeeds()
+        {
+            // Arrange
+            var services = new TestProjectSystemServices("C:\\To\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            // Act & Assert
+            await host.LoadAsync();
+            Assert.Empty(ProjectManager.Projects);
+
+            await host.DisposeAsync();
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task FallbackRazorProjectHost_BackgroundThread_CreateAndDispose_Succeeds()
+        {
+            // Arrange
+            var services = new TestProjectSystemServices("Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            // Act & Assert
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact] // This can happen if the .xaml files aren't included correctly.
+        public async Task OnProjectChanged_NoRulesDefined()
+        {
+            // Arrange
+            var changes = new TestProjectChangeDescription[]
+            {
+            };
+
+            var services = new TestProjectSystemServices("Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
+            {
+                AssemblyVersion = new Version(2, 0),
+            };
+
+            // Act & Assert
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectChanged_ReadsProperties_InitializesProject()
+        {
+            // Arrange
+            ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
+            ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
+            {
+                [ItemReference.FullPathPropertyName] = "C:\\Path\\Index.cshtml",
+            });
+            NoneItems.Item("About.cshtml", new Dictionary<string, string>()
+            {
+                [ItemReference.FullPathPropertyName] = "C:\\Path\\About.cshtml",
+            });
+
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ReferenceItems.ToChange(),
+                 ContentItems.ToChange(),
+                 NoneItems.ToChange(),
+            };
+
+            var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
+            {
+                AssemblyVersion = new Version(2, 0), // Mock for reading the assembly's version
+            };
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal("C:\\Path\\Test.csproj", snapshot.FilePath);
+            Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
+
+            Assert.Collection(
+                snapshot.DocumentFilePaths,
+                filePath => Assert.Equal("C:\\Path\\Index.cshtml", filePath),
+                filePath => Assert.Equal("C:\\Path\\About.cshtml", filePath));
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectChanged_NoAssemblyFound_DoesNotIniatializeProject()
+        {
+            // Arrange
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ReferenceItems.ToChange(),
+            };
+            var services = new TestProjectSystemServices("Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert
+            Assert.Empty(ProjectManager.Projects);
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectChanged_AssemblyFoundButCannotReadVersion_DoesNotIniatializeProject()
+        {
+            // Arrange
+            ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
+
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ReferenceItems.ToChange(),
+            };
+
+            var services = new TestProjectSystemServices("Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert
+            Assert.Empty(ProjectManager.Projects);
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectChanged_UpdateProject_Succeeds()
+        {
+            // Arrange
+            ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
+            var afterChangeContentItems = new ItemCollection(ManagedProjectSystemSchema.ContentItem.SchemaName);
+            ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
+            {
+                [ItemReference.FullPathPropertyName] = "C:\\Path\\Index.cshtml",
+            });
+
+            var initialChanges = new TestProjectChangeDescription[]
+            {
+                 ReferenceItems.ToChange(),
+                 ContentItems.ToChange(),
+            };
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ReferenceItems.ToChange(),
+                 afterChangeContentItems.ToChange(ContentItems.ToSnapshot()),
+            };
+
+            var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
+            {
+                AssemblyVersion = new Version(2, 0),
+            };
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act - 1
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(initialChanges)));
+
+            // Assert - 1
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal("C:\\Path\\Test.csproj", snapshot.FilePath);
+            Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
+            var filePath = Assert.Single(snapshot.DocumentFilePaths);
+            Assert.Equal("C:\\Path\\Index.cshtml", filePath);
+
+            // Act - 2
+            host.AssemblyVersion = new Version(1, 0);
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 2
+            snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal("C:\\Path\\Test.csproj", snapshot.FilePath);
+            Assert.Same(FallbackRazorConfiguration.MVC_1_0, snapshot.Configuration);
+            Assert.Empty(snapshot.DocumentFilePaths);
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectChanged_VersionRemoved_DeinitializesProject()
+        {
+            // Arrange
+            ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
+
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ReferenceItems.ToChange(),
+            };
+
+            var services = new TestProjectSystemServices("Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
+            {
+                AssemblyVersion = new Version(2, 0),
+            };
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act - 1
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 1
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal("Test.csproj", snapshot.FilePath);
+            Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
+
+            // Act - 2
+            host.AssemblyVersion = null;
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 2
+            Assert.Empty(ProjectManager.Projects);
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectChanged_AfterDispose_IgnoresUpdate()
+        {
+            // Arrange
+            ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
+            ContentItems.Item("Index.cshtml", new Dictionary<string, string>()
+            {
+                [ItemReference.FullPathPropertyName] = "C:\\Path\\Index.cshtml",
+            });
+
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ReferenceItems.ToChange(),
+                 ContentItems.ToChange(),
+            };
+
+            var services = new TestProjectSystemServices("C:\\Path\\Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
+            {
+                AssemblyVersion = new Version(2, 0),
+            };
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act - 1
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 1
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal("C:\\Path\\Test.csproj", snapshot.FilePath);
+            Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
+            var filePath = Assert.Single(snapshot.DocumentFilePaths);
+            Assert.Equal("C:\\Path\\Index.cshtml", filePath);
+
+            // Act - 2
+            await Task.Run(async () => await host.DisposeAsync());
+
+            // Assert - 2
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act - 3
+            host.AssemblyVersion = new Version(1, 1);
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 3
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        [ForegroundFact]
+        public async Task OnProjectRenamed_RemovesHostProject_CopiesConfiguration()
+        {
+            // Arrange
+            ReferenceItems.Item("c:\\nuget\\Microsoft.AspNetCore.Mvc.razor.dll");
+
+            var changes = new TestProjectChangeDescription[]
+            {
+                 ReferenceItems.ToChange(),
+            };
+
+            var services = new TestProjectSystemServices("Test.csproj");
+
+            var host = new TestFallbackRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager)
+            {
+                AssemblyVersion = new Version(2, 0), // Mock for reading the assembly's version
+            };
+
+            await Task.Run(async () => await host.LoadAsync());
+            Assert.Empty(ProjectManager.Projects);
+
+            // Act - 1
+            await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+
+            // Assert - 1
+            var snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal("Test.csproj", snapshot.FilePath);
+            Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
+
+            // Act - 2
+            services.UnconfiguredProject.FullPath = "Test2.csproj";
+            await Task.Run(async () => await host.OnProjectRenamingAsync());
+
+            // Assert - 1
+            snapshot = Assert.Single(ProjectManager.Projects);
+            Assert.Equal("Test2.csproj", snapshot.FilePath);
+            Assert.Same(FallbackRazorConfiguration.MVC_2_0, snapshot.Configuration);
+
+            await Task.Run(async () => await host.DisposeAsync());
+            Assert.Empty(ProjectManager.Projects);
+        }
+
+        private class TestFallbackRazorProjectHost : FallbackRazorProjectHost
+        {
+            internal TestFallbackRazorProjectHost(IUnconfiguredProjectCommonServices commonServices, Workspace workspace, ProjectConfigurationFilePathStore projectConfigurationFilePathStore, ProjectSnapshotManagerBase projectManager)
+                : base(commonServices, workspace, projectConfigurationFilePathStore, projectManager)
+            {
+            }
+
+            public Version AssemblyVersion { get; set; }
+
+            protected override Version GetAssemblyVersion(string filePath)
+            {
+                return AssemblyVersion;
+            }
+        }
+
+        private class TestProjectSnapshotManager : DefaultProjectSnapshotManager
+        {
+            public TestProjectSnapshotManager(ForegroundDispatcher dispatcher, Workspace workspace)
+                : base(dispatcher, Mock.Of<ErrorReporter>(MockBehavior.Strict), Array.Empty<ProjectSnapshotChangeTrigger>(), workspace)
+            {
+            }
+        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test.csproj
@@ -24,7 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(VSMAC_NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In addition to a blanket merge I:
- Update Shell packages to match latest dev17 bits.
- Comb through pre-existing "hacks" and removed ones that are no longer required.
- Re-enabled all tests.
- Trimmed unnecessary dependencies