### PR TITLE
Correct '<' classification in Textmate

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -87,10 +87,21 @@
 
       <!-- Begin HTML specific colorization -->
 
-      <!-- [<]a[>] href[=]"Hello"> -->
+      <!-- [<]a href="Hello"[>]-->
       <dict>
         <key>scope</key>
-        <string>punctuation.definition.tag, punctuation.separator.key-value.html</string>
+        <string>punctuation.definition.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>HTML Tag Delimiter</string>
+        </dict>
+      </dict>
+
+      <!-- <a href[=]"Hello"> -->
+      <dict>
+        <key>scope</key>
+        <string>punctuation.separator.key-value.html</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -87,7 +87,7 @@
 
       <!-- Begin HTML specific colorization -->
 
-      <!-- [<]a href="Hello"[>]-->
+      <!-- [<]a href="Hello"[/>]-->
       <dict>
         <key>scope</key>
         <string>punctuation.definition.tag</string>


### PR DESCRIPTION
### Summary of the changes
 - The problem here was that our TextMate definition was overgeneralizing `HTML Operator` to include the `<` and `>`. By giving it it's own entry we can match it to `HTML Tag Delimiter` which matches the behavior in regular HTML files.

Fixes: https://github.com/dotnet/aspnetcore/issues/35860