### PR TITLE
RazorFormattingPass

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Examine the _end_ of the diagnostic to see if we're at the
             // start of an (im/ex)plicit expression. Looking at the start
             // of the diagnostic isn't sufficient.
-            if(d.Range is null)
+            if (d.Range is null)
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -224,6 +224,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Examine the _end_ of the diagnostic to see if we're at the
             // start of an (im/ex)plicit expression. Looking at the start
             // of the diagnostic isn't sufficient.
+            if(d.Range is null)
+            {
+                return false;
+            }
+
             var owner = syntaxTree.GetOwner(sourceText, d.Range.End);
 
             var markupAttributeNode = owner.FirstAncestorOrSelf<RazorSyntaxNode>(n =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
@@ -35,8 +35,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             _logger = loggerFactory.CreateLogger<CSharpFormattingPass>();
         }
 
-        // Run after the HTML formatter pass.
-        public override int Order => DefaultOrder - 4;
+        // Run after the HTML and Razor formatter pass.
+        public override int Order => DefaultOrder - 3;
 
         public async override Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result, CancellationToken cancellationToken)
         {
@@ -71,8 +71,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             cancellationToken.ThrowIfCancellationRequested();
 
             // We make an optimistic attempt at fixing corner cases.
-            var cleanupChanges = CleanupDocument(changedContext);
-            changedText = changedText.WithChanges(cleanupChanges);
             changedContext = await changedContext.WithTextAsync(changedText);
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
@@ -70,11 +70,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // We make an optimistic attempt at fixing corner cases.
-            changedContext = await changedContext.WithTextAsync(changedText);
-
-            cancellationToken.ThrowIfCancellationRequested();
-
             var indentationChanges = await AdjustIndentationAsync(changedContext, cancellationToken);
             if (indentationChanges.Count > 0)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -84,6 +84,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public Range Range { get; private set; } = null!;
 
+        /// <summary>A Dictionary of int (line number) to IndentationContext.</summary>
+        /// <remarks>
+        /// Don't use this to discover the indentation level you should have, use
+        /// <see cref="TryGetIndentationLevel(int, out int)"/> which operates on the position rather than just the line.
+        /// </remarks>
         public IReadOnlyDictionary<int, IndentationContext> Indentations { get; private set; } = null!;
 
         public IReadOnlyList<FormattingSpan> FormattingSpans { get; private set; } = null!;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
@@ -173,7 +173,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeRange = codeNode.GetRangeWithoutWhitespace(source);
             if (openBraceRange is not null &&
                 codeRange is not null &&
-                openBraceRange.End.Line == codeRange.Start.Line)
+                openBraceRange.End.Line == codeRange.Start.Line &&
+                // Because we don't always know what kind of Razor object we're operating on we have to do this to avoid duplicate edits.
+                // The other way to accomplish this would be to apply the edits after every node and function, but that's not in scope for my current work.
+                !edits.Any(e => e.Range.End == codeRange.End))
             {
                 var additionalIndentationLevel = GetAdditionalIndentationLevel(context, openBraceRange);
                 var newText = context.NewLineString;
@@ -193,7 +196,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var closeBraceRange = closeBraceNode.GetRangeWithoutWhitespace(source);
             if (codeRange is not null &&
                 closeBraceRange is not null &&
-                codeRange.End.Line == closeBraceRange.Start.Line)
+                codeRange.End.Line == closeBraceRange.Start.Line &&
+                // Because we don't always know what kind of Razor object we're operating on we have to do this to avoid duplicate edits.
+                // The other way to accomplish this would be to apply the edits after every node and function, but that's not in scope for my current work.
+                !edits.Any(e => e.Range.End == codeRange.End))
             {
                 var edit = new TextEdit
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
@@ -155,8 +155,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 directiveBody.Keyword.GetContent().Equals("functions"))
             {
                 var cSharpCode = directiveBody.CSharpCode;
-                var openBrace = cSharpCode.Children.First(c => c.Kind == SyntaxKind.RazorMetaCode);
-                var closeBrace = cSharpCode.Children.Last(c => c.Kind == SyntaxKind.RazorMetaCode);
+                var openBrace = cSharpCode.Children.FirstOrDefault(c => c.Kind == SyntaxKind.RazorMetaCode);
+                var closeBrace = cSharpCode.Children.LastOrDefault(c => c.Kind == SyntaxKind.RazorMetaCode);
                 var code = cSharpCode.Children.First(c => c.Kind == SyntaxKind.CSharpCodeBlock) as CSharpCodeBlockSyntax;
 
                 openBraceNode = openBrace;
@@ -212,14 +212,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             int GetAdditionalIndentationLevel(FormattingContext context, Range range)
             {
                 var indentation = context.Indentations[range.Start.Line];
-                var desiredIndentationLevel = (indentation.HtmlIndentationLevel * (int)context.Options.TabSize) + (indentation.RazorIndentationLevel * (int)context.Options.TabSize);
-                if(additionalIndentation)
+                var desiredIndentationLevel = indentation.HtmlIndentationLevel + indentation.RazorIndentationLevel;
+                if (additionalIndentation)
                 {
-                    desiredIndentationLevel += (int)context.Options.TabSize;
+                    desiredIndentationLevel++;
                 }
-                var currentIndentationLevel = codeNode.GetLeadingWhitespaceLength() + openBraceNode.GetTrailingWhitespaceLength();
+                var desiredIndentationOffset = context.GetIndentationOffsetForLevel(desiredIndentationLevel);
+                // TODO: This is not quite right as it would count a tab or \r\n as 1 length
+                var currentIndentationOffset = codeNode.GetLeadingWhitespaceLength() + openBraceNode.GetTrailingWhitespaceLength();
 
-                return desiredIndentationLevel - currentIndentationLevel;
+                return desiredIndentationOffset - currentIndentationOffset;
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxListExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxListExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         internal static bool TryGetCloseBraceNode(this SyntaxList<RazorSyntaxNode> children, [NotNullWhen(true)] out RazorMetaCodeSyntax? brace)
         {
             // If there is no whitespace between the directive and the brace then there will only be
-            // three children and the brace should be the first child
+            // three children and the brace should be the last child
             brace = null;
             if (children.LastOrDefault(c => c.Kind == Language.SyntaxKind.RazorMetaCode) is RazorMetaCodeSyntax metaCode)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxListExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxListExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public static class SyntaxListExtensions
+    {
+        internal static SyntaxNode PreviousSiblingOrSelf(this SyntaxList<RazorSyntaxNode> syntaxList, RazorSyntaxNode syntaxNode)
+        {
+            var index = syntaxList.IndexOf(syntaxNode);
+
+            if (index == 0)
+            {
+                return syntaxNode;
+            }
+            else
+            {
+                return syntaxList[index - 1];
+            }
+        }
+
+        internal static SyntaxNode NextSiblingOrSelf(this SyntaxList<RazorSyntaxNode> syntaxList, RazorSyntaxNode syntaxNode)
+        {
+            var index = syntaxList.IndexOf(syntaxNode);
+
+            if (index == syntaxList.Count - 1)
+            {
+                return syntaxNode;
+            }
+            else
+            {
+                return syntaxList[index + 1];
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxListExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxListExtensions.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
@@ -14,6 +19,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (index == 0)
             {
                 return syntaxNode;
+            }
+            else if (index == -1)
+            {
+                throw new ArgumentException("The provided node was not in the SyntaxList");
             }
             else
             {
@@ -29,10 +38,77 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 return syntaxNode;
             }
+            else if (index == -1)
+            {
+                throw new ArgumentException("The provided node was not in the SyntaxList");
+            }
             else
             {
                 return syntaxList[index + 1];
             }
+        }
+
+
+        internal static bool TryGetOpenBraceNode(this SyntaxList<RazorSyntaxNode> children, [NotNullWhen(true)] out RazorMetaCodeSyntax? brace)
+        {
+            // If there is no whitespace between the directive and the brace then there will only be
+            // three children and the brace should be the first child
+            brace = null;
+            if (children.FirstOrDefault(c => c.Kind == Language.SyntaxKind.RazorMetaCode) is RazorMetaCodeSyntax metaCode)
+            {
+                var token = metaCode.MetaCode.SingleOrDefault(m => m.Kind == Language.SyntaxKind.LeftBrace);
+                if (token != null)
+                {
+                    brace = metaCode;
+                }
+            }
+
+            return brace != null;
+        }
+        internal static bool TryGetCloseBraceNode(this SyntaxList<RazorSyntaxNode> children, [NotNullWhen(true)] out RazorMetaCodeSyntax? brace)
+        {
+            // If there is no whitespace between the directive and the brace then there will only be
+            // three children and the brace should be the first child
+            brace = null;
+            if (children.LastOrDefault(c => c.Kind == Language.SyntaxKind.RazorMetaCode) is RazorMetaCodeSyntax metaCode)
+            {
+                var token = metaCode.MetaCode.SingleOrDefault(m => m.Kind == Language.SyntaxKind.RightBrace);
+                if (token != null)
+                {
+                    brace = metaCode;
+                }
+            }
+
+            return brace != null;
+        }
+        internal static bool TryGetOpenBraceToken(this SyntaxList<RazorSyntaxNode> children, [NotNullWhen(true)] out SyntaxToken? brace)
+        {
+            brace = null;
+            if (children.TryGetOpenBraceNode(out var metacode))
+            {
+                var token = metacode.MetaCode.SingleOrDefault(m => m.Kind == Language.SyntaxKind.LeftBrace);
+                if (token != null)
+                {
+                    brace = token;
+                }
+            }
+
+            return brace != null;
+        }
+
+        internal static bool TryGetCloseBraceToken(this SyntaxList<RazorSyntaxNode> children, [NotNullWhen(true)] out SyntaxToken? brace)
+        {
+            brace = null;
+            if (children.TryGetCloseBraceNode(out var metacode))
+            {
+                var token = metacode.MetaCode.SingleOrDefault(m => m.Kind == Language.SyntaxKind.RightBrace);
+                if (token != null)
+                {
+                    brace = token;
+                }
+            }
+
+            return brace != null;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxNodeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxNodeExtensions.cs
@@ -92,5 +92,129 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             return range;
         }
+
+        public static Range? GetRangeWithoutWhitespace(this SyntaxNode node, RazorSourceDocument source)
+        {
+            if (node is null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var tokens = node.GetTokens();
+
+            SyntaxToken firstToken = null;
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                var token = tokens[i];
+                if (!IsWhitespace(token))
+                {
+                    firstToken = token;
+                    break;
+                }
+            }
+
+            SyntaxToken lastToken = null;
+            for (var i = tokens.Count - 1; i >= 0; i--)
+            {
+                var token = tokens[i];
+                if (!IsWhitespace(token))
+                {
+                    lastToken = token;
+                    break;
+                }
+            }
+
+            if (firstToken is null && lastToken is null)
+            {
+                return null;
+            }
+
+            var startPositionSpan = GetLinePositionSpan(firstToken, source, node.SpanStart);
+            var endPositionSpan = GetLinePositionSpan(lastToken, source, node.Span.Start);
+
+            var range = new Range(
+                new Position(startPositionSpan.Start.Line, startPositionSpan.Start.Character),
+                new Position(endPositionSpan.End.Line, endPositionSpan.End.Character));
+
+            return range;
+
+            // This is needed because SyntaxToken positions taken from GetTokens
+            // are relative to their parent node and not to the document.
+            static LinePositionSpan GetLinePositionSpan(SyntaxNode node, RazorSourceDocument source, int parentStart)
+            {
+                if (node is null)
+                {
+                    throw new ArgumentNullException(nameof(node));
+                }
+
+                if (source is null)
+                {
+                    throw new ArgumentNullException(nameof(source));
+                }
+
+                var start = node.Position + parentStart;
+                var end = node.EndPosition + parentStart;
+
+                if (start == source.Length && node.FullWidth == 0)
+                {
+                    // Marker symbol at the end of the document.
+                    var location = node.GetSourceLocation(source);
+                    var position = GetLinePosition(location);
+                    return new LinePositionSpan(position, position);
+                }
+
+                var startLocation = source.Lines.GetLocation(start);
+                var endLocation = source.Lines.GetLocation(end);
+                var startPosition = GetLinePosition(startLocation);
+                var endPosition = GetLinePosition(endLocation);
+
+                return new LinePositionSpan(startPosition, endPosition);
+
+                static LinePosition GetLinePosition(SourceLocation location)
+                {
+                    return new LinePosition(location.LineIndex, location.CharacterIndex);
+                }
+            }
+        }
+
+        public static int GetLeadingWhitespaceLength(this SyntaxNode node)
+        {
+            var tokens = node.GetTokens();
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                var token = tokens[i];
+                if (!IsWhitespace(token))
+                {
+                    return i;
+                }
+            }
+
+            return 0;
+        }
+
+        public static int GetTrailingWhitespaceLength(this SyntaxNode node)
+        {
+            var tokens = node.GetTokens();
+            for (var i = 0;  i < tokens.Count; i++)
+            {
+                var token = tokens[(tokens.Count - 1) - i];
+                if (!IsWhitespace(token))
+                {
+                    return i;
+                }
+            }
+
+            return 0;
+        }
+
+        private static bool IsWhitespace(SyntaxToken token)
+        {
+            return token.Kind == SyntaxKind.Whitespace || token.Kind == SyntaxKind.NewLine;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxNodeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxNodeExtensions.cs
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var tokens = node.GetTokens();
             for (var i = 0;  i < tokens.Count; i++)
             {
-                var token = tokens[(tokens.Count - 1) - i];
+                var token = tokens[tokens.Count - 1 - i];
                 if (!IsWhitespace(token))
                 {
                     return i;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxTokenExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SyntaxTokenExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using SyntaxKind = Microsoft.AspNetCore.Razor.Language.SyntaxKind;
+using SyntaxToken = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxToken;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal static class SyntaxTokenExtensions
+    {
+        public static bool IsWhitespace(this SyntaxToken token)
+        {
+            return token.Kind == SyntaxKind.Whitespace || token.Kind == SyntaxKind.NewLine;
+        }
+
+        public static bool IsSpace(this SyntaxToken token)
+        {
+            return token.Kind == SyntaxKind.Whitespace && token.Content.Equals(" ", StringComparison.Ordinal);
+        }
+
+        public static bool IsTab(this SyntaxToken token)
+        {
+            return token.Kind == SyntaxKind.Whitespace && token.Content.Equals("\t", StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -70,7 +70,7 @@ expected: @"@functions {
     public class Foo
     {
         void Method()
-        { 
+        {
             <div></div>
         }
     }
@@ -93,7 +93,7 @@ expected: @"@code {
     public class Foo
     {
         void Method()
-        { 
+        {
             @DateTime.Now
         }
     }
@@ -116,7 +116,7 @@ expected: @"@functions {
     public class Foo
     {
         void Method()
-        { 
+        {
             @(DateTime.Now)
         }
     }
@@ -469,6 +469,29 @@ expected: @"@code {
 	}
 }
 ",
+insertSpaces: false);
+
+        }
+        [Fact]
+        public async Task CodeBlockDirective_UseTabsWithTabSize8_HTML()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@code {
+ public class Foo{}
+        void Method(  ) {<div></div>
+}
+}
+",
+expected: @"@code {
+	public class Foo { }
+	void Method()
+	{
+		<div></div>
+	}
+}
+",
+tabSize: 8,
 insertSpaces: false);
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -37,6 +37,36 @@ expected: @"@code {
         }
 
         [Fact]
+        public async Task Formats_MultipleBlocksInADirective()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@{
+void Method(){
+var x = ""foo"";
+@(DateTime.Now)
+    <p></p>
+var y= ""fooo"";
+}
+}
+<div>
+        </div>
+",
+expected: @"@{
+    void Method()
+    {
+        var x = ""foo"";
+        @(DateTime.Now)
+        <p></p>
+        var y = ""fooo"";
+    }
+}
+<div>
+</div>
+");
+        }
+
+        [Fact]
         public async Task Formats_NonCodeBlockDirectives()
         {
             await RunFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -86,6 +86,31 @@ expected: @"@{
         }
 
         [Fact]
+        public async Task Formats_CodeBlockDirectiveWithMarkup_NonBraced()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@functions {
+ public class Foo{
+void Method() { var x = ""t""; <div></div> var y = ""t"";}
+}
+}
+",
+expected: @"@functions {
+    public class Foo
+    {
+        void Method()
+        {
+            var x = ""t"";
+            <div></div>
+            var y = ""t"";
+        }
+    }
+}
+");
+        }
+
+        [Fact]
         public async Task Formats_CodeBlockDirectiveWithMarkup()
         {
             await RunFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -394,6 +394,16 @@ tagHelpers: tagHelpers);
         }
 
         [Fact]
+        public async Task FormatsShortBlock()
+        {
+            await RunFormattingTestAsync(
+                input: @"@{<p></p>}",
+                expected: @"@{
+    <p></p>
+}");
+        }
+
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/26836")]
         public async Task FormatNestedBlock()
         {


### PR DESCRIPTION
### Summary of the changes
 - By using the SyntaxTree instead of a string to decide where to edit formatting we simplify the logic somewhat and set ourselves up to benefit from any future improvements that might be made to the SyntaxTree/Compiler.

Fixes: https://github.com/dotnet/aspnetcore/issues/33689

All tests pass as-is, but I wanna come back to this in a day or so (once my brain clears and I won't be testing the same stuff the tests do) and exercise things manually in case I've broken anything the tests don't cover, then add tests for that too. If anyone else wants to give that a shake I'm happy to have the help. 