### PR TITLE
Don't format object, collection and array initalizers

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -451,10 +451,7 @@ input: @"
             {
                 public Foo()
                 {
-                    var arr = new string[ ] {
-""One"", ""two"",
-""three""
-                    };
+                    var arr = new string[ ] { ""One"", ""two"",""three"" };
                     var str = @""
 This should
 not
@@ -478,10 +475,7 @@ expected: @"@using System.Buffers
     {
         public Foo()
         {
-            var arr = new string[] {
-""One"", ""two"",
-""three""
-                };
+            var arr = new string[] { ""One"", ""two"", ""three"" };
             var str = @""
 This should
 not
@@ -688,6 +682,52 @@ expected: @"@code {
         </Counter>
         forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
     }
+}
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/34320")]
+        public async Task CodeBlock_ObjectCollectionArrayInitializers()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@code {
+    public List<object> AList = new List<object>()
+    {
+        new
+        {
+            Name = ""One"",
+            Goo = new
+            {
+                First = 1,
+                Second = 2
+            },
+            Bar = new string[] {
+                ""Hello"",
+                ""There""
+            }
+        }
+    };
+}
+",
+expected: @"@code {
+    public List<object> AList = new List<object>()
+    {
+        new
+        {
+            Name = ""One"",
+            Goo = new
+            {
+                First = 1,
+                Second = 2
+            },
+            Bar = new string[] {
+                ""Hello"",
+                ""There""
+            }
+        }
+    };
 }
 ");
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -690,6 +690,8 @@ expected: @"@code {
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/34320")]
         public async Task CodeBlock_ObjectCollectionArrayInitializers()
         {
+            // The C# Formatter doesn't touch these types of initializers, so nor to we. This test
+            // just verifies we don't regress things and start moving code around.
             await RunFormattingTestAsync(
 input: @"
 @code {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/34320

I don't love this, but it is better than the current behaviour. Curious for your thoughts.

Also this took way too long to find out what was going on 😛