### PR TITLE
Update dependent projects when razor files are added or removed

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces.Extensions
+{
+    internal static class ProjectExtensions
+    {
+        internal static Document GetRequiredDocument(this Project project, DocumentId? documentId)
+        {
+            if (project is null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            if (documentId is null)
+            {
+                throw new ArgumentNullException(nameof(documentId));
+            }
+
+            var document = project.GetDocument(documentId);
+
+            if (document is null)
+            {
+                throw new InvalidOperationException($"The document {documentId} did  not exist in {project.Name}");
+            }
+
+            return document;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/SolutionExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/SolutionExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces.Extensions
+{
+    internal static class SolutionExtensions
+    {
+        internal static Project GetRequiredProject(this Solution solution, ProjectId? projectId)
+        {
+            if (solution is null)
+            {
+                throw new ArgumentNullException(nameof(solution));
+            }
+
+            if (projectId is null)
+            {
+                throw new ArgumentNullException(nameof(projectId));
+            }
+
+            var project = solution.GetProject(projectId);
+
+            if (project is null)
+            {
+                throw new InvalidOperationException($"The projectId {projectId} did not exist in {solution}.");
+            }
+
+            return project;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
@@ -118,7 +118,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                         case WorkspaceChangeKind.ProjectAdded:
                             {
                                 project = e.NewSolution.GetRequiredProject(e.ProjectId);
-
                                 EnqueueUpdateOnProjectAndDependencies(project, e.NewSolution);
                                 break;
                             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -89,7 +89,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     "Three",
                     "Three",
                     LanguageNames.CSharp,
-                    filePath: "Three.csproj"));
+                    filePath: "Three.csproj",
+                    documents: new[] { razorDocumentInfo }));
 
             ProjectNumberOne = SolutionWithTwoProjects.GetProject(projectId1);
             ProjectNumberTwo = SolutionWithTwoProjects.GetProject(projectId2);
@@ -135,6 +136,56 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public DocumentId BackgroundVirtualCSharpDocumentId { get; }
 
         public DocumentId PartialComponentClassDocumentId { get; }
+
+        [UITheory]
+        [InlineData(WorkspaceChangeKind.DocumentAdded)]
+        [InlineData(WorkspaceChangeKind.DocumentChanged)]
+        [InlineData(WorkspaceChangeKind.DocumentRemoved)]
+        public async Task WorkspaceChanged_DocumentEvents_EnqueuesUpdatesForDependentProjects(WorkspaceChangeKind kind)
+        {
+            // Arrange
+            var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+            var detector = new WorkspaceProjectStateChangeDetector(workspaceStateGenerator, Dispatcher, WorkQueue)
+            {
+                NotifyWorkspaceChangedEventComplete = new ManualResetEventSlim(initialState: false),
+            };
+            WorkQueueTestAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+
+            var projectManager = new TestProjectSnapshotManager(Dispatcher, new[] { detector }, Workspace);
+
+            await Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                projectManager.ProjectAdded(HostProjectOne);
+                projectManager.ProjectAdded(HostProjectTwo);
+                projectManager.ProjectAdded(HostProjectThree);
+            }, CancellationToken.None);
+
+            // Initialize with a project. This will get removed.
+            var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.SolutionAdded, oldSolution: EmptySolution, newSolution: SolutionWithOneProject);
+            detector.Workspace_WorkspaceChanged(Workspace, e);
+            detector.NotifyWorkspaceChangedEventComplete.Wait();
+            detector.NotifyWorkspaceChangedEventComplete.Reset();
+
+            e = new WorkspaceChangeEventArgs(kind, oldSolution: SolutionWithOneProject, newSolution: SolutionWithDependentProject);
+
+            var solution = SolutionWithDependentProject.WithProjectAssemblyName(ProjectNumberThree.Id, "Changed");
+
+            e = new WorkspaceChangeEventArgs(kind, oldSolution: SolutionWithDependentProject, newSolution: solution, projectId: ProjectNumberThree.Id, documentId: RazorDocumentId);
+
+            // Act
+            detector.Workspace_WorkspaceChanged(Workspace, e);
+            detector.NotifyWorkspaceChangedEventComplete.Wait();
+
+            // Assert
+            Assert.Equal(3, WorkQueueTestAccessor.Work.Count);
+            Assert.Contains(WorkQueueTestAccessor.Work, u => u.Key == ProjectNumberOne.FilePath);
+            Assert.Contains(WorkQueueTestAccessor.Work, u => u.Key == ProjectNumberTwo.FilePath);
+            Assert.Contains(WorkQueueTestAccessor.Work, u => u.Key == ProjectNumberThree.FilePath);
+
+            WorkQueueTestAccessor.BlockBackgroundWorkStart.Set();
+            WorkQueueTestAccessor.NotifyBackgroundWorkCompleted.Wait();
+            Assert.Empty(WorkQueueTestAccessor.Work);
+        }
 
         [UIFact]
         public async Task WorkspaceChanged_ProjectEvents_EnqueuesUpdatesForDependentProjects()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -187,8 +187,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Empty(WorkQueueTestAccessor.Work);
         }
 
-        [UIFact]
-        public async Task WorkspaceChanged_ProjectEvents_EnqueuesUpdatesForDependentProjects()
+        [UITheory]
+        [InlineData(WorkspaceChangeKind.ProjectChanged)]
+        [InlineData(WorkspaceChangeKind.ProjectAdded)]
+        [InlineData(WorkspaceChangeKind.ProjectRemoved)]
+
+        public async Task WorkspaceChanged_ProjectEvents_EnqueuesUpdatesForDependentProjects(WorkspaceChangeKind kind)
         {
             // Arrange
             var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
@@ -206,7 +210,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 projectManager.ProjectAdded(HostProjectTwo);
                 projectManager.ProjectAdded(HostProjectThree);
             }, CancellationToken.None);
-            var kind = WorkspaceChangeKind.ProjectChanged;
 
             // Initialize with a project. This will get removed.
             var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.SolutionAdded, oldSolution: EmptySolution, newSolution: SolutionWithOneProject);


### PR DESCRIPTION
### Summary of the changes
 - We needed to expand the scenarios under which the project.razor.json gets updated for dependent projects.
 - Considered adding tests, but no tests of this class yet deal with document updates, so there's a fair bit to work through and I'll come back to that.

Fixes: https://github.com/dotnet/aspnetcore/issues/33957
