### PR TITLE
Prevent C# AdhocWorkspace from probing MEF services.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/AdhocServices.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/AdhocServices.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 
@@ -13,8 +12,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
     {
         private readonly IEnumerable<IWorkspaceService> _workspaceServices;
         private readonly IEnumerable<ILanguageService> _razorLanguageServices;
+        private readonly HostWorkspaceServices _fallbackServices;
 
-        private AdhocServices(IEnumerable<IWorkspaceService> workspaceServices, IEnumerable<ILanguageService> razorLanguageServices)
+        private AdhocServices(
+            IEnumerable<IWorkspaceService> workspaceServices,
+            IEnumerable<ILanguageService> razorLanguageServices,
+            HostWorkspaceServices fallbackServices)
         {
             if (workspaceServices == null)
             {
@@ -26,8 +29,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 throw new ArgumentNullException(nameof(razorLanguageServices));
             }
 
+            if (fallbackServices is null)
+            {
+                throw new ArgumentNullException(nameof(fallbackServices));
+            }
+
             _workspaceServices = workspaceServices;
             _razorLanguageServices = razorLanguageServices;
+            _fallbackServices = fallbackServices;
         }
 
         protected override HostWorkspaceServices CreateWorkspaceServices(Workspace workspace)
@@ -37,13 +46,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 throw new ArgumentNullException(nameof(workspace));
             }
 
-            return new AdhocWorkspaceServices(this, _workspaceServices, _razorLanguageServices, workspace);
+            return new AdhocWorkspaceServices(this, _workspaceServices, _razorLanguageServices, workspace, _fallbackServices);
         }
 
-        public static HostServices Create(IEnumerable<ILanguageService> razorLanguageServices)
-            => Create(Enumerable.Empty<IWorkspaceService>(), razorLanguageServices);
-
-        public static HostServices Create(IEnumerable<IWorkspaceService> workspaceServices, IEnumerable<ILanguageService> razorLanguageServices)
-            => new AdhocServices(workspaceServices, razorLanguageServices);
+        public static HostServices Create(IEnumerable<IWorkspaceService> workspaceServices, IEnumerable<ILanguageService> razorLanguageServices, HostWorkspaceServices fallbackServices)
+            => new AdhocServices(workspaceServices, razorLanguageServices, fallbackServices);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AdhocWorkspaceFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AdhocWorkspaceFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class AdhocWorkspaceFactory
+    {
+        public abstract AdhocWorkspace Create();
+
+        public abstract AdhocWorkspace Create(IEnumerable<IWorkspaceService> workspaceServices);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultAdhocWorkspaceFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultAdhocWorkspaceFactory.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultAdhocWorkspaceFactory : AdhocWorkspaceFactory
+    {
+        private readonly HostWorkspaceServicesProvider _hostWorkspaceServicesProvider;
+
+        public DefaultAdhocWorkspaceFactory(HostWorkspaceServicesProvider hostWorkspaceServicesProvider)
+        {
+            if (hostWorkspaceServicesProvider is null)
+            {
+                throw new ArgumentNullException(nameof(hostWorkspaceServicesProvider));
+            }
+
+            _hostWorkspaceServicesProvider = hostWorkspaceServicesProvider;
+        }
+
+        public override AdhocWorkspace Create() => Create(Enumerable.Empty<IWorkspaceService>());
+
+        public override AdhocWorkspace Create(IEnumerable<IWorkspaceService> workspaceServices)
+        {
+            if (workspaceServices is null)
+            {
+                throw new ArgumentNullException(nameof(workspaceServices));
+            }
+
+            var fallbackServices = _hostWorkspaceServicesProvider.GetServices();
+            var services = AdhocServices.Create(
+                workspaceServices,
+                razorLanguageServices: Enumerable.Empty<ILanguageService>(),
+                fallbackServices);
+            var workspace = new AdhocWorkspace(services);
+            return workspace;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultHostWorkspaceServicesProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultHostWorkspaceServicesProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class DefaultHostWorkspaceServicesProvider : HostWorkspaceServicesProvider
+    {
+        // We mark this as Lazy because construction of an AdhocWorkspace without services will utilize MEF under the covers
+        // which can be expensive and we don't want to do that until absolutely necessary.
+        private static readonly Lazy<Workspace> DefaultWorkspace = new Lazy<Workspace>(() => new AdhocWorkspace());
+
+        public override HostWorkspaceServices GetServices() => DefaultWorkspace.Value.Services;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/HostWorkspaceServicesProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/HostWorkspaceServicesProvider.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal abstract class HostWorkspaceServicesProvider
+    {
+        public abstract HostWorkspaceServices GetServices();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -137,6 +137,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<FilePathNormalizer>();
                         services.AddSingleton<ForegroundDispatcher, DefaultForegroundDispatcher>();
                         services.AddSingleton<GeneratedDocumentPublisher, DefaultGeneratedDocumentPublisher>();
+                        services.AddSingleton<AdhocWorkspaceFactory, DefaultAdhocWorkspaceFactory>();
                         services.AddSingleton<ProjectSnapshotChangeTrigger>((services) => services.GetRequiredService<GeneratedDocumentPublisher>());
 
                         services.AddSingleton<DocumentVersionCache, DefaultDocumentVersionCache>();
@@ -240,6 +241,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                         // Defaults: For when the caller hasn't provided them through the `configure` action.
                         services.TryAddSingleton<LanguageServerFeatureOptions, DefaultLanguageServerFeatureOptions>();
+
+                        // Defaults: For when the caller hasn't provided them through the `configure` action.
+                        services.TryAddSingleton<HostWorkspaceServicesProvider, DefaultHostWorkspaceServicesProvider>();
                     }));
 
             try

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
         private readonly RazorLanguageServerLogHubLoggerProviderFactory _logHubLoggerProviderFactory;
         private readonly VSLanguageServerFeatureOptions _vsLanguageServerFeatureOptions;
-
+        private readonly VSHostWorkspaceServicesProvider _vsHostWorkspaceServicesProvider;
         private readonly object _shutdownLock;
         private RazorLanguageServer _server;
         private IDisposable _serverShutdownDisposable;
@@ -53,7 +53,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             LSPRequestInvoker requestInvoker,
             ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
             RazorLanguageServerLogHubLoggerProviderFactory logHubLoggerProviderFactory,
-            VSLanguageServerFeatureOptions vsLanguageServerFeatureOptions)
+            VSLanguageServerFeatureOptions vsLanguageServerFeatureOptions,
+            VSHostWorkspaceServicesProvider vsHostWorkspaceServicesProvider)
         {
             if (customTarget is null)
             {
@@ -85,13 +86,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw new ArgumentNullException(nameof(vsLanguageServerFeatureOptions));
             }
 
+            if (vsHostWorkspaceServicesProvider is null)
+            {
+                throw new ArgumentNullException(nameof(vsHostWorkspaceServicesProvider));
+            }
+
             _customMessageTarget = customTarget;
             _middleLayer = middleLayer;
             _requestInvoker = requestInvoker;
             _projectConfigurationFilePathStore = projectConfigurationFilePathStore;
             _logHubLoggerProviderFactory = logHubLoggerProviderFactory;
             _vsLanguageServerFeatureOptions = vsLanguageServerFeatureOptions;
-
+            _vsHostWorkspaceServicesProvider = vsHostWorkspaceServicesProvider;
             _shutdownLock = new object();
         }
 
