### PR TITLE
Have different dispatcher schedulers for VS & our language server.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/BackgroundDocumentGenerator.cs
@@ -199,7 +199,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 {
                     await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
                         () => NotifyDocumentsProcessed(work),
-                        CancellationToken.None);
+                        CancellationToken.None).ConfigureAwait(false);
                 }
 
                 lock (_work)
@@ -331,7 +331,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         {
             _ = _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
                 () => _projectManager.ReportError(ex),
-                CancellationToken.None);
+                CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 _documentResolver.TryResolveDocument(request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
 
                 return documentSnapshot;
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             if (document is null || cancellationToken.IsCancellationRequested)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 _documentResolver.TryResolveDocument(request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
 
                 return documentSnapshot;
-            }, CancellationToken.None);
+            }, CancellationToken.None).ConfigureAwait(false);
 
             if (document is null || cancellationToken.IsCancellationRequested)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 _documentResolver.TryResolveDocument(request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
 
                 return documentSnapshot;
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             if (document is null || cancellationToken.IsCancellationRequested)
             {
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 _documentResolver.TryResolveDocument(request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
 
                 return documentSnapshot;
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             if (document is null || cancellationToken.IsCancellationRequested)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 _documentResolver.TryResolveDocument(request.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
 
                 return documentSnapshot;
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             if (document is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LSPProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LSPProjectSnapshotManagerDispatcher.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable enable
+
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class LSPProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcherBase
+    {
+        private const string ThreadName = "Razor." + nameof(LSPProjectSnapshotManagerDispatcher);
+
+        public LSPProjectSnapshotManagerDispatcher() : base(ThreadName)
+        {
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
                 }
 
                 return documentSnapshot;
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             if (document is null || cancellationToken.IsCancellationRequested)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     FileSystemWatcher_ProjectConfigurationFileEvent(configurationFilePath, RazorFileChangeKind.Added);
                 }
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             // This is an entry point for testing
             OnInitializationFinished();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     FileSystemWatcher_ProjectFileEvent(projectFilePath, RazorFileChangeKind.Added);
                 }
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             // This is an entry point for testing
             OnInitializationFinished();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
                 ClearClosedDocuments,
-                CancellationToken.None);
+                CancellationToken.None).ConfigureAwait(false);
         }
 
         // Internal for testing

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 _documentResolver.TryResolveDocument(notification.TextDocument.Uri.GetAbsoluteOrUNCPath(), out var documentSnapshot);
 
                 return documentSnapshot;
-            }, CancellationToken.None);
+            }, CancellationToken.None).ConfigureAwait(false);
 
             var sourceText = await document.GetTextAsync();
             sourceText = ApplyContentChanges(notification.ContentChanges, sourceText);
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
                 () => _projectService.UpdateDocument(document.FilePath, sourceText, notification.TextDocument.Version.Value),
-                CancellationToken.None);
+                CancellationToken.None).ConfigureAwait(false);
 
             return Unit.Value;
         }
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
                 () => _projectService.OpenDocument(notification.TextDocument.Uri.GetAbsoluteOrUNCPath(), sourceText, notification.TextDocument.Version.Value),
-                CancellationToken.None);
+                CancellationToken.None).ConfigureAwait(false);
 
             return Unit.Value;
         }
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
                 () => _projectService.CloseDocument(notification.TextDocument.Uri.GetAbsoluteOrUNCPath()),
-                CancellationToken.None);
+                CancellationToken.None).ConfigureAwait(false);
 
             return Unit.Value;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     FileSystemWatcher_RazorFileEvent(razorFilePath, RazorFileChangeKind.Added);
                 }
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             // This is an entry point for testing
             OnInitializationFinished();
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
                 () => NotifyAfterDelay_ProjectSnapshotManagerDispatcher(physicalFilePath),
