### PR TITLE
Add support for Razor warning severity.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticConverter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticConverter.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return severity switch
             {
                 RazorDiagnosticSeverity.Error => DiagnosticSeverity.Error,
+                RazorDiagnosticSeverity.Warning => DiagnosticSeverity.Warning,
                 _ => DiagnosticSeverity.Information,
             };
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticConverterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDiagnosticConverterTest.cs
@@ -42,6 +42,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
+        public void ConvertSeverity_WarningReturnsWarning()
+        {
+            // Arrange
+            var expectedSeverity = DiagnosticSeverity.Warning;
+
+            // Act
+            var severity = RazorDiagnosticConverter.ConvertSeverity(RazorDiagnosticSeverity.Warning);
+
+            // Assert
+            Assert.Equal(expectedSeverity, severity);
+        }
+
+        [Fact]
         public void ConvertSpanToRange_ReturnsConvertedRange()
         {
             // Arrange


### PR DESCRIPTION
- Compiler added support for this so we need to react.

### Before:
![image](https://user-images.githubusercontent.com/2008729/120720207-8c155b80-c480-11eb-89c7-30c110017344.png)

### After:
![image](https://user-images.githubusercontent.com/2008729/120720118-596b6300-c480-11eb-9a4a-68811b070f19.png)

Fixes dotnet/aspnetcore#33231