### PR TITLE
Add Razor options service in response to Roslyn changes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,7 +92,7 @@
     <Tooling_MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.21103.2</Tooling_MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.0.0-preview-2-31228-438</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.0.35-gdeb9415fdc</MicrosoftVisualStudioPackagesVersion>
-    <RoslynPackageVersion>3.10.0-2.21179.6</RoslynPackageVersion>
+    <RoslynPackageVersion>4.0.0-2.21310.7</RoslynPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -117,7 +117,7 @@
     <MicrosoftVisualStudioTextLogicPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextLogicPackageVersion>
     <MicrosoftVisualStudioThreadingPackageVersion>16.9.45-alpha</MicrosoftVisualStudioThreadingPackageVersion>
     <MicrosoftVisualStudioWebPackageVersion>16.10.0-preview-1-31008-014</MicrosoftVisualStudioWebPackageVersion>
-    <MicrosoftVisualStudioValidationPackageVersion>16.10.22-alpha</MicrosoftVisualStudioValidationPackageVersion>
+    <MicrosoftVisualStudioValidationPackageVersion>17.0.12-alpha</MicrosoftVisualStudioValidationPackageVersion>
     <MicrosoftWebToolsLanguagesHtmlPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesHtmlPackageVersion>
     <MicrosoftWebToolsLanguagesLanguageServerServerPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesLanguageServerServerPackageVersion>
     <MicrosoftWebToolsLanguagesSharedPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesSharedPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,7 +92,7 @@
     <Tooling_MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.21103.2</Tooling_MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.0.0-preview-2-31228-438</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.0.35-gdeb9415fdc</MicrosoftVisualStudioPackagesVersion>
-    <RoslynPackageVersion>4.0.0-2.21310.7</RoslynPackageVersion>
+    <RoslynPackageVersion>4.0.0-3.21317.9</RoslynPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDocumentServiceProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDocumentServiceProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
         private readonly object _lock;
 
         private IRazorSpanMappingService _spanMappingService;
-        private IRazorDocumentExcerptService _excerptService;
+        private IRazorDocumentExcerptService _documentExcerptService;
         private IRazorDocumentPropertiesService _documentPropertiesService;
 
         public RazorDocumentServiceProvider()
@@ -37,7 +37,9 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 return this as TService;
             }
 
