### PR TITLE
Remove auto-complete of "<" to "<|>"

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -11,16 +11,13 @@
   ],
   "autoCloseBefore": ";:.,=}])>`\"' \r\n\t",
   "autoClosingPairs": [
-    { "open": "<", "close": ">"},
     { "open": "{", "close": "}"},
     { "open": "[", "close": "]"},
     { "open": "(", "close": ")" },
     { "open": "'", "close": "'" },
     { "open": "\"", "close": "\"" },
     { "open": "@*", "close": "*@", "notIn": [ "string" ] },
-
-    // The "close" is `--` instead of `-->` because of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1348281
-    { "open": "<!--", "close":  "--", "notIn": [ "comment", "string" ] }
+    { "open": "<!--", "close":  "-->", "notIn": [ "comment", "string" ] }
   ],
   "surroundingPairs": [
     { "open": "'", "close": "'" },


### PR DESCRIPTION
- Many users don't know to overtype the ">" bracket which ends up being more confusing to users.
- Also fixed HTML comment auto-complete.

/cc @mikadumont 