### PR TITLE
Change C# Workspace TagHelper change detection to be batched.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchableWorkItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchableWorkItem.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
+{
+    internal abstract class BatchableWorkItem
+    {
+        public abstract ValueTask ProcessAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchableWorkItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchableWorkItem.cs
@@ -8,8 +8,17 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
+    /// <summary>
+    /// A work item that represents a unit of work. This is intended to be overridden so consumers can represent any
+    /// unit of work that fits their need.
+    /// </summary>
     internal abstract class BatchableWorkItem
     {
+        /// <summary>
+        /// Processes a unit of work.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the unit of work</param>
+        /// <returns>A task</returns>
         public abstract ValueTask ProcessAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchingWorkQueue.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchingWorkQueue.cs
@@ -1,0 +1,263 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
+{
+    internal sealed class BatchingWorkQueue : IDisposable
+    {
+        private readonly Dictionary<string, BatchableWorkItem> _work;
+        private readonly TimeSpan _batchingTimeSpan;
+        private readonly ErrorReporter _errorReporter;
+        private readonly CancellationTokenSource _disposalCts;
+        private Timer? _timer;
+        private bool _disposed;
+
+        public BatchingWorkQueue(
+            TimeSpan batchingTimeSpan,
+            StringComparer keyComparer,
+            ErrorReporter errorReporter)
+        {
+            if (keyComparer is null)
+            {
+                throw new ArgumentNullException(nameof(keyComparer));
+            }
+
+            if (errorReporter is null)
+            {
+                throw new ArgumentNullException(nameof(errorReporter));
+            }
+
+            _batchingTimeSpan = batchingTimeSpan;
+            _errorReporter = errorReporter;
+            _disposalCts = new CancellationTokenSource();
+            _work = new Dictionary<string, BatchableWorkItem>(keyComparer);
+        }
+
+        private bool IsScheduledOrRunning => _timer != null;
+
+        // Used in unit tests to ensure we can control when background work starts.
+        private ManualResetEventSlim? BlockBackgroundWorkStart { get; set; }
+
+        // Used in unit tests to ensure we can know when background work finishes.
+        private ManualResetEventSlim? NotifyBackgroundWorkStarting { get; set; }
+
+        // Used in unit tests to ensure we can know when background has captured its current workload.
+        private ManualResetEventSlim? NotifyBackgroundCapturedWorkload { get; set; }
+
+        // Used in unit tests to ensure we can control when background work completes.
+        private ManualResetEventSlim? BlockBackgroundWorkCompleting { get; set; }
+
+        // Used in unit tests to ensure we can know when background work finishes.
+        private ManualResetEventSlim? NotifyBackgroundWorkCompleted { get; set; }
+
+        // Used in unit tests to ensure we can know when errors are reported
+        private ManualResetEventSlim? NotifyErrorBeingReported { get; set; }
+
+        public void Enqueue(string key, BatchableWorkItem workItem)
+        {
+            lock (_work)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                // We only want to store the last 'seen' work item. That way when we pick one to process it's
+                // always the latest version to use.
+                _work[key] = workItem;
+
+                StartWorker();
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_work)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _timer?.Dispose();
+                _work.Clear();
+                _disposalCts.Cancel();
+                _disposalCts.Dispose();
+            }
+        }
+
+        private void StartWorker()
+        {
+            // Access to the timer is protected by the lock in Enqueue and in Timer_TickAsync
+            if (_timer == null)
+            {
+                // Timer will fire after a fixed delay, but only once.
+                _timer = NonCapturingTimer.Create(
+                    state => _ = ((BatchingWorkQueue)state).Timer_TickAsync(),
+                    this,
+                    _batchingTimeSpan,
+                    Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        private async Task Timer_TickAsync()
+        {
+            try
+            {
+                // Timer is stopped.
+                _timer!.Change(Timeout.Infinite, Timeout.Infinite);
+
+                OnStartingBackgroundWork();
+
+                KeyValuePair<string, BatchableWorkItem>[] work;
+                lock (_work)
+                {
+                    work = _work.ToArray();
+                    _work.Clear();
+                }
+
+                OnBackgroundCapturedWorkload();
+
+                for (var i = 0; i < work.Length; i++)
+                {
+                    var workItem = work[i].Value;
+                    try
+                    {
+                        await workItem.ProcessAsync(_disposalCts.Token).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Work item failed to process, allow the other process events to continue.
+                        _errorReporter.ReportError(ex);
+                    }
+                }
+
+                OnCompletingBackgroundWork();
+
+                lock (_work)
+                {
+                    // Resetting the timer allows another batch of work to start.
+                    _timer.Dispose();
+                    _timer = null;
+
+                    // If more work came in while we were running start the worker again if we're still alive
+                    if (_work.Count > 0 && !_disposed)
+                    {
+                        StartWorker();
+                    }
+                }
+
+                OnCompletedBackgroundWork();
+            }
+            catch (Exception ex)
+            {
+                // This is something totally unexpected
+                Debug.Fail("Batching work queue failed unexpectedly");
+                _errorReporter.ReportError(ex);
+            }
+        }
+
+        private void OnStartingBackgroundWork()
+        {
+            if (BlockBackgroundWorkStart != null)
+            {
+                BlockBackgroundWorkStart.Wait();
+                BlockBackgroundWorkStart.Reset();
+            }
+
+            if (NotifyBackgroundWorkStarting != null)
+            {
+                NotifyBackgroundWorkStarting.Set();
+            }
+        }
+
+        private void OnCompletingBackgroundWork()
+        {
+            if (BlockBackgroundWorkCompleting != null)
+            {
+                BlockBackgroundWorkCompleting.Wait();
+                BlockBackgroundWorkCompleting.Reset();
+            }
+        }
+
+        private void OnCompletedBackgroundWork()
+        {
+            if (NotifyBackgroundWorkCompleted != null)
+            {
+                NotifyBackgroundWorkCompleted.Set();
+            }
+        }
+
+        private void OnBackgroundCapturedWorkload()
+        {
+            if (NotifyBackgroundCapturedWorkload != null)
+            {
+                NotifyBackgroundCapturedWorkload.Set();
+            }
+        }
+
+        internal TestAccessor GetTestAccessor()
+            => new(this);
+
+        internal class TestAccessor
+        {
+            private readonly BatchingWorkQueue _queue;
+
+            public TestAccessor(BatchingWorkQueue queue)
+            {
+                _queue = queue;
+            }
+
+            public bool IsScheduledOrRunning => _queue.IsScheduledOrRunning;
+
+            public Dictionary<string, BatchableWorkItem> Work => _queue._work;
+
+            public ManualResetEventSlim? BlockBackgroundWorkStart
+            {
+                get => _queue.BlockBackgroundWorkStart;
+                set => _queue.BlockBackgroundWorkStart = value;
+            }
+
+            public ManualResetEventSlim? NotifyBackgroundWorkStarting
+            {
+                get => _queue.NotifyBackgroundWorkStarting;
+                set => _queue.NotifyBackgroundWorkStarting = value;
+            }
+
+            public ManualResetEventSlim? NotifyBackgroundCapturedWorkload
+            {
+                get => _queue.NotifyBackgroundCapturedWorkload;
+                set => _queue.NotifyBackgroundCapturedWorkload = value;
+            }
+
+            public ManualResetEventSlim? BlockBackgroundWorkCompleting
+            {
+                get => _queue.BlockBackgroundWorkCompleting;
+                set => _queue.BlockBackgroundWorkCompleting = value;
+            }
+
+            public ManualResetEventSlim? NotifyBackgroundWorkCompleted
+            {
+                get => _queue.NotifyBackgroundWorkCompleted;
+                set => _queue.NotifyBackgroundWorkCompleted = value;
+            }
+
+            public ManualResetEventSlim? NotifyErrorBeingReported
+            {
+                get => _queue.NotifyErrorBeingReported;
+                set => _queue.NotifyErrorBeingReported = value;
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/BatchingWorkQueueTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/BatchingWorkQueueTest.cs
@@ -1,0 +1,253 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
+{
+    public class BatchingWorkQueueTest : IDisposable
+    {
+        public BatchingWorkQueueTest()
+        {
+            ErrorReporter = new TestErrorReporter();
+            WorkQueue = new BatchingWorkQueue(TimeSpan.FromMilliseconds(1), StringComparer.Ordinal, ErrorReporter);
+            TestAccessor = WorkQueue.GetTestAccessor();
+            TestAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
+        }
+
+        private BatchingWorkQueue WorkQueue { get; }
+
+        private BatchingWorkQueue.TestAccessor TestAccessor { get; }
+
+        private TestErrorReporter ErrorReporter { get; }
+
+        [Fact]
+        public void Enqueue_ProcessesNotifications_AndGoesBackToSleep()
+        {
+            // Arrange
+            var workItem = new TestBatchableWorkItem();
+            TestAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+            TestAccessor.BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false);
+
+            // Act
+            WorkQueue.Enqueue("key", workItem);
+
+            // Assert
+            Assert.True(TestAccessor.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.NotEmpty(TestAccessor.Work);
+
+            // Allow the background work to proceed.
+            TestAccessor.BlockBackgroundWorkStart.Set();
+            TestAccessor.BlockBackgroundWorkCompleting.Set();
+
+            TestAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.False(TestAccessor.IsScheduledOrRunning, "Queue should not have restarted");
+            Assert.Empty(TestAccessor.Work);
+            Assert.True(workItem.Processed);
+            Assert.Empty(ErrorReporter.ReportedExceptions);
+        }
+
+        [Fact]
+        public void Enqueue_BatchesNotificationsByKey_ProcessesLast()
+        {
+            // Arrange
+            var originalWorkItem = new ThrowingBatchableWorkItem();
+            var newestWorkItem = new TestBatchableWorkItem();
+            TestAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+
+            // Act
+            WorkQueue.Enqueue("key", originalWorkItem);
+            WorkQueue.Enqueue("key", newestWorkItem);
+
+            // Assert
+            Assert.True(TestAccessor.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.NotEmpty(TestAccessor.Work);
+
+            // Allow the background work to start.
+            TestAccessor.BlockBackgroundWorkStart.Set();
+            TestAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.Empty(TestAccessor.Work);
+
+            Assert.False(originalWorkItem.Processed);
+            Assert.True(newestWorkItem.Processed);
+            Assert.Empty(ErrorReporter.ReportedExceptions);
+        }
+
+        [Fact]
+        public void Enqueue_ProcessesNotifications_AndRestarts()
+        {
+            // Arrange
+            var initialWorkItem = new TestBatchableWorkItem();
+            var workItemToCauseRestart = new TestBatchableWorkItem();
+            TestAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+            TestAccessor.NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false);
+            TestAccessor.NotifyBackgroundCapturedWorkload = new ManualResetEventSlim(initialState: false);
+            TestAccessor.BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false);
+            TestAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
+
+            // Act & Assert
+            WorkQueue.Enqueue("key", initialWorkItem);
+
+            Assert.True(TestAccessor.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.NotEmpty(TestAccessor.Work);
+
+            // Allow the background work to start.
+            TestAccessor.BlockBackgroundWorkStart.Set();
+
+            TestAccessor.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.True(TestAccessor.IsScheduledOrRunning, "Worker should be processing now");
+
+            TestAccessor.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(3));
+            Assert.Empty(TestAccessor.Work);
+
+            WorkQueue.Enqueue("key", workItemToCauseRestart);
+            Assert.NotEmpty(TestAccessor.Work); // Now we should see the worker restart when it finishes.
+
+            // Allow work to complete, which should restart the timer.
+            TestAccessor.BlockBackgroundWorkCompleting.Set();
+
+            TestAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+            TestAccessor.NotifyBackgroundWorkCompleted.Reset();
+
+            // It should start running again right away.
+            Assert.True(TestAccessor.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.NotEmpty(TestAccessor.Work);
+
+            // Allow the background work to proceed.
+            TestAccessor.BlockBackgroundWorkStart.Set();
+
+            TestAccessor.BlockBackgroundWorkCompleting.Set();
+            TestAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.False(TestAccessor.IsScheduledOrRunning, "Queue should not have restarted");
+            Assert.Empty(TestAccessor.Work);
+            Assert.True(initialWorkItem.Processed);
+            Assert.True(workItemToCauseRestart.Processed);
+            Assert.Empty(ErrorReporter.ReportedExceptions);
+        }
+
+        [Fact]
+        public void Enqueue_ThrowingWorkItem_DoesNotPreventProcessingSubsequentItems()
+        {
+            // Arrange
+            var throwingWorkItem = new ThrowingBatchableWorkItem();
+            var validWorkItem = new TestBatchableWorkItem();
+            TestAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+
+            // Act
+            WorkQueue.Enqueue("key", throwingWorkItem);
+            WorkQueue.Enqueue("key2", validWorkItem);
+
+            // Assert
+            Assert.True(TestAccessor.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.NotEmpty(TestAccessor.Work);
+
+            // Allow the background work to start.
+            TestAccessor.BlockBackgroundWorkStart.Set();
+            TestAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.Empty(TestAccessor.Work);
+
+            Assert.True(throwingWorkItem.Processed);
+            Assert.True(validWorkItem.Processed);
+            Assert.Single(ErrorReporter.ReportedExceptions);
+        }
+
+        [Fact]
+        public void Enqueue_DisposedPreventsRestart()
+        {
+            // Arrange
+            var initialWorkItem = new TestBatchableWorkItem();
+            var workItemToCauseRestart = new TestBatchableWorkItem();
+            TestAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+            TestAccessor.NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false);
+            TestAccessor.NotifyBackgroundCapturedWorkload = new ManualResetEventSlim(initialState: false);
+            TestAccessor.BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false);
+            TestAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
+
+            // Act & Assert
+            WorkQueue.Enqueue("key", initialWorkItem);
+
+            Assert.True(TestAccessor.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+            Assert.NotEmpty(TestAccessor.Work);
+
+            // Allow the background work to start.
+            TestAccessor.BlockBackgroundWorkStart.Set();
+
+            TestAccessor.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(3));
+
+            Assert.True(TestAccessor.IsScheduledOrRunning, "Worker should be processing now");
+
+            TestAccessor.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(3));
+            Assert.Empty(TestAccessor.Work);
+
+            WorkQueue.Enqueue("key", workItemToCauseRestart);
+            Assert.NotEmpty(TestAccessor.Work);
+
+            // Disposing before the queue has a chance to restart;
+            WorkQueue.Dispose();
+
+            // Allow work to complete, which should restart the timer.
+            TestAccessor.BlockBackgroundWorkCompleting.Set();
+
+            TestAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3));
+            TestAccessor.NotifyBackgroundWorkCompleted.Reset();
+
+            // It should start running again right away.
+            Assert.False(TestAccessor.IsScheduledOrRunning, "Queue should be scheduled during Enqueue");
+
+            // Dispose clears the work queue
+            Assert.Empty(TestAccessor.Work);
+
+            Assert.True(initialWorkItem.Processed);
+            Assert.False(workItemToCauseRestart.Processed);
+            Assert.Empty(ErrorReporter.ReportedExceptions);
+        }
+
+        public void Dispose()
+        {
+            WorkQueue.Dispose();
+        }
+
+        private class TestBatchableWorkItem : BatchableWorkItem
+        {
+            public bool Processed { get; private set; }
+
+            public override ValueTask ProcessAsync(CancellationToken cancellationToken)
+            {
+                Processed = true;
+                return new ValueTask();
+            }
+        }
+
+        private class ThrowingBatchableWorkItem : TestBatchableWorkItem
+        {
+            public override ValueTask ProcessAsync(CancellationToken cancellationToken)
+            {
+                base.ProcessAsync(cancellationToken);
+                throw new InvalidOperationException();
+            }
+        }
+
+        private class TestErrorReporter : ErrorReporter
+        {
+            private readonly List<Exception> _reportedExceptions = new List<Exception>();
+
+            public IReadOnlyList<Exception> ReportedExceptions => _reportedExceptions;
+
+            public override void ReportError(Exception exception) => _reportedExceptions.Add(exception);
+
+            public override void ReportError(Exception exception, ProjectSnapshot project) => _reportedExceptions.Add(exception);
+
+            public override void ReportError(Exception exception, Project workspaceProject) => _reportedExceptions.Add(exception);
+        }
+    }
+}


### PR DESCRIPTION
- The ultimate goal of this PR is to change how we calculate TagHelpers so we don't rely as heavily on Task cancellation exceptions. Prior to this we'd detect changes to the workspace and then aggressively cancel TagHelper resolution requests as more changes came in. Turns out when loading/unloading/changing solution configurations this call path was hit extensively and caused perf regressions. Therefore this change set is meant to remove the canceled exceptions here:
![image](https://i.imgur.com/GZWTCGB.png)

- The approach I took to resolve this is to entirely change how we resolve TagHelpers. We now batch all requests for TagHelpers and then will process them one at a time. We already had this concept in other parts of Razor so I abstracted the "worker queue" logic into its own `BatchingWorkQueue` data type.
  - The batching work queue will take in work under a key and then on a cadence will process said work.
  - The work is not processed in parallel. We could have made it parallel but there's not a driver for this now.
  - The queue is intelligent about teardown scenarios (`Dispose`) so that work will stop processing + no additional work will be allowed.
- One reallllly positive side effect of this approach is perceived performance benefits of understanding TagHelpers. Prior to this TagHelper resolution would be reset infinitely upon typing in a file. Now that we have a batching resolution mechanism, TagHelpers will always resolve which makes faster development flows feel a lot snappier.
- Lowered the workspace project state change detector delay window down to 1 second. This is kind of an orthogonal change but was motivated due to other delays we have in the system compounding in unexpected ways. Due to our batching now we're able to do this without a concern.
- Added tests for batching work queue and the workspace project state change detector.

### Before
![image](https://i.imgur.com/jYBPaNb.gif)

### After
![image](https://i.imgur.com/3s3wKTT.gif)

Fixes dotnet/aspnetcore#35047