-                CancellationToken.None);
+                CancellationToken.None).ConfigureAwait(false);
         }
 
         private void NotifyAfterDelay_ProjectSnapshotManagerDispatcher(string physicalFilePath)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 }
 
                 return documentSnapshot;
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
             var sourceText = await documentSnapshot.GetTextAsync();
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     documentVersion = null;
                 }
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             if (request.Kind != RazorLanguageKind.CSharp)
             {
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 {
                     documentVersion = null;
                 }
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
             if (codeDocument.IsUnsupported())

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<RequestInvoker, RazorOmniSharpRequestInvoker>();
 
                         services.AddSingleton<FilePathNormalizer>();
-                        services.AddSingleton<ProjectSnapshotManagerDispatcher, DefaultProjectSnapshotManagerDispatcher>();
+                        services.AddSingleton<ProjectSnapshotManagerDispatcher, LSPProjectSnapshotManagerDispatcher>();
                         services.AddSingleton<GeneratedDocumentPublisher, DefaultGeneratedDocumentPublisher>();
                         services.AddSingleton<AdhocWorkspaceFactory, DefaultAdhocWorkspaceFactory>();
                         services.AddSingleton<ProjectSnapshotChangeTrigger>((services) => services.GetRequiredService<GeneratedDocumentPublisher>());

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -604,7 +604,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                 _documentVersionCache.TryGetDocumentVersion(documentSnapshot, out var version);
 
                 return (documentSnapshot, version);
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             return documentInfo;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/DefaultOmniSharpProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/DefaultOmniSharpProjectSnapshotManagerDispatcher.cs
@@ -11,11 +11,20 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     {
         public DefaultOmniSharpProjectSnapshotManagerDispatcher()
         {
-            InternalDispatcher = new DefaultProjectSnapshotManagerDispatcher();
+            InternalDispatcher = new OmniSharpProjectSnapshotManagerDispatcher();
         }
 
         public override TaskScheduler DispatcherScheduler => InternalDispatcher.DispatcherScheduler;
 
         public override void AssertDispatcherThread([CallerMemberName] string caller = null) => InternalDispatcher.AssertDispatcherThread(caller);
+
+        private class OmniSharpProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcherBase
+        {
+            private const string ThreadName = "Razor." + nameof(OmniSharpProjectSnapshotManagerDispatcher);
+
+            public OmniSharpProjectSnapshotManagerDispatcher() : base(ThreadName)
+            {
+            }
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpWorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpWorkspaceProjectStateChangeDetector.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed
                             Debug.Fail("Unexpected error when initializing solution: " + ex);
                         }
                     },
-                    CancellationToken.None);
+                    CancellationToken.None).ConfigureAwait(false);
             }
 
             // We override Workspace_WorkspaceChanged in order to enforce calls to this to be on the project snapshot manager's
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed
                             Debug.Fail("Unexpected error when handling a workspace changed event: " + ex);
                         }
                     },
-                    CancellationToken.None);
+                    CancellationToken.None).ConfigureAwait(false);
             }
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             projectInstance = _projectInstanceEvaluator.Evaluate(projectInstance);
 
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
-                () => UpdateProjectState(projectInstance), CancellationToken.None);
+                () => UpdateProjectState(projectInstance), CancellationToken.None).ConfigureAwait(false);
         }
 
         private void UpdateProjectState(ProjectInstance projectInstance)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                                 state.self.EnqueueUpdateOnProjectAndDependencies(project, state.NewSolution);
                             },
                             (self: this, e.ProjectId, e.NewSolution),
-                            CancellationToken.None);
+                            CancellationToken.None).ConfigureAwait(false);
                         break;
 
                     case WorkspaceChangeKind.ProjectChanged:
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                                 state.self.EnqueueUpdateOnProjectAndDependencies(project, state.NewSolution);
                             },
                             (self: this, e.ProjectId, e.NewSolution),
-                            CancellationToken.None);
+                            CancellationToken.None).ConfigureAwait(false);
                         break;
 
                     case WorkspaceChangeKind.ProjectRemoved:
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                                 }
                             },
                             (self: this, e.ProjectId, e.OldSolution),
-                            CancellationToken.None);
+                            CancellationToken.None).ConfigureAwait(false);
                         break;
 
                     case WorkspaceChangeKind.DocumentAdded:
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                                 }
                             },
                             (self: this, e.ProjectId, e.DocumentId, e.NewSolution),
-                            CancellationToken.None);
+                            CancellationToken.None).ConfigureAwait(false);
                         break;
 
                     case WorkspaceChangeKind.DocumentRemoved:
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                                 }
                             },
                             (self: this, e.OldSolution, e.ProjectId, e.DocumentId, e.NewSolution),
-                            CancellationToken.None);
+                            CancellationToken.None).ConfigureAwait(false);
                         break;
 
                     case WorkspaceChangeKind.DocumentChanged:
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                                 }
                             },
                             (self: this, e.OldSolution, e.ProjectId, e.DocumentId, e.NewSolution),
-                            CancellationToken.None);
+                            CancellationToken.None).ConfigureAwait(false);
                         break;
 
                     case WorkspaceChangeKind.SolutionAdded:
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                                 state.self.InitializeSolution(state.NewSolution);
                             },
                             (self: this, oldProjectPaths: e.OldSolution?.Projects.Select(p => p?.FilePath), e.NewSolution),
-                            CancellationToken.None);
+                            CancellationToken.None).ConfigureAwait(false);
                         break;
                 }
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorDocumentManager.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 {
                     // tracker.Subscribe() accesses the project snapshot manager, which needs to be run on the
                     // project snapshot manager's specialized thread.
-                    await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() => tracker.Subscribe(), CancellationToken.None);
+                    await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() => tracker.Subscribe(), CancellationToken.None).ConfigureAwait(false);
                 }
             }
         }
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     {
                         // tracker.Unsubscribe() should be in sync with tracker.Subscribe(). The latter of needs to be run
                         // on the project snapshot manager's specialized thread, so we run both on it.
-                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() => documentTracker.Unsubscribe(), CancellationToken.None);
+                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() => documentTracker.Unsubscribe(), CancellationToken.None).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocument.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             if (textBuffer == null)
             {
                 _ = _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
-                    () => _fileTracker.StartListening(), CancellationToken.None);
+                    () => _fileTracker.StartListening(), CancellationToken.None).ConfigureAwait(false);
             }
             else
             {
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             }
 
             _ = _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
