### PR TITLE
Handle spaces in C# semantic requests

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -24,11 +24,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public string Normalize(string filePath)
         {
-            return NormalizeFilePath(filePath);
-        }
-
-        public static string NormalizeFilePath(string filePath)
-        {
             if (string.IsNullOrEmpty(filePath))
             {
                 return "/";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -24,6 +24,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public string Normalize(string filePath)
         {
+            return NormalizeFilePath(filePath);
+        }
+
+        public static string NormalizeFilePath(string filePath)
+        {
             if (string.IsNullOrEmpty(filePath))
             {
                 return "/";

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -32,6 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly RazorUIContextManager _uIContextManager;
         private readonly IDisposable _razorReadyListener;
         private readonly RazorLSPClientOptionsMonitor _clientOptionsMonitor;
+
         private const string RazorReadyFeature = "Razor-Initialization";
 
         [ImportingConstructor]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -279,14 +280,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(semanticTokensParams));
             }
 
-            var normalizedPath = FilePathNormalizer.NormalizeFilePath(semanticTokensParams.TextDocument.Uri.OriginalString);
-            var normalizedUri = new Uri(normalizedPath);
-            if (!_documentManager.TryGetDocument(normalizedUri, out var documentSnapshot))
-            {
-                return null;
-            }
-
-            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
+            var csharpDoc = GetCSharpDocumentSnapshsot(semanticTokensParams.TextDocument.Uri);
+            if (csharpDoc is null)
             {
                 return null;
             }
@@ -316,12 +311,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(semanticTokensEditsParams));
             }
 
-            if (!_documentManager.TryGetDocument(semanticTokensEditsParams.TextDocument.Uri, out var documentSnapshot))
-            {
-                return null;
-            }
-
-            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
+            var csharpDoc = GetCSharpDocumentSnapshsot(semanticTokensEditsParams.TextDocument.Uri);
+            if (csharpDoc is null)
             {
                 return null;
             }
@@ -356,6 +347,24 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 throw new ArgumentException("Returned tokens should be of type SemanticTokens or SemanticTokensEdits.");
             }
+        }
+
+        private CSharpVirtualDocumentSnapshot GetCSharpDocumentSnapshsot(Uri uri)
+        {
+            var normalizedString = uri.GetAbsoluteOrUNCPath();
+            var normalizedUri = new Uri(WebUtility.UrlDecode(normalizedString));
+
+            if (!_documentManager.TryGetDocument(normalizedUri, out var documentSnapshot))
+            {
+                return null;
+            }
+
+            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
+            {
+                return null;
+            }
+
+            return csharpDoc;
         }
 
         public override async Task RazorServerReadyAsync(CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -32,7 +32,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly RazorUIContextManager _uIContextManager;
         private readonly IDisposable _razorReadyListener;
         private readonly RazorLSPClientOptionsMonitor _clientOptionsMonitor;
-
         private const string RazorReadyFeature = "Razor-Initialization";
 
         [ImportingConstructor]
@@ -279,7 +278,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(semanticTokensParams));
             }
 
-            if (!_documentManager.TryGetDocument(semanticTokensParams.TextDocument.Uri, out var documentSnapshot))
+            var normalizedPath = FilePathNormalizer.NormalizeFilePath(semanticTokensParams.TextDocument.Uri.OriginalString);
+            var normalizedUri = new Uri(normalizedPath);
+            if (!_documentManager.TryGetDocument(normalizedUri, out var documentSnapshot))
             {
                 return null;
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -396,9 +396,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public async Task ProvideSemanticTokensAsync_ReturnsSemanticTokensAsync()
         {
             // Arrange
-            var testDocUri = new Uri("C:/path/to/file.razor");
-            var testVirtualDocUri = new Uri("C:/path/to/file2.razor.g");
-            var testCSharpDocUri = new Uri("C:/path/to/file.razor.g.cs");
+            var testDocUri = new Uri("C:/path/to - project/file.razor");
+            var testVirtualDocUri = new Uri("C:/path/to - project/file2.razor.g");
+            var testCSharpDocUri = new Uri("C:/path/to - project/file.razor.g.cs");
 
             var documentVersion = 0;
             var testVirtualDocument = new TestVirtualDocumentSnapshot(testVirtualDocUri, 0);
@@ -406,7 +406,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             LSPDocumentSnapshot testDocument = new TestLSPDocumentSnapshot(testDocUri, documentVersion, testVirtualDocument, csharpVirtualDocument);
 
             var documentManager = new Mock<TrackingLSPDocumentManager>(MockBehavior.Strict);
-            documentManager.Setup(manager => manager.TryGetDocument(It.IsAny<Uri>(), out testDocument))
+            documentManager.Setup(manager => manager.TryGetDocument(testDocUri, out testDocument))
                 .Returns(true);
 
             var expectedcSharpResults = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals.SemanticTokens();
@@ -429,7 +429,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
-                    Uri = testDocUri
+                    Uri = new Uri("C:/path/to%20-%20project/file.razor")
                 }
             };
             var expectedResults = new ProvideSemanticTokensResponse(expectedcSharpResults, documentVersion);


### PR DESCRIPTION
### Summary of the changes
 - Normalize Uri's coming into C# Semantic token requests to prevent false-negatives.

Fixes: https://github.com/dotnet/aspnetcore/issues/32369
