### PR TITLE
Change RazorLSP content type & settings to "Razor".

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     internal static class RazorLSPConstants
     {
-        public const string RazorLSPContentTypeName = "RazorLSP";
+        public const string RazorLSPContentTypeName = "Razor";
 
         public const string CSHTMLFileExtension = ".cshtml";
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLangaugeInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageService`IVsLangaugeInfo.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     {
         public int GetLanguageName(out string bstrName)
         {
-            bstrName = "RazorLSP";
+            bstrName = "Razor";
             return VSConstants.S_OK;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -9,7 +9,7 @@
 // Defines where the language configuration file for a given
 // language name is (partial value of the content type name).
 [$RootKey$\TextMate\LanguageConfiguration\ContentTypeMapping]
-"RazorLSP"="$PackageFolder$\language-configuration.json"
+"Razor"="$PackageFolder$\language-configuration.json"
 
 [$RootKey$\TextMate\LanguageConfiguration\GrammarMapping]
 "source.js"="$PackageFolder$\javascript-language-configuration.json"
@@ -19,10 +19,10 @@
 // Sets up Razor's default settings in Tools->Options.
 // Razor's default settings can be found in the VS repo at:
 //     src/VSCommonContent/profiles/General.vssettings
-[$RootKey$\AutomationProperties\TextEditor\RazorLSP]
+[$RootKey$\AutomationProperties\TextEditor\Razor]
 @="#110"
 "Description"="#112"
-"Name"="RazorLSP"
+"Name"="Razor"
 "Package"="{f5e7e720-1401-11d1-883b-0000f87579d2}"
 "ResourcePackage"="{13b72f58-279e-49e0-a56d-296be02f0805}"
 "ProfileSave"=dword:00000001
@@ -30,7 +30,7 @@
 
 // Provides additional Tools->Options settings not covered
 // by the settings in General.vssettings.
-[$RootKey$\Languages\Language Services\RazorLSP]
+[$RootKey$\Languages\Language Services\Razor]
 @="{4513FA64-5B72-4B58-9D4C-1D3C81996C2C}"
 "Package"="{13b72f58-279e-49e0-a56d-296be02f0805}"
 "ShowBraceCompletion"=dword:00000001


### PR DESCRIPTION
- The `Razor` name is more appropriate for extenders so before we go on-by-default the intent is to translate the Razor settings and content type over to the new "Razor" name.
- Played around with changing class & property names from `RazorLSPXYZ` to `RazorXYZ`. In the end things were just a bit too confusing with all the legacy that was pre-existing. Too many services overlapped and made it really hard to reason about what was "new" and what wasn't. Isolating this change to only be the content type / settings felt better.

Fixes dotnet/aspnetcore#33266