-                () => _fileTracker.StopListening(), CancellationToken.None);
+                () => _fileTracker.StopListening(), CancellationToken.None).ConfigureAwait(false);
 
             _snapshotTracker.StartTracking(textBuffer);
             EditorTextBuffer = textBuffer;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 {
                     var document = (EditorDocument)sender;
                     _projectManager.DocumentChanged(document.ProjectFilePath, document.DocumentFilePath, document.TextLoader);
-                }, CancellationToken.None);
+                }, CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 {
                     var document = (EditorDocument)sender;
                     _projectManager.DocumentChanged(document.ProjectFilePath, document.DocumentFilePath, document.EditorTextContainer.CurrentText);
-                }, CancellationToken.None);
+                }, CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 {
                     var document = (EditorDocument)sender;
                     _projectManager.DocumentOpened(document.ProjectFilePath, document.DocumentFilePath, document.EditorTextContainer.CurrentText);
-                }, CancellationToken.None);
+                }, CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 {
                     var document = (EditorDocument)sender;
                     _projectManager.DocumentClosed(document.ProjectFilePath, document.DocumentFilePath, document.TextLoader);
-                }, CancellationToken.None);
+                }, CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
@@ -8,7 +8,13 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     [Export(typeof(ProjectSnapshotManagerDispatcher))]
-    internal class VisualStudioProjectSnapshotManagerDispatcher : DefaultProjectSnapshotManagerDispatcher
+    internal class VisualStudioProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcherBase
     {
+        private const string ThreadName = "Razor." + nameof(VisualStudioProjectSnapshotManagerDispatcher);
+
+        public VisualStudioProjectSnapshotManagerDispatcher() : base(ThreadName)
+        {
+
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/RazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/RazorProjectHostBase.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
         protected async Task UpdateHostProjectUnsafeAsync(HostProject newHostProject)
         {
             await ProjectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
-                () => UpdateHostProjectProjectSnapshotManagerDispatcher(newHostProject), CancellationToken.None);
+                () => UpdateHostProjectProjectSnapshotManagerDispatcher(newHostProject), CancellationToken.None).ConfigureAwait(false);
         }
 
         protected async Task ExecuteWithLockAsync(Func<Task> func)

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
@@ -8,7 +8,13 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
 {
     [Export(typeof(ProjectSnapshotManagerDispatcher))]
-    internal class VisualStudioProjectSnapshotManagerDispatcher : DefaultProjectSnapshotManagerDispatcher
+    internal class VisualStudioProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcherBase
     {
+        private const string ThreadName = "Razor." + nameof(VisualStudioProjectSnapshotManagerDispatcher);
+
+        public VisualStudioProjectSnapshotManagerDispatcher() : base(ThreadName)
+        {
+
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -27,7 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         public async Task Handle_MissingFile()
         {
             // Arrange
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), _emptyDocumentResolver);
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, _emptyDocumentResolver);
             var data = JObject.FromObject(new AddUsingsCodeActionParams()
             {
                 Uri = new Uri("c:/Test.razor"),
@@ -50,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             codeDocument.SetUnsupported();
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var data = JObject.FromObject(new AddUsingsCodeActionParams()
             {
                 Uri = new Uri(documentPath),
@@ -73,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = string.Empty;
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new AddUsingsCodeActionParams
             {
                 Uri = documentUri,
@@ -107,7 +106,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@page \"/\"{Environment.NewLine}";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new AddUsingsCodeActionParams
             {
                 Uri = documentUri,
@@ -148,7 +147,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = projectEngine.Process(projectItem);
             codeDocument.SetFileKind(FileKinds.Legacy);
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new AddUsingsCodeActionParams
             {
                 Uri = documentUri,
@@ -181,7 +180,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"<table>{Environment.NewLine}<tr>{Environment.NewLine}</tr>{Environment.NewLine}</table>";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new AddUsingsCodeActionParams
             {
                 Uri = documentUri,
@@ -214,7 +213,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@namespace Testing{Environment.NewLine}";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new AddUsingsCodeActionParams
             {
                 Uri = documentUri,
@@ -247,7 +246,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@page \"/\"{Environment.NewLine}@namespace Testing{Environment.NewLine}";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new AddUsingsCodeActionParams
             {
                 Uri = documentUri,
@@ -280,7 +279,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@using System";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new AddUsingsCodeActionParams
             {
                 Uri = documentUri,
@@ -313,7 +312,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@using System{Environment.NewLine}@using System.Linq{Environment.NewLine}";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new AddUsingsCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new AddUsingsCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new AddUsingsCodeActionParams
             {
                 Uri = documentUri,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/AddUsingsCSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/AddUsingsCSharpCodeActionResolverTest.cs
@@ -2,22 +2,21 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
-using OmniSharp.Extensions.JsonRpc;
-using System.Threading;
-using Newtonsoft.Json.Linq;
-using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
@@ -191,7 +190,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             documentVersionCache ??= CreateDocumentVersionCache();
 
             addUsingResolver = new AddUsingsCSharpCodeActionResolver(
-                new DefaultProjectSnapshotManagerDispatcher(),
+                Dispatcher,
                 CreateDocumentResolver(documentPath, codeDocument),
                 languageServer,
                 documentVersionCache);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionResolverTest.cs
@@ -2,24 +2,23 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
-using OmniSharp.Extensions.JsonRpc;
-using System.Threading;
-using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
-using Newtonsoft.Json.Linq;
-using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions;
-using System.Linq;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
@@ -203,7 +202,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             razorFormattingService ??= CreateRazorFormattingService(documentUri);
 
             csharpCodeActionResolver = new DefaultCSharpCodeActionResolver(
-                new DefaultProjectSnapshotManagerDispatcher(),
+                Dispatcher,
                 CreateDocumentResolver(documentPath, codeDocument),
                 languageServer,
                 razorFormattingService,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
@@ -4,18 +4,17 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
@@ -27,7 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         public async Task Handle_MissingFile()
         {
             // Arrange
-            var resolver = new CreateComponentCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), _emptyDocumentResolver);
+            var resolver = new CreateComponentCodeActionResolver(Dispatcher, _emptyDocumentResolver);
             var data = JObject.FromObject(new CreateComponentCodeActionParams()
             {
                 Uri = new Uri("c:/Test.razor"),
@@ -50,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             codeDocument.SetUnsupported();
 
-            var resolver = new CreateComponentCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new CreateComponentCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var data = JObject.FromObject(new CreateComponentCodeActionParams()
             {
                 Uri = new Uri(documentPath),
@@ -73,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             codeDocument.SetFileKind(FileKinds.Legacy);
 
-            var resolver = new CreateComponentCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new CreateComponentCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var data = JObject.FromObject(new CreateComponentCodeActionParams()
             {
                 Uri = new Uri(documentPath),
@@ -96,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@page \"/test\"";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new CreateComponentCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new CreateComponentCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new CreateComponentCodeActionParams
             {
                 Uri = documentUri,
@@ -126,7 +125,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@page \"/test\"{Environment.NewLine}@namespace Another.Namespace";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new CreateComponentCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument));
+            var resolver = new CreateComponentCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument));
             var actionParams = new CreateComponentCodeActionParams
             {
                 Uri = documentUri,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -4,20 +4,19 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
-using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
@@ -35,7 +34,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         public async Task Handle_MissingFile()
         {
             // Arrange
-            var resolver = new ExtractToCodeBehindCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), _emptyDocumentResolver, FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(Dispatcher, _emptyDocumentResolver, FilePathNormalizer);
             var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
             {
                 Uri = new Uri("c:/Test.razor"),
@@ -61,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             codeDocument.SetUnsupported();
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
             var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
             {
                 Uri = new Uri("c:/Test.razor"),
@@ -87,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             codeDocument.SetFileKind(FileKinds.Legacy);
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
             var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
             {
                 Uri = new Uri("c:/Test.razor"),
@@ -113,7 +112,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@page \"/test\"{Environment.NewLine}@code {{ private var x = 1; }}";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
             var actionParams = new ExtractToCodeBehindCodeActionParams
             {
                 Uri = documentUri,
@@ -157,7 +156,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@page \"/test\"{Environment.NewLine}@functions {{ private var x = 1; }}";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
             var actionParams = new ExtractToCodeBehindCodeActionParams
             {
                 Uri = documentUri,
@@ -201,7 +200,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var contents = $"@page \"/test\"\n@using System.Diagnostics{Environment.NewLine}@code {{ private var x = 1; }}";
             var codeDocument = CreateCodeDocument(contents);
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(new DefaultProjectSnapshotManagerDispatcher(), CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(Dispatcher, CreateDocumentResolver(documentPath, codeDocument), FilePathNormalizer);
             var actionParams = new ExtractToCodeBehindCodeActionParams
             {
                 Uri = documentUri,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 var kvp = Assert.Single(synchronizer.ProjectInfoMap);
                 await Dispatcher.RunOnDispatcherThreadAsync(
-                    () => kvp.Value.ProjectUpdateTask.Wait(), CancellationToken.None);
+                    () => kvp.Value.ProjectUpdateTask.Wait(), CancellationToken.None).ConfigureAwait(false);
             }
             else
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -995,7 +994,7 @@ slf*@";
             }
         }
 
-        private static (RazorSemanticTokensInfoService, Mock<ClientNotifierServiceBase>) GetDefaultRazorSemanticTokenInfoService(
+        private (RazorSemanticTokensInfoService, Mock<ClientNotifierServiceBase>) GetDefaultRazorSemanticTokenInfoService(
             Queue<DocumentSnapshot> documentSnapshots,
             ProvideSemanticTokensResponse? cSharpTokens = null,
             (OmniSharpRange, OmniSharpRange?)[]? documentMappings = null,
@@ -1028,7 +1027,7 @@ slf*@";
             var loggingFactory = new Mock<LoggerFactory>(MockBehavior.Strict);
             loggingFactory.Protected().Setup("CheckDisposed").CallBase();
 
-            var projectSnapshotManagerDispatcher = new DefaultProjectSnapshotManagerDispatcher();
+            var projectSnapshotManagerDispatcher = Dispatcher;
 
             var documentResolver = new TestDocumentResolver(documentSnapshots);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/BackgroundDocumentProcessedPublisherTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document));
+            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document)).ConfigureAwait(false);
 
             // Assert
             Assert.Same(originalSolution, Workspace.CurrentSolution);
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document));
+            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document)).ConfigureAwait(false);
 
             // Assert
             Assert.Same(originalSolution, Workspace.CurrentSolution);
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document));
+            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document)).ConfigureAwait(false);
 
             // Assert
             Assert.Same(originalSolution, Workspace.CurrentSolution);
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document));
+            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document)).ConfigureAwait(false);
 
             // Assert
             var project = Assert.Single(Workspace.CurrentSolution.Projects);
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document));
+            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document)).ConfigureAwait(false);
 
             // Assert
             var project = Assert.Single(Workspace.CurrentSolution.Projects);
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document));
+            await RunOnDispatcherThreadAsync(() => processedPublisher.DocumentProcessed(document)).ConfigureAwait(false);
 
             // Assert
             var afterProcessedDocument = Workspace.GetDocument(backgroundDocumentFilePath);
