### PR TITLE
Remove `>` from C# completion triggers.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     internal class CompletionHandler : IRequestHandler<CompletionParams, SumType<CompletionItem[], CompletionList>?>
     {
         private static readonly IReadOnlyList<string> RazorTriggerCharacters = new[] { "@" };
-        private static readonly IReadOnlyList<string> CSharpTriggerCharacters = new[] { " ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", ">", "~" };
+        private static readonly IReadOnlyList<string> CSharpTriggerCharacters = new[] { " ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", "~" };
         private static readonly IReadOnlyList<string> HtmlTriggerCharacters = new[] { ":", "@", "#", ".", "!", "*", ",", "(", "[", "=", "-", "<", "&", "\\", "/", "'", "\"", "=", ":", " ", "`" };
 
         public static readonly IReadOnlyList<string> AllTriggerCharacters = new HashSet<string>(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -353,6 +353,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var purposefullyRemovedTriggerCharacters = new[]
             {
                 "_", // https://github.com/dotnet/aspnetcore-tooling/pull/2827
+
+                // C# uses '>' as a trigger character for pointer operations. This conflicts heavily with HTML's auto-closing support
+                // Therefore, for perf reasons we purposefully remove the trigger character since using pointers in Razor is quite rare.
                 ">"
             };
             mergedTriggerCharEnumeration = mergedTriggerCharEnumeration.Except(purposefullyRemovedTriggerCharacters);


### PR DESCRIPTION
- C# uses '>' as a trigger character for pointer operations. This conflicts heavily with HTML's auto-closing support.
- Therefore, for perf reasons we purposefully remove the trigger character since using pointers in Razor is quite rare.
