### PR TITLE
Update .editorconfig naming for instance fields

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,3 +76,13 @@ csharp_using_directive_placement = outside_namespace
 
 # xUnit1004: Test methods should not be skipped
 dotnet_diagnostic.xUnit1004.severity = refactoring
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _


### PR DESCRIPTION
I ran into this many times when working on https://github.com/dotnet/aspnetcore-tooling/pull/3808.
Before, the below example would try to generate the field `errorReporter` instead of `_errorReporter`. Now it generates the correct naming style:
![image](https://user-images.githubusercontent.com/16968319/124715448-dfcbf800-deb7-11eb-9b49-dc26a5584d8e.png)