@@ -122,13 +122,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             {
                 projectSnapshotManager.ProjectAdded(hostProject);
                 projectSnapshotManager.DocumentAdded(hostProject, hostDocument);
-            });
+            }).ConfigureAwait(false);
             var originalSolution = Workspace.CurrentSolution;
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
             processedPublisher.Initialize(projectSnapshotManager);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => projectSnapshotManager.DocumentRemoved(hostProject, hostDocument));
+            await RunOnDispatcherThreadAsync(() => projectSnapshotManager.DocumentRemoved(hostProject, hostDocument)).ConfigureAwait(false);
 
             // Assert
             Assert.Same(originalSolution, Workspace.CurrentSolution);
@@ -145,13 +145,13 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             {
                 projectSnapshotManager.ProjectAdded(hostProject);
                 projectSnapshotManager.DocumentAdded(hostProject, hostDocument);
-            });
+            }).ConfigureAwait(false);
             var originalSolution = Workspace.CurrentSolution;
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
             processedPublisher.Initialize(projectSnapshotManager);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => projectSnapshotManager.DocumentRemoved(hostProject, hostDocument));
+            await RunOnDispatcherThreadAsync(() => projectSnapshotManager.DocumentRemoved(hostProject, hostDocument)).ConfigureAwait(false);
 
             // Assert
             Assert.Same(originalSolution, Workspace.CurrentSolution);
