### PR TITLE
Revert "Revert "Capture CoreCLR ServiceHub dependencies in VSIX" (#39…

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -19,6 +19,7 @@
     <FileSignInfo Include="OmniSharp.Extensions.LanguageProtocol.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OmniSharp.Extensions.LanguageServer.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OmniSharp.Extensions.LanguageServer.Shared.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Nerdbank.Streams.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/Razor.sln
+++ b/src/Razor/Razor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28410.60
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31415.485
 MinimumVisualStudioVersion = 16.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3C0D6505-79B3-49D0-B4C3-176F0F1836ED}"
 	ProjectSection(SolutionItems) = preProject
@@ -85,6 +85,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common", "test\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common.csproj", "{1C7BBF16-3507-4A23-91B4-9EEA03409C72}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Remote.Razor.Test", "test\Microsoft.CodeAnalysis.Remote.Razor.Test\Microsoft.CodeAnalysis.Remote.Razor.Test.csproj", "{39233703-B752-43AC-AD86-E9D3E61B4AD9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Remote.Razor.CoreComponents", "src\Microsoft.CodeAnalysis.Remote.Razor.CoreComponents\Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj", "{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -390,6 +392,14 @@ Global
 		{39233703-B752-43AC-AD86-E9D3E61B4AD9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{39233703-B752-43AC-AD86-E9D3E61B4AD9}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{39233703-B752-43AC-AD86-E9D3E61B4AD9}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -432,6 +442,7 @@ Global
 		{0FC409AF-B92B-42D0-9096-1F20360D2672} = {92463391-81BE-462B-AC3C-78C6C760741F}
 		{1C7BBF16-3507-4A23-91B4-9EEA03409C72} = {92463391-81BE-462B-AC3C-78C6C760741F}
 		{39233703-B752-43AC-AD86-E9D3E61B4AD9} = {92463391-81BE-462B-AC3C-78C6C760741F}
+		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0035341D-175A-4D05-95E6-F1C2785A1E26}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectEngineFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectEngineFactory.cs
@@ -3,9 +3,8 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
     [ExportCustomProjectEngineFactory("Default", SupportsSerialization = true)]
     internal class DefaultProjectEngineFactory : IProjectEngineFactory

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_1_0.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_1_0.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
     [ExportCustomProjectEngineFactory("MVC-1.0", SupportsSerialization = true)]
     internal class LegacyProjectEngineFactory_1_0 : IProjectEngineFactory

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_1_1.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_1_1.cs
@@ -4,14 +4,14 @@
 using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
-    [ExportCustomProjectEngineFactory("MVC-3.0", SupportsSerialization = true)]
-    internal class LegacyProjectEngineFactory_3_0 : IProjectEngineFactory
+    [ExportCustomProjectEngineFactory("MVC-1.1", SupportsSerialization = true)]
+    internal class LegacyProjectEngineFactory_1_1 : IProjectEngineFactory
     {
-        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X";
+
         public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {
             // Rewrite the assembly name into a full name just like this one, but with the name of the MVC design time assembly.
@@ -25,8 +25,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             return RazorProjectEngine.Create(configuration, fileSystem, b =>
             {
-                CompilerFeatures.Register(b);
-
                 initializer.Initialize(b);
                 configure?.Invoke(b);
             });

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_2_0.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_2_0.cs
@@ -4,15 +4,13 @@
 using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
-    [ExportCustomProjectEngineFactory("MVC-1.1", SupportsSerialization = true)]
-    internal class LegacyProjectEngineFactory_1_1 : IProjectEngineFactory
+    [ExportCustomProjectEngineFactory("MVC-2.0", SupportsSerialization = true)]
+    internal class LegacyProjectEngineFactory_2_0 : IProjectEngineFactory
     {
-        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X";
-
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X";
         public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {
             // Rewrite the assembly name into a full name just like this one, but with the name of the MVC design time assembly.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_2_1.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_2_1.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
     // Currently we provide a fixed configuration for 2.1, but this is a point-in-time issue. We plan
     // to make the 2.1 configuration more flexible and less hardcoded.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_3_0.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyProjectEngineFactory_3_0.cs
@@ -4,14 +4,13 @@
 using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 
-namespace Microsoft.VisualStudio.Editor.Razor
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
-    [ExportCustomProjectEngineFactory("MVC-2.0", SupportsSerialization = true)]
-    internal class LegacyProjectEngineFactory_2_0 : IProjectEngineFactory
+    [ExportCustomProjectEngineFactory("MVC-3.0", SupportsSerialization = true)]
+    internal class LegacyProjectEngineFactory_3_0 : IProjectEngineFactory
     {
-        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X";
+        private const string AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
         public RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {
             // Rewrite the assembly name into a full name just like this one, but with the name of the MVC design time assembly.
@@ -25,6 +24,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             return RazorProjectEngine.Create(configuration, fileSystem, b =>
             {
+                CompilerFeatures.Register(b);
+
                 initializer.Initialize(b);
                 configure?.Invoke(b);
             });

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="$(MicrosoftCodeAnalysisRazorPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="$(Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Tooling_MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.NonCapturingTimer.Sources" Version="$(MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj
@@ -1,0 +1,44 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <!-- The purpose of this project is to include all dependecies of Microsoft.CodeAnalysis.Remote.Razor targeting .Net Core -->
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.Remote.Razor\Microsoft.CodeAnalysis.Remote.Razor.csproj" />
+  </ItemGroup>
+
+  <!-- Special target only consumed at VSIX creation time -->
+  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Publish" Returns="@(_PublishedFiles)">
+    <ItemGroup>
+      <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->
+
+      <!-- We're only targeting netcoreapp3.1 to ensure the SDK consumes all transitive dependencies, we don't actually need an executable -->
+      <_PublishedFiles Include="$(PublishDir)**\*.*" Exclude="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.*"/>      
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Extension)' == '.pdb'" />
+
+      <!-- Exclude dependencies that are guaranteed to be in our host / could cause trouble otherwise -->
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'MessagePack.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'MessagePack.Annotations.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.AnalyzerUtilities.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.CSharp.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.CSharp.Features.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.CSharp.Workspaces.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.Features.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.Remote.Workspaces.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.Scripting.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.Workspaces.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.ExternalAccess.Razor.dll'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.Win32.Registry.dll'" />
+
+      <!-- Set TargetPath -->
+      <_PublishedFiles Update="@(_PublishedFiles)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Program.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Program.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.CoreComponents
+{
+    internal static class Program
+    {
+#pragma warning disable IDE0060 // Remove unused parameter
+        public static void Main(string[] args)
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -25,6 +25,7 @@
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 
     <SetupProductArch>neutral</SetupProductArch>
+    <ServiceHubCoreSubPath>ServiceHubCore</ServiceHubCoreSubPath>
   </PropertyGroup>
 
   <!-- Include Razor SDK design time assets in the VSIX -->
@@ -56,6 +57,18 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Microsoft.VisualStudio.Razor.TagHelperProvider64S.servicehub.service.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="$(ServiceHubCoreSubPath)\Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="$(ServiceHubCoreSubPath)\Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="$(ServiceHubCoreSubPath)\Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -164,6 +177,20 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj" />
     <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
     <ProjectReference Include="..\Microsoft.CodeAnalysis.Remote.Razor\Microsoft.CodeAnalysis.Remote.Razor.csproj" />
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.Remote.Razor.CoreComponents\Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj">
+      <Name>Microsoft.CodeAnalysis.Remote.Razor.CoreComponents</Name>
+      <!-- This project targets netcoreapp -->
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <IncludeOutputGroupsInVSIX>PublishProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
+      <Private>false</Private>
+      <VSIXSubPath>$(ServiceHubCoreSubPath)</VSIXSubPath>
+
+      <!-- Disable NGEN. Core assemblies are crossgened. -->
+      <Ngen>false</Ngen>
+    </ProjectReference>
+
     <ProjectReference Include="..\Microsoft.VisualStudio.Editor.Razor\Microsoft.VisualStudio.Editor.Razor.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServer.ContainedLanguage\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServices.Razor\Microsoft.VisualStudio.LanguageServices.Razor.csproj" />
@@ -220,6 +247,7 @@
   <Target Name="_GenerateVSIXBindingRedirects" DependsOnTargets="PrepareForBuild;GetAssemblyVersion" BeforeTargets="CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(_GeneratedVSIXBindingRedirectFile)">
     <ItemGroup>
       <BindingRedirectAssemblies Include="@(ProjectReference)" AssemblyName="%(Filename)" />
+      <BindingRedirectAssemblies Remove="@(ProjectReference)" Condition="%(ProjectReference.Name) == 'Microsoft.CodeAnalysis.Remote.Razor.CoreComponents'" />
       <BindingRedirectAssemblies Include="$(AssemblyName)" AssemblyName="$(AssemblyName)" />
     </ItemGroup>
     <PropertyGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -21,9 +21,11 @@ namespace Microsoft.VisualStudio.RazorExtension
     [AboutDialogInfo(PackageGuidString, "Razor (ASP.NET Core)", "#110", "#112", IconResourceID = "#400")]
     [ProvideService(typeof(RazorLanguageService))]
     [ProvideLanguageService(typeof(RazorLanguageService), RazorLSPConstants.RazorLSPContentTypeName, 110)]
-    [ProvideBrokeredServiceHubService("Microsoft.VisualStudio.Razor.TagHelperProvider", Audience = Shell.ServiceBroker.ServiceAudience.Local)]
-    [ProvideBrokeredServiceHubService("Microsoft.VisualStudio.Razor.TagHelperProvider64", Audience = Shell.ServiceBroker.ServiceAudience.Local)]
-    [ProvideBrokeredServiceHubService("Microsoft.VisualStudio.Razor.TagHelperProvider64S", Audience = Shell.ServiceBroker.ServiceAudience.Local)]
+    [ProvideBrokeredServiceHubService("Microsoft.VisualStudio.Razor.TagHelperProvider", Audience = ServiceAudience.Local)]
+    [ProvideBrokeredServiceHubService("Microsoft.VisualStudio.Razor.TagHelperProvider64", Audience = ServiceAudience.Local)]
+    [ProvideBrokeredServiceHubService("Microsoft.VisualStudio.Razor.TagHelperProvider64S", Audience = ServiceAudience.Local)]
+    [ProvideBrokeredServiceHubService("Microsoft.VisualStudio.Razor.TagHelperProviderCore64", ServiceLocation = ProvideBrokeredServiceHubServiceAttribute.DefaultServiceLocation + @"\ServiceHubCore", Audience = ServiceAudience.Local)]
+    [ProvideBrokeredServiceHubService("Microsoft.VisualStudio.Razor.TagHelperProviderCore64S", ServiceLocation = ProvideBrokeredServiceHubServiceAttribute.DefaultServiceLocation + @"\ServiceHubCore", Audience = ServiceAudience.Local)]
     [Guid(PackageGuidString)]
     public sealed class RazorPackage : AsyncPackage
     {

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json
@@ -1,0 +1,3 @@
+﻿[
+  "..\\..\\managedLanguages\\VBCSharp\\LanguageServices\\Core"
+]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json
@@ -1,0 +1,11 @@
+﻿{
+  "host": "coreClr",
+  "hostId": "RoslynCodeAnalysisService",
+  "hostGroupAllowed": true,
+  "entryPoint": {
+    "assemblyPath": "Microsoft.CodeAnalysis.Remote.Razor.dll",
+    "fullClassName": "Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory",
+    "AssemblySearchPathsConfig": "Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json"
+  },
+  "friendServices": [ "roslynRemoteHostCore64" ]
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json
@@ -1,0 +1,11 @@
+﻿{
+  "host": "coreClr",
+  "hostId": "RoslynCodeAnalysisServiceS",
+  "hostGroupAllowed": true,
+  "entryPoint": {
+    "assemblyPath": "Microsoft.CodeAnalysis.Remote.Razor.dll",
+    "fullClassName": "Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory",
+    "AssemblySearchPathsConfig": "Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json"
+  },
+  "friendServices": [ "roslynRemoteHostCore64S" ]
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -26,9 +26,11 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.RazorExtension.Custom" Path="Microsoft.VisualStudio.RazorExtension.Custom.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="Microsoft.VisualStudio.Razor.TagHelperProvider.servicehub.service" />
-    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="Microsoft.VisualStudio.Razor.TagHelperProvider64.servicehub.service" />
-    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="Microsoft.VisualStudio.Razor.TagHelperProvider64S.servicehub.service" />
+    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="Microsoft.VisualStudio.Razor.TagHelperProvider.servicehub.service.json" />
+    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="Microsoft.VisualStudio.Razor.TagHelperProvider64.servicehub.service.json" />
+    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="Microsoft.VisualStudio.Razor.TagHelperProvider64S.servicehub.service.json" />
+    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="ServiceHubCore\Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json" />
+    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="ServiceHubCore\Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll" />

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectSnapshotProjectEngineFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectSnapshotProjectEngineFactoryTest.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.VisualStudio.Editor.Razor;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Xunit;
 
 using Mvc1_X = Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X;


### PR DESCRIPTION
Reverts https://github.com/dotnet/aspnetcore-tooling/pull/3972, the original PR of which was originally reverted due to RPS issues that seem to have been figured out. (Validation insertion: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/340366?_a=overview)

cc @genlu 