### PR TITLE
Add cascadeTerminateToConfigurations to browser config

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
@@ -101,6 +101,8 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
             noDebug: configuration.noDebug || false,
             port: debuggingPort,
             ...configuration.browserConfig,
+            // When the browser debugging session is stopped, propogate
+            // this and terminate the debugging session of the Blazor dev server.
             cascadeTerminateToConfigurations: [SERVER_APP_NAME],
         };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/BlazorDebugConfigurationProvider.ts
@@ -101,6 +101,7 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
             noDebug: configuration.noDebug || false,
             port: debuggingPort,
             ...configuration.browserConfig,
+            cascadeTerminateToConfigurations: [SERVER_APP_NAME],
         };
 
         try {


### PR DESCRIPTION
### Summary of the changes
 
Adds the `cascadeTerminateToConfigurations` property to the browser configuration. This causes the debugging session hosting the dev server to be stopped when the user stops the browser debugging session.

Fixes: https://github.com/dotnet/aspnetcore/issues/32393