@@ -168,14 +168,14 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             {
                 projectSnapshotManager.ProjectAdded(hostProject);
                 projectSnapshotManager.DocumentAdded(hostProject, hostDocument);
-            });
+            }).ConfigureAwait(false);
             var backgroundDocumentFilePath = hostDocument.FilePath + BackgroundDocumentProcessedPublisher.BackgroundVirtualDocumentSuffix;
             AddRoslynDocument(backgroundDocumentFilePath);
             var processedPublisher = new BackgroundDocumentProcessedPublisher(Dispatcher, Workspace, LoggerFactory);
             processedPublisher.Initialize(projectSnapshotManager);
 
             // Act
-            await RunOnDispatcherThreadAsync(() => projectSnapshotManager.DocumentRemoved(hostProject, hostDocument));
+            await RunOnDispatcherThreadAsync(() => projectSnapshotManager.DocumentRemoved(hostProject, hostDocument)).ConfigureAwait(false);
 
             // Assert
             var project = Assert.Single(Workspace.CurrentSolution.Projects);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/DefaultProjectChangePublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/DefaultProjectChangePublisherTest.cs
@@ -145,10 +145,10 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var publisher = new TestProjectChangePublisher(LoggerFactory);
             publisher.Initialize(snapshotManager);
             var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
-            await RunOnDispatcherThreadAsync(() => snapshotManager.ProjectAdded(hostProject));
+            await RunOnDispatcherThreadAsync(() => snapshotManager.ProjectAdded(hostProject)).ConfigureAwait(false);
 
             // Act & Assert
-            await RunOnDispatcherThreadAsync(() => snapshotManager.ProjectRemoved(hostProject));
+            await RunOnDispatcherThreadAsync(() => snapshotManager.ProjectRemoved(hostProject)).ConfigureAwait(false);
         }
 
         private class TestProjectChangePublisher : DefaultProjectChangePublisher

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/MSBuildProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/MSBuildProjectManagerTest.cs
@@ -55,14 +55,14 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 var hostDocument = new OmniSharpHostDocument("file.cshtml", "file.cshtml", FileKinds.Legacy);
                 projectManager.DocumentAdded(hostProject, hostDocument);
                 return projectManager.GetLoadedProject(hostProject.FilePath);
-            });
+            }).ConfigureAwait(false);
 
             // Act
             await RunOnDispatcherThreadAsync(() =>
                 msbuildProjectManager.SynchronizeDocuments(
                     configuredHostDocuments,
                     projectSnapshot,
-                    hostProject));
+                    hostProject)).ConfigureAwait(false);
 
             // Assert
             await RunOnDispatcherThreadAsync(() =>
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 Assert.Equal("file.cshtml", document.FilePath);
                 Assert.Equal("file.cshtml", document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
-            });
+            }).ConfigureAwait(false);
         }
 
         [Fact]
