### PR TITLE
Add better C# commenting & smart indent support

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -215,7 +215,7 @@
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
-          <string>User Members - Parameters</string>
+          <string>parameter name</string>
         </dict>
       </dict>
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/csharp-language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/csharp-language-configuration.json
@@ -6,12 +6,14 @@
   "brackets": [
     [ "{", "}" ],
     [ "[", "]" ],
-    [ "(", ")" ]
-  ],
-  "autoClosingPairs": [
-    [ "{", "}" ],
-    [ "[", "]" ],
     [ "(", ")" ],
+    [ "/*", "*/" ]
+  ],
+  "autoCloseBefore": ";:.,=}])>` \r\n\t",
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
     {
       "open": "'",
       "close": "'",
@@ -21,6 +23,11 @@
       "open": "\"",
       "close": "\"",
       "notIn": [ "string", "comment" ]
+    },
+    {
+      "open": "/*",
+      "close": "*/",
+      "notIn": [ "string" ]
     }
   ],
   "surroundingPairs": [
@@ -42,5 +49,67 @@
     "decreaseIndentPattern": "^((?!.*?\\/\\*).*\\*\\/)?\\s*[\\}\\]].*$",
     "unIndentedLinePattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*\\/\\s*$|^(\\t|[ ])*[ ]\\*\\/\\s*$|^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!\\/))*)?$"
   },
-  "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)"
+  "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)",
+  "onEnterRules": [
+    {
+      // e.g.  // ...|
+      "beforeText": "^\\s*\\/\\/",
+      "afterText": "(\\s*[^\\s]+)+\\s*$",
+      "action": {
+        "indent": "none",
+        "appendText": "// "
+      }
+    },
+    {
+      // e.g. /* | */
+      "beforeText": "^\\s*\\/\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+      "afterText": "^\\s*\\*\\/$",
+      "action": {
+        "indent": "indentOutdent",
+        "appendText": " * "
+      }
+    },
+    {
+      // e.g. /* ...|
+      "beforeText": "^\\s*\\/\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+      "action": {
+        "indent": "none",
+        "appendText": " * "
+      }
+    },
+    {
+      // e.g.  * ...|
+      "beforeText": "^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!\\/))*)?$",
+      "previousLineText": "(?=^(\\s*(\\/\\*|\\*)).*)(?=(?!(\\s*\\*\\/)))",
+      "action": {
+        "indent": "none",
+        "appendText": "* "
+      }
+    },
+    {
+      // e.g.  */|
+      "beforeText": "^(\\t|[ ])*[ ]\\*\\/\\s*$",
+      "action": {
+        "indent": "none",
+        "removeText": 1
+      }
+    },
+    {
+      // e.g.  *-----*/|
+      "beforeText": "^(\\t|[ ])*[ ]\\*[^/]*\\*\\/\\s*$",
+      "action": {
+        "indent": "none",
+        "removeText": 1
+      }
+    }
+    // Cannot auto-include doc-comments yet because C# will OnAutoInsert doc comment continuations asynchronously. Once they remove the support
+    // we can rely on this: https://github.com/dotnet/roslyn/issues/54431
+    //{
+    //  "beforeText": "^\\s*\\/\\/\\/\\s?",
+    //  "action": {
+    //    "indent": "none",
+    //    "appendText": "/// "
+    //  }
+    //}
+  ]
 }


### PR DESCRIPTION
- Enables:
    - `// ABC | DEF` On Enter =>
    ```C#
    // ABC
    // DEF
    ```
    - `/*` => `/*|*/` auto-complete
    - `/*|*/` On Enter =>
    ```C#
    /*
     * |
     */
    ```
    - ` * |` On Enter =>
    ```C#
    /*
     *
     * |
     */
    ```
    - Block commenting highlighting
    

- Also fixed an unrelated issue where in the platform logs there were complaints about C#'s TextMate usage of `User Members - Parameters`, changed this to be the proper identifier.

### Before
![image](https://i.imgur.com/7Ovjtx2.gif)

### After
![image](https://i.imgur.com/4DBoliW.gif)

-------

Found issues:
- Brace navigation on `/*` or `*/` doesn't work. [Issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1348264/)
- language-configuration.json Smart indent doesn't look at the "last line" it looks at the last line with content. [Issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1348266/]
- C# uses OnAutoInsert to provide `///` auto-inclusions, this can be done via language-configuration.json and doesn't need C# to do this asynchronously. [Issue](https://github.com/dotnet/roslyn/issues/54431)

--------

- [OnEnterRule Specification](https://code.visualstudio.com/api/language-extensions/language-configuration-guide#on-enter-rules)

Fixes dotnet/aspnetcore#33898

