### PR TITLE
Don't active language server on UI thread.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -121,6 +121,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public async Task<Connection> ActivateAsync(CancellationToken token)
         {
+            // Swap to background thread, nothing below needs to be done on the UI thread.
+            await TaskScheduler.Default;
+
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
 
             await EnsureCleanedUpServerAsync(token).ConfigureAwait(false);


### PR DESCRIPTION
- Turns out a lot of our language server initialization logic runs on the UI thread and that logic can take a significant amount of time; especially when restarting a language server.

Fixes dotnet/aspnetcore#33191