### PR TITLE
Update dependent projects with modified TagHelpers

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
@@ -117,8 +117,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                                 if (TryGetProjectSnapshot(project?.FilePath, out var _))
                                 {
                                     EnqueueUpdate(e.ProjectId);
-                                }
 
+                                    var dependencyGraph = e.NewSolution.GetProjectDependencyGraph();
+                                    var dependentProjectIds = dependencyGraph.GetProjectsThatTransitivelyDependOnThisProject(e.ProjectId);
+                                    foreach (var dependentProjectId in dependentProjectIds)
+                                    {
+                                        EnqueueUpdate(dependentProjectId);
+                                    }
+                                }
                                 break;
                             }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     "Two",
                     LanguageNames.CSharp,
                     filePath: "Two.csproj",
-                    projectReferences: new[]{ project3Reference }))
+                    projectReferences: new[] { project3Reference }))
                 .AddProject(ProjectInfo.Create(
                     projectId3,
                     VersionStamp.Default,
@@ -165,11 +165,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             detector.NotifyWorkspaceChangedEventComplete.Wait();
 
             // Assert
-            Assert.Collection(
-                detector._deferredUpdates,
-                p => Assert.Equal(ProjectNumberThree.Id, p.Key),
-                p => Assert.Equal(ProjectNumberTwo.Id, p.Key),
-                p => Assert.Equal(ProjectNumberOne.Id, p.Key));
+            Assert.Equal(3, detector._deferredUpdates.Count);
+            Assert.Contains(detector._deferredUpdates, u => u.Key == ProjectNumberOne.Id);
+            Assert.Contains(detector._deferredUpdates, u => u.Key == ProjectNumberTwo.Id);
+            Assert.Contains(detector._deferredUpdates, u => u.Key == ProjectNumberThree.Id);
         }
 
         [UITheory]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -63,6 +63,34 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     LanguageNames.CSharp,
                     filePath: "Three.csproj"));
 
+            var project2Reference = new ProjectReference(projectId2);
+            var project3Reference = new ProjectReference(projectId3);
+            SolutionWithDependentProject = EmptySolution.GetIsolatedSolution()
+                .AddProject(ProjectInfo.Create(
+                    projectId1,
+                    VersionStamp.Default,
+                    "One",
+                    "One",
+                    LanguageNames.CSharp,
+                    filePath: "One.csproj",
+                    documents: new[] { cshtmlDocumentInfo, razorDocumentInfo, partialComponentClassDocumentInfo, backgroundDocumentInfo },
+                    projectReferences: new[] { project2Reference }))
+                .AddProject(ProjectInfo.Create(
+                    projectId2,
+                    VersionStamp.Default,
+                    "Two",
+                    "Two",
+                    LanguageNames.CSharp,
+                    filePath: "Two.csproj",
+                    projectReferences: new[]{ project3Reference }))
+                .AddProject(ProjectInfo.Create(
+                    projectId3,
+                    VersionStamp.Default,
+                    "Three",
+                    "Three",
+                    LanguageNames.CSharp,
+                    filePath: "Three.csproj"));
+
             ProjectNumberOne = SolutionWithTwoProjects.GetProject(projectId1);
             ProjectNumberTwo = SolutionWithTwoProjects.GetProject(projectId2);
             ProjectNumberThree = SolutionWithOneProject.GetProject(projectId3);
@@ -84,6 +112,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private Solution SolutionWithTwoProjects { get; }
 
+        private Solution SolutionWithDependentProject { get; }
+
         private Project ProjectNumberOne { get; }
 
         private Project ProjectNumberTwo { get; }
@@ -97,6 +127,33 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public DocumentId BackgroundVirtualCSharpDocumentId { get; }
 
         public DocumentId PartialComponentClassDocumentId { get; }
+
+        [UIFact]
+        public void WorkspaceChanged_ProjectEvents_EnqueuesUpdatesForDependentProjects()
+        {
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator, Dispatcher);
+
+            var projectManager = new TestProjectSnapshotManager(Dispatcher, new[] { detector }, Workspace);
+            projectManager.ProjectAdded(HostProjectOne);
+            projectManager.ProjectAdded(HostProjectTwo);
+            projectManager.ProjectAdded(HostProjectThree);
+            var kind = WorkspaceChangeKind.ProjectChanged;
+
+            var solution = SolutionWithDependentProject.WithProjectAssemblyName(ProjectNumberThree.Id, "Changed");
+
+            var e = new WorkspaceChangeEventArgs(kind, oldSolution: SolutionWithDependentProject, newSolution: solution, projectId: ProjectNumberThree.Id);
+
+            // Act
+            detector.Workspace_WorkspaceChanged(Workspace, e);
+
+            // Assert
+            Assert.Equal(3, detector._deferredUpdates.Count);
+            Assert.NotNull(detector._deferredUpdates.Where(kvp => kvp.Key.Equals(ProjectNumberOne)));
+            Assert.NotNull(detector._deferredUpdates.Where(kvp => kvp.Key.Equals(ProjectNumberTwo)));
+            Assert.NotNull(detector._deferredUpdates.Where(kvp => kvp.Key.Equals(ProjectNumberThree)));
+        }
 
         [UITheory]
         [InlineData(WorkspaceChangeKind.SolutionAdded)]
@@ -365,7 +422,7 @@ namespace Microsoft.AspNetCore.Components
             await document.GetSemanticModelAsync();
 
             var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.DocumentChanged, oldSolution: solution, newSolution: solution, projectId: ProjectNumberOne.Id, PartialComponentClassDocumentId);
-            
+
             // Act
             detector.Workspace_WorkspaceChanged(Workspace, e);
 


### PR DESCRIPTION
(Retargetting main-vs-deps)
### Summary of the changes
 - Previously if we had a project RCL.csproj, and App.csproj (with App depending on RCL) and you changed the name of a Component in RCL it would NOT update the project.razor.json of App with the new info. By getting a list of all the dependent projects and forcing an update on them we make sure that project.razor.json for App serializes and then all the correct things happen in our Error list.

This works when tested locally, but I'm warry of it being too big of a hammer since it does force file operations, which could get potentially expensive on a large project for which the root has changed. I tried a similar approach in a couple other places that did not work, but if someone has a more targeted idea I'm open.
Fixes: dotnet/aspnetcore#31282

I'll need to re-test this now  that I've re-targeted.