### PR TITLE
Don't leak when documents / projects / solutions get removed or closed.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDynamicFileInfoProvider.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
-    internal abstract class RazorDynamicFileInfoProvider
+    internal abstract class RazorDynamicFileInfoProvider : ProjectSnapshotChangeTrigger
     {
         public abstract void UpdateLSPFileInfo(Uri documentUri, DynamicDocumentContainer documentContainer);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -382,6 +382,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             public IReadOnlyDictionary<string, DynamicDocumentContainer> DynamicDocuments => _dynamicDocuments;
 
+            public override void Initialize(ProjectSnapshotManagerBase projectManager)
+            {
+            }
+
             public override void SuppressDocument(string projectFilePath, string documentFilePath)
             {
                 _dynamicDocuments[documentFilePath] = null;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDynamicFileInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDynamicFileInfoProviderTest.cs
@@ -2,37 +2,161 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Moq;
 using Xunit;
 using Xunit.Sdk;
+using static Microsoft.CodeAnalysis.Razor.Workspaces.DefaultRazorDynamicFileInfoProvider;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor.ProjectSystem
 {
-    public class DefaultRazorDynamicFileInfoProviderTest
+    public class DefaultRazorDynamicFileInfoProviderTest : WorkspaceTestBase
     {
         public DefaultRazorDynamicFileInfoProviderTest()
         {
-            DocumentServiceFactory = Mock.Of<RazorDocumentServiceProviderFactory>(MockBehavior.Strict);
+            DocumentServiceFactory = new DefaultRazorDocumentServiceProviderFactory();
             EditorFeatureDetector = Mock.Of<LSPEditorFeatureDetector>(MockBehavior.Strict);
+            ProjectSnapshotManager = new TestProjectSnapshotManager(Workspace)
+            {
+                AllowNotifyListeners = true
+            };
+            var hostProject = new HostProject("C:\\project.csproj", RazorConfiguration.Default, rootNamespace: "TestNamespace");
+            ProjectSnapshotManager.ProjectAdded(hostProject);
+            var hostDocument1 = new HostDocument("C:\\document1.razor", "document1.razor", FileKinds.Component);
+            ProjectSnapshotManager.DocumentAdded(hostProject, hostDocument1, new EmptyTextLoader(hostDocument1.FilePath));
+            var hostDocument2 = new HostDocument("C:\\document2.razor", "document2.razor", FileKinds.Component);
+            ProjectSnapshotManager.DocumentAdded(hostProject, hostDocument2, new EmptyTextLoader(hostDocument2.FilePath));
+            Project = ProjectSnapshotManager.GetSnapshot(hostProject);
+            Document1 = (DefaultDocumentSnapshot)Project.GetDocument(hostDocument1.FilePath);
+            Document2 = (DefaultDocumentSnapshot)Project.GetDocument(hostDocument2.FilePath);
+
+            Provider = new DefaultRazorDynamicFileInfoProvider(DocumentServiceFactory, EditorFeatureDetector);
+            TestAccessor = Provider.GetTestAccessor();
+            Provider.Initialize(ProjectSnapshotManager);
+
+            var lspDocumentContainer = new Mock<DynamicDocumentContainer>(MockBehavior.Strict);
+            lspDocumentContainer.SetupSet(c => c.SupportsDiagnostics = true).Verifiable();
+            lspDocumentContainer.Setup(container => container.GetTextLoader(It.IsAny<string>())).Returns(new EmptyTextLoader(string.Empty));
+            LSPDocumentContainer = lspDocumentContainer.Object;
         }
+
+        private DefaultRazorDynamicFileInfoProvider Provider { get; }
+
+        private TestAccessor TestAccessor { get; }
 
         private RazorDocumentServiceProviderFactory DocumentServiceFactory { get; }
         private LSPEditorFeatureDetector EditorFeatureDetector { get; }
+
+        private TestProjectSnapshotManager ProjectSnapshotManager { get; }
+
+        private DefaultProjectSnapshot Project { get; }
+
+        private DefaultDocumentSnapshot Document1 { get; }
+
+        private DefaultDocumentSnapshot Document2 { get; }
+
+        private DynamicDocumentContainer LSPDocumentContainer { get; }
 
         [Fact]
         public void UpdateLSPFileInfo_UnknownFile_Noops()
         {
             // Arrange
-            var provider = new DefaultRazorDynamicFileInfoProvider(DocumentServiceFactory, EditorFeatureDetector);
-            provider.Updated += (sender, args) => throw new XunitException("Should not have been called.");
+            Provider.Updated += (sender, args) => throw new XunitException("Should not have been called.");
 
             // Act & Assert
             var documentContainer = new Mock<DynamicDocumentContainer>(MockBehavior.Strict);
             documentContainer.SetupSet(c => c.SupportsDiagnostics = true).Verifiable();
-            provider.UpdateLSPFileInfo(new Uri("C:/this/does/not/exist.razor"), documentContainer.Object);
+            Provider.UpdateLSPFileInfo(new Uri("C:/this/does/not/exist.razor"), documentContainer.Object);
         }
 
-        // Can't currently add any more tests because of IVT restrictions from Roslyn
+        [Fact]
+        public async Task UpdateLSPFileInfo_Updates()
+        {
+            // Arrange
+            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document1.FilePath, CancellationToken.None).ConfigureAwait(false);
+            var called = false;
+            Provider.Updated += (sender, args) => called = true;
+
+            // Act
+            Provider.UpdateLSPFileInfo(new Uri(Document1.FilePath), LSPDocumentContainer);
+
+            // Assert
+            Assert.True(called);
+        }
+
+        [Fact]
+        public async Task UpdateLSPFileInfo_ProjectRemoved_Noops()
+        {
+            // Arrange
+            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document1.FilePath, CancellationToken.None).ConfigureAwait(false);
+            var called = false;
+            Provider.Updated += (sender, args) => called = true;
+            ProjectSnapshotManager.ProjectRemoved(Project.HostProject);
+
+            // Act
+            Provider.UpdateLSPFileInfo(new Uri(Document1.FilePath), LSPDocumentContainer);
+
+            // Assert
+            Assert.False(called);
+        }
+
+        [Fact]
+        public async Task UpdateLSPFileInfo_DocumentRemoved_Noops()
+        {
+            // Arrange
+            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document1.FilePath, CancellationToken.None).ConfigureAwait(false);
+            var called = false;
+            Provider.Updated += (sender, args) => called = true;
+            ProjectSnapshotManager.DocumentRemoved(Project.HostProject, Document1.State.HostDocument);
+
+            // Act
+            Provider.UpdateLSPFileInfo(new Uri(Document1.FilePath), LSPDocumentContainer);
+
+            // Assert
+            Assert.False(called);
+        }
+
+        [Fact]
+        public async Task UpdateLSPFileInfo_UnrelatedDocumentRemoved_UpdateOnlyValidDocuments()
+        {
+            // Arrange
+            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document1.FilePath, CancellationToken.None).ConfigureAwait(false);
+            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document2.FilePath, CancellationToken.None).ConfigureAwait(false);
+            var callCount = 0;
+            Provider.Updated += (sender, documentFilePath) =>
+            {
+                Assert.Equal(Document1.FilePath, documentFilePath);
+                callCount++;
+            };
+            ProjectSnapshotManager.DocumentRemoved(Project.HostProject, Document2.State.HostDocument);
+
+            // Act
+            Provider.UpdateLSPFileInfo(new Uri(Document2.FilePath), LSPDocumentContainer);
+            Provider.UpdateLSPFileInfo(new Uri(Document1.FilePath), LSPDocumentContainer);
+
+            // Assert
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task UpdateLSPFileInfo_SolutionClosing_ClearsAllDocuments()
+        {
+            // Arrange
+            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document1.FilePath, CancellationToken.None).ConfigureAwait(false);
+            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document2.FilePath, CancellationToken.None).ConfigureAwait(false);
+            Provider.Updated += (sender, documentFilePath) => throw new InvalidOperationException("Should not have been called!");
+
+            ProjectSnapshotManager.SolutionClosed();
+            ProjectSnapshotManager.DocumentClosed(Project.FilePath, Document1.FilePath, new EmptyTextLoader(string.Empty));
+
+            // Act & Assert
+            Provider.UpdateLSPFileInfo(new Uri(Document2.FilePath), LSPDocumentContainer);
+            Provider.UpdateLSPFileInfo(new Uri(Document1.FilePath), LSPDocumentContainer);
+        }
     }
 }


### PR DESCRIPTION
- After investigation we found that Roslyn doesn't call into our "remove" method for our dynamic file info provider stack when projects/solutions tear down. From Roslyn's perspective this is by-design. To ensure this by-design behavior mistake doesn't get repeated I've decorated our pre-existing `RemoveDynamicFileInfoAsync` method with a nice comment indicating why we shouldn't rely on it. The true future proof fix here will be removing the remove call-path on Roslyn's front.
- Ultimately this fix encompasses hooking into our `ProjectSnapshotManager` event loop to detect cases when projects/documents/solutions get removed and tear down our internal state in response. This ensures that we no longer leak entries when solutions are closed. Specifically these entries no longer leak:
![image](https://i.imgur.com/tTKO2As.png)

- Significantly expanded our test infrastructure and used the `TestAccessor` pattern to work around IVT limitations.

Fixes dotnet/aspnetcore#35865