@@ -156,6 +162,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 logging.AddProvider(_loggerProvider);
             });
             services.AddSingleton<LanguageServerFeatureOptions>(_vsLanguageServerFeatureOptions);
+            services.AddSingleton<HostWorkspaceServicesProvider>(_vsHostWorkspaceServicesProvider);
         }
 
         private Trace GetVerbosity()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VSHostWorkspaceServicesProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/VSHostWorkspaceServicesProvider.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.VisualStudio.LanguageServices;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Export(typeof(VSHostWorkspaceServicesProvider))]
+    internal class VSHostWorkspaceServicesProvider : HostWorkspaceServicesProvider
+    {
+        private readonly CodeAnalysis.Workspace _workspace;
+
+        [ImportingConstructor]
+        public VSHostWorkspaceServicesProvider([Import(typeof(VisualStudioWorkspace))] CodeAnalysis.Workspace workspace)
+        {
+            if (workspace is null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _workspace = workspace;
+        }
+
+        public override HostWorkspaceServices GetServices() => _workspace.Services;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshotManager.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshotManager.cs
@@ -26,13 +26,13 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
                 throw new ArgumentNullException(nameof(dispatcher));
             }
 
-            var services = AdhocServices.Create(
+            var services = TestServices.Create(
                 workspaceServices: new[]
                 {
                     new DefaultProjectSnapshotProjectEngineFactory(new FallbackProjectEngineFactory(), ProjectEngineFactories.Factories)
                 },
                 razorLanguageServices: Enumerable.Empty<ILanguageService>());
-            var workspace = new AdhocWorkspace(services);
+            var workspace = TestWorkspace.Create(services);
             var testProjectManager = new TestProjectSnapshotManager(dispatcher, workspace);
 
             return testProjectManager;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -35,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
-            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider });
+            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
                 TextDocument = new TextDocumentIdentifier(uri),
@@ -70,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 ResolvedTextEdit = new TextEdit()
             };
-            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider1, insertProvider2 });
+            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider1, insertProvider2 }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
                 TextDocument = new TextDocumentIdentifier(uri),
@@ -107,7 +108,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 ResolvedTextEdit = new TextEdit()
             };
-            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider1, insertProvider2 });
+            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider1, insertProvider2 }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
                 TextDocument = new TextDocumentIdentifier(uri),
@@ -138,7 +139,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true);
             var insertProvider2 = new TestOnAutoInsertProvider("<", canResolve: true);
-            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider1, insertProvider2 });
+            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider1, insertProvider2 }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
                 TextDocument = new TextDocumentIdentifier(uri),
