### PR TITLE
Don't block serial requests on long-running parallel requests.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -125,7 +125,7 @@
     <MonoDevelopSdkPackageVersion>1.0.15</MonoDevelopSdkPackageVersion>
     <MoqPackageVersion>4.16.0</MoqPackageVersion>
     <NerdbankStreamsPackageVersion>2.7.74</NerdbankStreamsPackageVersion>
-    <OmniSharpExtensionsLanguageServerPackageVersion>0.19.3-nimullen-refacto0024</OmniSharpExtensionsLanguageServerPackageVersion>
+    <OmniSharpExtensionsLanguageServerPackageVersion>0.19.5</OmniSharpExtensionsLanguageServerPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.37.13</OmniSharpMSBuildPackageVersion>
     <StreamJsonRpcPackageVersion>2.8.21</StreamJsonRpcPackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.3.2</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -125,7 +125,7 @@
     <MonoDevelopSdkPackageVersion>1.0.15</MonoDevelopSdkPackageVersion>
     <MoqPackageVersion>4.16.0</MoqPackageVersion>
     <NerdbankStreamsPackageVersion>2.7.74</NerdbankStreamsPackageVersion>
-    <OmniSharpExtensionsLanguageServerPackageVersion>0.19.4</OmniSharpExtensionsLanguageServerPackageVersion>
+    <OmniSharpExtensionsLanguageServerPackageVersion>0.19.3-nimullen-refacto0024</OmniSharpExtensionsLanguageServerPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.37.13</OmniSharpMSBuildPackageVersion>
     <StreamJsonRpcPackageVersion>2.8.21</StreamJsonRpcPackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.3.2</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonRpc/JsonRpcRequestScheduler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonRpc/JsonRpcRequestScheduler.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Threading;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
