### PR TITLE
Add loggers to tests for future logging goodness

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
@@ -3,11 +3,17 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     public class CSharpStatementBlockOnTypeFormattingTest : FormattingTestBase
     {
+        public CSharpStatementBlockOnTypeFormattingTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
         [Fact]
         public async Task CloseCurly_IfBlock_SingleLine()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -5,11 +5,17 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     public class CodeDirectiveFormattingTest : FormattingTestBase
     {
+        public CodeDirectiveFormattingTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
         [Fact]
         public async Task FormatsCodeBlockDirective()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
@@ -4,11 +4,17 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     public class CodeDirectiveOnTypeFormattingTest : FormattingTestBase
     {
+        public CodeDirectiveOnTypeFormattingTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
         [Fact]
         public async Task CloseCurly_Class_SingleLine()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -23,6 +23,7 @@ using Moq;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
@@ -38,11 +39,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         private static readonly AsyncLocal<string> s_fileName = new AsyncLocal<string>();
         private static readonly IReadOnlyList<TagHelperDescriptor> s_defaultComponents = GetDefaultRuntimeComponents();
 
-        public FormattingTestBase()
+        public FormattingTestBase(ITestOutputHelper output)
         {
             TestProjectPath = GetProjectDirectory();
             FilePathNormalizer = new FilePathNormalizer();
-            LoggerFactory = Mock.Of<ILoggerFactory>(factory => factory.CreateLogger(It.IsAny<string>()) == Mock.Of<ILogger>(MockBehavior.Strict), MockBehavior.Strict);
+            LoggerFactory = new FormattingTestLoggerFactory(output);
         }
 
         public static string TestProjectPath { get; private set; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestLoggerFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestLoggerFactory.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class FormattingTestLoggerFactory : ILoggerFactory
+    {
+        private ITestOutputHelper _output;
+
+        public FormattingTestLoggerFactory(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new FormattingTestLogger(_output);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    internal class FormattingTestLogger : ILogger
+    {
+        private readonly ITestOutputHelper _output;
+
+        public FormattingTestLogger(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) =>
+            new NullScope();
+
+        public bool IsEnabled(LogLevel logLevel)
+            => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var stringBuilder = new StringBuilder();
+            var source = formatter(state, exception);
+            stringBuilder.AppendLine(source);
+
+            if (exception != null)
+            {
+                stringBuilder.AppendLine(exception.ToString());
+            }
+
+            try
+            {
+                _output.WriteLine(stringBuilder.ToString());
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private class NullScope : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
@@ -14,6 +15,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         internal override bool UseTwoPhaseCompilation => true;
 
         internal override bool DesignTime => true;
+
+        public HtmlFormattingTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
 
         [Fact]
         public async Task FormatsSimpleHtmlTag()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
@@ -4,11 +4,17 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     public class RazorFormattingTest : FormattingTestBase
     {
+        public RazorFormattingTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
         [Fact]
         public async Task CodeBlock_SpansMultipleLines()
         {


### PR DESCRIPTION
I'm not adding actual logging until I know for sure it doesn't leak to users in VS, but this at least enables logging calls to go somewhere in test explorer.