### PR TITLE
Don't use "HTML Server-Side Script"

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -39,7 +39,7 @@
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
-          <string>RazorTransition</string>
+          <string>RazorDirective</string>
         </dict>
       </dict>
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -39,7 +39,7 @@
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
-          <string>HTML Server-Side Script</string>
+          <string>RazorTransition</string>
         </dict>
       </dict>
 


### PR DESCRIPTION
### Summary of the changes
 - We were still seeing highlighting on "@" after I made some other changes, it turns out that was because TextMate was overriding our color options with HTML Server-Side Script.

Fixes part of https://github.com/dotnet/aspnetcore/issues/34770