### PR TITLE
Upgrade CSS language-configuration.json

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/css-language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/css-language-configuration.json
@@ -46,5 +46,10 @@
       "start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
       "end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
     }
-  }
+  },
+  "indentationRules": {
+    "increaseIndentPattern": "(^.*\\{[^}]*$)",
+    "decreaseIndentPattern": "^\\s*\\}"
+  },
+  "wordPattern": "(#?-?\\d*\\.\\d\\w*%?)|(::?[\\w-]*(?=[^,{;]*[,{]))|(([@#.!])?[\\w-?]+%?|[@#!.])"
 }


### PR DESCRIPTION
- Added `wordPattern` and `indentationRules`.
  - `wordPattern` influences all sorts of features, completion being one of them so if you type `foo-bar` completion won't dismiss when you type the `-`.
  - `indentationRules` influence the indentation when you enter a newline or the base indentation for your cursor when you click around the document (smart indent).
-  Played around with it a bit in the editor and everything seemed to work. Found [some issues with completion in CSS](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1335055/) but that was due to unrelated bits.

Part of dotnet/aspnetcore#33085