### PR TITLE
Remove exception catch from RazorLSPTextViewConnectionListener

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPTextViewConnectionListener.cs
@@ -234,28 +234,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             // options later when the server sends us a workspace/configuration request.
             _clientOptionsMonitor.UpdateOptions(settings);
 
-            try
-            {
-                // Make sure the server updates the settings on their side by sending a
-                // workspace/didChangeConfiguration request. This notifies the server that the user's
-                // settings have changed. The server will then query the client's options monitor (already
-                // updated via the line above) by sending a workspace/configuration request.
-                // NOTE: This flow uses polyfilling because VS doesn't yet support workspace configuration
-                // updates. Once they do, we can get rid of this extra logic.
-                await _requestInvoker.ReinvokeRequestOnServerAsync<DidChangeConfigurationParams, Unit>(
-                    Methods.WorkspaceDidChangeConfigurationName,
-                    RazorLSPConstants.RazorLanguageServerName,
-                    CheckRazorServerCapability,
-                    new DidChangeConfigurationParams(),
-                    CancellationToken.None);
-            }
-            catch (Exception)
-            {
-                // This may happen if the TextView finishes attaching before the Razor language server is
-                // initialized. Ideally, the platform should be queuing requests until the language server
-                // is ready. However, we should catch any exceptions here just in case since VS will crash
-                // if an exception is hit in this method.
-            }
+            // Make sure the server updates the settings on their side by sending a
+            // workspace/didChangeConfiguration request. This notifies the server that the user's
+            // settings have changed. The server will then query the client's options monitor (already
+            // updated via the line above) by sending a workspace/configuration request.
+            // NOTE: This flow uses polyfilling because VS doesn't yet support workspace configuration
+            // updates. Once they do, we can get rid of this extra logic.
+            await _requestInvoker.ReinvokeRequestOnServerAsync<DidChangeConfigurationParams, Unit>(
+                Methods.WorkspaceDidChangeConfigurationName,
+                RazorLSPConstants.RazorLanguageServerName,
+                CheckRazorServerCapability,
+                new DidChangeConfigurationParams(),
+                CancellationToken.None);
         }
 
         private static bool CheckRazorServerCapability(JToken token)


### PR DESCRIPTION
It looks like [this VSTS issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1306491) no longer repros after the LSP refactor. To confirm, I put a delay at the beginning of [this method](https://github.com/dotnet/aspnetcore-tooling/blob/af9d6a1563dd9df3ad1dc917c8d8788ac1230f02/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs#L130) to ensure the TextView finishes attaching first.