### PR TITLE
Fix injected service rename crash

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentPublisher.cs
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 if (_mappingService == null)
                 {
-                    _mappingService = new CSharpSpanMappingService(_lspDocumentMappingProvider, _documentSnapshot, _textSnapshot);
+                    _mappingService = new RazorLSPSpanMappingService(_lspDocumentMappingProvider, _documentSnapshot, _textSnapshot);
                 }
 
                 return _mappingService;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RangeExtensions.cs
@@ -8,7 +8,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     internal static class RangeExtensions
     {
-        private static readonly Range UndefinedRange = new()
+        // Internal for testing only
+        internal static readonly Range UndefinedRange = new()
         {
             Start = new Position(-1, -1),
             End = new Position(-1, -1)


### PR DESCRIPTION
### Summary of the changes
 - The Razor LSP span mapping service wasn't dealing with mapping failures correctly, which crashed rename in some scenarios.
 - Also renamed `CSharpSpanMappingService` to `RazorLSPSpanMappingService` to better reflect its purpose (@NTaylorMullen this was per your suggestion in a previous convo).

When working on this issue I periodically noticed a separate issue where rename doesn't work entirely (i.e. trying to rename something and nothing happens), so I'm trying to investigate that as well and may file a separate issue in a bit.

Fixes: 
https://github.com/dotnet/aspnetcore/issues/30949