### PR TITLE
Fix DocumentState's WeakReference to Razor output.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -395,7 +395,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     }
                     else if (targetTask.Status == TaskStatus.Faulted)
                     {
-                        tcs.SetException(targetTask.Exception);
+                        // Faulted tasks area always aggregate exceptions so we need to extract the "true" exception if it's available:
+                        var exception = targetTask.Exception.InnerException ?? targetTask.Exception;
+                        tcs.SetException(exception);
                     }
                 }
             }


### PR DESCRIPTION
- Turned out the flaky test was in fact caused by me :D. When I made our document parsing mechanics not occur inside of locks / not occupy thread time for concurrent requests I inadvetantly broke the ability for our document state to accurately weak reference Razor parsed output. Because of this tests would be flaky because in some scenarios they'd expect that document versions would be cached when in fact they weren't.

Fixes dotnet/aspnetcore#33208
