### PR TITLE
Turn Razor LSP editor on-by-default.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 throw new ArgumentNullException(nameof(documentFilePath));
             }
 
-            if (_lspEditorFeatureDetector.IsLSPEditorFeatureEnabled())
+            if (_lspEditorFeatureDetector.IsLSPEditorAvailable())
             {
                 return;
             }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LSPEditorFeatureDetector.cs
@@ -7,13 +7,13 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
     {
         public abstract bool IsLSPEditorAvailable(string documentMoniker, object hierarchy);
 
+        public abstract bool IsLSPEditorAvailable();
+
         /// <summary>
         /// A remote client is a LiveShare guest or a Codespaces instance
         /// </summary>
         public abstract bool IsRemoteClient();
 
         public abstract bool IsLiveShareHost();
-
-        public abstract bool IsLSPEditorFeatureEnabled();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         internal void ProjectSnapshotManager_Changed(object sender, ProjectChangeEventArgs args)
         {
-            if (!_lspEditorFeatureDetector.IsLSPEditorFeatureEnabled())
+            if (!_lspEditorFeatureDetector.IsLSPEditorAvailable())
             {
                 return;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/MacLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/MacLSPEditorFeatureDetector.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
     {
         public override bool IsLSPEditorAvailable(string documentMoniker, object hierarchy) => false;
 
-        public override bool IsLSPEditorFeatureEnabled() => false;
+        public override bool IsLSPEditorAvailable() => false;
 
         public override bool IsLiveShareHost() => false;
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -17,12 +17,6 @@
 "source.css"="$PackageFolder$\css-language-configuration.json"
 "source.cs"="$PackageFolder$\csharp-language-configuration.json"
 
-[$RootKey$\FeatureFlags\Razor\LSP\Editor]
-"Description"="Enables the Razor Language Server Protocol powered editor experience for Razor (ASP.NET Core)."
-"Value"=dword:00000000
-"Title"="Enable experimental Razor editor (requires restart)"
-"PreviewPaneChannels"="*"
-
 // Sets up Razor's default settings in Tools->Options.
 // Razor's default settings can be found in the VS repo at:
 //     src/VSCommonContent/profiles/General.vssettings

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultLSPEditorFeatureDetectorTest.cs
@@ -9,14 +9,29 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     public class DefaultLSPEditorFeatureDetectorTest
     {
         [Fact]
-        public void IsLSPEditorAvailable_ShouldUseLegacyEditorTrue_ReturnsFalse()
+        public void IsLSPEditorAvailable_ProjectSupported_ReturnsTrue()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                ProjectSupportsLSPEditorValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsLSPEditorAvailable_LegacyEditorEnabled_ReturnsFalse()
         {
             // Arrange
             var featureDetector = new TestLSPEditorFeatureDetector()
             {
                 UseLegacyEditor = true,
-                IsFeatureFlagEnabledValue = true,
-                ProjectSupportsRazorLSPEditorValue = true,
+                ProjectSupportsLSPEditorValue = true,
             };
 
             // Act
@@ -24,57 +39,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             // Assert
             Assert.False(result);
-        }
-
-        [Fact]
-        public void IsLSPEditorAvailable_EnvironmentVariableTrue_ReturnsTrue()
-        {
-            // Arrange
-            var featureDetector = new TestLSPEditorFeatureDetector()
-            {
-                EnvironmentFeatureEnabledValue = true,
-                ProjectSupportsRazorLSPEditorValue = true,
-            };
-
-            // Act
-            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void IsLSPEditorAvailable_FeatureFlagEnabled_ReturnsTrue()
-        {
-            // Arrange
-            var featureDetector = new TestLSPEditorFeatureDetector()
-            {
-                IsFeatureFlagEnabledValue = true,
-                ProjectSupportsRazorLSPEditorValue = true,
-            };
-
-            // Act
-            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void IsLSPEditorAvailable_IsVSServer_ReturnsTrue()
-        {
-            // Arrange
-            var featureDetector = new TestLSPEditorFeatureDetector()
-            {
-                IsVSServerValue = true,
-                ProjectSupportsRazorLSPEditorValue = true,
-            };
-
-            // Act
-            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
-
-            // Assert
-            Assert.True(result);
         }
 
         [Fact]
@@ -84,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var featureDetector = new TestLSPEditorFeatureDetector()
             {
                 IsVSRemoteClientValue = true,
-                ProjectSupportsRazorLSPEditorValue = true,
+                ProjectSupportsLSPEditorValue = true,
             };
 
             // Act
@@ -95,13 +59,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         [Fact]
-        public void IsLSPEditorAvailable_IsLiveShareHost_ReturnsFalse()
+        public void IsLSPEditorAvailable_UnsupportedProject_ReturnsFalse()
         {
             // Arrange
             var featureDetector = new TestLSPEditorFeatureDetector()
             {
-                IsLiveShareHostValue = true,
-                ProjectSupportsRazorLSPEditorValue = true,
+                ProjectSupportsLSPEditorValue = false,
             };
 
             // Act
@@ -109,70 +72,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             // Assert
             Assert.False(result);
-        }
-
-        [Fact]
-        public void IsLSPEditorAvailable_IsLiveShareGuest_ReturnsFalse()
-        {
-            // Arrange
-            var featureDetector = new TestLSPEditorFeatureDetector()
-            {
-                IsLiveShareGuestValue = true,
-                ProjectSupportsRazorLSPEditorValue = true,
-            };
-
-            // Act
-            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void IsLSPEditorAvailable_UnknownEnvironment_ReturnsFalse()
-        {
-            // Arrange
-            var featureDetector = new TestLSPEditorFeatureDetector();
-
-            // Act
-            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void IsLSPEditorAvailable_FeatureFlagEnabled_UnsupportedProject_ReturnsFalse()
-        {
-            // Arrange
-            var featureDetector = new TestLSPEditorFeatureDetector()
-            {
-                IsFeatureFlagEnabledValue = true,
-                ProjectSupportsRazorLSPEditorValue = false,
-            };
-
-            // Act
-            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void IsLSPEditorAvailable_FeatureFlagEnabled_SupportedProject_ReturnsTrue()
-        {
-            // Arrange
-            var featureDetector = new TestLSPEditorFeatureDetector()
-            {
-                IsFeatureFlagEnabledValue = true,
-                ProjectSupportsRazorLSPEditorValue = true,
-            };
-
-            // Act
-            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
-
-            // Assert
-            Assert.True(result);
         }
 
         [Fact]
@@ -208,22 +107,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         [Fact]
-        public void IsRemoteClient_FeatureFlagEnabled_ReturnsFalse()
-        {
-            // Arrange
-            var featureDetector = new TestLSPEditorFeatureDetector()
-            {
-                IsFeatureFlagEnabledValue = true,
-            };
-
-            // Act
-            var result = featureDetector.IsRemoteClient();
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
         public void IsRemoteClient_UnknownEnvironment_ReturnsFalse()
         {
             // Arrange
@@ -240,35 +123,23 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             public bool UseLegacyEditor { get; set; }
 
-            public bool EnvironmentFeatureEnabledValue { get; set; }
-
-            public bool IsFeatureFlagEnabledValue { get; set; }
-
             public bool IsLiveShareGuestValue { get; set; }
 
             public bool IsLiveShareHostValue { get; set; }
 
             public bool IsVSRemoteClientValue { get; set; }
 
-            public bool IsVSServerValue { get; set; }
+            public bool ProjectSupportsLSPEditorValue { get; set; }
 
-            public bool ProjectSupportsRazorLSPEditorValue { get; set; }
-
-            private protected override bool ShouldUseLegacyEditor() => UseLegacyEditor;
+            public override bool IsLSPEditorAvailable() => !UseLegacyEditor;
 
             public override bool IsLiveShareHost() => IsLiveShareHostValue;
-
-            private protected override bool EnvironmentFeatureEnabled() => EnvironmentFeatureEnabledValue;
-
-            private protected override bool IsFeatureFlagEnabledCached() => IsFeatureFlagEnabledValue;
 
             private protected override bool IsLiveShareGuest() => IsLiveShareGuestValue;
 
             private protected override bool IsVSRemoteClient() => IsVSRemoteClientValue;
 
-            private protected override bool IsVSServer() => IsVSServerValue;
-
-            private protected override bool ProjectSupportsRazorLSPEditor(string documentMoniker, IVsHierarchy hierarchy) => ProjectSupportsRazorLSPEditorValue;
+            private protected override bool ProjectSupportsLSPEditor(string documentMoniker, IVsHierarchy hierarchy) => ProjectSupportsLSPEditorValue;
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorProjectChangePublisherTest.cs
@@ -477,7 +477,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             static TestDefaultRazorProjectChangePublisher()
             {
                 _lspEditorFeatureDetector
-                    .Setup(t => t.IsLSPEditorFeatureEnabled())
+                    .Setup(t => t.IsLSPEditorAvailable())
                     .Returns(true);
             }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectSystem/RazorDocumentInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectSystem/RazorDocumentInfoProviderTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public RazorDocumentInfoProviderTest()
         {
             var serviceProviderFactory = new DefaultRazorDocumentServiceProviderFactory();
-            var lspEditorEnabledFeatureDetector = Mock.Of<LSPEditorFeatureDetector>(detector => detector.IsLSPEditorFeatureEnabled() == true, MockBehavior.Strict);
+            var lspEditorEnabledFeatureDetector = Mock.Of<LSPEditorFeatureDetector>(detector => detector.IsLSPEditorAvailable() == true, MockBehavior.Strict);
             InnerDynamicDocumentInfoProvider = new DefaultRazorDynamicFileInfoProvider(serviceProviderFactory, lspEditorEnabledFeatureDetector);
             ProjectSnapshotManager = new TestProjectSnapshotManager(Workspace);
 


### PR DESCRIPTION
- Removed the experimental editor feature flag and all the implications it imposed in our feature detector in regards to LiveShare.
- Updated tests to verify only what's still valuable.

Fixes dotnet/aspnetcore#33295
