### PR TITLE
Add support for Tag Helper opt-out operator

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LinkedEditingRangeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LinkedEditingRangeHandler.cs
@@ -133,6 +133,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
+            // Add Razor's Tag Helper opt-out operator to the word pattern
+            linkedEditingRangeResult.WordPattern = linkedEditingRangeResult.WordPattern.Insert(0, "[!?]");
+
             linkedEditingRangeResult.Ranges = mappingResult.Ranges;
             _logger.LogInformation("Returned remapped result.");
             return linkedEditingRangeResult;


### PR DESCRIPTION
### Summary of the changes
- Adds support for the Tag Helper opt-out operator `!`. My knowledge of HTML is limited so I'm not sure if I missed any cases, let me know if I did!
 - The LSP side of this PR has been merged in: https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/344266

Fixes: 
https://github.com/dotnet/aspnetcore/issues/33126