### PR TITLE
Add support for contextual Razor commenting.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -339,7 +339,13 @@
             {
                 "language": "aspnetcorerazor",
                 "scopeName": "text.aspnetcorerazor",
-                "path": "./syntaxes/aspnetcorerazor.tmLanguage.json"
+                "path": "./syntaxes/aspnetcorerazor.tmLanguage.json",
+                "embeddedLanguages": {
+                  "source.cs": "csharp",
+                  "text.html.basic": "html",
+                  "source.js": "javascript",
+                  "source.css": "css"
+                }
             }
         ],
         "commands": [

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -62,6 +62,7 @@
           "name": "keyword.control.razor.directive.codeblock.open"
         }
       },
+      "contentName": "source.cs",
       "patterns": [
         {
           "include": "#razor-codeblock-body"
@@ -309,6 +310,7 @@
     },
     "implicit-expression": {
       "name": "meta.expression.implicit.cshtml",
+      "contentName": "source.cs",
       "begin": "(?<![[:alpha:][:alnum:]])(@)",
       "beginCaptures": {
         "1": {
@@ -572,6 +574,7 @@
         }
       },
       "name": "meta.structure.razor.directive.codeblock",
+      "contentName": "source.cs",
       "patterns": [
         {
           "include": "source.cs"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -34,6 +34,7 @@ repository:
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.razor.directive.codeblock.open' }
+    contentName: 'source.cs'
     patterns:
       - include: '#razor-codeblock-body'
     end: '(\})'
@@ -162,6 +163,7 @@ repository:
 
   implicit-expression:
     name: 'meta.expression.implicit.cshtml'
+    contentName: 'source.cs'
     begin: '(?<![[:alpha:][:alnum:]])(@)'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
@@ -301,6 +303,7 @@ repository:
     beginCaptures:
       1: { name: 'keyword.control.razor.directive.codeblock.open' }
     name: 'meta.structure.razor.directive.codeblock'
+    contentName: 'source.cs'
     patterns:
       - include: 'source.cs'
     end: '(\})'

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -11,6 +11,12 @@
 [$RootKey$\TextMate\LanguageConfiguration\ContentTypeMapping]
 "RazorLSP"="$PackageFolder$\language-configuration.json"
 
+[$RootKey$\TextMate\LanguageConfiguration\GrammarMapping]
+"text.html.basic"="$PackageFolder$\html-language-configuration.json"
+"source.js"="$PackageFolder$\javascript-language-configuration.json"
+"source.css"="$PackageFolder$\css-language-configuration.json"
+"source.cs"="$PackageFolder$\csharp-language-configuration.json"
+
 [$RootKey$\FeatureFlags\Razor\LSP\Editor]
 "Description"="Enables the Razor Language Server Protocol powered editor experience for Razor (ASP.NET Core)."
 "Value"=dword:00000000

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -84,6 +84,22 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="csharp-language-configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="css-language-configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="html-language-configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="javascript-language-configuration.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
 
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/cgmanifest.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/cgmanifest.json
@@ -10,7 +10,7 @@
         }
       },
       "license": "MIT",
-      "description": "The files in the EmbeddedGrammars folder: csharp.tmLanguage, css.tmLanguage.json, html.tmLanguage.json and JavaScript.tmLanguage.json were pulled directly from VSCode. Also, the csharp-language-configuration.json, css-language-configuration.json, html-language-configuration.json and javascript-language-configuration.json files were also pulled directly from VSCode.",
+      "description": "The files in the EmbeddedGrammars folder: csharp.tmLanguage, css.tmLanguage.json, html.tmLanguage.json and JavaScript.tmLanguage.json were pulled directly from VSCode. Also, the csharp-language-configuration.json, css-language-configuration.json, html-language-configuration.json and javascript-language-configuration.json files were pulled directly from VSCode.",
       "version": "https://github.com/microsoft/vscode/tree/2e16c59fde65096c9ac2b3334f6b8b1fcbf87606"
     }
   ],

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/cgmanifest.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/cgmanifest.json
@@ -10,7 +10,7 @@
         }
       },
       "license": "MIT",
