### PR TITLE
Fix HTML tag auto-completion in code blocks.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -145,6 +145,28 @@ tagHelpers: new[] { NormalOrSelfClosingTagHelper });
         }
 
         [Fact]
+        public void OnTypeCloseAngle_NormalOrSelfClosingTagHelperTagStructure_CodeBlock()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+@{
+    <test>$$
+}
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+@{
+    <test>$0</test>
+}
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { NormalOrSelfClosingTagHelper });
+        }
+
+        [Fact]
         public void OnTypeCloseAngle_WithSlash_WithoutEndTagTagHelperTagStructure()
         {
             RunAutoInsertTest(
@@ -193,6 +215,28 @@ expected: @"
 @addTagHelper *, TestAssembly
 
 <test />
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { WithoutEndTagTagHelper });
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_WithoutEndTagTagHelperTagStructure_CodeBlock()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+@{
+    <test>$$
+}
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+@{
+    <test>
+}
 ",
 fileKind: FileKinds.Legacy,
 tagHelpers: new[] { WithoutEndTagTagHelper });
@@ -259,6 +303,22 @@ expected: @"
         }
 
         [Fact]
+        public void OnTypeCloseAngle_ClosesStandardHTMLTag_CodeBlock()
+        {
+            RunAutoInsertTest(
+input: @"
+@{
+    <div>$$
+}
+",
+expected: @"
+@{
+    <div>$0</div>
+}
+");
+        }
+
+        [Fact]
         public void OnTypeCloseAngle_ClosesVoidHTMLTag()
         {
             RunAutoInsertTest(
@@ -267,6 +327,22 @@ input: @"
 ",
 expected: @"
     <input />
+");
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_ClosesVoidHTMLTag_CodeBlock()
+        {
+            RunAutoInsertTest(
+input: @"
+@{
+    <input>$$
+}
+",
+expected: @"
+@{
+    <input />
+}
 ");
         }
 


### PR DESCRIPTION
- Found that the Razor compiler has some really interesting [quirks](https://github.com/dotnet/aspnetcore/issues/33919) when it comes to finding the "owner" of an HTML element when within code blocks. Added some "ensurement" methods to workaround these quirks until the compiler can fix them.
- Added tests.

### Before
![image](https://i.imgur.com/mFTekBJ.gif)

### After
![image](https://i.imgur.com/KB2hZfl.gif)

Fixes dotnet/aspnetcore#33901