+{
+    internal class JsonRpcRequestScheduler : IDisposable
+    {
+        private readonly Task _processingQueueTask;
+        private readonly AsyncQueue<QueueItem> _queue;
+        private readonly CancellationTokenSource _disposedCancellationTokenSource;
+        private readonly ILogger<JsonRpcRequestScheduler> _logger;
+
+        public JsonRpcRequestScheduler(ILoggerFactory loggerFactory)
+        {
+            _disposedCancellationTokenSource = new CancellationTokenSource();
+            _logger = loggerFactory.CreateLogger<JsonRpcRequestScheduler>();
+            _queue = new AsyncQueue<QueueItem>();
+
+            // Start the queue processing
+            _processingQueueTask = ProcessQueueAsync();
+        }
+
+        public bool Schedule(RequestProcessType type, string identifier, ProcessSchedulerDelegate processAsync)
+        {
+            lock (_disposedCancellationTokenSource)
+            {
+                if (_disposedCancellationTokenSource.IsCancellationRequested)
+                {
+                    // Shutting down
+                    return false;
+                }
+            }
+
+            var queueItem = new QueueItem(type, identifier, processAsync);
+
+            // Try and enqueue item, if this fails it means we're tearing down.
+            var enqueued = _queue.TryEnqueue(queueItem);
+            return enqueued;
+        }
+
+        public void Dispose()
+        {
+            lock (_disposedCancellationTokenSource)
+            {
+                if (_disposedCancellationTokenSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                _disposedCancellationTokenSource.Cancel();
+            }
+        }
+
+        private async Task ProcessQueueAsync()
+        {
+            try
+            {
+                while (!_disposedCancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    var work = await _queue.DequeueAsync(_disposedCancellationTokenSource.Token).ConfigureAwait(false);
+
+                    _logger.LogDebug("Queueing {Type} {Identifier} request for processing", work.Type, work.Identifier);
+
+                    if (work.Type == RequestProcessType.Serial)
+                    {
+                        // Serial requests block other requests from starting to ensure up-to-date state is used.
+                        await work.ProcessAsync(_disposedCancellationTokenSource.Token).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _ = Task.Run(() => work.ProcessAsync(_disposedCancellationTokenSource.Token), _disposedCancellationTokenSource.Token);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // We're shutting down
+            }
+            catch (Exception e)
+            {
+                _logger.LogCritical($"Work queue threw an uncaught exception. Stopping processing: {e.Message}");
+            }
+        }
+
+        private record QueueItem(RequestProcessType Type, string Identifier, ProcessSchedulerDelegate ProcessAsync);
+
+        public delegate Task ProcessSchedulerDelegate(CancellationToken cancellationToken);
+
+        public TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        public class TestAccessor
+        {
+            private readonly JsonRpcRequestScheduler _requestScheduler;
+
+            public TestAccessor(JsonRpcRequestScheduler requestScheduler)
+            {
+                _requestScheduler = requestScheduler;
+            }
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+            public Task CompleteWorkAsync() => _requestScheduler._processingQueueTask;
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonRpc/JsonRpcRequestScheduler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonRpc/JsonRpcRequestScheduler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,15 +31,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
 
         public bool Schedule(RequestProcessType type, string identifier, ProcessSchedulerDelegate processAsync)
         {
-            lock (_disposedCancellationTokenSource)
-            {
-                if (_disposedCancellationTokenSource.IsCancellationRequested)
-                {
-                    // Shutting down
-                    return false;
-                }
-            }
-
             var queueItem = new QueueItem(type, identifier, processAsync);
 
             // Try and enqueue item, if this fails it means we're tearing down.
@@ -47,15 +40,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
 
         public void Dispose()
         {
-            lock (_disposedCancellationTokenSource)
+            if (_disposedCancellationTokenSource.IsCancellationRequested)
             {
-                if (_disposedCancellationTokenSource.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                _disposedCancellationTokenSource.Cancel();
+                return;
             }
+
+            _disposedCancellationTokenSource.Cancel();
         }
 
         private async Task ProcessQueueAsync()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonRpc/RazorOmniSharpRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonRpc/RazorOmniSharpRequestInvoker.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.JsonRpc.Server;
+using OmniSharp.Extensions.JsonRpc.Server.Messages;
+using static Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc.JsonRpcRequestScheduler;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
+{
+    internal class RazorOmniSharpRequestInvoker : RequestInvoker
+    {
+        private readonly TimeSpan _requestTimeout;
+        private readonly IOutputHandler _outputHandler;
+        private readonly IRequestRouter<IHandlerDescriptor?> _requestRouter;
+        private readonly IRequestProcessIdentifier _requestProcessIdentifier;
+        private readonly JsonRpcRequestScheduler _requestScheduler;
+        private readonly ILogger<RazorOmniSharpRequestInvoker> _logger;
+
+        public RazorOmniSharpRequestInvoker(
+            RequestInvokerOptions options,
+            IOutputHandler outputHandler,
+            IRequestRouter<IHandlerDescriptor?> requestRouter,
+            IRequestProcessIdentifier requestProcessIdentifier,
+            ILoggerFactory loggerFactory)
+        {
+            _requestTimeout = options.RequestTimeout;
+            _outputHandler = outputHandler;
+            _requestRouter = requestRouter;
+            _requestProcessIdentifier = requestProcessIdentifier;
+            _requestScheduler = new JsonRpcRequestScheduler(loggerFactory);
+            _logger = loggerFactory.CreateLogger<RazorOmniSharpRequestInvoker>();
+        }
+
+        public override RequestInvocationHandle InvokeRequest(IRequestDescriptor<IHandlerDescriptor?> descriptor, Request request)
+        {
+            if (descriptor.Default is null)
+            {
+                throw new ArgumentNullException(nameof(descriptor.Default));
+            }
+
+            var handle = new RequestInvocationHandle(request);
+            var type = _requestProcessIdentifier.Identify(descriptor.Default);
+
+            var schedulerDelegate = BuildRequestDelegate(descriptor, request, handle);
+            _requestScheduler.Schedule(type, $"{request.Method}:{request.Id}", schedulerDelegate);
+
+            return handle;
+        }
+
+        public override void InvokeNotification(IRequestDescriptor<IHandlerDescriptor?> descriptor, Notification notification)
+        {
+            if (descriptor.Default is null)
+            {
+                throw new ArgumentNullException(nameof(descriptor.Default));
+            }
+
+            var type = _requestProcessIdentifier.Identify(descriptor.Default);
+            var schedulerDelegate = BuildNotificationDelegate(descriptor, notification);
+            _requestScheduler.Schedule(type, notification.Method, schedulerDelegate);
+        }
+
+        public override void Dispose()
+        {
+            _requestScheduler.Dispose();
+        }
+
+        private ProcessSchedulerDelegate BuildRequestDelegate(IRequestDescriptor<IHandlerDescriptor?> descriptors, Request request, RequestInvocationHandle handle)
+        {
+            return async (cancellationToken) =>
+            {
+                try
+                {
+                    var result = await InvokeRequestAsync(cancellationToken).ConfigureAwait(false);
+                    _outputHandler.Send(result.Value);
+                }
+                finally
+                {
+                    handle.Dispose();
+                }
+            };
+
+            async Task<ErrorResponse> InvokeRequestAsync(CancellationToken cancellationToken)
+            {
+                var timeoutCts = new CancellationTokenSource(_requestTimeout);
+                var combinedCts = CancellationTokenSource.CreateLinkedTokenSource(handle.CancellationTokenSource.Token, timeoutCts.Token, cancellationToken);
+
+                using var timer = _logger.TimeDebug("Processing request {Method}:{Id}", request.Method, request.Id);
+                try
+                {
+                    var result = await _requestRouter.RouteRequest(descriptors, request, combinedCts.Token).ConfigureAwait(false);
+                    return result;
+                }
+                catch (OperationCanceledException)
+                {
+                    if (timeoutCts.IsCancellationRequested)
+                    {
+                        _logger.LogTrace("Request {Method}:{Id} was cancelled, due to timeout", request.Method, request.Id);
+                        return new RequestCancelled(request.Id, request.Method);
+                    }
+
+                    _logger.LogTrace("Request {Method}:{Id} was cancelled", request.Method, request.Id);
+                    return new RequestCancelled(request.Id, request.Method);
+                }
+                catch (RpcErrorException e)
+                {
+                    _logger.LogCritical(Events.UnhandledRequest, e, "Failed to handle request {Method}:{Id}", request.Method, request.Id);
+                    return new RpcError(
+                        request.Id,
+                        request.Method,
+                        new ErrorMessage(e.Code, e.Message, e.Error));
+                }
+                catch (Exception e)
+                {
+                    _logger.LogCritical(Events.UnhandledRequest, e, "Failed to handle request {Method}:{Id}. Unhandled exception", request.Method, request.Id);
+                    return new InternalError(request.Id, request.Method, e.ToString());
+                }
+            }
+        }
+
+        private ProcessSchedulerDelegate BuildNotificationDelegate(IRequestDescriptor<IHandlerDescriptor?> descriptors, Notification notification)
+        {
+            return async (cancellationToken) =>
+            {
+                var timeoutCts = new CancellationTokenSource(_requestTimeout);
+                var combinedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+
+                using var timer = _logger.TimeDebug("Processing notification {Method}", notification.Method);
+                try
+                {
+                    await _requestRouter.RouteNotification(descriptors, notification, combinedCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    if (timeoutCts.IsCancellationRequested)
+                    {
+                        _logger.LogTrace("Notification {Method} was cancelled due to timeout", notification.Method);
+                        return;
+                    }
+
+                    _logger.LogTrace("Notification {Method} was cancelled", notification.Method);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogCritical(Events.UnhandledRequest, e, "Failed to handle notification {Method}", notification.Method);
+                }
+            };
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hover;
+using Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.Refactoring;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
@@ -134,6 +135,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddLogging(builder => builder
                             .SetMinimumLevel(logLevel)
                             .AddLanguageProtocolLogging());
+
+                        services.AddSingleton<RequestInvoker, RazorOmniSharpRequestInvoker>();
 
                         services.AddSingleton<FilePathNormalizer>();
                         services.AddSingleton<ProjectSnapshotManagerDispatcher, DefaultProjectSnapshotManagerDispatcher>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/JsonRpc/JsonRpcRequestSchedulerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/JsonRpc/JsonRpcRequestSchedulerTest.cs
@@ -151,26 +151,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
             Assert.False(serialRequest2Called);
         }
 
-        [Fact]
-        public void Shutdown_PreventsScheduling()
-        {
-            // Arrange
-            var called = false;
-            var request = new ProcessSchedulerDelegate((cancellationToken) =>
-            {
-                called = true;
-                return Task.CompletedTask;
-            });
-            Scheduler.Dispose();
-
-            // Act
-            var scheduled = Scheduler.Schedule(RequestProcessType.Serial, "Request", request);
-
-            // Assert
-            Assert.False(scheduled);
-            Assert.False(called);
-        }
-
         public void Dispose()
         {
             Scheduler.Dispose();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/JsonRpc/JsonRpcRequestSchedulerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/JsonRpc/JsonRpcRequestSchedulerTest.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using OmniSharp.Extensions.JsonRpc;
+using Xunit;
+using static Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc.JsonRpcRequestScheduler;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
+{
+    public class JsonRpcRequestSchedulerTest : IDisposable
+    {
+        public JsonRpcRequestSchedulerTest()
+        {
+            Scheduler = new JsonRpcRequestScheduler(TestLoggerFactory.Instance);
+            TestAccessor = Scheduler.GetTestAccessor();
+        }
+
+        private JsonRpcRequestScheduler Scheduler { get; }
+
+        private TestAccessor TestAccessor { get; }
+
+        [Fact]
+        public void SerialRequests_RunInOrder()
+        {
+            // Arrange
+            var manualResetEvent = new ManualResetEventSlim(initialState: false);
+            var callOrder = new List<int>();
+            var serialRequest1 = new ProcessSchedulerDelegate((cancellationToken) =>
+            {
+                callOrder.Add(1);
+                return Task.CompletedTask;
+            });
+            var serialRequest2 = new ProcessSchedulerDelegate((cancellationToken) =>
+            {
+                callOrder.Add(2);
+                manualResetEvent.Set();
+                return Task.CompletedTask;
+            });
+
+            // Act
+            Scheduler.Schedule(RequestProcessType.Serial, "SerialRequest1", serialRequest1);
+            Scheduler.Schedule(RequestProcessType.Serial, "SerialRequest2", serialRequest2);
+
+            // Assert
+            Assert.True(manualResetEvent.Wait(TimeSpan.FromSeconds(10)));
+            Assert.Equal(new[] { 1, 2 }, callOrder);
+        }
+
+        [Fact]
+        public void SerialRequests_RunImmediatelyAfterLongRunningParallelRequests()
+        {
+            // Arrange
+            var callOrder = new List<int>();
+            var parallelRequest = new ProcessSchedulerDelegate(async (cancellationToken) =>
+            {
+                await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken).ConfigureAwait(false);
+                callOrder.Add(2);
+            });
+            var notifySerialRequest2Done = new ManualResetEventSlim(initialState: false);
+            var serialRequest = new ProcessSchedulerDelegate((cancellationToken) =>
+            {
+                callOrder.Add(1);
+                notifySerialRequest2Done.Set();
+                return Task.CompletedTask;
+            });
+
+            // Act
+            Scheduler.Schedule(RequestProcessType.Parallel, "ParallelRequest", parallelRequest);
+            Scheduler.Schedule(RequestProcessType.Serial, "SerialRequest", serialRequest);
+
+            // Assert
+            Assert.True(notifySerialRequest2Done.Wait(TimeSpan.FromSeconds(10)));
+            Assert.Equal(new[] { 1 }, callOrder);
+        }
+
+        [Fact]
+        public async Task SerialRequests_WaitsForPreviousSerialRequests()
+        {
+            // Arrange
+            var blockSerialRequest1 = new AsyncManualResetEvent(initialState: false);
+            var serialRequest1 = new ProcessSchedulerDelegate((cancellationToken) => blockSerialRequest1.WaitAsync(cancellationToken));
+            var notifySerialRequest2Done = new AsyncManualResetEvent(initialState: false);
+            var serialRequest2 = new ProcessSchedulerDelegate((cancellationToken) =>
+            {
+                notifySerialRequest2Done.Set();
+                return Task.CompletedTask;
+            });
+
+            // Act
+            Scheduler.Schedule(RequestProcessType.Serial, "SerialRequest1", serialRequest1);
+            Scheduler.Schedule(RequestProcessType.Serial, "SerialRequest2", serialRequest2);
+
+            // Assert
+            Assert.False(notifySerialRequest2Done.IsSet);
+            blockSerialRequest1.Set();
+            using var timeoutToken = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await notifySerialRequest2Done.WaitAsync(timeoutToken.Token);
+        }
+
+        [Fact]
+        public async Task ParallelRequests_SynchronousDoNotBlockScheduler()
+        {
+            // Arrange
+            var synchronousBlock = new ManualResetEventSlim(initialState: false);
+            var parallelRequest1 = new ProcessSchedulerDelegate((cancellationToken) =>
+            {
+                synchronousBlock.Wait(cancellationToken);
+                return Task.CompletedTask;
+            });
+            var notifyParallelRequest2Done = new AsyncManualResetEvent(initialState: false);
+            var parallelRequest2 = new ProcessSchedulerDelegate((cancellationToken) =>
+            {
+                notifyParallelRequest2Done.Set();
+                return Task.CompletedTask;
+            });
+
+            // Act
+            Scheduler.Schedule(RequestProcessType.Parallel, "ParallelRequest1", parallelRequest1);
+            Scheduler.Schedule(RequestProcessType.Parallel, "ParallelRequest2", parallelRequest2);
+
+            // Assert
+            using var timeoutToken = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await notifyParallelRequest2Done.WaitAsync(timeoutToken.Token);
+        }
+
+        [Fact]
+        public async Task Shutdown_StopsQueue()
+        {
+            // Arrange
+            var serialRequest2Called = false;
+            var serialRequest1 = new ProcessSchedulerDelegate((cancellationToken) => Task.Delay(TimeSpan.FromMinutes(5), cancellationToken));
+            var serialRequest2 = new ProcessSchedulerDelegate((cancellationToken) =>
+            {
+                serialRequest2Called = true;
+                return Task.CompletedTask;
+            });
+            Scheduler.Schedule(RequestProcessType.Serial, "SerialRequest1", serialRequest1);
+            Scheduler.Schedule(RequestProcessType.Serial, "SerialRequest2", serialRequest2);
+
+            // Act
+            Scheduler.Dispose();
+
+            // Assert
+            using var timeoutToken = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await Task.Run(() => TestAccessor.CompleteWorkAsync(), timeoutToken.Token);
+            Assert.False(serialRequest2Called);
+        }
+
+        [Fact]
+        public void Shutdown_PreventsScheduling()
+        {
+            // Arrange
+            var called = false;
+            var request = new ProcessSchedulerDelegate((cancellationToken) =>
+            {
+                called = true;
+                return Task.CompletedTask;
+            });
+            Scheduler.Dispose();
+
+            // Act
+            var scheduled = Scheduler.Schedule(RequestProcessType.Serial, "Request", request);
+
+            // Assert
+            Assert.False(scheduled);
+            Assert.False(called);
+        }
+
+        public void Dispose()
+        {
+            Scheduler.Dispose();
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/JsonRpc/RazorOmniSharpRequestInvokerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/JsonRpc/RazorOmniSharpRequestInvokerTest.cs
@@ -1,0 +1,369 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.JsonRpc.Client;
+using OmniSharp.Extensions.JsonRpc.Server;
+using OmniSharp.Extensions.JsonRpc.Server.Messages;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
+{
+    public class RazorOmniSharpRequestInvokerTest
+    {
+        public RazorOmniSharpRequestInvokerTest()
+        {
+            Options = new RequestInvokerOptions(
+                requestTimeout: TimeSpan.FromSeconds(10),
+                supportContentModified: false,
+                concurrency: int.MaxValue);
+            OutputHandler = new TestOutputHandler();
+            RequestRouter = new TestRequestRouter(routeDelay: TimeSpan.Zero);
+            RequestDescriptor = new TestRequestDescriptor("textDocument/didOpen");
+            Request = new Request(id: "serial", RequestDescriptor.Default.Method, @params: null);
+            NotificationDescriptor = new TestRequestDescriptor("textDocument/didChange");
+            Notification = new Notification(NotificationDescriptor.Default.Method, @params: null);
+        }
+
+        private Notification Notification { get; }
+
+        private IRequestDescriptor<IHandlerDescriptor> NotificationDescriptor { get; }
+
+        private Request Request { get; }
+
+        private IRequestDescriptor<IHandlerDescriptor> RequestDescriptor { get; }
+
+        private RequestInvokerOptions Options { get; }
+
+        private TestOutputHandler OutputHandler { get; }
+
+        private TestRequestRouter RequestRouter { get; }
+
+        [Fact]
+        public async Task InvokeRequest_RoutesRequest()
+        {
+            // Arrange
+            using var requestInvoker = CreateRequestInvoker();
+
+            // Act
+            var handle = requestInvoker.InvokeRequest(RequestDescriptor, Request);
+            using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForCompletionAsync(handle, timeoutTokenSource.Token).ConfigureAwait(false);
+
+            // Assert
+            var response = Assert.Single(OutputHandler.SentItems);
+            Assert.IsType<TestSuccessfulResponse>(response);
+        }
+
+        [Fact]
+        public async Task InvokeRequest_CanTimeout()
+        {
+            // Arrange
+            var requestRouter = new TestRequestRouter(routeDelay: TimeSpan.FromMinutes(1));
+            using var requestInvoker = CreateRequestInvoker(requestTimeout: TimeSpan.FromMilliseconds(1), requestRouter);
+
+            // Act
+            var handle = requestInvoker.InvokeRequest(RequestDescriptor, Request);
+            using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForCompletionAsync(handle, timeoutTokenSource.Token).ConfigureAwait(false);
+
+            // Assert
+            var response = Assert.Single(OutputHandler.SentItems);
+            Assert.IsType<RequestCancelled>(response);
+        }
+
+        [Fact]
+        public async Task InvokeRequest_CanBeCancelled()
+        {
+            // Arrange
+            var requestRouter = new TestRequestRouter(routeDelay: TimeSpan.FromMinutes(1));
+            using var requestInvoker = CreateRequestInvoker(requestRouter: requestRouter);
+            var handle = requestInvoker.InvokeRequest(RequestDescriptor, Request);
+
+            // Act
+            handle.CancellationTokenSource.Cancel();
+            using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForCompletionAsync(handle, timeoutTokenSource.Token).ConfigureAwait(false);
+
+            // Assert
+            var response = Assert.Single(OutputHandler.SentItems);
+            Assert.IsType<RequestCancelled>(response);
+        }
+
+        [Fact]
+        public async Task InvokeRequest_ShutdownCancels()
+        {
+            // Arrange
+            var requestRouter = new TestRequestRouter(routeDelay: TimeSpan.FromMinutes(1));
+            using var requestInvoker = CreateRequestInvoker(requestRouter: requestRouter);
+            var handle = requestInvoker.InvokeRequest(RequestDescriptor, Request);
+
+            // Act
+            requestInvoker.Dispose(); // Shutdown the invoker
+
+            using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForCompletionAsync(handle, timeoutTokenSource.Token).ConfigureAwait(false);
+
+            // Assert
+            var response = Assert.Single(OutputHandler.SentItems);
+            Assert.IsType<RequestCancelled>(response);
+        }
+
+        [Fact]
+        public async Task InvokeRequest_UnexpectedError()
+        {
+            // Arrange
+            var requestRouter = new TestRequestRouter(onRequestCallback: () => throw new InvalidOperationException());
+            using var requestInvoker = CreateRequestInvoker(requestRouter: requestRouter);
+
+            // Act
+            var handle = requestInvoker.InvokeRequest(RequestDescriptor, Request);
+            using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForCompletionAsync(handle, timeoutTokenSource.Token).ConfigureAwait(false);
+
+            // Assert
+            var response = Assert.Single(OutputHandler.SentItems);
+            Assert.IsType<InternalError>(response);
+        }
+
+        [Fact]
+        public async Task InvokeNotification_RoutesNotification()
+        {
+            // Arrange
+            using var requestInvoker = CreateRequestInvoker();
+            var asyncResetEvent = new AsyncManualResetEvent(initialState: false);
+            RequestRouter.OnNotificationCompleted += (notification) =>
+            {
+                asyncResetEvent.Set();
+            };
+
+            // Act
+            requestInvoker.InvokeNotification(NotificationDescriptor, Notification);
+
+            // Assert
+            using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await asyncResetEvent.WaitAsync(timeoutTokenSource.Token).ConfigureAwait(false);
+            Assert.Empty(OutputHandler.SentItems);
+        }
+
+        [Fact]
+        public async Task InvokeNotification_CanTimeout()
+        {
+            // Arrange
+            var requestRouter = new TestRequestRouter(routeDelay: TimeSpan.FromMinutes(1));
+            using var requestInvoker = CreateRequestInvoker(requestTimeout: TimeSpan.FromMilliseconds(1), requestRouter);
+            var asyncResetEvent = new AsyncManualResetEvent(initialState: false);
+            requestRouter.OnNotificationCancelled += (notification) =>
+            {
+                asyncResetEvent.Set();
+            };
+
+            // Act
+            requestInvoker.InvokeNotification(NotificationDescriptor, Notification);
+
+            // Assert
+            using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await asyncResetEvent.WaitAsync(timeoutTokenSource.Token).ConfigureAwait(false);
+            Assert.Empty(OutputHandler.SentItems);
+        }
+
+        [Fact]
+        public async Task InvokeNotification_ShutdownCancels()
+        {
+            // Arrange
+            var requestRouter = new TestRequestRouter(routeDelay: TimeSpan.FromMinutes(1));
+            using var requestInvoker = CreateRequestInvoker(requestRouter: requestRouter);
+            var asyncResetEvent = new AsyncManualResetEvent(initialState: false);
+            requestRouter.OnNotificationCancelled += (notification) =>
+            {
+                asyncResetEvent.Set();
+            };
+            requestInvoker.InvokeNotification(NotificationDescriptor, Notification);
+
+            // Act
+            requestInvoker.Dispose(); // Shutdown the invoker
+
+            // Assert
+            using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await asyncResetEvent.WaitAsync(timeoutTokenSource.Token).ConfigureAwait(false);
+            Assert.Empty(OutputHandler.SentItems);
+        }
+
+        private Task WaitForCompletionAsync(RequestInvocationHandle handle, CancellationToken cancellationToken)
+        {
+            var asyncResetEvent = new AsyncManualResetEvent(initialState: false);
+            handle.OnComplete += (r) =>
+            {
+                asyncResetEvent.Set();
+            };
+            return asyncResetEvent.WaitAsync(cancellationToken);
+        }
+
+        private RazorOmniSharpRequestInvoker CreateRequestInvoker(
+            TimeSpan? requestTimeout = null,
+            TestRequestRouter requestRouter = null)
+        {
+            var options = requestTimeout == null ? Options : new RequestInvokerOptions(requestTimeout.Value, supportContentModified: false, concurrency: int.MaxValue);
+            requestRouter ??= RequestRouter;
+            var requestInvoker = new RazorOmniSharpRequestInvoker(
+                options,
+                OutputHandler,
+                requestRouter,
+                TestRequestProcessIdentifier.Instance,
+                TestLoggerFactory.Instance);
+            return requestInvoker;
+        }
+
+        private class TestOutputHandler : IOutputHandler
+        {
+            private readonly List<object> _sentItems = new();
+
+            public IReadOnlyList<object> SentItems => _sentItems;
+
+            public void Send(object value)
+            {
+                _sentItems.Add(value);
+            }
+
+            public Task StopAsync()
+            {
+                return Task.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private class TestRequestRouter : IRequestRouter<IHandlerDescriptor>
+        {
+            private readonly TimeSpan _routeDelay;
+            private readonly Action _onRequestCallback;
+
+            public event Action<Notification> OnNotificationCancelled;
+
+            public event Action<Notification> OnNotificationCompleted;
+
+            public TestRequestRouter(
+                TimeSpan? routeDelay = null,
+                Action onRequestCallback = null)
+            {
+                _routeDelay = routeDelay ?? TimeSpan.Zero;
+                _onRequestCallback = onRequestCallback;
+            }
+
+            public IRequestDescriptor<IHandlerDescriptor> GetDescriptors(Notification notification)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IRequestDescriptor<IHandlerDescriptor> GetDescriptors(Request request)
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task RouteNotification(IRequestDescriptor<IHandlerDescriptor> descriptors, Notification notification, CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await Task.Delay(_routeDelay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    OnNotificationCancelled?.Invoke(notification);
+                    throw;
+                }
+
+                OnNotificationCompleted?.Invoke(notification);
+            }
+
+            public async Task<ErrorResponse> RouteRequest(IRequestDescriptor<IHandlerDescriptor> descriptors, Request request, CancellationToken cancellationToken)
+            {
+                _onRequestCallback?.Invoke();
+
+                await Task.Delay(_routeDelay, cancellationToken).ConfigureAwait(false);
+
+                var successfulResponse = new TestSuccessfulResponse(request.Id, request);
+                return new ErrorResponse(successfulResponse);
+            }
+        }
+
+        private record TestSuccessfulResponse : OutgoingResponse
+        {
+            public TestSuccessfulResponse(object id, Request request) : base(id, result: true, request)
+            {
+
+            }
+        }
+
+        private class TestRequestProcessIdentifier : IRequestProcessIdentifier
+        {
+            public static readonly TestRequestProcessIdentifier Instance = new();
+
+            private TestRequestProcessIdentifier()
+            {
+            }
+
+            public RequestProcessType Identify(IHandlerDescriptor descriptor)
+            {
+                if (descriptor.Method.StartsWith("textDocument/did"))
+                {
+                    return RequestProcessType.Serial;
+                }
+
+                return RequestProcessType.Parallel;
+            }
+        }
+
+        private class TestRequestDescriptor : IRequestDescriptor<IHandlerDescriptor>
+        {
+            public TestRequestDescriptor(string method)
+            {
+                Default = new TestHandlerDescriptor(method);
+            }
+
+            public IHandlerDescriptor Default { get; }
+
+            public IEnumerator<IHandlerDescriptor> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            private class TestHandlerDescriptor : IHandlerDescriptor
+            {
+                public TestHandlerDescriptor(string method)
+                {
+                    Method = method;
+                }
+                public string Method { get; }
+
+                public Type HandlerType => throw new NotImplementedException();
+
+                public Type ImplementationType => throw new NotImplementedException();
+
+                public Type Params => throw new NotImplementedException();
+
+                public Type Response => throw new NotImplementedException();
+
+                public bool HasReturnType => throw new NotImplementedException();
+
+                public bool IsDelegatingHandler => throw new NotImplementedException();
+
+                public IJsonRpcHandler Handler => throw new NotImplementedException();
+
+                public RequestProcessType? RequestProcessType => throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/JsonRpc/TestLoggerFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/JsonRpc/TestLoggerFactory.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
+{
+    public class TestLoggerFactory : ILoggerFactory
+    {
+        public static readonly TestLoggerFactory Instance = new();
+
+        private TestLoggerFactory()
+        {
+
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName) => new TestLogger();
+
+        public void Dispose()
+        {
+        }
+
+        private class TestLogger : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) => new DisposableScope();
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+            }
+
+            private class DisposableScope : IDisposable
+            {
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- We now include our own request invoker that doesn't respect content modified or concurrency options. Reasons being is that content modified in O# represents a Serial request has come in, cancel all parallel requests; we don't want this in VS because it can operate on out-of-date data. We then don't need to respect the concurrency option because by default we have unbounded concurrency :D.
- Our request invoker has the following patterns:
    - Request is serial, await it before executing any additional requests
    - Request is parallel, fire and forget it. Allow O# to cancel it if needed.
- Broke up request invocation & request scheduling in order to follow O#'s separation of concerns. This enables us to function semi-like the defaults in the framework while simultaneously enabling new features.
- Added extensive tests for both the scheduler and invoker.

Fixes dotnet/aspnetcore#31356