### PR TITLE
Fix typing self-closing tag out char-by-char.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -102,7 +102,7 @@ input: @"
 expected: @"
 @addTagHelper *, TestAssembly
 
-<input />$0
+<input />
 ",
 fileKind: FileKinds.Legacy,
 tagHelpers: new[] { UnspecifiedInputTagHelper });
@@ -145,6 +145,42 @@ tagHelpers: new[] { NormalOrSelfClosingTagHelper });
         }
 
         [Fact]
+        public void OnTypeCloseAngle_WithSlash_WithoutEndTagTagHelperTagStructure()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<test />$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<test />
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { WithoutEndTagTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_WithSpace_WithoutEndTagTagHelperTagStructure()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<test >$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<test />
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { WithoutEndTagTagHelper });
+        }
+
+        [Fact]
         public void OnTypeCloseAngle_WithoutEndTagTagHelperTagStructure()
         {
             RunAutoInsertTest(
@@ -156,7 +192,7 @@ input: @"
 expected: @"
 @addTagHelper *, TestAssembly
 
-<test />$0
+<test />
 ",
 fileKind: FileKinds.Legacy,
 tagHelpers: new[] { WithoutEndTagTagHelper });
@@ -230,7 +266,31 @@ input: @"
     <input>$$
 ",
 expected: @"
-    <input />$0
+    <input />
+");
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_WithSlash_ClosesVoidHTMLTag()
+        {
+            RunAutoInsertTest(
+input: @"
+    <input />$$
+",
+expected: @"
+    <input />
+");
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_WithSpace_ClosesVoidHTMLTag()
+        {
+            RunAutoInsertTest(
+input: @"
+    <input >$$
+",
+expected: @"
+    <input />
 ");
         }
 


### PR DESCRIPTION
- Prior to this when you'd type out an end-tag with a `/` we'd still auto-close the end-tag. To account for this added a slash check for our without end tag completion providers.
- Found that when adjusting self-closing tags we didn't actually need snippet completion because cursor is already in an expected location. Therefore, swapped the logic to not require snippets.
- Fixed an orthogonal issue where whitespace leading a `/` would be re-added on self-closing tag addition.
- Updated and added new tests.

### Before:
![image](https://i.imgur.com/DS0tkYp.gif)

### After:
![image](https://i.imgur.com/NC9rvyl.gif)

Fixes dotnet/aspnetcore#33770