### PR TITLE
Add support for building 2.1 Razor projects using the RazorSDK

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -959,10 +959,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        protected void MapDirectives(Action<SyntaxListBuilder<RazorSyntaxNode>, CSharpTransitionSyntax> handler, params string[] directives)
+        // Internal for testing.
+        internal void MapDirectives(Action<SyntaxListBuilder<RazorSyntaxNode>, CSharpTransitionSyntax> handler, params string[] directives)
         {
             foreach (var directive in directives)
             {
+                if (_directiveParserMap.ContainsKey(directive))
+                {
+                    // It is possible for the list to contain duplicates in cases when the project is misconfigured.
+                    // In those cases, we shouldn't register multiple handlers per keyword.
+                    continue;
+                }
+
                 _directiveParserMap.Add(directive, (builder, transition) =>
                 {
                     handler(builder, transition);

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/SdkRazorGenerate.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/SdkRazorGenerate.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.Razor.Tasks
 {
-    public class RazorGenerate : DotNetToolTask
+    public class SdkRazorGenerate : DotNetToolTask
     {
         private static readonly string[] SourceRequiredMetadata = new string[]
         {
@@ -148,16 +148,16 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     builder.AppendLine(RootNamespace);
                 }
 
-                if (!string.IsNullOrEmpty(CSharpLanguageVersion))
-                {
-                    builder.AppendLine("--csharp-language-version");
-                    builder.AppendLine(CSharpLanguageVersion);
-                }
-
                 if (GenerateDeclaration)
                 {
                     builder.AppendLine("--generate-declaration");
                 }
+            }
+
+            if (!string.IsNullOrEmpty(CSharpLanguageVersion))
+            {
+                builder.AppendLine("--csharp-language-version");
+                builder.AppendLine(CSharpLanguageVersion);
             }
 
             for (var i = 0; i < Extensions.Length; i++)

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/SdkRazorTagHelper.cs
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/SdkRazorTagHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.Razor.Tasks
 {
-    public class RazorTagHelper : DotNetToolTask
+    public class SdkRazorTagHelper : DotNetToolTask
     {
         private const string Identity = "Identity";
         private const string AssemblyName = "AssemblyName";

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
@@ -17,12 +17,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
 
   <UsingTask
-    TaskName="Microsoft.AspNetCore.Razor.Tasks.RazorGenerate"
+    TaskName="Microsoft.AspNetCore.Razor.Tasks.SdkRazorGenerate"
     AssemblyFile="$(RazorSdkBuildTasksAssembly)"
     Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
   <UsingTask
-    TaskName="Microsoft.AspNetCore.Razor.Tasks.RazorTagHelper"
+    TaskName="Microsoft.AspNetCore.Razor.Tasks.SdkRazorTagHelper"
     AssemblyFile="$(RazorSdkBuildTasksAssembly)"
     Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
@@ -38,8 +38,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Used to hash file inputs for RazorGenerate -->
     <_RazorGenerateInputsHash></_RazorGenerateInputsHash>
     <_RazorGenerateInputsHashFile>$(IntermediateOutputPath)$(MSBuildProjectName).RazorCoreGenerate.cache</_RazorGenerateInputsHashFile>
-
-    <_RazorToolAssembly Condition="'$(_RazorToolAssembly)'==''">$(RazorSdkDirectoryRoot)tools\netcoreapp3.0\rzc.dll</_RazorToolAssembly>
   </PropertyGroup>
 
   <!--
@@ -96,10 +94,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <FileWrites Include="$(_RazorTagHelperInputCache)" />
     </ItemGroup>
 
-    <RazorTagHelper
+    <SdkRazorTagHelper
       Debug="$(_RazorDebugTagHelperTask)"
       DebugTool="$(_RazorDebugTagHelperTool)"
-      ToolAssembly="$(_RazorToolAssembly)"
+      ToolAssembly="$(_RazorSdkToolAssembly)"
       UseServer="$(UseRazorBuildServer)"
       ForceServer="$(_RazorForceBuildServer)"
       PipeName="$(_RazorBuildServerPipeName)"
@@ -112,7 +110,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
         TaskParameter="TagHelperManifest"
         ItemName="FileWrites"/>
-    </RazorTagHelper>
+    </SdkRazorTagHelper>
   </Target>
 
   <Target Name="_ResolveRazorGenerateOutputs" Condition="'@(RazorGenerateWithTargetPath)' != ''">
@@ -147,10 +145,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       Directories="%(_RazorGenerateOutput.RelativeDir)"
       Condition="!Exists('%(_RazorGenerateOutput.RelativeDir)')" />
 
-    <RazorGenerate
+    <SdkRazorGenerate
       Debug="$(_RazorDebugGenerateCodeTask)"
       DebugTool="$(_RazorDebugGenerateCodeTool)"
-      ToolAssembly="$(_RazorToolAssembly)"
+      ToolAssembly="$(_RazorSdkToolAssembly)"
       UseServer="$(UseRazorBuildServer)"
       ForceServer="$(_RazorForceBuildServer)"
       PipeName="$(_RazorBuildServerPipeName)"

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Component.targets
@@ -103,10 +103,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RazorComponentDeclarationManifest>$(IntermediateOutputPath)$(MSBuildProjectName).RazorComponents.declaration.json</_RazorComponentDeclarationManifest>
     </PropertyGroup>
 
-    <RazorGenerate
+    <SdkRazorGenerate
       Debug="$(_RazorDebugGenerateCodeTask)"
       DebugTool="$(_RazorDebugGenerateCodeTool)"
-      ToolAssembly="$(_RazorToolAssembly)"
+      ToolAssembly="$(_RazorSdkToolAssembly)"
       UseServer="$(UseRazorBuildServer)"
       ForceServer="$(_RazorForceBuildServer)"
       PipeName="$(_RazorBuildServerPipeName)"

--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -33,6 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_RazorSdkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp3.1</_RazorSdkTasksTFM>
     <_RazorSdkTasksTFM Condition=" '$(_RazorSdkTasksTFM)' == ''">net46</_RazorSdkTasksTFM>
     <RazorSdkBuildTasksAssembly>$(RazorSdkBuildTasksDirectoryRoot)$(_RazorSdkTasksTFM)\Microsoft.NET.Sdk.Razor.Tasks.dll</RazorSdkBuildTasksAssembly>
+    <_RazorSdkToolAssembly>$(RazorSdkDirectoryRoot)tools\netcoreapp3.0\rzc.dll</_RazorSdkToolAssembly>
   </PropertyGroup>
 
   <!-- Resolve the RazorLangVersion based on values imported or TFM. -->
@@ -336,15 +337,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Determine what compiler and versions of the language to target. For 2.x targeting projects, these are carried by packages referenced by the project. Use this -->
 
-  <!-- Use the 2.x compiler if we're building an application that references Microsoft.AspNetCore.Razor.Design. -->
-  <Import Project="$(RazorCodeGenerationTargetsPath)"
-    Condition="'$(IsRazorCompilerReferenced)' == 'true' AND '$(RazorCodeGenerationTargetsPath)' != '' AND Exists('$(RazorCodeGenerationTargetsPath)')" />
-
   <!-- When targeting 3.x and later projects, we have to infer configuration by inspecting the project. -->
   <Import Project="Microsoft.NET.Sdk.Razor.Configuration.targets" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true'" />
 
-  <!-- For projects targeting 3.x and later, use the compiler that ships in the SDK -->
-  <Import Project="Microsoft.NET.Sdk.Razor.CodeGeneration.targets" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true'" />
+  <Import Project="Microsoft.NET.Sdk.Razor.CodeGeneration.targets" />
 
   <Import Project="Microsoft.NET.Sdk.Razor.Component.targets" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true'" />
 

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest21NetFx.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildIntegrationTest21NetFx.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
+{
+    public class BuildIntegrationTest21NetFx :
+        MSBuildIntegrationTestBase,
+        IClassFixture<LegacyBuildServerTestFixture>
+    {
+        private const string TestProjectName = "SimpleMvc21NetFx";
+
+        public BuildIntegrationTest21NetFx(LegacyBuildServerTestFixture buildServer)
+            : base(buildServer)
+        {
+        }
+
+        public string OutputFileName => $"{TestProjectName}.exe";
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        [InitializeTestProject(TestProjectName)]
+        public async Task BuildingProject_CopyToOutputDirectoryFiles()
+        {
+            TargetFramework = "net461";
+
+            // Build
+            var result = await DotnetMSBuild("Build");
+
+            Assert.BuildPassed(result);
+            // No cshtml files should be in the build output directory
+            Assert.FileCountEquals(result, 0, Path.Combine(OutputPath, "Views"), "*.cshtml");
+
+            // refs are required for runtime compilation in desktop targeting projects.
+            Assert.FileCountEquals(result, 97, Path.Combine(OutputPath, "refs"), "*.dll");
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        [InitializeTestProject(TestProjectName)]
+        public async Task PublishingProject_CopyToPublishDirectoryItems()
+        {
+            TargetFramework = "net461";
+
+            // Build
+            var result = await DotnetMSBuild("Publish");
+
+            Assert.BuildPassed(result);
+
+            // refs shouldn't be produced by default
+            Assert.FileCountEquals(result, 0, Path.Combine(PublishOutputPath, "refs"), "*.dll");
+
+            // Views shouldn't be produced by default
+            Assert.FileCountEquals(result, 0, Path.Combine(PublishOutputPath, "Views"), "*.cshtml");
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        [InitializeTestProject(TestProjectName)]
+        public async Task Publish_IncludesRefAssemblies_WhenCopyRefAssembliesToPublishDirectoryIsSet()
+        {
+            TargetFramework = "net461";
+
+            // Build
+            var result = await DotnetMSBuild("Publish", "/p:CopyRefAssembliesToPublishDirectory=true");
+
+            Assert.BuildPassed(result);
+
+            // refs should be present if CopyRefAssembliesToPublishDirectory is set.
+            Assert.FileExists(result, PublishOutputPath, "refs", "System.Threading.Tasks.Extensions.dll");
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildPerformanceTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildPerformanceTest.cs
@@ -26,8 +26,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.BuildPassed(result);
             var summary = ParseTaskPerformanceSummary(result.Output);
 
-            Assert.Equal(1, summary.First(f => f.Name == "RazorGenerate").Calls);
-            Assert.Equal(1, summary.First(f => f.Name == "RazorTagHelper").Calls);
+            Assert.Equal(1, summary.First(f => f.Name == "SdkRazorGenerate").Calls);
+            Assert.Equal(1, summary.First(f => f.Name == "SdkRazorTagHelper").Calls);
 
             // Incremental builds
             for (var i = 0; i < 2; i++)
@@ -37,8 +37,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Assert.BuildPassed(result);
                 summary = ParseTaskPerformanceSummary(result.Output);
 
-                Assert.DoesNotContain(summary, item => item.Name == "RazorGenerate");
-                Assert.DoesNotContain(summary, item => item.Name == "RazorTagHelper");
+                Assert.DoesNotContain(summary, item => item.Name == "SdkRazorGenerate");
+                Assert.DoesNotContain(summary, item => item.Name == "SdkRazorTagHelper");
             }
         }
 
@@ -52,8 +52,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var summary = ParseTaskPerformanceSummary(result.Output);
 
             // One for declaration build, one for the "real" code gen
-            Assert.Equal(2, summary.First(f => f.Name == "RazorGenerate").Calls);
-            Assert.Equal(1, summary.First(f => f.Name == "RazorTagHelper").Calls);
+            Assert.Equal(2, summary.First(f => f.Name == "SdkRazorGenerate").Calls);
+            Assert.Equal(1, summary.First(f => f.Name == "SdkRazorTagHelper").Calls);
 
             // Incremental builds
             for (var i = 0; i < 2; i++)
@@ -63,8 +63,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Assert.BuildPassed(result);
                 summary = ParseTaskPerformanceSummary(result.Output);
 
-                Assert.DoesNotContain(summary, item => item.Name == "RazorGenerate");
-                Assert.DoesNotContain(summary, item => item.Name == "RazorTagHelper");
+                Assert.DoesNotContain(summary, item => item.Name == "SdkRazorGenerate");
+                Assert.DoesNotContain(summary, item => item.Name == "SdkRazorTagHelper");
             }
         }
 

--- a/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.NET.Sdk.Razor.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 var toolAssembly = Path.Combine(publishDir, "rzc.dll");
                 var result = await DotnetMSBuild(
                     "Build",
-                    $"/p:_RazorForceBuildServer=true /p:_RazorToolAssembly={toolAssembly}",
+                    $"/p:_RazorForceBuildServer=true /p:_RazorSdkToolAssembly={toolAssembly}",
                     suppressBuildServer: true); // We don't want to specify a pipe name
 
                 Assert.BuildPassed(result);

--- a/src/Razor/test/RazorLanguage.Test/Legacy/CSharpCodeParserTest.cs
+++ b/src/Razor/test/RazorLanguage.Test/Legacy/CSharpCodeParserTest.cs
@@ -211,5 +211,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Test.Legacy
             var diagnostic = Assert.Single(chunkGenerator.Diagnostics);
             Assert.Equal(expectedDiagnostic, diagnostic);
         }
+
+        [Fact]
+        public void MapDirectives_HandlesDuplicates()
+        {
+            // Arrange
+            var source = TestRazorSourceDocument.Create();
+            var options = RazorParserOptions.CreateDefault();
+            var context = new ParserContext(source, options);
+            var parser = new CSharpCodeParser(context);
+
+            // Act & Assert (Does not throw)
+            parser.MapDirectives((b, t) => { }, "test");
+            parser.MapDirectives((b, t) => { }, "test");
+        }
     }
 }

--- a/src/Razor/test/testapps/ClassLibraryMvc21/ClassLibraryMvc21.csproj
+++ b/src/Razor/test/testapps/ClassLibraryMvc21/ClassLibraryMvc21.csproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
-  <!-- 
-  This project references a shipped version of MVC and should not reference local builds of 
-  the CodeGeneration targets, rzc, or any of the test shims.
+  <!--
+    This project references a shipped version of MVC. It will reference the local build of Tasks and compiler, but not the test shims.
   -->
+  <PropertyGroup>
+    <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2">
       <!-- Avoid exporting types from real MVC that will conflict with the test shim -->

--- a/src/Razor/test/testapps/RestoreTestProjects/RestoreTestProjects.csproj
+++ b/src/Razor/test/testapps/RestoreTestProjects/RestoreTestProjects.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <!-- Intentionally not including SimpleMvc11 and SimpleMvc11NetFx here because they are restored in a separate target. -->
     <ProjectReference Include="..\SimpleMvc21\SimpleMvc21.csproj" />
+    <ProjectReference Include="..\SimpleMvc21NetFx\SimpleMvc21NetFx.csproj" />
     <ProjectReference Include="..\SimpleMvc22\SimpleMvc22.csproj" />
     <ProjectReference Include="..\SimpleMvc22NetFx\SimpleMvc22NetFx.csproj" />
     <ProjectReference Include="..\ClassLibraryMvc21\ClassLibraryMvc21.csproj" />

--- a/src/Razor/test/testapps/SimpleMvc21/SimpleMvc21.csproj
+++ b/src/Razor/test/testapps/SimpleMvc21/SimpleMvc21.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <!--
-    This project references a shipped version of MVC and should not reference local builds of
-    the CodeGeneration targets, rzc, or any of the test shims.
+    This project references a shipped version of MVC. It will reference the local build of Tasks and compiler, but not the test shims.
   -->
+  <PropertyGroup>
+    <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Razor/test/testapps/SimpleMvc21NetFx/Models/ErrorViewModel.cs
+++ b/src/Razor/test/testapps/SimpleMvc21NetFx/Models/ErrorViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace SimpleMvc.Models
+{
+    public class ErrorViewModel
+    {
+        public string RequestId { get; set; }
+
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+    }
+}

--- a/src/Razor/test/testapps/SimpleMvc21NetFx/Program.cs
+++ b/src/Razor/test/testapps/SimpleMvc21NetFx/Program.cs
@@ -1,0 +1,13 @@
+﻿
+namespace SimpleMvc
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            // Just make sure we have a reference to the MVC 2.2
+            var t = typeof(Microsoft.AspNetCore.Mvc.IActionResult);
+            System.Console.WriteLine(t.FullName);
+        }
+    }
+}

--- a/src/Razor/test/testapps/SimpleMvc21NetFx/SimpleMvc21NetFx.csproj
+++ b/src/Razor/test/testapps/SimpleMvc21NetFx/SimpleMvc21NetFx.csproj
@@ -13,8 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
   </ItemGroup>
 
   <!-- Test Placeholder -->

--- a/src/Razor/test/testapps/SimpleMvc21NetFx/SimpleTagHelper.cs
+++ b/src/Razor/test/testapps/SimpleMvc21NetFx/SimpleTagHelper.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace SimpleMvc
+{
+    public class SimpleTagHelper : TagHelper
+    {
+    }
+}

--- a/src/Razor/test/testapps/SimpleMvc21NetFx/Views/Home/Index.cshtml
+++ b/src/Razor/test/testapps/SimpleMvc21NetFx/Views/Home/Index.cshtml
@@ -1,0 +1,108 @@
+﻿@{
+    ViewData["Title"] = "Home Page";
+}
+
+<div id="myCarousel" class="carousel slide" data-ride="carousel" data-interval="6000">
+    <ol class="carousel-indicators">
+        <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
+        <li data-target="#myCarousel" data-slide-to="1"></li>
+        <li data-target="#myCarousel" data-slide-to="2"></li>
+        <li data-target="#myCarousel" data-slide-to="3"></li>
+    </ol>
+    <div class="carousel-inner" role="listbox">
+        <div class="item active">
+            <img src="~/images/banner1.svg" alt="ASP.NET" class="img-responsive" />
+            <div class="carousel-caption" role="option">
+                <p>
+                    Learn how to build ASP.NET apps that can run anywhere.
+                    <a class="btn btn-default" href="https://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
+                        Learn More
+                    </a>
+                </p>
+            </div>
+        </div>
+        <div class="item">
+            <img src="~/images/banner2.svg" alt="Visual Studio" class="img-responsive" />
+            <div class="carousel-caption" role="option">
+                <p>
+                    There are powerful new features in Visual Studio for building modern web apps.
+                    <a class="btn btn-default" href="https://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409">
+                        Learn More
+                    </a>
+                </p>
+            </div>
+        </div>
+        <div class="item">
+            <img src="~/images/banner3.svg" alt="Package Management" class="img-responsive" />
+            <div class="carousel-caption" role="option">
+                <p>
+                    Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp.
+                    <a class="btn btn-default" href="https://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
+                        Learn More
+                    </a>
+                </p>
+            </div>
+        </div>
+        <div class="item">
+            <img src="~/images/banner4.svg" alt="Microsoft Azure" class="img-responsive" />
+            <div class="carousel-caption" role="option">
+                <p>
+                    Learn how Microsoft's Azure cloud platform allows you to build, deploy, and scale web apps.
+                    <a class="btn btn-default" href="https://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
+                        Learn More
+                    </a>
+                </p>
+            </div>
+        </div>
+    </div>
+    <a class="left carousel-control" href="#myCarousel" role="button" data-slide="prev">
+        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+        <span class="sr-only">Previous</span>
+    </a>
+    <a class="right carousel-control" href="#myCarousel" role="button" data-slide="next">
+        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+        <span class="sr-only">Next</span>
+    </a>
+</div>
+
+<div class="row">
+    <div class="col-md-3">
+        <h2>Application uses</h2>
+        <ul>
+            <li>Sample pages using ASP.NET Core MVC</li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
+            <li>Theming using <a href="https://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
+        </ul>
+    </div>
+    <div class="col-md-3">
+        <h2>How to</h2>
+        <ul>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkID=398600">Add a Controller and View</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=699315">Manage User Secrets using Secret Manager.</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=699316">Use logging to log a message.</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=699317">Add packages using NuGet.</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=699318">Add client packages using Bower.</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=699319">Target development, staging or production environment.</a></li>
+        </ul>
+    </div>
+    <div class="col-md-3">
+        <h2>Overview</h2>
+        <ul>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core such as Startup and middleware.</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=398602">Working with Data</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkId=398603">Security</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkID=699321">Client side development</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkID=699322">Develop on different platforms</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkID=699323">Read more on the documentation site</a></li>
+        </ul>
+    </div>
+    <div class="col-md-3">
+        <h2>Run &amp; Deploy</h2>
+        <ul>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkID=517851">Run your app</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkID=517853">Run tools such as EF migrations and more</a></li>
+            <li><a href="https://go.microsoft.com/fwlink/?LinkID=398609">Publish to Microsoft Azure Web Apps</a></li>
+        </ul>
+    </div>
+</div>

--- a/src/Razor/test/testapps/SimpleMvc21NetFx/Views/Shared/_Layout.cshtml
+++ b/src/Razor/test/testapps/SimpleMvc21NetFx/Views/Shared/_Layout.cshtml
@@ -1,0 +1,71 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - SimpleMvc</title>
+
+    <environment include="Development">
+        <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
+        <link rel="stylesheet" href="~/css/site.css" />
+    </environment>
+    <environment exclude="Development">
+        <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css"
+              asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
+              asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
+        <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
+    </environment>
+</head>
+<body>
+    <nav class="navbar navbar-inverse navbar-fixed-top">
+        <div class="container">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">SimpleMvc</a>
+            </div>
+            <div class="navbar-collapse collapse">
+                <ul class="nav navbar-nav">
+                    <li><a asp-area="" asp-controller="Home" asp-action="Index">Home</a></li>
+                    <li><a asp-area="" asp-controller="Home" asp-action="About">About</a></li>
+                    <li><a asp-area="" asp-controller="Home" asp-action="Contact">Contact</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container body-content">
+        @RenderBody()
+        <hr />
+        <footer>
+            <p>&copy; 2017 - SimpleMvc</p>
+        </footer>
+    </div>
+
+    <environment include="Development">
+        <script src="~/lib/jquery/dist/jquery.js"></script>
+        <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
+        <script src="~/js/site.js" asp-append-version="true"></script>
+    </environment>
+    <environment exclude="Development">
+        <script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.2.0.min.js"
+                asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
+                asp-fallback-test="window.jQuery"
+                crossorigin="anonymous"
+                integrity="sha384-K+ctZQ+LL8q6tP7I94W+qzQsfRV2a+AfHIi9k8z8l9ggpc8X+Ytst4yBo/hH+8Fk">
+        </script>
+        <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
+                asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
+                asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
+                crossorigin="anonymous"
+                integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa">
+        </script>
+        <script src="~/js/site.min.js" asp-append-version="true"></script>
+    </environment>
+
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/src/Razor/test/testapps/SimpleMvc21NetFx/Views/_ViewImports.cshtml
+++ b/src/Razor/test/testapps/SimpleMvc21NetFx/Views/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+@using SimpleMvc
+@using SimpleMvc.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@namespace SimpleMvc21

--- a/src/Razor/test/testapps/SimpleMvc21NetFx/Views/_ViewStart.cshtml
+++ b/src/Razor/test/testapps/SimpleMvc21NetFx/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/src/Razor/test/testapps/SimpleMvc22/SimpleMvc22.csproj
+++ b/src/Razor/test/testapps/SimpleMvc22/SimpleMvc22.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <!--
-    This project references a shipped version of MVC. It will reference the local build of Tasks but not the compiler or any test shims.
+    This project references a shipped version of MVC. It will reference the local build of Tasks and compiler but not the test shims.
   -->
   <PropertyGroup>
     <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>


### PR DESCRIPTION
This is a port of https://github.com/dotnet/sdk/pull/19094 to 3.1 that changes the RazorSDK to use the in-box
compiler when building 2.1 apps.

## Description

2.1 shipped a Razor compiler as a package which was referenced by ASP.NET Core MVC apps by default. This package contained a 2.1 binary that required the 2.1 .NET runtime. As part of our 2.1 EOL work, we updated the 6.0 SDK to instead use the Razor compiler that is carried in the SDK. This PR ports the change to the 3.1 Razor SDK.

## Customer Impact

Our 6.0 verification confirmed that the compiler in the SDK is highly compatible with the 2.1 compiler and users should be able to upgrade without issues.

## Regression?
- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [x] Medium
- [ ] Low

While we performed manual testing and have automated test to cover this scenario, it's possible there are some scenarios that the compiler's behavior has changed since 2.1 that isn't easily evident through our testing.

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [x] No
- [ ] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/35118
