### PR TITLE
Handle CSS diagnostics with C#

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CSSErrorCodes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CSSErrorCodes.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    // Note: This type should be kept in sync with WTE's ErrorCodes.cs
+    internal static class CSSErrorCodes
+    {
+        public const string MissingOpeningBrace = "CSS023";
+        public const string MissingSelectorAfterCombinator = "CSS029";
+        public const string MissingSelectorBeforeCombinatorCode = "CSS031";
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
@@ -234,6 +234,78 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
         }
 
         [Fact]
+        public async Task Handle_FilterDiagnostics_CSharpInsideStyleBlockSpace()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var codeDocument = CreateCodeDocumentWithCSharpProjection(
+                "<style> @DateTime.Now </style>",
+                "var __o = DateTime.Now",
+                new[] {
+                    new SourceMapping(
+                        new SourceSpan(4, 12),
+                        new SourceSpan(10, 12))
+                });
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
+            var request = new RazorDiagnosticsParams()
+            {
+                Kind = RazorLanguageKind.Html,
+                Diagnostics = new[] {
+                    new OmniSharpVSDiagnostic() {
+                        Range = new Range(new Position(0, 7), new Position(0, 7)),
+                        Code = CSSErrorCodes.MissingSelectorBeforeCombinatorCode,
+                        Severity = DiagnosticSeverity.Warning
+                    }
+                },
+                RazorDocumentUri = new Uri(documentPath),
+            };
+            var expectedRange = new Range(new Position(0, 8), new Position(0, 15));
+
+            // Act
+            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+
+            // Assert
+            Assert.Empty(response.Diagnostics);
+        }
+
+        [Fact]
+        public async Task Handle_FilterDiagnostics_CSharpInsideStyleBlock()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var codeDocument = CreateCodeDocumentWithCSharpProjection(
+                "<style> @DateTime.Now </style>",
+                "var __o = DateTime.Now",
+                new[] {
+                    new SourceMapping(
+                        new SourceSpan(4, 12),
+                        new SourceSpan(10, 12))
+                });
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
+            var request = new RazorDiagnosticsParams()
+            {
+                Kind = RazorLanguageKind.Html,
+                Diagnostics = new[] {
+                    new OmniSharpVSDiagnostic() {
+                        Range = new Range(new Position(0, 8), new Position(0, 15)),
+                        Code = CSSErrorCodes.MissingSelectorBeforeCombinatorCode,
+                        Severity = DiagnosticSeverity.Warning
+                    }
+                },
+                RazorDocumentUri = new Uri(documentPath),
+            };
+            var expectedRange = new Range(new Position(0, 8), new Position(0, 15));
+
+            // Act
+            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+
+            // Assert
+            Assert.Empty(response.Diagnostics);
+        }
+
+        [Fact]
         public async Task Handle_FilterDiagnostics_CSharpWarning()
         {
             // Arrange


### PR DESCRIPTION
### Summary of the changes
 - The presence of C# blocks in `<style>` elements really complicates things because of the the restrictive nature of the CSS syntax. We're flat-out ignoring some errors if a C# block is in the style element, which is not ideal but necessary until the HTML document no longer emits "~"'s.

Fixes: https://github.com/dotnet/aspnetcore/issues/33097
