### PR TITLE
Remove OnAutoInsert support for `=`.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -200,7 +200,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RazorOnAutoInsertProvider, CloseRazorCommentOnAutoInsertProvider>();
                         services.AddSingleton<RazorOnAutoInsertProvider, CloseTextTagOnAutoInsertProvider>();
                         services.AddSingleton<RazorOnAutoInsertProvider, AutoClosingTagOnAutoInsertProvider>();
-                        services.AddSingleton<RazorOnAutoInsertProvider, AttributeSnippetOnAutoInsertProvider>();
+
+                        // Disabling equals => `="|"` OnAutoInsert support until dynamic overtyping is a thing: https://github.com/dotnet/aspnetcore/issues/33677
+                        // services.AddSingleton<RazorOnAutoInsertProvider, AttributeSnippetOnAutoInsertProvider>();
 
                         // Formatting
                         services.AddSingleton<RazorFormattingService, DefaultRazorFormattingService>();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 },
                 OnAutoInsertProvider = new DocumentOnAutoInsertOptions()
                 {
-                    TriggerCharacters = new[] { ">", "=", "-", "'", "/", "\n" }
+                    TriggerCharacters = new[] { "-", "'", "/", "\n" }
                 },
                 DocumentOnTypeFormattingProvider = new DocumentOnTypeFormattingOptions()
                 {
@@ -323,7 +323,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var triggerCharEnumeration = mergedCapabilities.OnAutoInsertProvider?.TriggerCharacters ?? Enumerable.Empty<string>();
             var purposefullyRemovedTriggerCharacters = new[]
             {
-                ">" // https://github.com/dotnet/aspnetcore-tooling/pull/3797
+                ">", // https://github.com/dotnet/aspnetcore-tooling/pull/3797
+                "=", // https://github.com/dotnet/aspnetcore/issues/33677
             };
             triggerCharEnumeration = triggerCharEnumeration.Except(purposefullyRemovedTriggerCharacters);
             var onAutoInsertMergedTriggerChars = new HashSet<string>(triggerCharEnumeration);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     [ExportLspMethod(MSLSPMethods.OnAutoInsertName)]
     internal class OnAutoInsertHandler : IRequestHandler<DocumentOnAutoInsertParams, DocumentOnAutoInsertResponseItem>
     {
-        private static readonly HashSet<string> HTMLAllowedTriggerCharacters = new() { "=", "-" };
+        private static readonly HashSet<string> HTMLAllowedTriggerCharacters = new() { "-" };
         private static readonly HashSet<string> CSharpAllowedTriggerCharacters = new() { "'", "/", "\n" };
         private static readonly HashSet<string> AllAllowedTriggerCharacters = HTMLAllowedTriggerCharacters
             .Concat(CSharpAllowedTriggerCharacters)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnAutoInsertHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/OnAutoInsertHandlerTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.Null(response);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/33677")]
         public async Task HandleRequestAsync_InvokesHTMLServer_RemapsEdits()
         {
             // Arrange


### PR DESCRIPTION
- This ultimately means when a user types `=` they wont get quotes auto-added for them. The reason behind this is that those quotes are not "overtypeable" and it doesn't feel consistent vs. just typing quotes (they become overtypeable).
- While doing this change I also found that we were still broadcasting `>` as one of our OnAutoInsert options, corrected this while I was touching the code.
- Left the old `=` OnAutoInsert code in-tact with the intent that we can re-enable it once the platform enables dynamic overtyping for these types of scenarios

Fixes dotnet/aspnetcore#33677