### PR TITLE
Implement LinkedEditingRangeEndpoint for TagHelper opt-out

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
+{
+    internal static class LinePositionSpanExtensions
+    {
+        public static Range ToRange(this LinePositionSpan linePositionSpan)
+        {
+            var range = new Range
+            {
+                Start = new Position { Line = linePositionSpan.Start.Line, Character = linePositionSpan.Start.Character },
+                End = new Position { Line = linePositionSpan.End.Line, Character = linePositionSpan.End.Character }
+            };
+
+            return range;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/ILinkedEditingRangeHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/ILinkedEditingRangeHandler.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
+{
+    [Parallel, Method("textDocument/linkedEditingRange")]
+    internal interface ILinkedEditingRangeHandler : IJsonRpcRequestHandler<LinkedEditingRangeParams, LinkedEditingRanges>, IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Editor.Razor;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using System.Collections.Generic;
+using SyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
+{
+    internal class LinkedEditingRangeEndpoint : ILinkedEditingRangeHandler
+    {
+        // The regex below excludes characters that can never be valid in a TagHelper name.
+        // This is loosely based off logic from the Razor compiler:
+        // https://github.com/dotnet/aspnetcore/blob/main/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlTokenizer.cs
+        // Internal for testing only.
+        internal readonly string _wordPattern = @"!?[^ <>!\/\?\[\]=""\\@" + Environment.NewLine + "]+";
+
+        private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
+        private readonly DocumentResolver _documentResolver;
+        private readonly TagHelperFactsService _tagHelperFactsService;
+
+        public LinkedEditingRangeEndpoint(
+            ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
+            DocumentResolver documentResolver,
+            TagHelperFactsService tagHelperFactsService)
+        {
+            if (projectSnapshotManagerDispatcher is null)
+            {
+                throw new ArgumentNullException(nameof(projectSnapshotManagerDispatcher));
+            }
+
+            if (documentResolver is null)
+            {
+                throw new ArgumentNullException(nameof(documentResolver));
+            }
+
+            if (tagHelperFactsService is null)
+            {
+                throw new ArgumentNullException(nameof(tagHelperFactsService));
+            }
+
+            _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
+            _documentResolver = documentResolver;
+            _tagHelperFactsService = tagHelperFactsService;
+        }
+
+        public RegistrationExtensionResult GetRegistration()
+        {
+            const string AssociatedServerCapability = "linkedEditingRangeProvider";
+            var registrationOptions = new LinkedEditingRangeRegistrationOptions();
+            return new RegistrationExtensionResult(AssociatedServerCapability, registrationOptions);
+        }
+
+        public async Task<LinkedEditingRanges> Handle(
+            LinkedEditingRangeParams request,
+            CancellationToken cancellationToken)
+        {
+            var document = await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                _documentResolver.TryResolveDocument(
+                    request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
+
+                return documentSnapshot;
+            }, cancellationToken);
+
+            if (document is null || cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+
+            var codeDocument = await document.GetGeneratedOutputAsync();
+            if (codeDocument.IsUnsupported())
+            {
+                return null;
+            }
+
+            var location = await GetSourceLocation(request, document).ConfigureAwait(false);
+            var ancestors = GetAncestors(codeDocument, location);
+
+            // We only care if the user is within a TagHelper with a valid start and end tag.
+            if (_tagHelperFactsService.TryGetNearestAncestorStartAndEndTags(
+                    ancestors, out var startTag, out var endTag) &&
+                startTag.Name is not null && endTag.Name is not null)
+            {
+                var startSpan = startTag.Name.GetLinePositionSpan(codeDocument.Source);
+                var endSpan = endTag.Name.GetLinePositionSpan(codeDocument.Source);
+                var ranges = new Range[2] { startSpan.ToRange(), endSpan.ToRange() };
+
+                return new LinkedEditingRanges
+                {
+                    Ranges = ranges,
+                    WordPattern = _wordPattern
+                };
+            }
+
+            return null;
+
+            static async Task<SourceLocation> GetSourceLocation(
+                LinkedEditingRangeParams request,
+                DocumentSnapshot document)
+            {
+                var sourceText = await document.GetTextAsync().ConfigureAwait(false);
+                var linePosition = new LinePosition(request.Position.Line, request.Position.Character);
+                var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
+                var location = new SourceLocation(hostDocumentIndex, request.Position.Line, request.Position.Character);
+
+                return location;
+            }
+
+            static IEnumerable<SyntaxNode> GetAncestors(RazorCodeDocument codeDocument, SourceLocation location)
+            {
+                var syntaxTree = codeDocument.GetSyntaxTree();
+                var change = new SourceChange(location.AbsoluteIndex, length: 0, newText: "");
+                var owner = syntaxTree.Root.LocateOwner(change);
+                var ancestors = owner.Ancestors();
+
+                return ancestors;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeParams.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using MediatR;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
+{
+    internal class LinkedEditingRangeParams : TextDocumentPositionParams, IRequest<LinkedEditingRanges>, IBaseRequest
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeRegistrationOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeRegistrationOptions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
+{
+    internal class LinkedEditingRangeRegistrationOptions : IWorkDoneProgressOptions
+    {
+        public bool WorkDoneProgress { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRanges.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRanges.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
+{
+    internal class LinkedEditingRanges
+    {
+        [JsonProperty("ranges")]
+        public Range[] Ranges
+        {
+            get;
+            set;
+        }
+
+        //
+        // Summary:
+        //     Gets or sets the word pattern for the type rename.
+        [JsonProperty("wordPattern")]
+        public string WordPattern
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRanges.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRanges.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -19,9 +15,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
             set;
         }
 
-        //
-        // Summary:
-        //     Gets or sets the word pattern for the type rename.
         [JsonProperty("wordPattern")]
         public string WordPattern
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -33,6 +33,7 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
+using Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -129,6 +130,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<MonitorProjectConfigurationFilePathEndpoint>()
                     .WithHandler<RazorComponentRenameEndpoint>()
                     .WithHandler<RazorDefinitionEndpoint>()
+                    .WithHandler<LinkedEditingRangeEndpoint>()
                     .WithServices(services =>
                     {
                         services.AddLogging(builder => builder

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperFactsService.cs
@@ -229,5 +229,26 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             return (ancestorTagName: null, ancestorIsTagHelper: false);
         }
+
+        internal override bool TryGetNearestAncestorStartAndEndTags(
+            IEnumerable<SyntaxNode> ancestors,
+            out MarkupTagHelperStartTagSyntax startTag,
+            out MarkupTagHelperEndTagSyntax endTag)
+        {
+            foreach (var ancestor in ancestors)
+            {
+                if (ancestor is MarkupTagHelperElementSyntax tagHelperElement)
+                {
+                    // It's possible for start or end tag to be null in malformed cases.
+                    startTag = tagHelperElement.StartTag;
+                    endTag = tagHelperElement.EndTag;
+                    return startTag is not null && endTag is not null;
+                }
+            }
+
+            startTag = null;
+            endTag = null;
+            return false;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperFactsService.cs
@@ -18,6 +18,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public abstract IReadOnlyList<TagHelperDescriptor> GetTagHelpersGivenParent(TagHelperDocumentContext documentContext, string parentTag);
 
+        internal abstract bool TryGetNearestAncestorStartAndEndTags(IEnumerable<SyntaxNode> ancestors, out MarkupTagHelperStartTagSyntax startTag, out MarkupTagHelperEndTagSyntax endTag);
+
         // Internal for testing
         internal virtual IEnumerable<KeyValuePair<string, string>> StringifyAttributes(SyntaxList<RazorSyntaxNode> attributes)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
+{
+    public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
+    {
+        [Fact]
+        public async Task Handle_StartTag_ReturnsCorrectRange()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, TagHelperFactsService);
+            var request = new LinkedEditingRangeParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position { Line = 1, Character = 3 } // <te[||]st1></test1>
+            };
+
+            var expectedRanges = new Range[]
+            {
+                new Range
+                {
+                    Start = new Position { Line = 1, Character = 1 },
+                    End = new Position { Line = 1, Character = 6 }
+                },
+                new Range
+                {
+                    Start = new Position { Line = 1, Character = 9 },
+                    End = new Position { Line = 1, Character = 14 }
+                }
+            };
+
+            // Act
+            var result = await endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedRanges, result.Ranges);
+            Assert.Equal(endpoint._wordPattern, result.WordPattern);
+        }
+
+        [Fact]
+        public async Task Handle_EndTag_ReturnsCorrectRange()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, TagHelperFactsService);
+            var request = new LinkedEditingRangeParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position { Line = 1, Character = 9 } // <test1></[||]test1>
+            };
+
+            var expectedRanges = new Range[]
+            {
+                new Range
+                {
+                    Start = new Position { Line = 1, Character = 1 },
+                    End = new Position { Line = 1, Character = 6 }
+                },
+                new Range
+                {
+                    Start = new Position { Line = 1, Character = 9 },
+                    End = new Position { Line = 1, Character = 14 }
+                }
+            };
+
+            // Act
+            var result = await endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedRanges, result.Ranges);
+            Assert.Equal(endpoint._wordPattern, result.WordPattern);
+        }
+
+        [Fact]
+        public async Task Handle_NoTagHelper_ReturnsNull()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, TagHelperFactsService);
+            var request = new LinkedEditingRangeParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position { Line = 0, Character = 1 } // @[||]addTagHelper *
+            };
+
+            // Act
+            var result = await endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Handle_SelfClosingTagHelper_ReturnsNull()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, TagHelperFactsService);
+            var request = new LinkedEditingRangeParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position { Line = 1, Character = 3 } // <te[||]st1 />
+            };
+
+            // Act
+            var result = await endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Handle_NestedStartTags_ReturnsCorrectRange()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><test1></test1></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, TagHelperFactsService);
+            var request = new LinkedEditingRangeParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position { Line = 1, Character = 1 } // <[||]test1><test1></test1></test1>
+            };
+
+            var expectedRanges = new Range[]
+            {
+                new Range
+                {
+                    Start = new Position { Line = 1, Character = 1 },
+                    End = new Position { Line = 1, Character = 6 }
+                },
+                new Range
+                {
+                    Start = new Position { Line = 1, Character = 24 },
+                    End = new Position { Line = 1, Character = 29 }
+                }
+            };
+
+            // Act
+            var result = await endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedRanges, result.Ranges);
+            Assert.Equal(endpoint._wordPattern, result.WordPattern);
+        }
+
+        [Fact]
+        public void VerifyWordPatternCorrect()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var uri = new Uri("file://path/test.razor");
+            var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, TagHelperFactsService);
+
+            // Assert
+            Assert.True(Regex.Match("Test", endpoint._wordPattern).Length == 4);
+            Assert.True(Regex.Match("!Test", endpoint._wordPattern).Length == 5);
+            Assert.True(Regex.Match("!Test.Test2", endpoint._wordPattern).Length == 11);
+
+            Assert.True(Regex.Match("Te>st", endpoint._wordPattern).Length != 5);
+            Assert.True(Regex.Match("Te/st", endpoint._wordPattern).Length != 5);
+            Assert.True(Regex.Match("Te\\st", endpoint._wordPattern).Length != 5);
+            Assert.True(Regex.Match("Te!st", endpoint._wordPattern).Length != 5);
+            Assert.True(Regex.Match("Te" + Environment.NewLine + "st",
+                endpoint._wordPattern).Length != 4 + Environment.NewLine.Length);
+        }
+
+        private static DocumentResolver CreateDocumentResolver(string documentPath, RazorCodeDocument codeDocument)
+        {
+            var sourceTextChars = new char[codeDocument.Source.Length];
+            codeDocument.Source.CopyTo(0, sourceTextChars, 0, codeDocument.Source.Length);
+            var sourceText = SourceText.From(new string(sourceTextChars));
+            var documentSnapshot = Mock.Of<DocumentSnapshot>(document =>
+                document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
+                document.GetTextAsync() == Task.FromResult(sourceText), MockBehavior.Strict);
+            var documentResolver = new Mock<DocumentResolver>(MockBehavior.Strict);
+            documentResolver.Setup(resolver => resolver.TryResolveDocument(documentPath, out documentSnapshot))
+                .Returns(true);
+            return documentResolver.Object;
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the changes
 - Adds a `LinkedEditingRangeEndpoint` to implement proper TagHelper opt-out behavior. This activates only on TagHelpers and is meant to address https://github.com/dotnet/aspnetcore/issues/33126.
 - The LSP side of this PR was merged earlier this week: https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/344266 However, for some reason upgrading the LSP package version (not included in this PR) doesn't seem to contain the changes, even though I verified the changes locally. If anyone has any ideas on why this may be please let me know!

Fixes: 
https://github.com/dotnet/aspnetcore/issues/33126 (Once both this PR & the LSP PR have been merged and adopted)