### PR TITLE
Respect "Use legacy Razor editor HTML option".

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorFeatureDetectorTest.cs
@@ -9,6 +9,24 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     public class DefaultLSPEditorFeatureDetectorTest
     {
         [Fact]
+        public void IsLSPEditorAvailable_LegacyEditorTrue_ReturnsFalse()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                UseLegacyASPNETCoreEditor = true,
+                IsFeatureFlagEnabledValue = true,
+                ProjectSupportsRazorLSPEditorValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
         public void IsLSPEditorAvailable_EnvironmentVariableTrue_ReturnsTrue()
         {
             // Arrange
@@ -220,6 +238,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         private class TestLSPEditorFeatureDetector : DefaultLSPEditorFeatureDetector
         {
+            public bool UseLegacyASPNETCoreEditor { get; set; }
+
             public bool EnvironmentFeatureEnabledValue { get; set; }
 
             public bool IsFeatureFlagEnabledValue { get; set; }
@@ -233,6 +253,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             public bool IsVSServerValue { get; set; }
 
             public bool ProjectSupportsRazorLSPEditorValue { get; set; }
+
+            private protected override bool UseLegacyEditor() => UseLegacyASPNETCoreEditor;
 
             public override bool IsLiveShareHost() => IsLiveShareHostValue;
 


### PR DESCRIPTION
- There's now a new [`Use legacy Razor editor for ASP.NET Core`](https://github.com/dotnet/aspnetcore/issues/33291) in HTML's settings this PR adds the logic to respect that setting.
- By default we cache the use legacy editor setting to prevent any incoherent experiences in Razor.

Fixes dotnet/aspnetcore#33294