### PR TITLE
Address override completion issue with tabs

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Composition;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
@@ -240,7 +240,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         private class TestFormattingOptionsProvider : FormattingOptionsProvider
         {
-            public override FormattingOptions GetOptions(Uri lspDocumentUri) => null;
+            public override FormattingOptions GetOptions(Uri lspDocumentUri) => new FormattingOptions { InsertSpaces = true, TabSize = 4 };
         }
 
         private class TestDocumentMappingProvider : LSPDocumentMappingProvider


### PR DESCRIPTION
### Summary of the changes
 - The core problem here is that C# isn't respecting the user's tabs/spaces setting when generating override completion TextEdits. However, they can't currently respect the setting since LSP doesn't pass in any formatting options in completion requests. I believe the ideal fix here would be LSP including these options in completion requests (filed https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1332433 to track).
 - As a temporary workaround in the meantime, I added some logic so we manually convert spaces->tabs when necessary.

Fixes: 
https://github.com/dotnet/aspnetcore/issues/32555