### PR TITLE
Don't return component completions on delete & middle of word.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 if (containingTagNameToken.FullWidth > 1 &&
                     containingTagNameToken.Span.Start != location.AbsoluteIndex)
                 {
-                    // To align with HTML completion behavior we only want to only provide completion items if we're trying to resolve completion at the
+                    // To align with HTML completion behavior we only want to provide completion items if we're trying to resolve completion at the
                     // beginning of an HTML element name.
                     return Array.Empty<RazorCompletionItem>();
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     selectedAttributeNameLocation.Value.Length > 1 &&
                     selectedAttributeNameLocation.Value.Start != location.AbsoluteIndex)
                 {
-                    // To align with HTML completion behavior we only want to only provide completion items if we're trying to resolve completion at the
+                    // To align with HTML completion behavior we only want to provide completion items if we're trying to resolve completion at the
                     // beginning of an HTML attribute name. We do extra checks on prefix locations here in order to rule out malformed cases when the Razor
                     // compiler incorrectly parses multi-line attributes while in the middle of typing out an element. For instance:
                     //

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public void GetCompletionAt_AtHtmlElementNameEdge_ReturnsCompletions()
+        public void GetCompletionAt_AtHtmlElementNameEdge_ReturnsNoCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -134,14 +134,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), sourceSpan);
 
             // Assert
-            Assert.Collection(
-                completions,
-                completion => Assert.Equal("test1", completion.InsertText),
-                completion => Assert.Equal("test2", completion.InsertText));
+            Assert.Empty(completions);
         }
 
         [Fact]
-        public void GetCompletionAt_AtTagHelperElementNameEdge_ReturnsCompletions()
+        public void GetCompletionAt_AtTagHelperElementNameEdge_ReturnsNoCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -152,10 +149,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), sourceSpan);
 
             // Assert
-            Assert.Collection(
-                completions,
-                completion => Assert.Equal("test1", completion.InsertText),
-                completion => Assert.Equal("test2", completion.InsertText));
+            Assert.Empty(completions);
         }
 
         [Fact]
@@ -283,7 +277,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public void GetCompletionAt_MinimizedAttribute_ReturnsCompletions()
+        public void GetCompletionAt_MinimizedAttributeEdge_ReturnsNoCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -294,11 +288,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), sourceSpan);
 
             // Assert
-            AssertBoolIntCompletions(completions);
+            Assert.Empty(completions);
         }
 
         [Fact]
-        public void GetCompletionAt_MinimizedTagHelperAttribute_ReturnsCompletions()
+        public void GetCompletionAt_MinimizedTagHelperAttributeEdge_ReturnsNoCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -309,11 +303,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), sourceSpan);
 
             // Assert
-            AssertBoolIntCompletions(completions);
+            Assert.Empty(completions);
         }
 
         [Fact]
-        public void GetCompletionAt_HtmlAttribute_ReturnsCompletions()
+        public void GetCompletionAt_InHtmlAttributeName_ReturnsNoCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -324,11 +318,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), sourceSpan);
 
             // Assert
-            AssertBoolIntCompletions(completions);
+            Assert.Empty(completions);
         }
 
         [Fact]
-        public void GetCompletionAt_TagHelperAttribute_ReturnsCompletions()
+        public void GetCompletionAt_InTagHelperAttribute_ReturnsCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -339,11 +333,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), sourceSpan);
 
             // Assert
-            AssertBoolIntCompletions(completions);
+            Assert.Empty(completions);
         }
 
         [Fact]
-        public void GetCompletionsAt_MalformedAttributeValue_ReturnsCompletions()
+        public void GetCompletionsAt_MalformedAttributeValueInName_ReturnsNoCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -355,16 +349,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), sourceSpan);
 
             // Assert
-            AssertBoolIntCompletions(completions);
+            Assert.Empty(completions);
         }
 
         [Fact]
-        public void GetCompletionsAt_MalformedAttributeName_ReturnsCompletions()
+        public void GetCompletionsAt_MalformedAttributeNamePrefix_ReturnsCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int->", DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
+            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
 
             // Act
             var completions = service.GetCompletionItems(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), sourceSpan);


### PR DESCRIPTION
- To align with HTML completion behavior we do not return Razor directive completions when an implicit expression is more than just a start of a word or on deletion.
    - In the future when we've adopted the LSP embedded language re-design we wont need to special case "start of word" or on deletion because resolution of a HTML completion list will end up `null` and allow us to align to when HTML returns their completion items / to when we do ours.
- Added tests.

See [backing VSTS](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1338261) issue for end-user impact details

Fixes dotnet/aspnetcore#33676