### PR TITLE
Put back removed method into Razor parser

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
             catch (Exception ex)
             {
-                Debug.Fail(".WorkspaceProjectStateChangeDetector.Workspace_WorkspaceChanged threw exception:" +
+                Debug.Fail("WorkspaceProjectStateChangeDetector.Workspace_WorkspaceChanged threw exception:" +
                     Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
             }
         }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -145,6 +145,25 @@ namespace Microsoft.VisualStudio.Editor.Razor
             }
         }
 
+        // WebTools depends on this method. Do not remove until old editor is phased out
+        public override void QueueReparse()
+        {
+            // Can be called from any thread
+
+            if (_joinableTaskContext.IsOnMainThread)
+            {
+                ReparseOnUIThread();
+            }
+            else
+            {
+                _ = Task.Factory.StartNew(
+                    () => ReparseOnUIThread(),
+                    CancellationToken.None,
+                    TaskCreationOptions.None,
+                    TaskScheduler.FromCurrentSynchronizationContext());
+            }
+        }
+
         public void Dispose()
         {
            _joinableTaskContext.AssertUIThread();

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
@@ -23,6 +23,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public abstract bool HasPendingChanges { get; }
 
+        public abstract void QueueReparse();
+
         internal virtual Task<RazorCodeDocument> GetLatestCodeDocumentAsync(ITextSnapshot atOrNewerSnapshot, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
### Summary of the changes
 - I thought no one used this method so I removed it, but it turns out WebTools does, oops
 - [This](https://github.com/dotnet/aspnetcore-tooling/blob/f81a59a1013b63d6625ba2dd950ebcda023cf491/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs#L146) is the original method. I slightly modified it to fit with changes from the UI thread PR