### PR TITLE
Allow C# and JS members to auto-close in HTML attributes.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/javascript-language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/javascript-language-configuration.json
@@ -9,7 +9,7 @@
     [ "(", ")" ],
     [ "/*", "*/" ]
   ],
-  "autoCloseBefore": ";:.,=}])>` \r\n\t",
+  "autoCloseBefore": ";:.,=}])>`\"' \r\n\t",
   "autoClosingPairs": [
     {
       "open": "{",

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -9,7 +9,7 @@
     ["{", "}"],
     ["(", ")"]
   ],
-  "autoCloseBefore": ";:.,=}])>` \r\n\t",
+  "autoCloseBefore": ";:.,=}])>`\"' \r\n\t",
   "autoClosingPairs": [
     { "open": "<", "close": ">"},
     { "open": "{", "close": "}"},


### PR DESCRIPTION
- Adding quotes to the auto-close before specifications for JS and Razor

### Before
![EfnrcO26ku](https://user-images.githubusercontent.com/2008729/123737968-cc39e500-d858-11eb-9214-7a471a4fd60b.gif)

### After
![image](https://i.imgur.com/qztVSGr.gif)

Fixes dotnet/aspnetcore#33931