### PR TITLE
Fix "add using" Razor light bulb

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/ExtendedCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/ExtendedCodeActionContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
@@ -9,6 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
     internal class ExtendedCodeActionContext : CodeActionContext
     {
         [Optional]
+        [JsonProperty("_vs_selectionRange")]
         public Range SelectionRange { get; set; }
     }
 }


### PR DESCRIPTION
- After the LSP protocol refactor we weren't properly deserializing `SelectionRange` so we weren't understanding where a light bulb request was originating from resulting in us not providing any light bulbs.

![image](https://user-images.githubusercontent.com/2008729/127712737-5d1a7657-9a28-497b-b420-2fefcad5e11f.png)


Fixes dotnet/aspnetcore#34891