### PR TITLE
Add better CSS commenting support.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/css-language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/css-language-configuration.json
@@ -5,7 +5,8 @@
   "brackets": [
     [ "{", "}" ],
     [ "[", "]" ],
-    [ "(", ")" ]
+    [ "(", ")" ],
+    [ "/*", "*/" ]
   ],
   "autoClosingPairs": [
     {
@@ -32,6 +33,11 @@
       "open": "'",
       "close": "'",
       "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "/*",
+      "close": "*/",
+      "notIn": [ "string" ]
     }
   ],
   "surroundingPairs": [
@@ -51,5 +57,14 @@
     "increaseIndentPattern": "(^.*\\{[^}]*$)",
     "decreaseIndentPattern": "^\\s*\\}"
   },
-  "wordPattern": "(#?-?\\d*\\.\\d\\w*%?)|(::?[\\w-]*(?=[^,{;]*[,{]))|(([@#.!])?[\\w-?]+%?|[@#!.])"
+  "wordPattern": "(#?-?\\d*\\.\\d\\w*%?)|(::?[\\w-]*(?=[^,{;]*[,{]))|(([@#.!])?[\\w-?]+%?|[@#!.])",
+  "onEnterRules": [
+    {
+      "beforeText": "^\\s*\\/\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+      "afterText": "^\\s*\\*\\/$",
+      "action": {
+        "indent": "indentOutdent"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
- Enables:
    - `/*` => `/*|*/` auto-complete
    - `/*|*/` On Enter =>
    ```
    /*
        |
    */
    ```
    - Block commenting highlighting

### Before
![image](https://i.imgur.com/vwjBkST.gif)

### After
![image](https://i.imgur.com/MwUl8wP.gif)

-------

Found Platform issues:
- [Brace navigation on `/*` or `*/` doesn't work.](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1348264/)

--------

- [OnEnterRule Specification](https://code.visualstudio.com/api/language-extensions/language-configuration-guide#on-enter-rules)

Fixes dotnet/aspnetcore#33896
