### PR TITLE
Avoid capturing unnecessary solutions in WorkspaceProjectStateChangeDetector

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcher.cs
@@ -17,6 +17,9 @@ namespace Microsoft.CodeAnalysis.Razor
         public Task RunOnDispatcherThreadAsync(Action action, CancellationToken cancellationToken)
             => Task.Factory.StartNew(action, cancellationToken, TaskCreationOptions.None, DispatcherScheduler);
 
+        public Task RunOnDispatcherThreadAsync<T>(Action<T, CancellationToken> action, T state, CancellationToken cancellationToken)
+            => Task.Factory.StartNew(() => action(state, cancellationToken), cancellationToken, TaskCreationOptions.None, DispatcherScheduler);
+
         public Task<TResult> RunOnDispatcherThreadAsync<TResult>(Func<TResult> action, CancellationToken cancellationToken)
             => Task.Factory.StartNew(action, cancellationToken, TaskCreationOptions.None, DispatcherScheduler);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioFileChangeTracker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioFileChangeTracker.cs
@@ -72,22 +72,25 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
         {
             _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
-            if (_fileChangeUnadviseTask?.IsCompleted == false)
-            {
-                // An unadvise operation is still processing, block the project snapshot manager's thread until it completes.
-                _fileChangeUnadviseTask.Join();
-            }
-
             if (_fileChangeAdviseTask != null)
             {
                 // Already listening
                 return;
             }
 
+            // If an unadvise operation is still processing, we don't start listening until it completes.
+            if (_fileChangeUnadviseTask is not { IsCompleted: false } fileChangeUnadviseTaskToJoin)
+            {
+                fileChangeUnadviseTaskToJoin = null;
+            }
+
             _fileChangeAdviseTask = _joinableTaskContext.Factory.RunAsync(async () =>
             {
                 try
                 {
+                    if (fileChangeUnadviseTaskToJoin is not null)
+                        await fileChangeUnadviseTaskToJoin.JoinAsync().ConfigureAwait(true);
+
                     return await _fileChangeService.AdviseFileChangeAsync(FilePath, FileChangeFlags, this).ConfigureAwait(true);
                 }
                 catch (PathTooLongException)


### PR DESCRIPTION
* Join asynchronously instead of blocking the dispatcher thread
* Avoid capturing unnecessary solutions in WorkspaceProjectStateChangeDetector