### PR TITLE
Handle PathTooLongExceptions

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public static class DirectoryHelper
+    {
+        public static IEnumerable<string> GetFilteredFiles(string workspaceDirectory, string searchPattern, IReadOnlyCollection<string> ignoredNames, ILogger? logger = null)
+        {
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.GetFiles(workspaceDirectory, searchPattern, SearchOption.TopDirectoryOnly);
+            }
+            catch (PathTooLongException ex)
+            {
+                logger?.LogWarning(ex.Message);
+                yield break;
+            }
+
+            foreach (var file in files)
+            {
+                yield return file;
+            }
+
+            string[] directories;
+            try
+            {
+                directories = Directory.GetDirectories(workspaceDirectory);
+            }
+            catch (PathTooLongException ex)
+            {
+                logger?.LogWarning(ex.Message);
+                yield break;
+            }
+
+            foreach (var path in directories)
+            {
+                var directory = Path.GetDirectoryName(path);
+                if (!ignoredNames.Contains(directory))
+                {
+                    foreach (var result in GetFilteredFiles(path, searchPattern, ignoredNames, logger))
+                    {
+                        yield return result;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             ForegroundDispatcher foregroundDispatcher,
             FilePathNormalizer filePathNormalizer,
             IEnumerable<IProjectConfigurationFileChangeListener> listeners,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory = null)
         {
             if (foregroundDispatcher is null)
             {
@@ -47,15 +47,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(listeners));
             }
 
-            if (loggerFactory is null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
-
             _foregroundDispatcher = foregroundDispatcher;
             _filePathNormalizer = filePathNormalizer;
             _listeners = listeners;
-            _logger = loggerFactory.CreateLogger<ProjectConfigurationFileChangeDetector>();
+            _logger = loggerFactory?.CreateLogger<ProjectConfigurationFileChangeDetector>();
         }
 
         public async Task StartAsync(string workspaceDirectory, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly ILogger _logger;
         private FileSystemWatcher _watcher;
 
-        private static readonly IReadOnlyCollection<string> _ignoredDirectories = new string[]
+        private static readonly IReadOnlyCollection<string> s_ignoredDirectories = new string[]
         {
             "node_modules",
             "bin",
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         // Protected virtual for testing
         protected virtual IEnumerable<string> GetExistingConfigurationFiles(string workspaceDirectory)
         {
-            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile, _ignoredDirectories, _logger);
+            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile, s_ignoredDirectories, _logger);
 
             return files;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             "node_modules",
             "bin",
+            ".vs",
         };
 
         public ProjectConfigurationFileChangeDetector(
@@ -126,7 +127,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         // Protected virtual for testing
         protected virtual IEnumerable<string> GetExistingConfigurationFiles(string workspaceDirectory)
         {
-            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile, s_ignoredDirectories, _logger);
+            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile, s_ignoredDirectories, logger: _logger);
 
             return files;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _foregroundDispatcher = foregroundDispatcher;
             _filePathNormalizer = filePathNormalizer;
             _listeners = listeners;
-            _logger = loggerFactory.CreateLogger<ProjectFileChangeDetector>();
+            _logger = loggerFactory?.CreateLogger<ProjectFileChangeDetector>();
         }
 
         public async Task StartAsync(string workspaceDirectory, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -19,10 +18,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly FilePathNormalizer _filePathNormalizer;
         private readonly IEnumerable<IProjectFileChangeListener> _listeners;
-        private readonly ILogger _logger;
         private FileSystemWatcher _watcher;
 
-        private static readonly string[] _ignoredDirectories = new string[]{
+        private static readonly string[] s_ignoredDirectories = new string[]{
             "node_modules",
             "bin",
             "obj",
@@ -31,8 +29,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public ProjectFileChangeDetector(
             ForegroundDispatcher foregroundDispatcher,
             FilePathNormalizer filePathNormalizer,
-            IEnumerable<IProjectFileChangeListener> listeners,
-            ILoggerFactory loggerFactory)
+            IEnumerable<IProjectFileChangeListener> listeners)
         {
             if (foregroundDispatcher is null)
             {
@@ -49,15 +46,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(listeners));
             }
 
-            if (loggerFactory is null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
-
             _foregroundDispatcher = foregroundDispatcher;
             _filePathNormalizer = filePathNormalizer;
             _listeners = listeners;
-            _logger = loggerFactory?.CreateLogger<ProjectFileChangeDetector>();
         }
 
         public async Task StartAsync(string workspaceDirectory, CancellationToken cancellationToken)
@@ -135,7 +126,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         // Protected virtual for testing
         protected virtual IEnumerable<string> GetExistingProjectFiles(string workspaceDirectory)
         {
-            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, ProjectFileExtensionPattern, _ignoredDirectories, _logger);
+            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, ProjectFileExtensionPattern, s_ignoredDirectories);
 
             return files;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -20,7 +20,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly IEnumerable<IProjectFileChangeListener> _listeners;
         private FileSystemWatcher _watcher;
 
-        private static readonly string[] s_ignoredDirectories = new string[]{
+        private static readonly string[] s_ignoredDirectories = new string[]
+        {
             "node_modules",
             "bin",
             "obj",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -27,15 +26,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly List<FileSystemWatcher> _watchers;
         private readonly object _pendingNotificationsLock = new();
 
-        private static readonly string[] _ignoredDirectories = new string[]{
+        private static readonly string[] s_ignoredDirectories = new string[]{
             "node_modules",
         };
 
         public RazorFileChangeDetector(
             ForegroundDispatcher foregroundDispatcher,
             FilePathNormalizer filePathNormalizer,
-            IEnumerable<IRazorFileChangeListener> listeners,
-            ILoggerFactory loggerFactory = null)
+            IEnumerable<IRazorFileChangeListener> listeners)
         {
             if (foregroundDispatcher is null)
             {
@@ -158,7 +156,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             for (var i = 0; i < s_razorFileExtensions.Count; i++)
             {
                 var extension = s_razorFileExtensions[i];
-                var existingFiles = DirectoryHelper.GetFilteredFiles(workspaceDirectory, "*" + extension, _ignoredDirectories);
+                var existingFiles = DirectoryHelper.GetFilteredFiles(workspaceDirectory, "*" + extension, s_ignoredDirectories);
                 existingRazorFiles = existingRazorFiles.Concat(existingFiles);
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             ForegroundDispatcher foregroundDispatcher,
             FilePathNormalizer filePathNormalizer,
             IEnumerable<IRazorFileChangeListener> listeners,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory = null)
         {
             if (foregroundDispatcher is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -26,7 +26,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly List<FileSystemWatcher> _watchers;
         private readonly object _pendingNotificationsLock = new();
 
-        private static readonly string[] s_ignoredDirectories = new string[]{
+        private static readonly string[] s_ignoredDirectories = new string[]
+        {
             "node_modules",
         };
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DirectoryHelperTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DirectoryHelperTest.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Xunit;
+using static Microsoft.AspNetCore.Razor.LanguageServer.DirectoryHelper;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
+{
+    public class DirectoryHelperTest : TagHelperServiceTestBase
+    {
+        [Fact]
+        public void GetFilteredFiles_FindsFiles()
+        {
+            // Arrange
+            var firstProjectRazorJson = "HigherDirectory\\project.razor.json";
+            var secondProjectRazorJson = "HigherDirectory\\RealDirectory\\project.razor.json";
+
+            var workspaceDirectory = Path.Combine("LowerDirectory");
+            var searchPattern = "project.razor.json";
+            var ignoredDirectories = new[] { "node_modules" };
+            var fileResults = new Dictionary<string, IEnumerable<string>>() {
+                { "HigherDirectory", new []{ firstProjectRazorJson } },
+                { "RealDirectory", new []{ secondProjectRazorJson } },
+                { "LongDirectory", new[]{ "LONGPATH", "LONGPATH\\project.razor.json"} },
+                { "node_modules", null },
+            };
+            var directoryResults = new Dictionary<string, IEnumerable<string>>() {
+                { "LowerDirectory", new[]{ "HigherDirectory" } },
+                { "HigherDirectory", new[]{ "node_modules", "RealDirectory", "FakeDirectory", "LongDirectory" } },
+                { "node_modules", null },
+            };
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            var fileSystem = new TestFileSystem(fileResults, directoryResults);
+#pragma warning restore CS0612 // Type or member is obsolete
+
+            // Act
+            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, searchPattern, ignoredDirectories, fileSystem);
+
+            // Assert
+            Assert.Collection(files,
+                result => result.Equals(firstProjectRazorJson),
+                result => result.Equals(secondProjectRazorJson)
+            );
+        }
+
+        [Obsolete]
+        private class TestFileSystem : IFileSystem
+        {
+            private readonly IDictionary<string, IEnumerable<string>> _fileResults;
+            private readonly IDictionary<string, IEnumerable<string>> _directoryResults;
+
+            public TestFileSystem(
+                IDictionary<string, IEnumerable<string>> fileResults,
+                IDictionary<string, IEnumerable<string>> directoryResults)
+            {
+                _fileResults = fileResults;
+                _directoryResults = directoryResults;
+            }
+
+            public IEnumerable<string> GetDirectories(string workspaceDirectory)
+            {
+                var success = _directoryResults.TryGetValue(workspaceDirectory, out var results);
+                if (success)
+                {
+                    if (results is null)
+                    {
+                        Assert.True(false, "Tried to walk a directory which should have been ignored");
+                    }
+
+                    if (results.Any(s => s.Equals("LONGPATH")))
+                    {
+                        throw new PathTooLongException();
+                    }
+                    return results;
+                }
+                else
+                {
+                    throw new DirectoryNotFoundException();
+                }
+            }
+
+            public IEnumerable<string> GetFiles(string workspaceDirectory, string searchPattern, SearchOption searchOption)
+            {
+                var success = _fileResults.TryGetValue(workspaceDirectory, out var results);
+                if (success)
+                {
+                    if (results is null)
+                    {
+                        Assert.True(false, "Tried to walk a directory which should have been ignored");
+                    }
+
+                    if (results.Any(s => s.Equals("LONGPATH")))
+                    {
+                        throw new PathTooLongException();
+                    }
+                    return results;
+                }
+                else
+                {
+                    throw new DirectoryNotFoundException();
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 _cancellationTokenSource.Cancel();
             }
 
-            protected override IReadOnlyList<string> GetExistingConfigurationFiles(string workspaceDirectory)
+            protected override IEnumerable<string> GetExistingConfigurationFiles(string workspaceDirectory)
             {
                 return _existingConfigurationFiles;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectFileChangeDetectorTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 CancellationTokenSource cancellationTokenSource,
                 ForegroundDispatcher foregroundDispatcher,
                 IEnumerable<IProjectFileChangeListener> listeners,
-                IReadOnlyList<string> existingprojectFiles) : base(foregroundDispatcher, new FilePathNormalizer(), listeners, loggerFactory: null)
+                IReadOnlyList<string> existingprojectFiles) : base(foregroundDispatcher, new FilePathNormalizer(), listeners)
             {
                 _cancellationTokenSource = cancellationTokenSource;
                 _existingProjectFiles = existingprojectFiles;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectFileChangeDetectorTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 CancellationTokenSource cancellationTokenSource,
                 ForegroundDispatcher foregroundDispatcher,
                 IEnumerable<IProjectFileChangeListener> listeners,
-                IReadOnlyList<string> existingprojectFiles) : base(foregroundDispatcher, new FilePathNormalizer(), listeners)
+                IReadOnlyList<string> existingprojectFiles) : base(foregroundDispatcher, new FilePathNormalizer(), listeners, loggerFactory: null)
             {
                 _cancellationTokenSource = cancellationTokenSource;
                 _existingProjectFiles = existingprojectFiles;
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 _cancellationTokenSource.Cancel();
             }
 
-            protected override IReadOnlyList<string> GetExistingProjectFiles(string workspaceDirectory)
+            protected override IEnumerable<string> GetExistingProjectFiles(string workspaceDirectory)
             {
                 return _existingProjectFiles;
             }


### PR DESCRIPTION
### Summary of the changes
 - We can encounter `PathTooLongException` when traversing deeply nested structures such as `node_modules`, to avoid this lets avoid that folder all-together.
 - Also be more resilient to `PathTooLongException`. Rather than throwing we should swallow the exception then back out a level and continue the walk (though node_modules is the most likely cause, it could still happen). 

Fixes: https://github.com/dotnet/aspnetcore/issues/31237
