### PR TITLE
Add support for remapping rude edit diagnostics.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorSyntaxTreeExtensions.cs
@@ -80,5 +80,30 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var owner = syntaxTree.Root.LocateOwner(change);
             return owner;
         }
+
+        public static SyntaxNode GetOwner(this RazorSyntaxTree syntaxTree, SourceText sourceText, Range range)
+        {
+            if (syntaxTree is null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            if (sourceText is null)
+            {
+                throw new ArgumentNullException(nameof(sourceText));
+            }
+
+            if (range is null)
+            {
+                throw new ArgumentNullException(nameof(range));
+            }
+
+            var absoluteStartIndex = range.Start.GetAbsoluteIndex(sourceText);
+            var absoluteEndIndex = range.End.GetAbsoluteIndex(sourceText);
+            var length = absoluteEndIndex - absoluteStartIndex;
+            var change = new SourceChange(absoluteStartIndex, length, string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+            return owner;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextExtensions.cs
@@ -146,6 +146,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return null;
         }
 
+        // Given the source text and the current span, we start at the ending span location and iterate towards the start
+        // until we've reached a non-whitespace character.
+        // For instance "  abcdef  " would have a last non-whitespace offset of 7 to correspond to the charcter 'f'.
         public static int? GetLastNonWhitespaceOffset(this SourceText source, TextSpan? span, out int newLineCount)
         {
             if (source is null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SourceTextExtensions.cs
@@ -145,5 +145,33 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             return null;
         }
+
+        public static int? GetLastNonWhitespaceOffset(this SourceText source, TextSpan? span, out int newLineCount)
+        {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            span ??= new TextSpan(0, source.Length);
+            newLineCount = 0;
+
+            // If the span is at the end of the document it's common for the "End" to represent 1 past the end of the source
+            var indexableSpanEnd = Math.Min(span.Value.End, source.Length - 1);
+
+            for (var i = indexableSpanEnd; i >= span.Value.Start; i--)
+            {
+                if (!char.IsWhiteSpace(source[i]))
+                {
+                    return i - span.Value.Start;
+                }
+                else if (source[i] == '\n')
+                {
+                    newLineCount++;
+                }
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
- In our diagnostic translation tech we now can detect rude edits via the diagnostic code starting with `ENC`. Once we detect a rude edit diagnostic we then have to enter a separate range translation path because:
  1. Rude edit diagnostics have their ranges pre-mapped based off of Razor runtime #line pragma's which is entirely different code than what we see at design time.
  2. Not all rude edit diagnostics can actually be mapped and we need to fallback to something understandable.

- When remapping rude edits today we handle two scenarios seamlessly (edits map directly)
  1. C# statements
  2. C# expressions

  Other scenarios when a rude edit can occur may span multiple lines that have various Razor constructs on them (Razor comments can introduce this which I test against). In scenarios where we can't do a seamless re-map we rewrite the diagnostic to incorporate the entire beginning line (minus whitespace) all the way to the end-line (excluding whitespace). It's a less specific error but ensures we can properly display errors in the IDE even when other unexpected Razor constructs sit inbetween C# pieces.
- Added tests covering all the known and unknown situations we can encounter rude edit diagnostics.
- Issues found when digging into this change:
    - Diagnostics would disapear after edit and in order to see them I'd need to close/reopen the document. Is a bug on the CoreEditor being tracked [here](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1346430)
    - Diagnostics are being reported as an error (red squiggly). There's on-going work fix this in the editor tracked [here](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/981475) and our reaction is tracked [here](https://github.com/dotnet/aspnetcore/issues/33790).
    - To get any sort of diagnostic squiggles .NET 6 Preview 6 is required. This wasn't inserted into VS yet so to get it all working one needs to manually install preview6.

Current experience when you get a RudeEdit diagnostic:
![image](https://user-images.githubusercontent.com/2008729/123162442-75ca4200-d425-11eb-8160-a53bba4d1434.png)

Fixes dotnet/aspnetcore#33212
