### PR TITLE
Speed up SemanticTokens by synchronizing C# virtual documents

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer
                 RazorCodeDocument codeDocument,
                 TextDocumentIdentifier textDocumentIdentifier,
                 Range range,
-                long? documentVersion,
+                long documentVersion,
                 CancellationToken cancellationToken,
                 string previousResultId = null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensDeltaParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensDeltaParams.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    internal class ProvideSemanticTokensDeltaParams : SemanticTokensDeltaParams
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+        public long RequiredHostDocumentVersion { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensParams.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models
+{
+    [Obsolete("Proposed for the next version of the language server. May not work with all clients.  May be removed or changed in the future.")]
+    public class ProvideSemanticTokensParams : SemanticTokensParams
+    {
+        public long RequiredHostDocumentVersion { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
+using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using StreamJsonRpc;
 
@@ -41,11 +42,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         // Called by the Razor Language Server to provide semantic tokens from the platform.
         [JsonRpcMethod(LanguageServerConstants.RazorProvideSemanticTokensEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<ProvideSemanticTokensResponse> ProvideSemanticTokensAsync(SemanticTokensParams semanticTokensParams, CancellationToken cancellationToken);
+#pragma warning disable CS0618 // Type or member is obsolete
+        public abstract Task<ProvideSemanticTokensResponse> ProvideSemanticTokensAsync(ProvideSemanticTokensParams semanticTokensParams, CancellationToken cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         // Called by the Razor Language Server to provide semantic tokens edits from the platform.
         [JsonRpcMethod(LanguageServerConstants.RazorProvideSemanticTokensEditsEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<ProvideSemanticTokensEditsResponse> ProvideSemanticTokensEditsAsync(SemanticTokensEditsParams semanticTokensParams, CancellationToken cancellationToken);
+        public abstract Task<ProvideSemanticTokensEditsResponse> ProvideSemanticTokensEditsAsync(ProvideSemanticTokensDeltaParams semanticTokensParams, CancellationToken cancellationToken);
 
         [JsonRpcMethod(LanguageServerConstants.RazorServerReadyEndpoint, UseSingleObjectParameterDeserialization = true)]
         public abstract Task RazorServerReadyAsync(CancellationToken cancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -18,6 +18,8 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+using OmniSharpTextDocumentIdentifier = OmniSharp.Extensions.LanguageServer.Protocol.Models.TextDocumentIdentifier;
+using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
@@ -80,10 +82,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
             var disposable = new Mock<IDisposable>(MockBehavior.Strict);
             var clientOptionsMonitor = new Mock<RazorLSPClientOptionsMonitor>(MockBehavior.Strict);
+            var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object);
+                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -115,10 +118,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
             var disposable = new Mock<IDisposable>(MockBehavior.Strict);
             var clientOptionsMonitor = new Mock<RazorLSPClientOptionsMonitor>(MockBehavior.Strict);
+            var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object);
+                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -169,10 +173,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
             var disposable = new Mock<IDisposable>(MockBehavior.Strict);
             var clientOptionsMonitor = new Mock<RazorLSPClientOptionsMonitor>(MockBehavior.Strict);
+            var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object);
+                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -236,7 +241,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
             var request = new CodeActionParams()
             {
-                TextDocument = new LanguageServer.Protocol.TextDocumentIdentifier()
+                TextDocument = new TextDocumentIdentifier()
                 {
                     Uri = new Uri("C:/path/to/file.razor")
                 }
@@ -278,15 +283,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 It.IsAny<Func<JToken, bool>>(),
                 It.IsAny<CodeActionParams>(),
                 It.IsAny<CancellationToken>()
-            )).Returns(Task.FromResult<IEnumerable<ReinvokeResponse<VSCodeAction[]>>>(expectedResults));
+            )).Returns(Task.FromResult(expectedResults));
 
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
             var disposable = new Mock<IDisposable>(MockBehavior.Strict);
             var clientOptionsMonitor = new Mock<RazorLSPClientOptionsMonitor>(MockBehavior.Strict);
+            var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object);
+                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object, documentSynchronizer.Object);
             var request = new CodeActionParams()
             {
                 TextDocument = new LanguageServer.Protocol.TextDocumentIdentifier()
@@ -337,10 +343,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
             var disposable = new Mock<IDisposable>(MockBehavior.Strict);
             var clientOptionsMonitor = new Mock<RazorLSPClientOptionsMonitor>(MockBehavior.Strict);
+            var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object);
+                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object, documentSynchronizer.Object);
             var request = new VSCodeAction()
             {
                 Title = "Something",
@@ -353,6 +360,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             Assert.Equal(expectedCodeAction.Title, result.Title);
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Fact]
         public async Task ProvideSemanticTokensAsync_CannotLookupDocument_ReturnsNullAsync()
         {
@@ -362,12 +370,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             documentManager.Setup(manager => manager.TryGetDocument(It.IsAny<Uri>(), out document))
                 .Returns(false);
             var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
-            var request = new SemanticTokensParams()
+            var request = new ProvideSemanticTokensParams()
             {
-                TextDocument = new TextDocumentIdentifier()
+                TextDocument = new OmniSharp.Extensions.LanguageServer.Protocol.Models.TextDocumentIdentifier()
                 {
                     Uri = new Uri("C:/path/to/file.razor")
-                }
+                },
+                RequiredHostDocumentVersion = 1,
             };
 
             // Act
@@ -388,12 +397,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             documentManager.Setup(manager => manager.TryGetDocument(It.IsAny<Uri>(), out testDocument))
                 .Returns(true);
             var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object);
