### PR TITLE
Fix go-to-def issue with components

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -28,10 +28,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         /// <summary>Search for a component in a project based on its tag name and fully qualified name.</summary>
         /// <remarks>
-        /// This method makes several assumptions about the nature of components. First, it assumes that a component
-        /// a given name `Name` will be located in a file `Name.razor`. Second, it assumes that the namespace the
-        /// component is present in has the same name as the assembly its corresponding tag helper is loaded from.
-        /// Implicitly, this method inherits any assumptions made by TrySplitNamespaceAndType.
+        /// This method makes several assumptions about the nature of components. It assumes that a component
+        /// a given name `Name` will be located in a file `Name.razor`. Implicitly, this method also inherits
+        /// any assumptions made by TrySplitNamespaceAndType.
         /// </remarks>
         /// <param name="tagHelper">A TagHelperDescriptor to find the corresponding Razor component for.</param>
         /// <returns>The corresponding DocumentSnapshot if found, null otherwise.</returns>
@@ -53,11 +52,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             foreach (var project in projects)
             {
-                if (!project.FilePath.EndsWith($"{tagHelper.AssemblyName}.csproj", FilePathComparison.Instance))
-                {
-                    continue;
-                }
-
                 foreach (var path in project.DocumentFilePaths)
                 {
                     // Get document and code document

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -28,9 +28,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         /// <summary>Search for a component in a project based on its tag name and fully qualified name.</summary>
         /// <remarks>
-        /// This method makes several assumptions about the nature of components. It assumes that a component
-        /// a given name `Name` will be located in a file `Name.razor`. Implicitly, this method also inherits
-        /// any assumptions made by TrySplitNamespaceAndType.
+        /// This method makes several assumptions about the nature of components. First, it assumes that a component
+        /// a given name `Name` will be located in a file `Name.razor`. Second, it assumes that the namespace the
+        /// component is present in has the same name as the assembly its corresponding tag helper is loaded from.
+        /// Implicitly, this method inherits any assumptions made by TrySplitNamespaceAndType.
         /// </remarks>
         /// <param name="tagHelper">A TagHelperDescriptor to find the corresponding Razor component for.</param>
         /// <returns>The corresponding DocumentSnapshot if found, null otherwise.</returns>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -109,6 +109,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
             Assert.Null(documentSnapshot);
         }
 
+        [Fact]
+        public async Task Handle_FilePathAndAssemblyNameDifferent()
+        {
+            // Arrange
+            var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("AssemblyName", "Test", "Component2");
+            var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, _projectSnapshotManager);
+
+            // Act
+            var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor).ConfigureAwait(false);
+
+            // Assert
+            Assert.NotNull(documentSnapshot);
+        }
+
         internal static TagHelperDescriptor CreateRazorComponentTagHelperDescriptor(string assemblyName, string namespaceName, string tagName, string typeName = null)
         {
             typeName ??= tagName;


### PR DESCRIPTION
### Summary of the changes
 - An assembly's name and file path can differ, so we probably don't want to check for equality between the two.
 - Doesn't seem to impact performance _too_ much, in a large solution we still get results in about a second or less. Alternate solutions would either be to add a file path property to `TagHelperDescriptors` or an assembly name property to the project snapshot manager, but both of these seem to be quite a bit of work.
 - GTD still doesn't work with component attributes, filed https://github.com/dotnet/aspnetcore/issues/33096 to track.

Fixes https://github.com/dotnet/aspnetcore/issues/29841
