### PR TITLE
Report no SemanticTokens range capability

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                     Delta = true,
                 },
                 Legend = RazorSemanticTokensLegend.Instance,
-                Range = true,
+                Range = false,
             };
         }
 


### PR DESCRIPTION
### Summary of the changes
 - Since Razor doesn't currently have the capability to parse less than the full document (while still giving correct results) the Semantic Tokens Range requests (which are an optional optimization for LSP Servers which know how to return smaller sections of documents) actually end up hurting performance since we get multiple range requests all at once, each of which is walking the whole tree (not to mention paying the cost of LSP requests and serialization).
- To avoid this behavior we need only report that our LanguageServer does not support range requests.
- This takes our performance on startup for large apps/documents from 1-2 minutes to ~35 seconds.
- I've elected to leave the existing Range infrastructure in for now because it's never been a significant maintenance burden and the simple way we currently handle ranges is cheap, but I could be convinced we should delete it if someone feels strongly.

Fixes: https://github.com/dotnet/aspnetcore/issues/35396