-            var request = new SemanticTokensParams()
+            var request = new ProvideSemanticTokensParams()
             {
-                TextDocument = new TextDocumentIdentifier()
+                TextDocument = new OmniSharpTextDocumentIdentifier()
                 {
                     Uri = new Uri("C:/path/to/file.razor")
-                }
+                },
             };
 
             // Act
@@ -404,7 +413,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         }
 
         [Fact]
-        [Obsolete]
         public async Task ProvideSemanticTokensAsync_ReturnsSemanticTokensAsync()
         {
             // Arrange
@@ -423,26 +431,30 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var expectedcSharpResults = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals.SemanticTokens();
             var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
-            requestInvoker.Setup(invoker => invoker.ReinvokeRequestOnServerAsync<SemanticTokensParams, OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals.SemanticTokens>(
+            requestInvoker.Setup(invoker => invoker.ReinvokeRequestOnServerAsync<OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals.SemanticTokensParams, OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals.SemanticTokens>(
                 LanguageServerConstants.LegacyRazorSemanticTokensEndpoint,
                 LanguageServerKind.CSharp.ToLanguageServerName(),
-                It.IsAny<SemanticTokensParams>(),
+                It.IsAny<OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals.SemanticTokensParams>(),
                 It.IsAny<CancellationToken>()
             )).Returns(Task.FromResult(new ReinvokeResponse<OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals.SemanticTokens>(_languageClient, expectedcSharpResults)));
 
             var uIContextManager = new Mock<RazorUIContextManager>(MockBehavior.Strict);
             var disposable = new Mock<IDisposable>(MockBehavior.Strict);
             var clientOptionsMonitor = new Mock<RazorLSPClientOptionsMonitor>(MockBehavior.Strict);
+            var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
+            documentSynchronizer.Setup(r => r.TrySynchronizeVirtualDocumentAsync(0, It.IsAny<CSharpVirtualDocumentSnapshot>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(true));
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object);
-            var request = new SemanticTokensParams()
+                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object, documentSynchronizer.Object);
+            var request = new ProvideSemanticTokensParams()
             {
-                TextDocument = new TextDocumentIdentifier()
+                TextDocument = new OmniSharpTextDocumentIdentifier()
                 {
                     Uri = new Uri("C:/path/to%20-%20project/file.razor")
-                }
+                },
+                RequiredHostDocumentVersion = 0,
             };
             var expectedResults = new ProvideSemanticTokensResponse(expectedcSharpResults, documentVersion);
 
@@ -452,6 +464,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             // Assert
             Assert.Equal(expectedResults, result);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         [Fact]
         public async Task RazorServerReadyAsync_ReportsReadyAsync()
@@ -488,10 +501,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 .Setup(d => d.Dispose())
                 .Verifiable();
             var clientOptionsMonitor = new Mock<RazorLSPClientOptionsMonitor>(MockBehavior.Strict);
+            var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object);
+                uIContextManager.Object, disposable.Object, clientOptionsMonitor.Object, documentSynchronizer.Object);
 
             // Act
             await target.RazorServerReadyAsync(CancellationToken.None);


### PR DESCRIPTION
### Summary of the changes
 - When we make an edit we send `textDocument/didChange` to the client, causing VS to immediately trigger `textDocument\semanticTokens\edits`. The problem is, at that point C# (usually) hasn't propagated the new version and returns us the HostDocumentSyncVersion from the previous version. When the Razor and C# versions don't match we return null because otherwise we'd either cause any C# tokens to "flash" due to missing C# info or possibly mis-color if anything has moved. VSLanguageServerClient then puts us on a bit of a timer before trying again because we obviously have stuff to work out, and then by the time they've asked again everyone is caught up and we colorize.

This explains the behavior I was seeing where (other than a few initial `textDocument/semanticTokens` request) our total request time was actually very short (<50ms), but the time it takes for colors to show up is quite large(~.5 seconds).

Fixes: https://github.com/dotnet/aspnetcore/issues/34506.

Old behavior:
![It's slow to update colors](https://user-images.githubusercontent.com/14987221/126009514-36463480-4bc6-47c4-8a9c-3cc06d18a560.gif)

New behavior:
![Much snappier, almost faster than TextMate](https://user-images.githubusercontent.com/14987221/126009553-ffbe4abe-0cd2-4814-8c6d-b290aafc0b75.gif)

HUGE thanks to @gundermanc who spotted our null responses and let me know the consequences that might have.
