### PR TITLE
Reproduce MicrosoftDotNetBuildTasksFeed build break

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
     <!-- Used for BenchmarkDotNet prerelease packages -->
     <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
+    <add key="general-testing" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -148,5 +148,7 @@
     <!-- Temporary hack to workaround package restrictions for dev17 -->
     <MicrosoftInternalVisualStudioShellFrameworkPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkPackageVersion>
     <MicrosoftIORedistPackageVersion>4.7.1</MicrosoftIORedistPackageVersion>
+
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21322.1</MicrosoftDotNetBuildTasksFeedVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Summary of the changes

Running CI build with a hack removed from Microsoft.DotNet.Build.Tasks.Feed. Not to be merged.

Fixes: N/A
Related to: https://github.com/dotnet/msbuild/issues/5073
