### PR TITLE
WebEncode Plus

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 return "/";
             }
 
-            var decodedPath = WebUtility.UrlDecode(filePath);
+            var decodedPath = filePath.Contains("%") ? WebUtility.UrlDecode(filePath) : filePath;
             var normalized = decodedPath.Replace('\\', '/');
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -304,6 +304,7 @@
           {
             "scopes": {
               "razorComponentElement": [ "entity.name.class.element.component" ],
+              "RazorComponentAttribute": [ "entity.name.class.attribute.component" ],
               "razorComponentAttribute": [ "entity.name.class.attribute.component" ],
               "razorTagHelperElement": [ "entity.name.class.element.taghelper" ],
               "razorTagHelperAttribute": [ "entity.name.class.attribute.taghelper" ],

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -54,7 +54,7 @@ export class RazorLanguageServiceClient {
     public async getSemanticTokenLegend(): Promise<vscode.SemanticTokensLegend | undefined> {
         await this.ensureStarted();
 
-        const response = await this.serverClient.sendRequest<vscode.SemanticTokensLegend>('_ms_/textDocument/semanticTokensLegend', /*request param*/null);
+        const response = await this.serverClient.sendRequest<vscode.SemanticTokensLegend>('_vs_/textDocument/semanticTokensLegend', /*request param*/null);
 
         if (response.tokenTypes && response.tokenTypes.length > 0) {
             return response;
@@ -65,7 +65,7 @@ export class RazorLanguageServiceClient {
         await this.ensureStarted();
 
         const request = new SemanticTokensRequest(uri);
-        const response = await this.serverClient.sendRequest<vscode.SemanticTokens>('textDocument/semanticTokens', request);
+        const response = await this.serverClient.sendRequest<vscode.SemanticTokens>('textDocument/semanticTokens/full', request);
 
         if (response.data && response.data.length > 0) {
             return response;
@@ -87,7 +87,7 @@ export class RazorLanguageServiceClient {
         await this.ensureStarted();
 
         const request = new SemanticTokensEditRequest(uri, previousResultId);
-        const response = await this.serverClient.sendRequest<vscode.SemanticTokens | vscode.SemanticTokensEdits>('textDocument/semanticTokens/edits', request);
+        const response = await this.serverClient.sendRequest<vscode.SemanticTokens | vscode.SemanticTokensEdits>('textDocument/semanticTokens/full/delta', request);
 
         if (this.isSemanticTokens(response)) {
             return response;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Razor
             }
 
             // Absolute paths are usually encoded.
-            return WebUtility.UrlDecode(uri.AbsolutePath);
+            return uri.AbsolutePath.Contains("%")? WebUtility.UrlDecode(uri.AbsolutePath) : uri.AbsolutePath;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             var filePathNormalizer = new FilePathNormalizer();
 
             // Act
-            var normalized = filePathNormalizer.Normalize(null);
+            var normalized = filePathNormalizer.Normalize(string.Empty);
 
             // Assert
             Assert.Equal("/", normalized);
@@ -176,6 +176,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
             // Assert
             Assert.Equal("C:/path to/document.cshtml", normalized);
+        }
+
+        [Fact]
+        public void Normalize_UrlDecodesOnlyOnce()
+        {
+            // Arrange
+            var filePathNormalizer = new FilePathNormalizer();
+            var filePath = "C:/path%2Bto/document.cshtml";
+
+            // Act
+            var normalized = filePathNormalizer.Normalize(filePath);
+            normalized = filePathNormalizer.Normalize(normalized);
+
+            // Assert
+            Assert.Equal("C:/path+to/document.cshtml", normalized);
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 existingConfigurationFiles);
 
             // Act
-            await detector.StartAsync("/some/workspacedirectory", cts.Token);
+            await detector.StartAsync("/some/workspace+directory", cts.Token);
 
             // Assert
             Assert.Collection(eventArgs1,


### PR DESCRIPTION
### Summary of the changes
 - This wasn't just VSCode, affected VS as well.
 - Path's containing "special" characters get WebEncoded when we send them across the wire between client and server, so we run WebDecode on them so when we go searching for the file in question we get `My Project` instead of `My%20Project` (and thus things can be found). The one problem with that is `+`. If the server receives `My%2bProject` it correctly turns it into `My+Project`, but if you WebDecode again it becomes `My Project`. We currently WebDecode every time we run `Normalize`, which is >6 times one the one string in some circumstances.
 - The solution then is to only run it the once. I've tried to accomplish that here with a quick check to see if it's already been WebDecoded, we could also just  ensure that Normalize only ever gets called once (by the endpoints), but that's a much larger change which might affect a lot of areas.
 - In testing this in VSCode I realized that the SemanticTokens experience wasn't working because we'd changed a couple of names, so I included that here too.

Fixes: https://github.com/dotnet/aspnetcore/issues/33144