@@ -164,7 +165,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
-            var endpoint = new OnAutoInsertEndpoint(Dispatcher, EmptyDocumentResolver, new[] { insertProvider });
+            var endpoint = new OnAutoInsertEndpoint(Dispatcher, EmptyDocumentResolver, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
             var uri = new Uri("file://path/test.razor");
             var @params = new OnAutoInsertParams()
             {
@@ -194,7 +195,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
-            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider });
+            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
                 TextDocument = new TextDocumentIdentifier(uri),
@@ -222,7 +223,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var insertProvider = new TestOnAutoInsertProvider(">", canResolve: false);
-            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider });
+            var endpoint = new OnAutoInsertEndpoint(Dispatcher, documentResolver, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
                 TextDocument = new TextDocumentIdentifier(uri),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Testing;
@@ -39,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             };
 
             var provider = CreateProvider();
-            var context = FormattingContext.Create(uri, Mock.Of<DocumentSnapshot>(MockBehavior.Strict), codeDocument, options, new Range(position, position));
+            var context = FormattingContext.Create(uri, Mock.Of<DocumentSnapshot>(MockBehavior.Strict), codeDocument, options, TestAdhocWorkspaceFactory.Instance, new Range(position, position));
 
             // Act
             if (!provider.TryResolveInsertion(position, context, out var edit, out _))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
@@ -138,7 +139,7 @@ public class Foo { }
                 InsertSpaces = insertSpaces,
             };
 
-            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options);
+            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, TestAdhocWorkspaceFactory.Instance);
             return context;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
@@ -145,7 +146,7 @@ public class Foo { }
                 InsertSpaces = insertSpaces,
             };
 
-            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options);
+            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, TestAdhocWorkspaceFactory.Instance);
             return context;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
@@ -170,7 +171,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 new FormattingContentValidationPass(mappingService, FilePathNormalizer, client, LoggerFactory),
             };
 
-            return new DefaultRazorFormattingService(passes, LoggerFactory);
+            return new DefaultRazorFormattingService(passes, LoggerFactory, TestAdhocWorkspaceFactory.Instance);
         }
 
         private static SourceText ApplyEdits(SourceText source, TextEdit[] edits)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestAdhocWorkspaceFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestAdhocWorkspaceFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
+{
+    internal class TestAdhocWorkspaceFactory : AdhocWorkspaceFactory
+    {
+        public static readonly TestAdhocWorkspaceFactory Instance = new TestAdhocWorkspaceFactory();
+
+        private TestAdhocWorkspaceFactory()
+        {
+        }
+
+        public override AdhocWorkspace Create() => Create(Enumerable.Empty<IWorkspaceService>());
+
+        public override AdhocWorkspace Create(IEnumerable<IWorkspaceService> workspaceServices)
+        {
+            var services = TestServices.Create(workspaceServices, Enumerable.Empty<ILanguageService>());
+            var workspace = TestWorkspace.Create(services);
+            return workspace;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestWorkspace.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestWorkspace.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
 
         public static Workspace Create(Action<AdhocWorkspace> configure = null) => Create(services: null, configure: configure);
 
-        public static Workspace Create(HostServices services, Action<AdhocWorkspace> configure = null)
+        public static AdhocWorkspace Create(HostServices services, Action<AdhocWorkspace> configure = null)
         {
             lock (WorkspaceLock)
             {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorEditorFactoryServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorEditorFactoryServiceTest.cs
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 smartIndenterFactory
             });
 
-            var workspace = TestWorkspace.Create(services);
+            Workspace workspace = TestWorkspace.Create(services);
             var workspaceAccessor = new Mock<VisualStudioWorkspaceAccessor>(MockBehavior.Strict);
             workspaceAccessor.Setup(p => p.TryGetWorkspace(It.IsAny<ITextBuffer>(), out workspace))
                 .Returns(true);


### PR DESCRIPTION
- There are several locations in our stack where we construct an `AdhocWorkspace` because we don't have direct access to C#'s workspace. Primary reason behind us not having access is that our language server does not run in the same process as Roslyn. On paper constructing an `AdhocWorkspace` is easy; however; behind the scenes if you don't provide it any services it'll utilize MEF to find all the services it cares about. Turns out the default workspace impls actually depend on several services and the probing of the MEF services isn't cheap.
- To prevent us from incorrectly creating `AdhocWorkspaces` and to also enable the creation of the workspaces to re-use VS' workspaces (if available) I built out two key abstractions:
  1. `AdhocWorkspaceFactory`: As the name implies, it creates an adhoc workspace in an efficient manner
  2. `HostWorkspaceServicesProvider`: This is a bit of an impl detail but it enables our language server to utilize VS' workspace services in VS scenarios and in non-VS scenarios we fall back to using the MEF probing that we previously had.
- There was quite a bit of fallout from all of these changes so needed to flow the workspace factory to pretty much everything that cared about workspaces (project manager & formatting). Added some test types to aid in simplicity of this.

Fixes dotnet/aspnetcore#33250