### PR TITLE
Handle OperationCanceledException

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Razor
                         workspaceState = new ProjectWorkspaceState(tagHelperResolutionResult.Descriptors, csharpLanguageVersion);
                     }
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
                     // Abort work if we get a task cancelled exception
                     return;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
@@ -196,6 +196,11 @@ namespace Microsoft.CodeAnalysis.Razor
                     TaskCreationOptions.None,
                     _foregroundDispatcher.ForegroundScheduler).ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                // Abort work if we get a task canceled exception
+                return;
+            }
             catch (Exception ex)
             {
                 // This is something totally unexpected, let's just send it over to the project manager.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/OOPTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/OOPTagHelperResolver.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
 
                 return result;
             }
-            catch (Exception exception) when (!(exception is TaskCanceledException))
+            catch (Exception exception) when (!(exception is TaskCanceledException) && !(exception is OperationCanceledException))
             {
                 throw new InvalidOperationException($"An unexpected exception occurred when invoking '{typeof(DefaultTagHelperResolver).FullName}.{nameof(GetTagHelpersAsync)}' on the Razor language service.", exception);
             }


### PR DESCRIPTION
We needed to account for OperationCanceled as well as TaskCanceled. This doesn't end up "fixing" anything except preventing this scenario from being noise in the logs.