### PR TITLE
Properly serialize VS diagnostics during translation.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnostic.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnostic.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 
         /// <summary>
         /// Gets or sets a message shown when the user hovers over an error. If null, then message
-        /// is used(use <see cref="OmniSharpVSDiagnosticTags.SuppressEditorToolTip"/> to prevent a tool tip from being shown).
+        /// is used (use <see cref="OmniSharpVSDiagnosticTags.SuppressEditorToolTip"/> to prevent a tool tip from being shown).
         /// </summary>
         [JsonProperty("_ms_toolTip")]
         public string? ToolTip { get; set; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnostic.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnostic.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 #nullable enable
@@ -15,5 +16,50 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
         // We need to override the "Tags" property because the basic Diagnostic Tags property has a custom JsonConverter that does not allow
         // VS extensions to tags.
         public new Container<OmniSharpVSDiagnosticTag>? Tags { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project and context (e.g. Win32, MacOS, etc.) in which the diagnostic was generated.
+        /// </summary>
+        [JsonProperty("_ms_projects")]
+        public OmniSharpVSProjectAndContext[]? Projects { get; set; }
+
+        /// <summary>
+        /// Gets or sets an expanded description of the diagnostic.
+        /// </summary>
+        [JsonProperty("_ms_expandedMessage")]
+        public string? ExpandedMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets a message shown when the user hovers over an error. If null, then message
+        /// is used(use <see cref="OmniSharpVSDiagnosticTags.SuppressEditorToolTip"/> to prevent a tool tip from being shown).
+        /// </summary>
+        [JsonProperty("_ms_toolTip")]
+        public string? ToolTip { get; set; }
+
+        /// <summary>
+        /// Gets or sets some non-human readable identifier so that two diagnostics that are
+        /// equivalent(e.g.a syntax error in both a build for Win32 and MacOs) can be consolidated.
+        /// </summary>
+        [JsonProperty("_ms_identifier")]
+        public string? Identifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets a string describing the diagnostic types (e.g. Security, Performance, Style, ...).
+        /// </summary>
+        [JsonProperty("_ms_diagnosticType")]
+        public string? DiagnosticType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a rank associated with this diagnostic, used for the default sort.
+        /// Default == 300 will be used if no rank is specified.
+        /// </summary>
+        [JsonProperty("_ms_diagnosticRank")]
+        public OmniSharpVSDiagnosticRank? DiagnosticRank { get; set; }
+
+        /// <summary>
+        /// Gets or sets an ID used to associate this diagnostic with a corresponding line in the output window.
+        /// </summary>
+        [JsonProperty("_ms_outputId")]
+        public int? OutputId { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnostic.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnostic.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 
         /// <summary>
         /// Gets or sets some non-human readable identifier so that two diagnostics that are
-        /// equivalent(e.g.a syntax error in both a build for Win32 and MacOs) can be consolidated.
+        /// equivalent (e.g.a syntax error in both a build for Win32 and MacOs) can be consolidated.
         /// </summary>
         [JsonProperty("_ms_identifier")]
         public string? Identifier { get; set; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnosticRank.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnosticRank.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
+{
+    /// <summary>
+    /// Enum which represents the rank of a diagnostic.
+    /// </summary>
+    public enum OmniSharpVSDiagnosticRank
+    {
+        /// <summary>
+        /// Highest priority.
+        /// </summary>
+        Highest = 100,
+
+        /// <summary>
+        /// High priority.
+        /// </summary>
+        High = 200,
+
+        /// <summary>
+        /// Default priority.
+        /// </summary>
+        Default = 300,
+
+        /// <summary>
+        /// Low priority.
+        /// </summary>
+        Low = 400,
+
+        /// <summary>
+        /// Lowest priority.
+        /// </summary>
+        Lowest = 500,
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnosticTags.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnosticTags.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
+{
+    /// <summary>
+    /// Class which contains constant casted values for VS specific DiagnosticTags.
+    /// </summary>
+    public static class OmniSharpVSDiagnosticTags
+    {
+        /// <summary>
+        /// Error coming from the build.
+        /// </summary>
+        public const OmniSharpVSDiagnosticTag BuildError = (OmniSharpVSDiagnosticTag)(-1);
+
+        /// <summary>
+        /// Error coming from Intellisense.
+        /// </summary>
+        public const OmniSharpVSDiagnosticTag IntellisenseError = (OmniSharpVSDiagnosticTag)(-2);
+
+        /// <summary>
+        /// Diagnostic that could be generated from both builds and
+        /// Intellisense.
+        ///
+        /// Diagnostics tagged with PotentialDuplicate will be hidden
+        /// in the error list if:
+        ///     The error list is displaying build and intellisense errors.
+        ///     The identifier property the containing DiagnosticReport
+        ///     matches the supersedes property of another report for the
+        ///     same document.
+        ///
+        /// The latter condition(by itself) will also causes Diagnostics
+        /// tagged with the PotentialDuplicate tag to be hidden in the editor.
+        /// </summary>
+        public const OmniSharpVSDiagnosticTag PotentialDuplicate = (OmniSharpVSDiagnosticTag)(-3);
+
+        /// <summary>
+        /// Diagnostic is never displayed in the error list.
+        /// </summary>
+        public const OmniSharpVSDiagnosticTag HiddenInErrorList = (OmniSharpVSDiagnosticTag)(-4);
+
+        /// <summary>
+        /// Diagnostic is always displayed in the error list.
+        /// </summary>
+        public const OmniSharpVSDiagnosticTag VisibleInErrorList = (OmniSharpVSDiagnosticTag)(-5);
+
+        /// <summary>
+        /// Diagnostic is never displayed in the editor.
+        /// </summary>
+        public const OmniSharpVSDiagnosticTag HiddenInEditor = (OmniSharpVSDiagnosticTag)(-6);
+
+        /// <summary>
+        /// No tooltip is shown for the diagnostic in the editor.
+        /// </summary>
+        public const OmniSharpVSDiagnosticTag SuppressEditorToolTip = (OmniSharpVSDiagnosticTag)(-7);
+
+        /// <summary>
+        /// Diagnostic is represented in Editor as an EnC error.
+        /// </summary>
+        public const OmniSharpVSDiagnosticTag EditAndContinueError = (OmniSharpVSDiagnosticTag)(-8);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnosticTags.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSDiagnosticTags.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
         ///     matches the supersedes property of another report for the
         ///     same document.
         ///
-        /// The latter condition(by itself) will also causes Diagnostics
+        /// The latter condition (by itself) will also causes Diagnostics
         /// tagged with the PotentialDuplicate tag to be hidden in the editor.
         /// </summary>
         public const OmniSharpVSDiagnosticTag PotentialDuplicate = (OmniSharpVSDiagnosticTag)(-3);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSProjectAndContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSProjectAndContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
         public string? ProjectName { get; set; }
 
         /// <summary>
-        /// Gets or sets A human-readable identifier for the build context (e.g. Win32 or MacOS)
+        /// Gets or sets a human-readable identifier for the build context (e.g. Win32 or MacOS)
         /// in which the diagnostic was generated.
         /// </summary>
         public string? Context { get; set; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSProjectAndContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/OmniSharpVSProjectAndContext.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
+{
+    internal class OmniSharpVSProjectAndContext
+    {
+        /// <summary>
+        /// Gets or sets a human-readable identifier for the project in which the diagnostic was generated.
+        /// </summary>
+        public string? ProjectName { get; set; }
+
+        /// <summary>
+        /// Gets or sets A human-readable identifier for the build context (e.g. Win32 or MacOS)
+        /// in which the diagnostic was generated.
+        /// </summary>
+        public string? Context { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier for the project in which the diagnostic was generated.
+        /// </summary>
+        public string? ProjectIdentifier { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPRequestInvoker.cs
@@ -42,14 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
             // We need these converters so we don't lose information as part of the deserialization.
             _serializer = new JsonSerializer();
-            _serializer.Converters.Add(new VSExtensionConverter<ClientCapabilities, VSClientCapabilities>());
-            _serializer.Converters.Add(new VSExtensionConverter<CompletionItem, VSCompletionItem>());
-            _serializer.Converters.Add(new VSExtensionConverter<SignatureInformation, VSSignatureInformation>());
-            _serializer.Converters.Add(new VSExtensionConverter<Hover, VSHover>());
-            _serializer.Converters.Add(new VSExtensionConverter<ServerCapabilities, VSServerCapabilities>());
-            _serializer.Converters.Add(new VSExtensionConverter<SymbolInformation, VSSymbolInformation>());
-            _serializer.Converters.Add(new VSExtensionConverter<CompletionList, VSCompletionList>());
-            _serializer.Converters.Add(new VSExtensionConverter<CodeAction, VSCodeAction>());
+            _serializer.AddVSExtensionConverters();
         }
 
         public override Task<TOut> ReinvokeRequestOnServerAsync<TIn, TOut>(string method, string contentType, TIn parameters, CancellationToken cancellationToken)


### PR DESCRIPTION
- We were attempting to translate VS diagnostics into LSP bound diagnostics. The problem with this is that VSDiagnostics have many more fields than the normal LSP spec'd diagnostic type. Therefore, when we'd attempt to translate VSDiagnostics to their corresponding Razor positions we'd lose all of the VSDiagnostic data. One of the fields we lost was "Project", bringing all of the VS properties over to our O# implementation allows us to have a higher fidelity of diagnostic translation presenting things like the project for a diagnostic. To prevent future mismatches I brought over more than just the project members I brought over everything. This means that C# can build diagnostics however they want and we'll "do the right thing".
- Also found that when requesting diagnostics from C# we were similarly failing to deserialize a diagnostic into a VSDiagnostic due to lacking extension converters. Was able to replace a pre-existing custom `AddVSExtensionConverters` method with an official one.

![image](https://user-images.githubusercontent.com/2008729/124187311-7e98c480-da72-11eb-8bd0-16b58b2a787c.png)

Fixes dotnet/aspnetcore#33793