### PR TITLE
Allow auto-closing nested HTML tags in C# blocks.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -209,6 +209,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 var closeAngleSoureChange = new SourceChange(closeAngleIndex, length: 0, newText: string.Empty);
                 currentOwner = syntaxTree.Root.LocateOwner(closeAngleSoureChange);
             }
+            else if (currentOwner.Parent is MarkupEndTagSyntax ||
+                     currentOwner.Parent is MarkupTagHelperEndTagSyntax)
+            {
+                // Quirk: https://github.com/dotnet/aspnetcore/issues/33919#issuecomment-870233627
+                // When tags are nested within each other within a C# block like:
+                //
+                // @if (true)
+                // {
+                //     <div><em>|</div>
+                // }
+                //
+                // The owner will be the </div>. Note this does not happen outside of C# blocks.
+
+                var closeAngleIndex = afterCloseAngleIndex - 1;
+                var closeAngleSoureChange = new SourceChange(closeAngleIndex, length: 0, newText: string.Empty);
+                currentOwner = syntaxTree.Root.LocateOwner(closeAngleSoureChange);
+            }
 
             if (currentOwner?.Parent == null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 // The owner will be the </div>. Note this does not happen outside of C# blocks.
 
                 var closeAngleIndex = afterCloseAngleIndex - 1;
-                var closeAngleSoureChange = new SourceChange(closeAngleIndex, length: 0, newText: string.Empty);
+                var closeAngleSourceChange = new SourceChange(closeAngleIndex, length: 0, newText: string.Empty);
                 currentOwner = syntaxTree.Root.LocateOwner(closeAngleSoureChange);
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
                 var closeAngleIndex = afterCloseAngleIndex - 1;
                 var closeAngleSourceChange = new SourceChange(closeAngleIndex, length: 0, newText: string.Empty);
-                currentOwner = syntaxTree.Root.LocateOwner(closeAngleSoureChange);
+                currentOwner = syntaxTree.Root.LocateOwner(closeAngleSourceChange);
             }
 
             if (currentOwner?.Parent == null)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -145,6 +146,55 @@ tagHelpers: new[] { NormalOrSelfClosingTagHelper });
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/33930")]
+        public void OnTypeCloseAngle_TagHelperInHtml_NestedStatement()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<div><test>$$</div>
+}
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<div><test>$0</test></div>
+}
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { NormalOrSelfClosingTagHelper });
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/33930")]
+        public void OnTypeCloseAngle_TagHelperInTagHelper_NestedStatement()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<test><input>$$</test>
+}
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<test><input /></test>
+}
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { NormalOrSelfClosingTagHelper, UnspecifiedInputTagHelper });
+        }
+        [Fact]
         public void OnTypeCloseAngle_NormalOrSelfClosingTagHelperTagStructure_CodeBlock()
         {
             RunAutoInsertTest(
@@ -179,6 +229,31 @@ expected: @"
 @addTagHelper *, TestAssembly
 
 <test />
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { WithoutEndTagTagHelper });
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/33930")]
+        public void OnTypeCloseAngle_NestedStatement()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<div><test />$$</div>
+}
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<div><test /></div>
+}
 ",
 fileKind: FileKinds.Legacy,
 tagHelpers: new[] { WithoutEndTagTagHelper });
@@ -291,6 +366,25 @@ expected: @"
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/33930")]
+        public void OnTypeCloseAngle_ClosesStandardHTMLTag_NestedStatement()
+        {
+            RunAutoInsertTest(
+input: @"
+@if (true)
+{
+    <div><p>$$</div>
+}
+",
+expected: @"
+@if (true)
+{
+    <div><p>$0</p></div>
+}
+");
+        }
+
+        [Fact]
         public void OnTypeCloseAngle_ClosesStandardHTMLTag()
         {
             RunAutoInsertTest(
@@ -327,6 +421,25 @@ input: @"
 ",
 expected: @"
     <input />
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/33930")]
+        public void OnTypeCloseAngle_ClosesVoidHTMLTag_NestedStatement()
+        {
+            RunAutoInsertTest(
+input: @"
+@if (true)
+{
+    <strong><input>$$</strong>
+}
+",
+expected: @"
+@if (true)
+{
+    <strong><input /></strong>
+}
 ");
         }
 


### PR DESCRIPTION
- Ultimately this is due to [this quirk](https://github.com/dotnet/aspnetcore/issues/33919#issuecomment-870233627) of the Razor compiler
- Added tests

### Before
![image](https://i.imgur.com/X6WdMcH.gif)

### After
![image](https://i.imgur.com/2uZoExE.gif)

Fixes dotnet/aspnetcore#33930
