### PR TITLE
Fix typing `@` does not provide C# completion in VSCode.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCompletionItemProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorCompletionItemProvider.ts
@@ -21,6 +21,10 @@ export class RazorCompletionItemProvider
         projectedPosition: vscode.Position, triggerCharacter: string | undefined) {
 
         if (projectedUri) {
+            // "@" is not a valid trigger character for C# / HTML and therefore we need to translate
+            // it into a non-trigger invocation.
+            triggerCharacter = triggerCharacter === '@' ? undefined : triggerCharacter;
+
             const completions = await vscode
                 .commands
                 .executeCommand<vscode.CompletionList | vscode.CompletionItem[]>(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/TestOmniSharpWorkspace.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/TestOmniSharpWorkspace.cs
@@ -19,10 +19,22 @@ namespace OmniSharp
             {
                 var factory = LoggerFactory.Create((b) => { });
                 var hostServicesAggregator = new HostServicesAggregator(Enumerable.Empty<IHostServicesProvider>(), factory);
-                var fileSystemWatcher = Mock.Of<IFileSystemWatcher>(MockBehavior.Strict);
-                var workspace = new OmniSharpWorkspace(hostServicesAggregator, factory, fileSystemWatcher);
+                var workspace = new OmniSharpWorkspace(hostServicesAggregator, factory, TestFileSystemWatcher.Instance);
 
                 return workspace;
+            }
+        }
+
+        private class TestFileSystemWatcher : IFileSystemWatcher
+        {
+            public static readonly TestFileSystemWatcher Instance = new TestFileSystemWatcher();
+
+            private TestFileSystemWatcher()
+            {
+            }
+
+            public void Watch(string pathOrExtension, FileSystemNotificationCallback callback)
+            {
             }
         }
     }


### PR DESCRIPTION
- The `@` character is a valid Razor trigger but not a valid C#/HTML trigger. Therefore, when we see our `@` (transition) we'll translate it into a ctrl + space like invocation so all completions are queried.
- Testing this behavior is tracked separately [here](https://github.com/dotnet/aspnetcore/issues/19296).

Fixes dotnet/aspnetcore#34182