### PR TITLE
Remove temp HTMLX in LSP editor feature detector

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
@@ -16,7 +16,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     internal class DefaultLSPEditorFeatureDetector : LSPEditorFeatureDetector
     {
         private const string DotNetCoreCSharpCapability = "CSharp&CPS";
-        private const string UseLegacyASPNETCoreEditorSettingTemp = "TextEditor.HTMLX.Specific.UseLegacyASPNETCoreRazorEditor";
         private const string UseLegacyASPNETCoreEditorSetting = "TextEditor.HTML.Specific.UseLegacyASPNETCoreRazorEditor";
 
         private static readonly Guid LiveShareHostUIContextGuid = Guid.Parse("62de1aa5-70b0-4934-9324-680896466fe1");
@@ -49,12 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 Assumes.Present(settingsManager);
 
                 var useLegacyEditor = settingsManager.GetValueOrDefault<bool>(UseLegacyASPNETCoreEditorSetting);
-
-                // WebTools is in the process of renaming HTMLX -> HTML and this Temp setting represents the HTMLX variant of the setting.
-                // Once they've committed the fix we'll need to "do the right thing" for the point-in-time where things vary.
-                var useLegacyEditorTemp = settingsManager.GetValueOrDefault<bool>(UseLegacyASPNETCoreEditorSettingTemp);
-                var shouldUseLegacyEditor = useLegacyEditor || useLegacyEditorTemp;
-                return shouldUseLegacyEditor;
+                return useLegacyEditor;
             });
         }
 


### PR DESCRIPTION
### Summary of the changes
 - Since the WebTools side has been merged and inserted, we can delete the temp HTMLX setting: https://devdiv.visualstudio.com/DevDiv/_git/WebTools/commit/9a5dafc9441392b4902fbb4b586689d2a06e4dff?refName=refs%2Fheads%2Fmain