### PR TITLE
Don't block subsequent threads when Razor parser runs synchronously.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 }
             }
 
-            public Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetGeneratedOutputAndVersionAsync(DefaultProjectSnapshot project, DocumentSnapshot document)
+            public async Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetGeneratedOutputAndVersionAsync(DefaultProjectSnapshot project, DocumentSnapshot document)
             {
                 if (project == null)
                 {
@@ -327,18 +327,48 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 if (TaskUnsafeReference == null ||
                     !TaskUnsafeReference.TryGetTarget(out var taskUnsafe))
                 {
+                    TaskCompletionSource<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> tcs = null;
+
                     lock (_lock)
                     {
                         if (TaskUnsafeReference == null ||
                             !TaskUnsafeReference.TryGetTarget(out taskUnsafe))
                         {
-                            taskUnsafe = GetGeneratedOutputAndVersionCoreAsync(project, document);
+                            // So this is a bit confusing. Instead of directly calling the Razor parser inside of this lock we create an indirect TaskCompletionSource
+                            // to represent when it completes. The reason behind this is that there are several scenarios in which the Razor parser will run synchronously
+                            // (mostly all in VS) resulting in this lock being held for significantly longer than expected. To avoid threads queuing up repeatedly on the
+                            // above lock and blocking we can allow those threads to await asynchronously for the completion of the original parse.
+
+                            tcs = new();
+                            taskUnsafe = tcs.Task;
                             TaskUnsafeReference = new WeakReference<Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)>>(taskUnsafe);
                         }
                     }
+
+                    if (tcs == null)
+                    {
+                        // There's no task completion source created meaning a value was retrieved from cache, just return it.
+                        return await taskUnsafe.ConfigureAwait(false);
+                    }
+
+                    try
+                    {
+                        // Typically in VS scenarios this will run synchronously because all resources are readily available.
+                        var result = await GetGeneratedOutputAndVersionCoreAsync(project, document).ConfigureAwait(false);
+
+                        // Notify any memoized awaiters of the result.
+                        tcs.SetResult(result);
+                        return result;
+                    }
+                    catch (Exception ex)
+                    {
+                        tcs.SetException(ex);
+                        throw;
+                    }
                 }
 
-                return taskUnsafe;
+                // We were able to immediately retrieve the cached result, return as is.
+                return await taskUnsafe.ConfigureAwait(false);
             }
 
             private async Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetGeneratedOutputAndVersionCoreAsync(DefaultProjectSnapshot project, DocumentSnapshot document)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                             // (mostly all in VS) resulting in this lock being held for significantly longer than expected. To avoid threads queuing up repeatedly on the
                             // above lock and blocking we can allow those threads to await asynchronously for the completion of the original parse.
 
-                            tcs = new();
+                            tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
                             taskUnsafe = tcs.Task;
                             TaskUnsafeReference = new WeakReference<Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)>>(taskUnsafe);
                         }


### PR DESCRIPTION
- We have a single "parse Razor file" mechanism in our design time infrastructure who's primary goal is to start a parse for a Razor file and if someone else asks for said parse while one is already running to not start a second parse but instead return the task from the first. To do this we cache the parse task (weakly to not result in too much static memory growth) and return it to all consumers. Prior to this change we were caching the task for the parse under a lock. Meaning we were attempting to start the Razor parsing `Task` when a parse was requested and then allow any future requestor to party on the same task. Turns out us "starting" the Razor parser task would typically run synchronously in Visual Studio scenarios. In larger apps this resulted in several threads queuing up on our parser memoization task lock until our parse was complete. To tackle this instead of directly calling the Razor parser inside of a lock we create an indirect `TaskCompletionSource` to represent when it completes. Meaning the first parse will still run synchronously but all subsequent requests will yield due to the `TaskCompletionSource` until the original parse has completed.
- I profiled this with Perfview several times on a large app analyzing Completion, OnAutoInsert and CodeAction StreamJsonRpc request times. It wasn't the most accurate way to profile this due to the nature of the test but I tried to reduce as many variables as possible. Here's what I found:
  **Completion**: 2.2x faster
  **OnAutoInsert**: 2.2x faster
  **CodeActions**: 2.83x faster

Fixes dotnet/aspnetcore#32941