### PR TITLE
Fix component discovery issue

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks
 
         private class TestProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcher
         {
-            protected override bool IsDispatcherThread => true;
+            public override bool IsDispatcherThread => true;
 
             public override TaskScheduler DispatcherScheduler => TaskScheduler.Default;
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectSnapshotManagerDispatcher.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
     internal class DefaultProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcher
     {
-        protected override bool IsDispatcherThread
+        public override bool IsDispatcherThread
             => Thread.CurrentThread.ManagedThreadId == ProjectSnapshotManagerTaskScheduler.Instance.ThreadId;
 
         public override TaskScheduler DispatcherScheduler { get; } = ProjectSnapshotManagerTaskScheduler.Instance;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcher.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Razor
 {
     internal abstract class ProjectSnapshotManagerDispatcher
     {
-        protected abstract bool IsDispatcherThread { get; }
+        public abstract bool IsDispatcherThread { get; }
 
         public abstract TaskScheduler DispatcherScheduler { get; }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // All methods involving the project snapshot manager need to be run on the
             // project snapshot manager's specialized thread. The LSP editor should already
             // be on the specialized thread, however the old editor may be calling this
-            // constructor using the UI thread.
+            // constructor on the UI thread.
             if (_projectSnapshotManagerDispatcher.IsDispatcherThread)
             {
                 InitializeTriggers(this, _triggers);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -68,7 +68,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             _notificationWork = new Queue<ProjectChangeEventArgs>();
 
             // All methods involving the project snapshot manager need to be run on the
-            // project snapshot manager's specialized thread.
+            // project snapshot manager's specialized thread. The LSP editor should already
+            // be on the specialized thread, however the old editor may be calling this
+            // constructor using the UI thread.
             if (_projectSnapshotManagerDispatcher.IsDispatcherThread)
             {
                 InitializeTriggers(this, _triggers);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
 
             private Thread Thread { get; } = Thread.CurrentThread;
 
-            protected override bool IsDispatcherThread => Thread.CurrentThread == Thread;
+            public override bool IsDispatcherThread => Thread.CurrentThread == Thread;
         }
 
         private class ThrowingTaskScheduler : TaskScheduler

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectSnapshotManager.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectSnapshotManager.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         {
             var dispatcher = new Mock<ProjectSnapshotManagerDispatcher>(MockBehavior.Strict);
             dispatcher.Setup(d => d.AssertDispatcherThread(It.IsAny<string>())).Verifiable();
+            dispatcher.Setup(d => d.IsDispatcherThread).Returns(true);
             dispatcher.Setup(d => d.DispatcherScheduler).Returns(TaskScheduler.FromCurrentSynchronizationContext());
             return dispatcher.Object;
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/OOPTagHelperResolverTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/OOPTagHelperResolverTest.cs
@@ -180,6 +180,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             {
                 var dispatcher = new Mock<ProjectSnapshotManagerDispatcher>(MockBehavior.Strict);
                 dispatcher.Setup(d => d.AssertDispatcherThread(It.IsAny<string>())).Verifiable();
+                dispatcher.Setup(d => d.IsDispatcherThread).Returns(true);
                 dispatcher.Setup(d => d.DispatcherScheduler).Returns(TaskScheduler.FromCurrentSynchronizationContext());
                 return dispatcher.Object;
             }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/TestProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/TestProjectSnapshotManagerDispatcher.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
         private Thread Thread { get; } = Thread.CurrentThread;
 
-        protected override bool IsDispatcherThread => Thread.CurrentThread == Thread;
+        public override bool IsDispatcherThread => Thread.CurrentThread == Thread;
 
         private class ThrowingTaskScheduler : TaskScheduler
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
 using Xunit;
@@ -85,16 +83,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Building this list in the wrong order so we can verify priority matters
             var triggers = new[] { defaultPriorityTrigger, highPriorityTrigger };
 
-            // This particular test needs to use an actual non-test dispatcher due to threading
-            var dispatcher = new DefaultProjectSnapshotManagerDispatcher();
-
             // Act
-            var projectManager = new TestProjectSnapshotManager(dispatcher, triggers, Workspace)
-            {
-                NotifyTriggersFinishedInitializing = new ManualResetEventSlim()
-            };
-
-            projectManager.NotifyTriggersFinishedInitializing.Wait(); // Wait for triggers to finish processing on thread
+            var projectManager = new TestProjectSnapshotManager(Dispatcher, triggers, Workspace);
 
             // Assert
             Assert.Equal(new[] { "highPriority", "lowPriority" }, initializedOrder);


### PR DESCRIPTION
#3808 caused an issue where components occasionally weren't being discovered by the LSP editor. This was because of a threading issue in the ProjectSnapshotManager (PSM) constructor. To summarize, the root of the problem was:
- In the new LSP editor, the PSM constructor was called using the special PSM thread implemented in #3808.
- The constructor fired off the PSM constructor's triggers in a [fire-and-forget](https://github.com/dotnet/aspnetcore-tooling/blob/7cb041285430431b8b2fba1a4aeeb0315e69df34/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs#L72) fashion.
- Due to the fire-and-forget, the triggers sometimes weren't initialized until after [this line](https://github.com/dotnet/aspnetcore-tooling/blob/7cb041285430431b8b2fba1a4aeeb0315e69df34/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs#L552) was invoked. That line is intended to send notifications of which documents are open, but since the triggers may not be finished initializing, there may be no one to notify.

As a solution, we now initialize the triggers on a case-by-case basis. If we're already on the PSM thread (as is the case in the new LSP editor), we initialize the triggers inline. If we're not on the PSM thread (as in the case in the old editor), we queue the triggers on the PSM thread. (Thanks to Taylor for the idea!)