### PR TITLE
Allow purple squiggles for EnC scenarios in Razor.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/IRazorDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/IRazorDiagnosticsHandler.cs
@@ -4,7 +4,7 @@
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using OmniSharp.Extensions.JsonRpc;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 {
     [Parallel, Method(LanguageServerConstants.RazorTranslateDiagnosticsEndpoint)]
     internal interface IRazorDiagnosticsHandler : IJsonRpcRequestHandler<RazorDiagnosticsParams, RazorDiagnosticsResponse>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnostic.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnostic.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
+{
+    internal class OmniSharpVSDiagnostic : Diagnostic
+    {
+        public static readonly PlatformExtensionConverter<Diagnostic, OmniSharpVSDiagnostic> JsonConverter = new();
+
+        // We need to override the "Tags" property because the basic Diagnostic Tags property has a custom JsonConverter that does not allow
+        // VS extensions to tags.
+        public new Container<OmniSharpVSDiagnosticTag>? Tags { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnosticTag.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnosticTag.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
+{
+    /// <summary>
+    /// Diagnostic tag enum.
+    /// Additional metadata about the type of a diagnostic
+    /// </summary>
+    public enum OmniSharpVSDiagnosticTag
+    {
+        /// <summary>
+        /// Unused or unnecessary code.
+        /// Diagnostics with this tag are rendered faded out.
+        /// </summary>
+        Unnecessary = 1,
+
+        /// <summary>
+        /// Deprecated or obsolete code.
+        /// Clients are allowed to rendered diagnostics with this tag strike through.
+        /// </summary>
+        Deprecated = 2,
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsParams.cs
@@ -3,9 +3,8 @@
 
 using System;
 using MediatR;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 {
     // Note: This type should be kept in sync with the one in VisualStudio.LanguageServerClient assembly.
     internal class RazorDiagnosticsParams : IRequest<RazorDiagnosticsResponse>
@@ -14,6 +13,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public Uri RazorDocumentUri { get; set; }
 
-        public Diagnostic[] Diagnostics { get; set; }
+        public OmniSharpVSDiagnostic[] Diagnostics { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsResponse.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-
-namespace Microsoft.AspNetCore.Razor.LanguageServer
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 {
     // Note: This type should be kept in sync with the one in VisualStudio.LanguageServerClient assembly.
     internal class RazorDiagnosticsResponse
     {
-        public Diagnostic[] Diagnostics { get; set; }
+        public OmniSharpVSDiagnostic[] Diagnostics { get; set; }
 
         public int? HostDocumentVersion { get; set; }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -32,6 +32,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
+using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -66,6 +67,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Serializer.Instance.JsonSerializer.Converters.Add(PlatformAgnosticClientCapabilities.JsonConverter);
             Serializer.Instance.JsonSerializer.Converters.Add(PlatformAgnosticCompletionCapability.JsonConverter);
             Serializer.Instance.JsonSerializer.Converters.Add(OmniSharpVSCompletionContext.JsonConverter);
+            Serializer.Instance.JsonSerializer.Converters.Add(OmniSharpVSDiagnostic.JsonConverter);
 
             ILanguageServer server = null;
             var logLevel = RazorLSPOptions.GetLogLevelForTrace(trace);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
@@ -19,7 +19,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 {
     public class RazorDiagnosticsEndpointTest : LanguageServerTestBase
     {
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
-                Diagnostics = new[] { new Diagnostic() { Range = new Range(new Position(0, 10), new Position(0, 22)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 10), new Position(0, 22)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
             var expectedRange = new Range(new Position(0, 4), new Position(0, 16));
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
-                Diagnostics = new[] { new Diagnostic() { Range = new Range(new Position(0, 10), new Position(0, 22)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 10), new Position(0, 22)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
             var expectedRange = new Range(new Position(0, 4), new Position(0, 16));
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.CSharp,
 
                 // Rude edit diagnostics get mapped directly onto the Razor document via the corresponding "runtime" representation
-                Diagnostics = new[] { new Diagnostic() { Code = new DiagnosticCode("ENC123"), Range = new Range(new Position(0, 3), new Position(0, 16)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Code = new DiagnosticCode("ENC123"), Range = new Range(new Position(0, 3), new Position(0, 16)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
             var expectedRange = new Range(new Position(0, 3), new Position(0, 16));
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.CSharp,
 
                 // Rude edit diagnostics get mapped directly onto the Razor document via the corresponding "runtime" representation
-                Diagnostics = new[] { new Diagnostic() { Code = new DiagnosticCode("ENC123"), Range = new Range(new Position(0, 13), new Position(0, 23)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Code = new DiagnosticCode("ENC123"), Range = new Range(new Position(0, 13), new Position(0, 23)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
             var expectedRange = new Range(new Position(0, 13), new Position(0, 23));
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.CSharp,
 
                 // Rude edit diagnostics get mapped directly onto the Razor document via the corresponding "runtime" representation
-                Diagnostics = new[] { new Diagnostic() { Code = new DiagnosticCode("ENC123"), Range = new Range(new Position(0, 9), new Position(0, 36)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Code = new DiagnosticCode("ENC123"), Range = new Range(new Position(0, 9), new Position(0, 36)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
             var expectedRange = new Range(new Position(0, 1), new Position(0, 43));
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 Kind = RazorLanguageKind.CSharp,
                 Diagnostics = new[] {
-                    new Diagnostic() {
+                    new OmniSharpVSDiagnostic() {
                         Range = new Range(new Position(0, 10), new Position(0, 22)),
                         Code = RazorDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
                         Severity = DiagnosticSeverity.Warning
@@ -289,7 +289,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 Kind = RazorLanguageKind.CSharp,
                 Diagnostics = new[] {
-                    new Diagnostic() {
+                    new OmniSharpVSDiagnostic() {
                         Range = new Range(new Position(0, 10), new Position(0, 22)),
                         Code = RazorDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
                         Severity = DiagnosticSeverity.Error
@@ -326,7 +326,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 Kind = RazorLanguageKind.CSharp,
                 Diagnostics = new[] {
-                    new Diagnostic() {
+                    new OmniSharpVSDiagnostic() {
                         Severity = DiagnosticSeverity.Warning,
                         Range = new Range(new Position(0, 0), new Position(0, 3))
                     }
@@ -361,7 +361,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 Kind = RazorLanguageKind.CSharp,
                 Diagnostics = new[] {
-                    new Diagnostic() {
+                    new OmniSharpVSDiagnostic() {
                         Severity = DiagnosticSeverity.Error,
                         Range = new Range(new Position(0, 0), new Position(0, 3))
                     }
@@ -392,7 +392,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 Kind = RazorLanguageKind.CSharp,
                 Diagnostics = new[] {
-                    new Diagnostic() {
+                    new OmniSharpVSDiagnostic() {
                         Code = new DiagnosticCode("CS1525"),
                         Severity = DiagnosticSeverity.Error,
                         Range = new Range(new Position(0, 0), new Position(0, 3))
@@ -424,7 +424,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 Kind = RazorLanguageKind.CSharp,
                 Diagnostics = new[] {
-                    new Diagnostic() {
+                    new OmniSharpVSDiagnostic() {
                         Code = new DiagnosticCode("CS1525"),
                         Severity = DiagnosticSeverity.Error,
                         Range = new Range(new Position(0, 128), new Position(0, 128))
@@ -460,7 +460,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 Kind = RazorLanguageKind.CSharp,
                 Diagnostics = new[] {
-                    new Diagnostic() {
+                    new OmniSharpVSDiagnostic() {
                         Code = new DiagnosticCode("CS1525"),
                         Severity = DiagnosticSeverity.Error,
                         Range = new Range(new Position(0, 12), new Position(0, 13))
@@ -489,7 +489,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
-                Diagnostics = new[] { new Diagnostic() { Range = new Range(new Position(0, 16), new Position(0, 20)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 16), new Position(0, 20)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
 
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Razor,
-                Diagnostics = new[] { new Diagnostic() { Range = new Range(new Position(0, 3), new Position(0, 4)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 3), new Position(0, 4)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
 
@@ -543,7 +543,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
-                Diagnostics = new[] { new Diagnostic() { Range = new Range(new Position(0, 10), new Position(0, 22)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 10), new Position(0, 22)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
 
@@ -573,7 +573,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
-                Diagnostics = new[] { new Diagnostic() { Range = new Range(new Position(0, 18), new Position(0, 19)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 18), new Position(0, 19)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
 
@@ -605,11 +605,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[]
                 {
-                    new Diagnostic() { Range = new Range(new Position(0, 1), new Position(0, 2)) },     // start of `p` tag
-                    new Diagnostic() { Range = new Range(new Position(0, 13), new Position(0, 14)) },   // leading `abc`
-                    new Diagnostic() { Range = new Range(new Position(0, 25), new Position(0, 26)) },   // `@`
-                    new Diagnostic() { Range = new Range(new Position(0, 45), new Position(0, 46)) },   // trailing `abc`
-                    new Diagnostic() { Range = new Range(new Position(0, 55), new Position(0, 57)) }    // in `Hello`
+                    new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 1), new Position(0, 2)) },     // start of `p` tag
+                    new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 13), new Position(0, 14)) },   // leading `abc`
+                    new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 25), new Position(0, 26)) },   // `@`
+                    new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 45), new Position(0, 46)) },   // trailing `abc`
+                    new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 55), new Position(0, 57)) }    // in `Hello`
                 },
                 RazorDocumentUri = new Uri(documentPath),
             };
@@ -655,8 +655,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[]
                 {
-                    new Diagnostic() { Range = new Range(new Position(0, addTagHelper.Length + 20), new Position(0, addTagHelper.Length + 25)) },
-                    new Diagnostic() { Range = new Range(new Position(0, addTagHelper.Length + 38), new Position(0, addTagHelper.Length + 47)) }
+                    new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, addTagHelper.Length + 20), new Position(0, addTagHelper.Length + 25)) },
+                    new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, addTagHelper.Length + 38), new Position(0, addTagHelper.Length + 47)) }
                 },
                 RazorDocumentUri = new Uri(documentPath),
             };
@@ -701,12 +701,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[]
                 {
-                    new Diagnostic()
+                    new OmniSharpVSDiagnostic()
                     {
                         Code = new DiagnosticCode(HtmlErrorCodes.InvalidNestingErrorCode),
                         Range = new Range(new Position(4, 8), new Position(4, 17))
                     },
-                    new Diagnostic()
+                    new OmniSharpVSDiagnostic()
                     {
                         Code = new DiagnosticCode(HtmlErrorCodes.InvalidNestingErrorCode),
                         Range = new Range(new Position(10, 4), new Position(10, 13))
@@ -737,7 +737,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[]
                 {
-                    new Diagnostic()
+                    new OmniSharpVSDiagnostic()
                     {
                         Code = new DiagnosticCode(HtmlErrorCodes.MissingEndTagErrorCode),
                         Range = new Range(new Position(0, 0), new Position(0, 3))
@@ -767,7 +767,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[]
                 {
-                    new Diagnostic()
+                    new OmniSharpVSDiagnostic()
                     {
                         Code = new DiagnosticCode(HtmlErrorCodes.MissingEndTagErrorCode),
                         Range = new Range(new Position(0, 0), new Position(0, 3))
@@ -796,7 +796,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[]
                 {
-                    new Diagnostic()
+                    new OmniSharpVSDiagnostic()
                     {
                         Code = new DiagnosticCode(HtmlErrorCodes.UnexpectedEndTagErrorCode),
                         Range = new Range(new Position(0, 7), new Position(0, 9))


### PR DESCRIPTION
- The core issue was that the O# framework ends up using custom `JsonConverters` to serialize O# specific diagnostic tags. The drawback of this is that when working with VS diagnostics they don't respect custom tag values. To combat this I shadowed the `Tags` property in a new diagnostic type called `OmniSharpVSDiagnostic`.
- Created a new `Diagnostics` namespace to start throwing all of our diagnostic logic into.
- Updated tests.

**Before:** These squiggles would show as red errors

**After:**
![image](https://user-images.githubusercontent.com/2008729/124172769-142a5900-da5f-11eb-99cb-8d25cd6e4c43.png)

Fixes dotnet/aspnetcore#33790

/cc @dibarbet 
