### PR TITLE
Add missing for-loop snippet part

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 Label = "for (...)",
                 InsertText =
-                    @$"for (var ${{1:i}} = 0; ${{1:i}} < ${{2:length}}; ${{1:i}})
+                    @$"for (var ${{1:i}} = 0; ${{1:i}} < ${{2:length}}; ${{1:i}}++)
 {baseIndentationString}{{
 {baseIndentationPlus1String}$0
 {baseIndentationString}}}",


### PR DESCRIPTION
While prepping for showcase I noticed the for-loop snippet was missing a `++`.