@@ -95,21 +95,21 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 var hostDocument = new OmniSharpHostDocument("file.razor", "file.razor", FileKinds.Component);
                 projectManager.DocumentAdded(hostProject, hostDocument);
                 return projectManager.GetLoadedProject(hostProject.FilePath);
-            });
+            }).ConfigureAwait(false);
 
             // Act
             await RunOnDispatcherThreadAsync(() =>
                 msbuildProjectManager.SynchronizeDocuments(
                     configuredHostDocuments: Array.Empty<OmniSharpHostDocument>(),
                     projectSnapshot,
-                    hostProject));
+                    hostProject)).ConfigureAwait(false);
 
             // Assert
             await RunOnDispatcherThreadAsync(() =>
             {
                 var refreshedProject = projectManager.GetLoadedProject(hostProject.FilePath);
                 Assert.Empty(refreshedProject.DocumentFilePaths);
-            });
+            }).ConfigureAwait(false);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 projectManager.ProjectAdded(hostProject);
                 projectManager.DocumentAdded(hostProject, hostDocument);
                 return projectManager.GetLoadedProject(hostProject.FilePath);
-            });
+            }).ConfigureAwait(false);
             projectManager.Changed += (sender, args) => throw new XunitException("Should not have been notified");
 
             // Act & Assert
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 msbuildProjectManager.SynchronizeDocuments(
                     configuredHostDocuments,
                     projectSnapshot,
-                    hostProject));
+                    hostProject)).ConfigureAwait(false);
         }
 
         [Fact]
@@ -163,14 +163,14 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             {
                 projectManager.ProjectAdded(hostProject);
                 return projectManager.GetLoadedProject(hostProject.FilePath);
-            });
+            }).ConfigureAwait(false);
 
             // Act
             await RunOnDispatcherThreadAsync(() =>
                 msbuildProjectManager.SynchronizeDocuments(
                     configuredHostDocuments,
                     projectSnapshot,
-                    hostProject));
+                    hostProject)).ConfigureAwait(false);
 
             // Assert
             await RunOnDispatcherThreadAsync(() =>
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
                 var refreshedProject = projectManager.GetLoadedProject(hostProject.FilePath);
                 var document = refreshedProject.GetDocument("file.razor");
                 Assert.Equal(FileKinds.Component, document.FileKind);
-            });
+            }).ConfigureAwait(false);
         }
 
         // This is more of an integration level test to verify everything works end to end.
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             await msbuildProjectManager.ProjectLoadedAsync(args);
 
             // Assert
-            var project = await RunOnDispatcherThreadAsync(() => Assert.Single(projectManager.Projects));
+            var project = await RunOnDispatcherThreadAsync(() => Assert.Single(projectManager.Projects)).ConfigureAwait(false);
             Assert.Equal(projectInstance.ProjectFileLocation.File, project.FilePath);
             Assert.Same(CustomConfiguration, project.Configuration);
             var document = project.GetDocument(hostDocument.FilePath);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/TagHelperRefreshTriggerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/TagHelperRefreshTriggerTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             refreshTrigger.Initialize(projectManager);
 
             // Act
-            var result = await RunOnDispatcherThreadAsync(() => refreshTrigger.IsComponentFile("file.razor", "/path/to/project.csproj"));
+            var result = await RunOnDispatcherThreadAsync(() => refreshTrigger.IsComponentFile("file.razor", "/path/to/project.csproj")).ConfigureAwait(false);
 
             // Assert
             Assert.False(result);
@@ -87,10 +87,10 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var refreshTrigger = CreateRefreshTrigger();
             refreshTrigger.Initialize(projectManager);
             var hostProject = new OmniSharpHostProject("/path/to/project.csproj", RazorConfiguration.Default, "TestRootNamespace");
-            await RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(hostProject));
+            await RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(hostProject)).ConfigureAwait(false);
 
             // Act
-            var result = await RunOnDispatcherThreadAsync(() => refreshTrigger.IsComponentFile("file.razor", hostProject.FilePath));
+            var result = await RunOnDispatcherThreadAsync(() => refreshTrigger.IsComponentFile("file.razor", hostProject.FilePath)).ConfigureAwait(false);
 
             // Assert
             Assert.False(result);
@@ -109,10 +109,10 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             {
                 projectManager.ProjectAdded(hostProject);
                 projectManager.DocumentAdded(hostProject, hostDocument);
-            });
+            }).ConfigureAwait(false);
 
             // Act
-            var result = await RunOnDispatcherThreadAsync(() => refreshTrigger.IsComponentFile(hostDocument.FilePath, hostProject.FilePath));
+            var result = await RunOnDispatcherThreadAsync(() => refreshTrigger.IsComponentFile(hostDocument.FilePath, hostProject.FilePath)).ConfigureAwait(false);
 
             // Assert
             Assert.False(result);
