### PR TITLE
Don't return directive completions on delete & middle of word.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OmniSharpVSCompletionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OmniSharpVSCompletionContext.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal class OmniSharpVSCompletionContext : CompletionContext
+    {
+        public static readonly PlatformExtensionConverter<CompletionContext, OmniSharpVSCompletionContext> JsonConverter = new PlatformExtensionConverter<CompletionContext, OmniSharpVSCompletionContext>();
+
+        [JsonProperty("_ms_invokeKind")]
+        public OmniSharpVSCompletionInvokeKind InvokeKind { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OmniSharpVSCompletionInvokeKind.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OmniSharpVSCompletionInvokeKind.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal enum OmniSharpVSCompletionInvokeKind
+    {
+        Explicit = 0,
+        Typing = 1,
+        Deletion = 2
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -65,6 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Custom ClientCapabilities deserializer to extract platform specific capabilities
             Serializer.Instance.JsonSerializer.Converters.Add(PlatformAgnosticClientCapabilities.JsonConverter);
             Serializer.Instance.JsonSerializer.Converters.Add(PlatformAgnosticCompletionCapability.JsonConverter);
+            Serializer.Instance.JsonSerializer.Converters.Add(OmniSharpVSCompletionContext.JsonConverter);
 
             ILanguageServer server = null;
             var logLevel = RazorLSPOptions.GetLogLevelForTrace(trace);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -66,6 +66,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 return false;
             }
 
+            if (implicitExpression.FullWidth > 2)
+            {
+                // We only want to provide directive completions if the implicit expression is empty "@|" or at the beginning of a word "@i|", this ensures
+                // we're consistent with how C# typically provides completion items
+                return false;
+            }
+
             if (owner.ChildNodes().Any(n => !n.IsToken || !IsDirectiveCompletableToken((AspNetCore.Razor.Language.Syntax.SyntaxToken)n)))
             {
                 // Implicit expression contains invalid directive tokens

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -59,6 +59,54 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         private DocumentResolver EmptyDocumentResolver { get; }
 
         [Fact]
+        public void IsApplicableTriggerContext_Deletion_ReturnsFalse()
+        {
+            // Arrange
+            var completionContext = new OmniSharpVSCompletionContext()
+            {
+                InvokeKind = OmniSharpVSCompletionInvokeKind.Deletion
+            };
+
+            // Act
+            var result = RazorCompletionEndpoint.IsApplicableTriggerContext(completionContext);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsApplicableTriggerContext_Explicit_ReturnsTrue()
+        {
+            // Arrange
+            var completionContext = new OmniSharpVSCompletionContext()
+            {
+                InvokeKind = OmniSharpVSCompletionInvokeKind.Explicit
+            };
+
+            // Act
+            var result = RazorCompletionEndpoint.IsApplicableTriggerContext(completionContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsApplicableTriggerContext_Typing_ReturnsTrue()
+        {
+            // Arrange
+            var completionContext = new OmniSharpVSCompletionContext()
+            {
+                InvokeKind = OmniSharpVSCompletionInvokeKind.Typing
+            };
+
+            // Act
+            var result = RazorCompletionEndpoint.IsApplicableTriggerContext(completionContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
         public void TryConvert_Directive_ReturnsTrue()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -477,7 +477,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
-                Position = new Position(0, 1)
+                Position = new Position(0, 1),
+                Context = new OmniSharpVSCompletionContext(),
             };
 
             // Act
@@ -502,7 +503,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
-                Position = new Position(0, 1)
+                Position = new Position(0, 1),
+                Context = new OmniSharpVSCompletionContext(),
             };
 
             // Act
@@ -537,7 +539,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
-                Position = new Position(0, 1)
+                Position = new Position(0, 1),
+                Context = new OmniSharpVSCompletionContext(),
             };
 
             // Act
@@ -574,7 +577,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
-                Position = new Position(0, 6)
+                Position = new Position(0, 6),
+                Context = new OmniSharpVSCompletionContext(),
             };
 
             // Act

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -260,7 +260,21 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         }
 
         [Fact]
-        public void AtDirectiveCompletionPoint_ReturnsTrueForSimpleImplicitExpressions()
+        public void AtDirectiveCompletionPoint_ReturnsTrueForSimpleImplicitExpressionsStartOfWord()
+        {
+            // Arrange
+            var syntaxTree = CreateSyntaxTree("@m");
+            var location = new SourceSpan(1, 0);
+
+            // Act
+            var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void AtDirectiveCompletionPoint_ReturnsFalseForSimpleImplicitExpressions()
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@mod");
@@ -270,7 +284,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var result = DirectiveCompletionItemProvider.AtDirectiveCompletionPoint(syntaxTree, location);
 
             // Assert
-            Assert.True(result);
+            Assert.False(result);
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -74,12 +74,12 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         public async Task GetCompletionContextAsync_ProvidesCompletionsWhenAtCompletionPoint()
         {
             // Arrange
-            var text = "@addTag";
+            var text = "@";
             var parser = CreateParser(text, SectionDirective.Directive);
             var completionSource = new RazorDirectiveCompletionSource(Dispatcher, parser, CompletionFactsService);
             var documentSnapshot = new StringTextSnapshot(text);
-            var triggerLocation = new SnapshotPoint(documentSnapshot, 4);
-            var applicableSpan = new SnapshotSpan(documentSnapshot, new Span(1, 6 /* addTag */));
+            var triggerLocation = new SnapshotPoint(documentSnapshot, 1);
+            var applicableSpan = new SnapshotSpan(documentSnapshot, new Span(1, 0));
 
             // Act
             var completionContext = await Task.Run(


### PR DESCRIPTION
- To align with C# completion behavior we do not return Razor directive completions when an implicit expression is more than just a start of a word or on deletion.
    - In the future when we've adopted the LSP embedded language re-design we wont need to special case "start of word" or on deletion because resolution of a C# completion list will end up `null` and allow us to align to when C# returns their completion items / to when we do ours.
- Added a JsonConverter to allow our Razor language server to attempt to deserialize completion contexts into VS' form. In VSCode scenarios it'll still deserialize into VS' form but the value will be different.
- Added tests.

![image](https://user-images.githubusercontent.com/2008729/122996537-d42ced00-d35f-11eb-8c6e-961e0f274ab2.png)


Fixes dotnet/aspnetcore#33675