-            if (typeof(TService) == typeof(IRazorSpanMappingService))
+            var serviceType = typeof(TService);
+
+            if (serviceType == typeof(IRazorSpanMappingService))
             {
                 if (_spanMappingService == null)
                 {
@@ -53,23 +55,23 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 return (TService)_spanMappingService;
             }
 
-            if (typeof(TService) == typeof(IRazorDocumentExcerptService))
+            if (serviceType == typeof(IRazorDocumentExcerptService))
             {
-                if (_excerptService == null)
+                if (_documentExcerptService == null)
                 {
                     lock (_lock)
                     {
-                        if (_excerptService == null)
+                        if (_documentExcerptService == null)
                         {
-                            _excerptService = _documentContainer.GetExcerptService();
+                            _documentExcerptService = _documentContainer.GetExcerptService();
                         }
                     }
                 }
 
-                return (TService)_excerptService;
+                return (TService)_documentExcerptService;
             }
 
-            if (typeof(TService) == typeof(IRazorDocumentPropertiesService))
+            if (serviceType == typeof(IRazorDocumentPropertiesService))
             {
                 if (_documentPropertiesService == null)
                 {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSpanMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSpanMappingService.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
-    internal class RazorSpanMappingService: IRazorSpanMappingService
+    internal class RazorSpanMappingService : IRazorSpanMappingService
     {
         private readonly DocumentSnapshot _document;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/RazorFeedbackDiagnosticFileProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/RazorFeedbackDiagnosticFileProvider.cs
@@ -57,7 +57,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
                 return Array.Empty<string>();
             }
 
+#pragma warning disable VSTHRD110 // Observe result of async calls
             _joinableTaskFactory.RunAsync(() => ZipLogsAsync(logDirectory, zipFilePath));
+#pragma warning restore VSTHRD110 // Observe result of async calls
 
             return new[] { zipFilePath };
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/RazorFeedbackDiagnosticFileProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Feedback/RazorFeedbackDiagnosticFileProvider.cs
@@ -57,9 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Feedback
                 return Array.Empty<string>();
             }
 
-#pragma warning disable VSTHRD110 // Observe result of async calls
-            _joinableTaskFactory.RunAsync(() => ZipLogsAsync(logDirectory, zipFilePath));
-#pragma warning restore VSTHRD110 // Observe result of async calls
+            _ = _joinableTaskFactory.RunAsync(() => ZipLogsAsync(logDirectory, zipFilePath));
 
             return new[] { zipFilePath };
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDocumentOptionsService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDocumentOptionsService.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Composition;
+using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Razor.Editor;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
-    [Shared]
     [Export(typeof(IRazorDocumentOptionsService))]
     internal sealed class RazorDocumentOptionsService : IRazorDocumentOptionsService
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDocumentOptionsService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDocumentOptionsService.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Razor.Editor;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+{
+    [Shared]
+    [Export(typeof(IRazorDocumentOptionsService))]
+    internal sealed class RazorDocumentOptionsService : IRazorDocumentOptionsService
+    {
+        private readonly RazorLSPClientOptionsMonitor _optionsMonitor;
+
+        [ImportingConstructor]
+        public RazorDocumentOptionsService(RazorLSPClientOptionsMonitor optionsMonitor)
+        {
+            if (optionsMonitor is null)
+            {
+                throw new ArgumentNullException(nameof(optionsMonitor));
+            }
+
+            _optionsMonitor = optionsMonitor;
+        }
+
+        public async Task<OptionSet> GetDocumentOptionsAsync(Document document, CancellationToken cancellationToken)
+        {
+            if (document is null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            // TO-DO: We should switch to a per-document implementation once Razor starts supporting .editorconfig.
+            var editorSettings = _optionsMonitor.EditorSettings;
+
+            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            documentOptions = documentOptions.WithChangedOption(FormattingOptions.UseTabs, editorSettings.IndentWithTabs);
+            documentOptions = documentOptions.WithChangedOption(FormattingOptions.TabSize, editorSettings.IndentSize);
+            documentOptions = documentOptions.WithChangedOption(FormattingOptions.IndentationSize, editorSettings.IndentSize);
+
+            return documentOptions;
+        }
+
+        public Task<IRazorDocumentOptions> GetOptionsForDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            if (document is null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            // TO-DO: We should switch to a per-document implementation once Razor starts supporting .editorconfig.
+            var editorSettings = _optionsMonitor.EditorSettings;
+            return Task.FromResult<IRazorDocumentOptions>(new RazorDocumentOptions(document, editorSettings));
+        }
+
+        private sealed class RazorDocumentOptions : IRazorDocumentOptions
+        {
+            private readonly EditorSettings _editorSettings;
+            private readonly OptionKey _useTabsOptionKey;
+            private readonly OptionKey _tabSizeOptionKey;
+            private readonly OptionKey _indentationSizeOptionKey;
+
+            public RazorDocumentOptions(Document document, EditorSettings editorSettings)
+            {
+                _editorSettings = editorSettings;
+
+                _useTabsOptionKey = new OptionKey(FormattingOptions.UseTabs, document.Project.Language);
+                _tabSizeOptionKey = new OptionKey(FormattingOptions.TabSize, document.Project.Language);
+                _indentationSizeOptionKey = new OptionKey(FormattingOptions.IndentationSize, document.Project.Language);
+            }
+
+            public bool TryGetDocumentOption(OptionKey option, out object value)
+            {
+                if (option == _useTabsOptionKey)
+                {
+                    value = _editorSettings.IndentWithTabs;
+                    return true;
+                }
+                else if (option == _tabSizeOptionKey || option == _indentationSizeOptionKey)
+                {
+                    value = _editorSettings.IndentSize;
+                    return true;
+                }
+                else
+                {
+                    value = null;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDocumentOptionsService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDocumentOptionsService.cs
@@ -30,24 +30,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             _optionsMonitor = optionsMonitor;
         }
 
-        public async Task<OptionSet> GetDocumentOptionsAsync(Document document, CancellationToken cancellationToken)
-        {
-            if (document is null)
-            {
-                throw new ArgumentNullException(nameof(document));
-            }
-
-            // TO-DO: We should switch to a per-document implementation once Razor starts supporting .editorconfig.
-            var editorSettings = _optionsMonitor.EditorSettings;
-
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            documentOptions = documentOptions.WithChangedOption(FormattingOptions.UseTabs, editorSettings.IndentWithTabs);
-            documentOptions = documentOptions.WithChangedOption(FormattingOptions.TabSize, editorSettings.IndentSize);
-            documentOptions = documentOptions.WithChangedOption(FormattingOptions.IndentationSize, editorSettings.IndentSize);
-
-            return documentOptions;
-        }
-
         public Task<IRazorDocumentOptions> GetOptionsForDocumentAsync(Document document, CancellationToken cancellationToken)
         {
             if (document is null)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorDocumentOptionsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorDocumentOptionsServiceTest.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Editor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
+{
+    public class RazorDocumentOptionsServiceTest : WorkspaceTestBase
+    {
+        [Fact]
+        public async Task RazorDocumentOptionsService_ReturnsCorrectOptions_UseTabs()
+        {
+            // Arrange
+            var editorSettings = new EditorSettings(indentWithTabs: true, indentSize: 4);
+            var clientOptionsMonitor = new RazorLSPClientOptionsMonitor();
+            clientOptionsMonitor.UpdateOptions(editorSettings);
+            var optionsService = new RazorDocumentOptionsService(clientOptionsMonitor);
+
+            var document = InitializeDocument(SourceText.From("text"));
+
+            var useTabsOptionKey = GetUseTabsOptionKey(document);
+            var tabSizeOptionKey = GetTabSizeOptionKey(document);
+            var indentationSizeOptionKey = GetIndentationSizeOptionKey(document);
+
+            // Act
+            var documentOptions = await optionsService.GetOptionsForDocumentAsync(document, CancellationToken.None);
+            documentOptions.TryGetDocumentOption(useTabsOptionKey, out var useTabs);
+            documentOptions.TryGetDocumentOption(tabSizeOptionKey, out var tabSize);
+            documentOptions.TryGetDocumentOption(indentationSizeOptionKey, out var indentationSize);
+
+            // Assert
+            Assert.True((bool)useTabs);
+            Assert.Equal(4, (int)tabSize);
+            Assert.Equal(4, (int)indentationSize);
+        }
+
+        [Fact]
+        public async Task RazorDocumentOptionsService_ReturnsCorrectOptions_UseSpaces()
+        {
+            // Arrange
+            var editorSettings = new EditorSettings(indentWithTabs: false, indentSize: 2);
+            var clientOptionsMonitor = new RazorLSPClientOptionsMonitor();
+            clientOptionsMonitor.UpdateOptions(editorSettings);
+            var optionsService = new RazorDocumentOptionsService(clientOptionsMonitor);
+
+            var document = InitializeDocument(SourceText.From("text"));
+
+            var useTabsOptionKey = GetUseTabsOptionKey(document);
+            var tabSizeOptionKey = GetTabSizeOptionKey(document);
+            var indentationSizeOptionKey = GetIndentationSizeOptionKey(document);
+
+            // Act
+            var documentOptions = await optionsService.GetOptionsForDocumentAsync(document, CancellationToken.None);
+            documentOptions.TryGetDocumentOption(useTabsOptionKey, out var useTabs);
+            documentOptions.TryGetDocumentOption(tabSizeOptionKey, out var tabSize);
+            documentOptions.TryGetDocumentOption(indentationSizeOptionKey, out var indentationSize);
+
+            // Assert
+            Assert.False((bool)useTabs);
+            Assert.Equal(2, (int)tabSize);
+            Assert.Equal(2, (int)indentationSize);
+        }
+
+        private static OptionKey GetUseTabsOptionKey(Document document)
+            => new OptionKey(FormattingOptions.UseTabs, document.Project.Language);
+
+        private static OptionKey GetTabSizeOptionKey(Document document)
+            => new OptionKey(FormattingOptions.TabSize, document.Project.Language);
+
+        private static OptionKey GetIndentationSizeOptionKey(Document document)
+            => new OptionKey(FormattingOptions.IndentationSize, document.Project.Language);
+
+        // Adapted from DocumentExcerptServiceTestBase's InitializeDocument.
+        // Adds the text to a ProjectSnapshot, generates code, and updates the workspace.
+        private Document InitializeDocument(SourceText sourceText)
+        {
+            var baseDirectory = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "c:\\users\\example\\src" : "/home/example";
+            var hostProject = new HostProject(
+                Path.Combine(baseDirectory, "SomeProject", "SomeProject.csproj"), RazorConfiguration.Default, "SomeProject");
+            var hostDocument = new HostDocument(
+                Path.Combine(baseDirectory, "SomeProject", "File1.cshtml"), "File1.cshtml", FileKinds.Legacy);
+
+            var project = new DefaultProjectSnapshot(
+                ProjectState.Create(Workspace.Services, hostProject)
+                .WithAddedHostDocument(hostDocument, () => Task.FromResult(TextAndVersion.Create(sourceText, VersionStamp.Create()))));
+
+            var documentSnapshot = project.GetDocument(hostDocument.FilePath);
+
+            var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
+                ProjectId.CreateNewId(Path.GetFileNameWithoutExtension(hostDocument.FilePath)),
+                VersionStamp.Create(),
+                Path.GetFileNameWithoutExtension(hostDocument.FilePath),
+                Path.GetFileNameWithoutExtension(hostDocument.FilePath),
+                LanguageNames.CSharp,
+                hostDocument.FilePath));
+
+            solution = solution.AddDocument(
+                DocumentId.CreateNewId(solution.ProjectIds.Single(), hostDocument.FilePath),
+                hostDocument.FilePath,
+                new GeneratedDocumentTextLoader(documentSnapshot, hostDocument.FilePath));
+
+            var document = solution.Projects.Single().Documents.Single();
+            return document;
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the changes
 - Responding to Roslyn changes in https://github.com/dotnet/roslyn/pull/53879 which adds a Razor options service.
 - When implementing the Roslyn side, I tested out the changes in Razor and everything seemed to work. However, I can't currently test with the final upgraded packages versions because my dev17 build appears to be busted. 🤦‍♀️ so while I'm pretty confident that these changes work since I tested them before, I wasn't able to do a final test to make sure.

Fixes: 
dotnet/aspnetcore#32555