-      "description": "The files in the EmbeddedGrammars folder: csharp.tmLanguage, css.tmLanguage.json, html.tmLanguage.json and JavaScript.tmLanguage.json were pulled directly from VSCode.",
+      "description": "The files in the EmbeddedGrammars folder: csharp.tmLanguage, css.tmLanguage.json, html.tmLanguage.json and JavaScript.tmLanguage.json were pulled directly from VSCode. Also, the csharp-language-configuration.json, css-language-configuration.json, html-language-configuration.json and javascript-language-configuration.json files were also pulled directly from VSCode.",
       "version": "https://github.com/microsoft/vscode/tree/2e16c59fde65096c9ac2b3334f6b8b1fcbf87606"
     }
   ],

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/csharp-language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/csharp-language-configuration.json
@@ -1,0 +1,40 @@
+﻿{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": [ "/*", "*/" ]
+  },
+  "brackets": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ]
+  ],
+  "autoClosingPairs": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ],
+    {
+      "open": "'",
+      "close": "'",
+      "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "\"",
+      "close": "\"",
+      "notIn": [ "string", "comment" ]
+    }
+  ],
+  "surroundingPairs": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ],
+    [ "<", ">" ],
+    [ "'", "'" ],
+    [ "\"", "\"" ]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*#region\\b",
+      "end": "^\\s*#endregion\\b"
+    }
+  }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/css-language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/css-language-configuration.json
@@ -1,0 +1,50 @@
+﻿{
+  "comments": {
+    "blockComment": [ "/*", "*/" ]
+  },
+  "brackets": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ]
+  ],
+  "autoClosingPairs": [
+    {
+      "open": "{",
+      "close": "}",
+      "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "[",
+      "close": "]",
+      "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "(",
+      "close": ")",
+      "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "\"",
+      "close": "\"",
+      "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "'",
+      "close": "'",
+      "notIn": [ "string", "comment" ]
+    }
+  ],
+  "surroundingPairs": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ],
+    [ "\"", "\"" ],
+    [ "'", "'" ]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
+      "end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
+    }
+  }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/html-language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/html-language-configuration.json
@@ -1,0 +1,70 @@
+﻿{
+  "comments": {
+    "blockComment": [ "<!--", "-->" ]
+  },
+  "brackets": [
+    [ "<!--", "-->" ],
+    [ "<", ">" ],
+    [ "{", "}" ],
+    [ "(", ")" ]
+  ],
+  "autoClosingPairs": [
+    {
+      "open": "{",
+      "close": "}"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "'",
+      "close": "'"
+    },
+    {
+      "open": "\"",
+      "close": "\""
+    },
+    {
+      "open": "<!--",
+      "close": "-->",
+      "notIn": [ "comment", "string" ]
+    }
+  ],
+  "surroundingPairs": [
+    {
+      "open": "'",
+      "close": "'"
+    },
+    {
+      "open": "\"",
+      "close": "\""
+    },
+    {
+      "open": "{",
+      "close": "}"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "<",
+      "close": ">"
+    }
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*<!--\\s*#region\\b.*-->",
+      "end": "^\\s*<!--\\s*#endregion\\b.*-->"
+    }
+  }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/javascript-language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/javascript-language-configuration.json
@@ -1,0 +1,60 @@
+﻿{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": [ "/*", "*/" ]
+  },
+  "brackets": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ]
+  ],
+  "autoClosingPairs": [
+    {
+      "open": "{",
+      "close": "}"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "'",
+      "close": "'",
+      "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "\"",
+      "close": "\"",
+      "notIn": [ "string" ]
+    },
+    {
+      "open": "`",
+      "close": "`",
+      "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "/**",
+      "close": " */",
+      "notIn": [ "string" ]
+    }
+  ],
+  "surroundingPairs": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ],
+    [ "'", "'" ],
+    [ "\"", "\"" ],
+    [ "`", "`" ]
+  ],
+  "autoCloseBefore": ";:.,=}])>` \n\t",
+  "folding": {
+    "markers": {
+      "start": "^\\s*//\\s*#?region\\b",
+      "end": "^\\s*//\\s*#?endregion\\b"
+    }
+  }
+}


### PR DESCRIPTION
- Out-of-the box this doesn't actually enable contextual Razor commenting in Razor files. It requires changes from the platform; however, with those changes this works :)
- Added VSCode's C#, HTML, CSS and JavaScript language-configuration.json files and hooked them up in our pkgdef.
- Upated VSCode's embedded language mapping.
- Updated cgmanifest to record our newly acquired assets from VSCode.
- Found that when commenting single lines the platform (and VSCode) will look at the beginning of the line's scope association if you don't have anything selected and we weren't marking C# content as "source.cs", updated grammar accordingly.

## VS:

![image](https://i.imgur.com/4N6dDHF.gif)

## VSCode:

![image](https://i.imgur.com/SXX7MJC.gif)

Fixes dotnet/aspnetcore#14320