### PR TITLE
The WebTools team is changing razor content types per the razor team'…

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCommitManagerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCommitManagerProvider.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
     [Export(typeof(IAsyncCompletionCommitManagerProvider))]
     [Name("Razor directive attribute completion commit provider.")]
     [ContentType(RazorLanguage.CoreContentType)]
+    [ContentType(RazorConstants.LegacyCoreContentType)]
     internal class RazorDirectiveAttributeCommitManagerProvider : IAsyncCompletionCommitManagerProvider
     {
         public IAsyncCompletionCommitManager GetOrCreate(ITextView textView)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSourceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSourceProvider.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
     [Export(typeof(IAsyncCompletionSourceProvider))]
     [Name("Razor directive attribute completion provider.")]
     [ContentType(RazorLanguage.CoreContentType)]
+    [ContentType(RazorConstants.LegacyCoreContentType)]
     internal class RazorDirectiveAttributeCompletionSourceProvider : IAsyncCompletionSourceProvider
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSourceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSourceProvider.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
     [Export(typeof(IAsyncCompletionSourceProvider))]
     [Name("Razor directive completion provider.")]
     [ContentType(RazorLanguage.CoreContentType)]
+    [ContentType(RazorConstants.LegacyCoreContentType)]
     internal class RazorDirectiveCompletionSourceProvider : IAsyncCompletionSourceProvider
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorConstants.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+    internal static class RazorConstants
+    {
+        public const string LegacyContentType = "LegacyRazorCSharp";
+
+        public const string LegacyCoreContentType = "LegacyRazorCoreCSharp";
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.VisualStudio.Editor.Razor
 {
     [ContentType(RazorLanguage.CoreContentType)]
+    [ContentType(RazorConstants.LegacyCoreContentType)]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     [Export(typeof(ITextViewConnectionListener))]
     internal class RazorTextViewConnectionListener : ITextViewConnectionListener

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TextBufferExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TextBufferExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Editor.Razor;
 
 namespace Microsoft.VisualStudio.Text
 {
@@ -15,7 +16,7 @@ namespace Microsoft.VisualStudio.Text
                 throw new ArgumentNullException(nameof(textBuffer));
             }
 
-            return textBuffer.ContentType.IsOfType(RazorLanguage.CoreContentType);
+            return textBuffer.ContentType.IsOfType(RazorLanguage.CoreContentType) || textBuffer.ContentType.IsOfType(RazorConstants.LegacyCoreContentType);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceProviderTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 {
     public class RazorDirectiveCompletionSourceProviderTest : ForegroundDispatcherTestBase
     {
-        private IContentType RazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) == true, MockBehavior.Strict);
+        private IContentType RazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) || c.IsOfType(RazorConstants.LegacyContentType), MockBehavior.Strict);
 
         private IContentType NonRazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(It.IsAny<string>()) == false, MockBehavior.Strict);
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceProviderTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 {
     public class RazorDirectiveCompletionSourceProviderTest : ForegroundDispatcherTestBase
     {
-        private IContentType RazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) || c.IsOfType(RazorConstants.LegacyContentType), MockBehavior.Strict);
+        private IContentType RazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) && c.IsOfType(RazorConstants.LegacyContentType), MockBehavior.Strict);
 
         private IContentType NonRazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(It.IsAny<string>()) == false, MockBehavior.Strict);
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public DefaultVisualStudioDocumentTrackerTest()
         {
-            RazorCoreContentType = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) == true, MockBehavior.Strict);
+            RazorCoreContentType = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) || c.IsOfType(RazorConstants.LegacyContentType), MockBehavior.Strict);
             TextBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType, MockBehavior.Strict);
 
             FilePath = TestProjectData.SomeProjectFile1.FilePath;

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public DefaultVisualStudioDocumentTrackerTest()
         {
-            RazorCoreContentType = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) || c.IsOfType(RazorConstants.LegacyContentType), MockBehavior.Strict);
+            RazorCoreContentType = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) && c.IsOfType(RazorConstants.LegacyContentType), MockBehavior.Strict);
             TextBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType, MockBehavior.Strict);
 
             FilePath = TestProjectData.SomeProjectFile1.FilePath;


### PR DESCRIPTION
The WebTools team is changing razor content types per the razor team's request.

    Razor => LegacyRazor
    RazorCSharp => LegacyRazorCSharp
    RazorCoreCSharp => LegacyRazorCoreCSharp
    RazorVisualBasic => LegacyRazorVisualBasic

See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1338541