@@ -131,10 +131,10 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             {
                 projectManager.ProjectAdded(hostProject);
                 projectManager.DocumentAdded(hostProject, hostDocument);
-            });
+            }).ConfigureAwait(false);
 
             // Act
-            var result = await RunOnDispatcherThreadAsync(() => refreshTrigger.IsComponentFile(hostDocument.FilePath, hostProject.FilePath));
+            var result = await RunOnDispatcherThreadAsync(() => refreshTrigger.IsComponentFile(hostDocument.FilePath, hostProject.FilePath)).ConfigureAwait(false);
 
             // Assert
             Assert.True(result);
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public async Task ProjectLoaded_TriggersUpdate()
         {
             // Arrange
-            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1));
+            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1)).ConfigureAwait(false);
             using var mre = new ManualResetEventSlim(initialState: false);
             var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>(MockBehavior.Strict);
             workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public async Task ProjectLoaded_BatchesUpdates()
         {
             // Arrange
-            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1));
+            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1)).ConfigureAwait(false);
             using var mre = new ManualResetEventSlim(initialState: false);
             var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>(MockBehavior.Strict);
             workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public async Task RazorDocumentOutputChanged_TriggersUpdate()
         {
             // Arrange
-            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1));
+            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1)).ConfigureAwait(false);
             using var mre = new ManualResetEventSlim(initialState: false);
             var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>(MockBehavior.Strict);
             workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         public async Task RazorDocumentOutputChanged_BatchesUpdates()
         {
             // Arrange
-            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1));
+            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1)).ConfigureAwait(false);
             using var mre = new ManualResetEventSlim(initialState: false);
             var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>(MockBehavior.Strict);
             workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
@@ -266,14 +266,14 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             // Arrange
             using var workspace = TestWorkspace.Create();
             var projectManager = CreateProjectSnapshotManager();
-            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1));
+            await RunOnDispatcherThreadAsync(() => ProjectManager.ProjectAdded(Project1)).ConfigureAwait(false);
             var workspaceStateGenerator = new Mock<OmniSharpProjectWorkspaceStateGenerator>(MockBehavior.Strict);
             workspaceStateGenerator.Setup(generator => generator.Update(It.IsAny<Project>(), It.IsAny<OmniSharpProjectSnapshot>()))
                 .Throws<XunitException>();
             var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object, workspace);
 
             // Act & Assert
-            await RunOnDispatcherThreadAsync(() => refreshTrigger.UpdateAfterDelayAsync(Project1.FilePath));
+            await RunOnDispatcherThreadAsync(() => refreshTrigger.UpdateAfterDelayAsync(Project1.FilePath)).ConfigureAwait(false);
         }
 
         [Fact]
@@ -287,7 +287,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var refreshTrigger = CreateRefreshTrigger(workspaceStateGenerator.Object);
 
             // Act & Assert
-            await RunOnDispatcherThreadAsync(() => refreshTrigger.UpdateAfterDelayAsync(((ProjectInstance)Project1Instance).ProjectFileLocation.File));
+            await RunOnDispatcherThreadAsync(() => refreshTrigger.UpdateAfterDelayAsync(((ProjectInstance)Project1Instance).ProjectFileLocation.File)).ConfigureAwait(false);
         }
 
         private TagHelperRefreshTrigger CreateRefreshTrigger(OmniSharpProjectWorkspaceStateGenerator workspaceStateGenerator = null, Workspace workspace = null, int enqueueDelay = 1)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServices.Razor;
 using Microsoft.VisualStudio.LanguageServices.Razor.Test;
 using Microsoft.VisualStudio.Threading;
 using Moq;
@@ -18,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     public class WorkspaceProjectStateChangeDetectorTest : WorkspaceTestBase, IDisposable
     {
-        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new TestProjectSnapshotManagerDispatcher();
+        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new VisualStudioProjectSnapshotManagerDispatcher();
 
         public WorkspaceProjectStateChangeDetectorTest()
         {
@@ -158,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 projectManager.ProjectAdded(HostProjectOne);
                 projectManager.ProjectAdded(HostProjectTwo);
                 projectManager.ProjectAdded(HostProjectThree);
-            }, CancellationToken.None);
+            }, CancellationToken.None).ConfigureAwait(false);
 
             // Initialize with a project. This will get removed.
             var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.SolutionAdded, oldSolution: EmptySolution, newSolution: SolutionWithOneProject);
@@ -209,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 projectManager.ProjectAdded(HostProjectOne);
                 projectManager.ProjectAdded(HostProjectTwo);
                 projectManager.ProjectAdded(HostProjectThree);
-            }, CancellationToken.None);
+            }, CancellationToken.None).ConfigureAwait(false);
 
             // Initialize with a project. This will get removed.
             var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.SolutionAdded, oldSolution: EmptySolution, newSolution: SolutionWithOneProject);
@@ -257,7 +258,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             {
                 projectManager.ProjectAdded(HostProjectOne);
                 projectManager.ProjectAdded(HostProjectTwo);
-            }, CancellationToken.None);
+            }, CancellationToken.None).ConfigureAwait(false);
 
             var e = new WorkspaceChangeEventArgs(kind, oldSolution: EmptySolution, newSolution: SolutionWithTwoProjects);
 
