### PR TITLE
Run XLIFF on official builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
   <!-- Opt out Arcade features -->
   <PropertyGroup>
     <!-- Don't run xliff tools on official builds -->
-    <UsingToolXliff Condition="'$(OfficialBuildId)' != ''">false</UsingToolXliff>
+    <UsingToolXliff>true</UsingToolXliff>
   </PropertyGroup>
   <!-- Versioning for assemblies/packages -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,6 @@
   </PropertyGroup>
   <!-- Opt out Arcade features -->
   <PropertyGroup>
-    <!-- Don't run xliff tools on official builds -->
     <UsingToolXliff>true</UsingToolXliff>
   </PropertyGroup>
   <!-- Versioning for assemblies/packages -->


### PR DESCRIPTION
### Summary of the changes
 - Localizations weren't showing up in latest VS builds even though the vsix's produced locally worked. We need to run the XLIFF build so that the satellite assemblies are produced in order for them to be used.
