### PR TITLE
Parallelize more RZLS requests.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/IOnAutoInsertHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/IOnAutoInsertHandler.cs
@@ -5,7 +5,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {
-    [Serial, Method("textDocument/_ms_onAutoInsert")]
+    [Parallel, Method("textDocument/_ms_onAutoInsert")]
     internal interface IOnAutoInsertHandler : IJsonRpcRequestHandler<OnAutoInsertParams, OnAutoInsertResponse>, IRegistrationExtension
     {
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorDiagnosticsHandler.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    [Serial, Method(LanguageServerConstants.RazorTranslateDiagnosticsEndpoint)]
+    [Parallel, Method(LanguageServerConstants.RazorTranslateDiagnosticsEndpoint)]
     internal interface IRazorDiagnosticsHandler : IJsonRpcRequestHandler<RazorDiagnosticsParams, RazorDiagnosticsResponse>
     {
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorLanguageQueryHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorLanguageQueryHandler.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    [Serial, Method(LanguageServerConstants.RazorLanguageQueryEndpoint)]
+    [Parallel, Method(LanguageServerConstants.RazorLanguageQueryEndpoint)]
     internal interface IRazorLanguageQueryHandler : IJsonRpcRequestHandler<RazorLanguageQueryParams, RazorLanguageQueryResponse>
     {
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentEditsHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentEditsHandler.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    [Serial, Method(LanguageServerConstants.RazorMapToDocumentEditsEndpoint)]
+    [Parallel, Method(LanguageServerConstants.RazorMapToDocumentEditsEndpoint)]
     internal interface IRazorMapToDocumentEditsHandler : IJsonRpcRequestHandler<RazorMapToDocumentEditsParams, RazorMapToDocumentEditsResponse>
     {
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentRangesHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentRangesHandler.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    [Serial, Method(LanguageServerConstants.RazorMapToDocumentRangesEndpoint)]
+    [Parallel, Method(LanguageServerConstants.RazorMapToDocumentRangesEndpoint)]
     internal interface IRazorMapToDocumentRangesHandler : IJsonRpcRequestHandler<RazorMapToDocumentRangesParams, RazorMapToDocumentRangesResponse>
     {
     }


### PR DESCRIPTION
- In Razor scenarios this improves perf pretty much across the board by 50%.
- The only requests that should be "serial" are document state requests like `textDocument/didChange` etc. This was just a misunderstanding of how the `[Serial]` and `[Parallel]` attributes work in O#. So let me explain a bit more. When O# processes requests it starts it takes into account the `[Serial]`/`[Parallel]` mechanic:
  - `[Serial]`: Wait for the request to finish before starting the next
  - `[Parallel]`: Proceed to the next request to process, no need to await it.

  Because of this behavior the only types of requests that actually need to be serial are ones that mutate server state (the didChange's etc.). All others will queue behind a serial request, meaning if you get:
  1. `textDocument/completion` "@"
  2. `textDocument/didChange`  "D"
  3. `textDocument/completion` "D"
  4. `textDocument/codeAction`

  Then 1. will get kicked off first (but wont be awaited) and then 2 will get in line to "start" being invoked. Because 2 is `[Serial]` it'll then await 1 (it needs to ensure all prior work is done) and then it will call and await 2. Once 2 is completed 3 and 4 will start in parallel.

Fixes dotnet/aspnetcore#32941

@jimmylewis @ToddGrun @alexgav I dug through your code base a bit and saw some unnecessary `[Serial]` attributes. Changing them to `[Parallel]` can result in some pretty massive perf wins. Well at least in Razor's case they were some pretty massive wins 😄 