### PR TITLE
Fix formatting in child components

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -188,12 +188,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public override void VisitMarkupTagHelperElement(MarkupTagHelperElementSyntax node)
         {
-            var isComponent = IsComponentTagHelperNode(node);
+            var causesIndentation = CausesGeneratedCSharpIndentation(node);
 
             Visit(node.StartTag);
 
             _currentHtmlIndentationLevel++;
-            if (isComponent)
+            if (causesIndentation)
             {
                 _componentTracker.Push(node);
             }
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 Visit(child);
             }
 
-            if (isComponent)
+            if (causesIndentation)
             {
                 Debug.Assert(_componentTracker.Any(), "Component tracker should not be empty.");
                 _componentTracker.Pop();
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             Visit(node.EndTag);
 
-            static bool IsComponentTagHelperNode(MarkupTagHelperElementSyntax node)
+            static bool CausesGeneratedCSharpIndentation(MarkupTagHelperElementSyntax node)
             {
                 var tagHelperInfo = node.TagHelperInfo;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -214,8 +214,26 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             static bool IsComponentTagHelperNode(MarkupTagHelperElementSyntax node)
             {
-                return node.TagHelperInfo?.BindingResult?.Descriptors?.Any(
-                    d => d.IsComponentOrChildContentTagHelper()) ?? false;
+                var tagHelperInfo = node.TagHelperInfo;
+
+                if (tagHelperInfo is null)
+                {
+                    return false;
+                }
+
+                var descriptors = tagHelperInfo.BindingResult?.Descriptors;
+                if (descriptors is null)
+                {
+                    return false;
+                }
+
+                // Special case until a better API is available from https://github.com/dotnet/aspnetcore/issues/33630
+                if (descriptors.Any(d => d.ParsedTypeInfo.HasValue && d.ParsedTypeInfo.Value.Namespace == "Microsoft.AspNetCore.Components.Routing" && d.ParsedTypeInfo.Value.TypeName == "Router"))
+                {
+                    return false;
+                }
+
+                return descriptors.Any(d => d.IsComponentOrChildContentTagHelper());
             }
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -453,7 +453,7 @@ insertSpaces: false);
         {
             await RunFormattingTestAsync(
 input: @"
-@page ""/""  
+@page ""/""
 @{
  ViewData[""Title""] = ""Create"";
  <hr />
@@ -498,7 +498,7 @@ fileKind: FileKinds.Legacy);
         {
             await RunFormattingTestAsync(
 input: @"
-@page ""/""  
+@page ""/""
 
  <hr />
  <div class=""row"">
@@ -531,6 +531,51 @@ expected: @"@page ""/""
 tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
 insertSpaces: false,
 fileKind: FileKinds.Legacy);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/30382")]
+        public async Task FormatNestedComponents()
+        {
+            await RunFormattingTestAsync(
+input: @"
+<CascadingAuthenticationState>
+<Router AppAssembly=""@typeof(Program).Assembly"">
+    <Found Context=""routeData"">
+        <RouteView RouteData=""@routeData"" DefaultLayout=""@typeof(MainLayout)"" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout=""@typeof(MainLayout)"">
+            <p>Sorry, there's nothing at this address.</p>
+
+            @if (true)
+                    {
+                        <strong></strong>
+                }
+        </LayoutView>
+    </NotFound>
+</Router>
+</CascadingAuthenticationState>
+",
+expected: @"
+<CascadingAuthenticationState>
+    <Router AppAssembly=""@typeof(Program).Assembly"">
+        <Found Context=""routeData"">
+            <RouteView RouteData=""@routeData"" DefaultLayout=""@typeof(MainLayout)"" />
+        </Found>
+        <NotFound>
+            <LayoutView Layout=""@typeof(MainLayout)"">
+                <p>Sorry, there's nothing at this address.</p>
+
+                @if (true)
+                {
+                    <strong></strong>
+                }
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>
+");
         }
 
         private IReadOnlyList<TagHelperDescriptor> GetSurveyPrompt()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -578,6 +578,53 @@ expected: @"
 ");
         }
 
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/30382")]
+        public async Task FormatNestedComponents2()
+        {
+            await RunFormattingTestAsync(
+input: @"
+<GridTable>
+<ChildContent>
+<GridRow>
+<ChildContent>
+<GridCell>
+<ChildContent>
+<strong></strong>
+@if (true)
+{
+<strong></strong>
+}
+<strong></strong>
+</ChildContent>
+</GridCell>
+</ChildContent>
+</GridRow>
+</ChildContent>
+</GridTable>
+",
+expected: @"
+<GridTable>
+    <ChildContent>
+        <GridRow>
+            <ChildContent>
+                <GridCell>
+                    <ChildContent>
+                        <strong></strong>
+                        @if (true)
+                        {
+                            <strong></strong>
+                        }
+                        <strong></strong>
+                    </ChildContent>
+                </GridCell>
+            </ChildContent>
+        </GridRow>
+    </ChildContent>
+</GridTable>
+", tagHelpers: GetComponents());
+        }
+
         private IReadOnlyList<TagHelperDescriptor> GetSurveyPrompt()
         {
             AdditionalSyntaxTrees.Add(Parse(@"


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/30382

When a child component is a property of its parent component, it doesn't affect the indentation in the generated C#, but the formatter was assuming it did, leading to bad results.