@@ -295,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 projectManager.ProjectAdded(HostProjectOne);
                 projectManager.ProjectAdded(HostProjectTwo);
                 projectManager.ProjectAdded(HostProjectThree);
-            }, CancellationToken.None);
+            }, CancellationToken.None).ConfigureAwait(false);
 
             // Initialize with a project. This will get removed.
             var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.SolutionAdded, oldSolution: EmptySolution, newSolution: SolutionWithOneProject);
@@ -332,7 +333,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             WorkQueueTestAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
 
             var projectManager = new TestProjectSnapshotManager(Dispatcher, new[] { detector }, Workspace);
-            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None);
+            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None).ConfigureAwait(false);
 
             var solution = SolutionWithTwoProjects.WithProjectAssemblyName(ProjectNumberOne.Id, "Changed");
             var e = new WorkspaceChangeEventArgs(kind, oldSolution: SolutionWithTwoProjects, newSolution: solution, projectId: ProjectNumberOne.Id);
@@ -363,7 +364,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             Workspace.TryApplyChanges(SolutionWithTwoProjects);
             var projectManager = new TestProjectSnapshotManager(Dispatcher, new[] { detector }, Workspace);
-            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None);
+            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None).ConfigureAwait(false);
             workspaceStateGenerator.ClearQueue();
 
             var solution = SolutionWithTwoProjects.WithDocumentText(BackgroundVirtualCSharpDocumentId, SourceText.From("public class Foo{}"));
@@ -395,7 +396,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             Workspace.TryApplyChanges(SolutionWithTwoProjects);
             var projectManager = new TestProjectSnapshotManager(Dispatcher, new[] { detector }, Workspace);
-            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None);
+            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None).ConfigureAwait(false);
             workspaceStateGenerator.ClearQueue();
 
             var solution = SolutionWithTwoProjects.WithDocumentText(CshtmlDocumentId, SourceText.From("Hello World"));
@@ -427,7 +428,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             Workspace.TryApplyChanges(SolutionWithTwoProjects);
             var projectManager = new TestProjectSnapshotManager(Dispatcher, new[] { detector }, Workspace);
-            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None);
+            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None).ConfigureAwait(false);
             workspaceStateGenerator.ClearQueue();
 
             var solution = SolutionWithTwoProjects.WithDocumentText(RazorDocumentId, SourceText.From("Hello World"));
@@ -459,7 +460,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             Workspace.TryApplyChanges(SolutionWithTwoProjects);
             var projectManager = new TestProjectSnapshotManager(Dispatcher, new[] { detector }, Workspace);
-            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None);
+            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectOne), CancellationToken.None).ConfigureAwait(false);
             workspaceStateGenerator.ClearQueue();
 
             var sourceText = SourceText.From(
@@ -513,7 +514,7 @@ namespace Microsoft.AspNetCore.Components
             {
                 projectManager.ProjectAdded(HostProjectOne);
                 projectManager.ProjectAdded(HostProjectTwo);
-            }, CancellationToken.None);
+            }, CancellationToken.None).ConfigureAwait(false);
 
             var solution = SolutionWithTwoProjects.RemoveProject(ProjectNumberOne.Id);
             var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.ProjectRemoved, oldSolution: SolutionWithTwoProjects, newSolution: solution, projectId: ProjectNumberOne.Id);
@@ -538,7 +539,7 @@ namespace Microsoft.AspNetCore.Components
                 NotifyWorkspaceChangedEventComplete = new ManualResetEventSlim(initialState: false),
             };
             var projectManager = new TestProjectSnapshotManager(Dispatcher, new[] { detector }, Workspace);
-            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectThree), CancellationToken.None);
+            await Dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(HostProjectThree), CancellationToken.None).ConfigureAwait(false);
 
             var solution = SolutionWithOneProject;
             var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.ProjectAdded, oldSolution: EmptySolution, newSolution: solution, projectId: ProjectNumberThree.Id);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     public class WorkspaceProjectStateChangeDetectorTest : WorkspaceTestBase, IDisposable
     {
-        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new DefaultProjectSnapshotManagerDispatcher();
+        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new TestProjectSnapshotManagerDispatcher();
 
         public WorkspaceProjectStateChangeDetectorTest()
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServices.Razor.Test;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -29,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             }
         }
 
-        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new DefaultProjectSnapshotManagerDispatcher();
+        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new TestProjectSnapshotManagerDispatcher();
 
         public VsSolutionUpdatesProjectSnapshotChangeTriggerTest()
         {


### PR DESCRIPTION
- We were accidentally using the same dispatcher for VS & our language server. This PR changes the structure of how we construct our schedulers to require a thread name (easier to discover) & to also enforce all call sites to be more cautious of how they utilize the dispatcher.
- Updated all tests & instances of the dispatchers to use their own thread naming conventions.
- The separated naming also makes it easier to understand which dispatcher is doing what:
![image](https://i.imgur.com/ur5moB1.png)

Fixes dotnet/aspnetcore#35852