### PR TITLE
Remove `=` from HTML's trigger characters to avoid bug.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     {
         private static readonly IReadOnlyList<string> RazorTriggerCharacters = new[] { "@" };
         private static readonly IReadOnlyList<string> CSharpTriggerCharacters = new[] { " ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", "~" };
-        private static readonly IReadOnlyList<string> HtmlTriggerCharacters = new[] { ":", "@", "#", ".", "!", "*", ",", "(", "[", "=", "-", "<", "&", "\\", "/", "'", "\"", "=", ":", " ", "`" };
+        private static readonly IReadOnlyList<string> HtmlTriggerCharacters = new[] { ":", "@", "#", ".", "!", "*", ",", "(", "[", "-", "<", "&", "\\", "/", "'", "\"", "=", ":", " ", "`" };
 
         public static readonly IReadOnlyList<string> AllTriggerCharacters = new HashSet<string>(
             CSharpTriggerCharacters


### PR DESCRIPTION
- Due to a [VSTS issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1348317) we have to workaround this bug:
![D6bKUOd76Q](https://user-images.githubusercontent.com/2008729/123585269-c29c7880-d797-11eb-87d1-cfc1877d6feb.gif)

Fixes dotnet/aspnetcore#33903