### PR TITLE
Enable auto-complete of HTML elements in the RZLS.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.Extensions.Options;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
+{
+    internal class AutoClosingTagOnAutoInsertProvider : RazorOnAutoInsertProvider
+    {
+        // From http://dev.w3.org/html5/spec/Overview.html#elements-0
+        public static readonly HashSet<string> s_VoidElements = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "area",
+            "base",
+            "br",
+            "col",
+            "command",
+            "embed",
+            "hr",
+            "img",
+            "input",
+            "keygen",
+            "link",
+            "meta",
+            "menuitem",
+            "param",
+            "source",
+            "track",
+            "wbr"
+        };
+
+        private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
+
+        public AutoClosingTagOnAutoInsertProvider(IOptionsMonitor<RazorLSPOptions> optionsMonitor)
+        {
+            if (optionsMonitor is null)
+            {
+                throw new ArgumentNullException(nameof(optionsMonitor));
+            }
+
+            _optionsMonitor = optionsMonitor;
+        }
+
+        public override string TriggerCharacter => ">";
+
+        public override bool TryResolveInsertion(Position position, FormattingContext context, out TextEdit edit, out InsertTextFormat format)
+        {
+            if (position is null)
+            {
+                throw new ArgumentNullException(nameof(position));
+            }
+
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!_optionsMonitor.CurrentValue.AutoClosingTags)
+            {
+                format = default;
+                edit = default;
+                return false;
+            }
+
+            if (!TryGetTagInformation(context, position, out var tagName, out var autoClosingBehavior))
+            {
+                format = default;
+                edit = default;
+                return false;
+            }
+
+            format = InsertTextFormat.Snippet;
+            if (autoClosingBehavior == AutoClosingBehavior.Default)
+            {
+                edit = new TextEdit()
+                {
+                    NewText = $"$0</{tagName}>",
+                    Range = new Range(position, position)
+                };
+            }
+            else
+            {
+                Debug.Assert(autoClosingBehavior == AutoClosingBehavior.SelfClosing);
+
+                // Need to replace the `>` with ' />$0'
+                var replacementRange = new Range(
+                    start: new Position(position.Line, position.Character - 1),
+                    end: position);
+                edit = new TextEdit()
+                {
+                    NewText = " />$0",
+                    Range = replacementRange
+                };
+
+            }
+
+            return true;
+        }
+
+        private static bool TryGetTagInformation(FormattingContext context, Position position, out string name, out AutoClosingBehavior autoClosingBehavior)
+        {
+            var syntaxTree = context.CodeDocument.GetSyntaxTree();
+
+            var absoluteIndex = position.GetAbsoluteIndex(context.SourceText) - 1;
+            var change = new SourceChange(absoluteIndex, 0, string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+            if (owner?.Parent == null)
+            {
+                name = null;
+                autoClosingBehavior = default;
+                return false;
+            }
+
+            if (owner.Parent is MarkupStartTagSyntax startTag &&
+                startTag.Parent is MarkupElementSyntax)
+            {
+                name = startTag.Name.Content;
+                autoClosingBehavior = InferAutoClosingBehavior(name);
+                name = startTag.GetTagNameWithOptionalBang();
+                return true;
+            }
+
+            if (owner.Parent is MarkupTagHelperStartTagSyntax startTagHelper &&
+                startTagHelper.Parent is MarkupTagHelperElementSyntax tagHelperElement)
+            {
+                name = startTagHelper.Name.Content;
+
+                if (!TryGetTagHelperAutoClosingBehavior(tagHelperElement.TagHelperInfo.BindingResult, out autoClosingBehavior))
+                {
+                    autoClosingBehavior = InferAutoClosingBehavior(name);
+                }
+
+                return true;
+            }
+
+            autoClosingBehavior = default;
+            name = null;
+            return false;
+        }
+
+        private static AutoClosingBehavior InferAutoClosingBehavior(string name)
+        {
+            if (s_VoidElements.Contains(name))
+            {
+                return AutoClosingBehavior.SelfClosing;
+            }
+
+            return AutoClosingBehavior.Default;
+        }
+
+        private static bool TryGetTagHelperAutoClosingBehavior(TagHelperBinding bindingResult, out AutoClosingBehavior autoClosingBehavior)
+        {
+            var resolvedTagStructure = TagStructure.Unspecified;
+
+            foreach (var descriptor in bindingResult.Descriptors)
+            {
+                var tagMatchingRules = bindingResult.GetBoundRules(descriptor);
+                for (var i = 0; i < tagMatchingRules.Count; i++)
+                {
+                    var tagMatchingRule = tagMatchingRules[i];
+                    if (tagMatchingRule.TagStructure == TagStructure.NormalOrSelfClosing)
+                    {
+                        // We have a rule that indicates it can be normal or self-closing, that always wins because.
+                        // it's all encompassing. Meaning, even if all previous rules indicate "no children" and at least
+                        // one says it supports children we render the tag as having the potential to have children.
+                        autoClosingBehavior = AutoClosingBehavior.Default;
+                        return true;
+                    }
+
+                    resolvedTagStructure = tagMatchingRule.TagStructure;
+                }
+            }
+
+            Debug.Assert(resolvedTagStructure != TagStructure.NormalOrSelfClosing, "Normal tag structure should already have been preferred");
+
+            if (resolvedTagStructure == TagStructure.WithoutEndTag)
+            {
+                autoClosingBehavior = AutoClosingBehavior.SelfClosing;
+                return true;
+            }
+
+            autoClosingBehavior = default;
+            return false;
+        }
+
+        private enum AutoClosingBehavior
+        {
+            Default,
+            SelfClosing,
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             }
 
             format = InsertTextFormat.Snippet;
-            if (autoClosingBehavior == AutoClosingBehavior.Default)
+            if (autoClosingBehavior == AutoClosingBehavior.EndTag)
             {
                 edit = new TextEdit()
                 {
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 return AutoClosingBehavior.SelfClosing;
             }
 
-            return AutoClosingBehavior.Default;
+            return AutoClosingBehavior.EndTag;
         }
 
         private static bool TryGetTagHelperAutoClosingBehavior(TagHelperBinding bindingResult, out AutoClosingBehavior autoClosingBehavior)
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                         // We have a rule that indicates it can be normal or self-closing, that always wins because.
                         // it's all encompassing. Meaning, even if all previous rules indicate "no children" and at least
                         // one says it supports children we render the tag as having the potential to have children.
-                        autoClosingBehavior = AutoClosingBehavior.Default;
+                        autoClosingBehavior = AutoClosingBehavior.EndTag;
                         return true;
                     }
 
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
         private enum AutoClosingBehavior
         {
-            Default,
+            EndTag,
             SelfClosing,
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -123,8 +123,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             if (owner.Parent is MarkupStartTagSyntax startTag &&
                 startTag.Parent is MarkupElementSyntax)
             {
-                name = startTag.Name.Content;
-                autoClosingBehavior = InferAutoClosingBehavior(name);
+                var unescapedTagName = startTag.Name.Content;
+                autoClosingBehavior = InferAutoClosingBehavior(unescapedTagName);
+
+                // Finally capture the entire tag name with the potential escape operator.
                 name = startTag.GetTagNameWithOptionalBang();
                 return true;
             }
@@ -169,7 +171,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                     var tagMatchingRule = tagMatchingRules[i];
                     if (tagMatchingRule.TagStructure == TagStructure.NormalOrSelfClosing)
                     {
-                        // We have a rule that indicates it can be normal or self-closing, that always wins because.
+                        // We have a rule that indicates it can be normal or self-closing, that always wins because
                         // it's all encompassing. Meaning, even if all previous rules indicate "no children" and at least
                         // one says it supports children we render the tag as having the potential to have children.
                         autoClosingBehavior = AutoClosingBehavior.EndTag;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -199,6 +199,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RazorOnAutoInsertProvider, HtmlSmartIndentOnAutoInsertProvider>();
                         services.AddSingleton<RazorOnAutoInsertProvider, CloseRazorCommentOnAutoInsertProvider>();
                         services.AddSingleton<RazorOnAutoInsertProvider, CloseTextTagOnAutoInsertProvider>();
+                        services.AddSingleton<RazorOnAutoInsertProvider, AutoClosingTagOnAutoInsertProvider>();
                         services.AddSingleton<RazorOnAutoInsertProvider, AttributeSnippetOnAutoInsertProvider>();
 
                         // Formatting

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -323,7 +323,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var triggerCharEnumeration = mergedCapabilities.OnAutoInsertProvider?.TriggerCharacters ?? Enumerable.Empty<string>();
             var purposefullyRemovedTriggerCharacters = new[]
             {
-                ">"
+                ">" // https://github.com/dotnet/aspnetcore-tooling/pull/3797
             };
             triggerCharEnumeration = triggerCharEnumeration.Except(purposefullyRemovedTriggerCharacters);
             var onAutoInsertMergedTriggerChars = new HashSet<string>(triggerCharEnumeration);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -321,6 +321,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         private async Task VerifyMergedOnAutoInsertAsync(VSServerCapabilities mergedCapabilities)
         {
             var triggerCharEnumeration = mergedCapabilities.OnAutoInsertProvider?.TriggerCharacters ?? Enumerable.Empty<string>();
+            var purposefullyRemovedTriggerCharacters = new[]
+            {
+                ">"
+            };
+            triggerCharEnumeration = triggerCharEnumeration.Except(purposefullyRemovedTriggerCharacters);
             var onAutoInsertMergedTriggerChars = new HashSet<string>(triggerCharEnumeration);
             if (!onAutoInsertMergedTriggerChars.SetEquals(triggerCharEnumeration))
             {
@@ -347,7 +352,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var mergedCommitChars = new HashSet<string>(mergedAllCommitCharEnumeration);
             var purposefullyRemovedTriggerCharacters = new[]
             {
-                "_" // https://github.com/dotnet/aspnetcore-tooling/pull/2827
+                "_", // https://github.com/dotnet/aspnetcore-tooling/pull/2827
+                ">"
             };
             mergedTriggerCharEnumeration = mergedTriggerCharEnumeration.Except(purposefullyRemovedTriggerCharacters);
             var mergedTriggerChars = new HashSet<string>(mergedTriggerCharEnumeration);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     [ExportLspMethod(MSLSPMethods.OnAutoInsertName)]
     internal class OnAutoInsertHandler : IRequestHandler<DocumentOnAutoInsertParams, DocumentOnAutoInsertResponseItem>
     {
-        private static readonly HashSet<string> HTMLAllowedTriggerCharacters = new() { ">", "=", "-" };
+        private static readonly HashSet<string> HTMLAllowedTriggerCharacters = new() { "=", "-" };
         private static readonly HashSet<string> CSharpAllowedTriggerCharacters = new() { "'", "/", "\n" };
         private static readonly HashSet<string> AllAllowedTriggerCharacters = HTMLAllowedTriggerCharacters
             .Concat(CSharpAllowedTriggerCharacters)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             get
             {
-
                 var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
                 descriptor.SetTypeName("TestNamespace.TestTagHelper");
                 descriptor.TagMatchingRule(builder => builder.RequireTagName("test").RequireTagStructure(TagStructure.Unspecified));
@@ -29,7 +28,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             get
             {
-
                 var descriptor = TagHelperDescriptorBuilder.Create("TestInputTagHelper", "TestAssembly");
                 descriptor.SetTypeName("TestNamespace.TestInputTagHelper");
                 descriptor.TagMatchingRule(builder => builder.RequireTagName("input").RequireTagStructure(TagStructure.Unspecified));
@@ -42,7 +40,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             get
             {
-
                 var descriptor = TagHelperDescriptorBuilder.Create("TestInputTagHelper", "TestAssembly");
                 descriptor.SetTypeName("TestNamespace.TestInputTagHelper");
                 descriptor.TagMatchingRule(builder => builder.RequireTagName("input").RequireTagStructure(TagStructure.NormalOrSelfClosing));
@@ -55,7 +52,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             get
             {
-
                 var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper2", "TestAssembly");
                 descriptor.SetTypeName("TestNamespace.TestTagHelper2");
                 descriptor.TagMatchingRule(builder => builder.RequireTagName("test").RequireTagStructure(TagStructure.NormalOrSelfClosing));
@@ -68,7 +64,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             get
             {
-
                 var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper3", "TestAssembly");
                 descriptor.SetTypeName("TestNamespace.TestTagHelper3");
                 descriptor.TagMatchingRule(builder => builder.RequireTagName("test").RequireTagStructure(TagStructure.WithoutEndTag));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -1,0 +1,264 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
+{
+    public class AutoClosingTagOnAutoInsertProviderTest : RazorOnAutoInsertProviderTestBase
+    {
+        private RazorLSPOptions Options { get; set; } = RazorLSPOptions.Default;
+
+        private static TagHelperDescriptor UnspecifiedTagHelper
+        {
+            get
+            {
+
+                var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
+                descriptor.SetTypeName("TestNamespace.TestTagHelper");
+                descriptor.TagMatchingRule(builder => builder.RequireTagName("test").RequireTagStructure(TagStructure.Unspecified));
+
+                return descriptor.Build();
+            }
+        }
+
+        private static TagHelperDescriptor UnspecifiedInputTagHelper
+        {
+            get
+            {
+
+                var descriptor = TagHelperDescriptorBuilder.Create("TestInputTagHelper", "TestAssembly");
+                descriptor.SetTypeName("TestNamespace.TestInputTagHelper");
+                descriptor.TagMatchingRule(builder => builder.RequireTagName("input").RequireTagStructure(TagStructure.Unspecified));
+
+                return descriptor.Build();
+            }
+        }
+
+        private static TagHelperDescriptor NormalOrSelfclosingInputTagHelper
+        {
+            get
+            {
+
+                var descriptor = TagHelperDescriptorBuilder.Create("TestInputTagHelper", "TestAssembly");
+                descriptor.SetTypeName("TestNamespace.TestInputTagHelper");
+                descriptor.TagMatchingRule(builder => builder.RequireTagName("input").RequireTagStructure(TagStructure.NormalOrSelfClosing));
+
+                return descriptor.Build();
+            }
+        }
+
+        private static TagHelperDescriptor NormalOrSelfClosingTagHelper
+        {
+            get
+            {
+
+                var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper2", "TestAssembly");
+                descriptor.SetTypeName("TestNamespace.TestTagHelper2");
+                descriptor.TagMatchingRule(builder => builder.RequireTagName("test").RequireTagStructure(TagStructure.NormalOrSelfClosing));
+
+                return descriptor.Build();
+            }
+        }
+
+        private static TagHelperDescriptor WithoutEndTagTagHelper
+        {
+            get
+            {
+
+                var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper3", "TestAssembly");
+                descriptor.SetTypeName("TestNamespace.TestTagHelper3");
+                descriptor.TagMatchingRule(builder => builder.RequireTagName("test").RequireTagStructure(TagStructure.WithoutEndTag));
+
+                return descriptor.Build();
+            }
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_NormalOrSelfClosingStructureOverridesVoidTagBehavior()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<input>$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<input>$0</input>
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { NormalOrSelfclosingInputTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_UnspeccifiedStructureInheritsVoidTagBehavior()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<input>$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<input />$0
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { UnspecifiedInputTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_UnspeccifiedTagHelperTagStructure()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<test>$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<test>$0</test>
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { UnspecifiedTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_NormalOrSelfClosingTagHelperTagStructure()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<test>$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<test>$0</test>
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { NormalOrSelfClosingTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_WithoutEndTagTagHelperTagStructure()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<test>$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<test />$0
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { WithoutEndTagTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_MultipleApplicableTagHelperTagStructures()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<test>$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<test>$0</test>
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { UnspecifiedTagHelper, NormalOrSelfClosingTagHelper, WithoutEndTagTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_EscapedTagTagHelperAutoCompletesWithEscape()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<!test>$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<!test>$0</!test>
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { NormalOrSelfClosingTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_AlwaysClosesStandardHTMLTag()
+        {
+            RunAutoInsertTest(
+input: @"
+    <div><div>$$</div>
+",
+expected: @"
+    <div><div>$0</div></div>
+");
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_ClosesStandardHTMLTag()
+        {
+            RunAutoInsertTest(
+input: @"
+    <div>$$
+",
+expected: @"
+    <div>$0</div>
+");
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_ClosesVoidHTMLTag()
+        {
+            RunAutoInsertTest(
+input: @"
+    <input>$$
+",
+expected: @"
+    <input />$0
+");
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_AutoInsertDisabled_Noops()
+        {
+            Options = new RazorLSPOptions(Trace.Off, enableFormatting: true, autoClosingTags: false, insertSpaces: true, tabSize: 4);
+            RunAutoInsertTest(
+input: @"
+    <div>$$
+",
+expected: @"
+    <div>
+");
+        }
+
+        internal override RazorOnAutoInsertProvider CreateProvider()
+        {
+            var optionsMonitor = new Mock<IOptionsMonitor<RazorLSPOptions>>(MockBehavior.Strict);
+            optionsMonitor.SetupGet(o => o.CurrentValue).Returns(Options);
+
+            var provider = new AutoClosingTagOnAutoInsertProvider(optionsMonitor.Object);
+            return provider;
+        }
+    }
+}


### PR DESCRIPTION
- Transitioned HTML tag auto-completion into the Razor language server. Reasoning:
    - Auto-completing tags is a super common behavior that typically results in our HTMLC# world resolving the language, re-invoking and then remapping.
    - We were going to have to absorb a piece of this tech no matter what because the HTML language server would never auto-complete tags with bang-escapes.
    - We were going to have to absorb a piece of this tech no matter what because the HTML language server does not know about TagHelper TagStructure auto-complete behaviors.
- The purpose of this change was perf motivated (roughly increases speed by 25-50%) but in turn I also enabled two new feature parity bits: bang escape auto-complete and TagHelper tag structure respects.
- Hardcoded the list of void elements to auto-complete. At first this felt odd but it actually matches what our parser expects (same hard coded list) which means we'll more often be correct (yay!).
- Added loads of tests.

Part of dotnet/aspnetcore#31356