### PR TITLE
Add workspace trust config and always return inspectUri

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -33,6 +33,11 @@
   "files": [
     "BlazorDebugProxy/"
   ],
+  "capabilities": {
+		"untrustedWorkspaces": {
+			"supported": true
+		}
+	},
   "contributes": {},
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -2,7 +2,7 @@
   "name": "blazorwasm-companion",
   "displayName": "Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension",
   "description": "A companion extension for debugging Blazor WebAssembly applications in VS Code. Must be installed alongside the C# extension.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dotnet/aspnetcore-tooling.git"
@@ -34,10 +34,10 @@
     "BlazorDebugProxy/"
   ],
   "capabilities": {
-		"untrustedWorkspaces": {
-			"supported": true
-		}
-	},
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {},
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/src/extension.ts
@@ -62,6 +62,9 @@ export function activate(context: vscode.ExtensionContext) {
             return;
         } catch (error) {
             outputChannel.appendLine(`ERROR: ${error}`);
+            return {
+                inspectUri: '{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}',
+            };
         }
     });
 


### PR DESCRIPTION
### Summary of the changes
 - Adds the config required for the new workspace trust feature in VS Code
 - Returns the fall-back `inspectUri` value from the exception handler in the debugging extension
