### PR TITLE
[Ported] Avoid capturing unnecessary solutions in WorkspaceProjectStateChangeDetector 

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcher.cs
@@ -17,6 +17,9 @@ namespace Microsoft.CodeAnalysis.Razor
         public Task RunOnDispatcherThreadAsync(Action action, CancellationToken cancellationToken)
             => Task.Factory.StartNew(action, cancellationToken, TaskCreationOptions.None, DispatcherScheduler);
 
+        public Task RunOnDispatcherThreadAsync<TParameter>(Action<TParameter, CancellationToken> action, TParameter state, CancellationToken cancellationToken)
+            => Task.Factory.StartNew(() => action(state, cancellationToken), cancellationToken, TaskCreationOptions.None, DispatcherScheduler);
+
         public Task<TResult> RunOnDispatcherThreadAsync<TResult>(Func<TResult> action, CancellationToken cancellationToken)
             => Task.Factory.StartNew(action, cancellationToken, TaskCreationOptions.None, DispatcherScheduler);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
@@ -110,147 +110,173 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             {
                 // Method needs to be run on the project snapshot manager's specialized thread
                 // due to project snapshot manager access.
-                await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() =>
+                Project project;
+                switch (e.Kind)
                 {
-                    Project project;
-                    switch (e.Kind)
-                    {
-                        case WorkspaceChangeKind.ProjectAdded:
+                    case WorkspaceChangeKind.ProjectAdded:
+                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
+                            static (state, _) =>
                             {
-                                project = e.NewSolution.GetRequiredProject(e.ProjectId);
-                                EnqueueUpdateOnProjectAndDependencies(project, e.NewSolution);
-                                break;
-                            }
+                                project = state.NewSolution.GetRequiredProject(state.ProjectId);
+                                state.self.EnqueueUpdateOnProjectAndDependencies(project, state.NewSolution);
+                            },
+                            (self: this, e.ProjectId, e.NewSolution),
+                            CancellationToken.None);
+                        break;
 
-                        case WorkspaceChangeKind.ProjectChanged:
-                        case WorkspaceChangeKind.ProjectReloaded:
+                    case WorkspaceChangeKind.ProjectChanged:
+                    case WorkspaceChangeKind.ProjectReloaded:
+                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
+                            static (state, _) =>
                             {
-                                project = e.NewSolution.GetRequiredProject(e.ProjectId);
+                                project = state.NewSolution.GetRequiredProject(state.ProjectId);
 
-                                EnqueueUpdateOnProjectAndDependencies(project, e.NewSolution);
-                                break;
-                            }
+                                state.self.EnqueueUpdateOnProjectAndDependencies(project, state.NewSolution);
+                            },
+                            (self: this, e.ProjectId, e.NewSolution),
+                            CancellationToken.None);
+                        break;
 
-                        case WorkspaceChangeKind.ProjectRemoved:
+                    case WorkspaceChangeKind.ProjectRemoved:
+                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
+                            static (state, _) =>
                             {
-                                project = e.OldSolution.GetRequiredProject(e.ProjectId);
+                                project = state.OldSolution.GetRequiredProject(state.ProjectId);
 
-                                if (TryGetProjectSnapshot(project.FilePath, out var projectSnapshot))
+                                if (state.self.TryGetProjectSnapshot(project.FilePath, out var projectSnapshot))
                                 {
-                                    EnqueueUpdateOnProjectAndDependencies(e.ProjectId!, project: null, e.OldSolution, projectSnapshot!);
+                                    state.self.EnqueueUpdateOnProjectAndDependencies(state.ProjectId!, project: null, state.OldSolution, projectSnapshot!);
                                 }
-                                break;
-                            }
+                            },
+                            (self: this, e.ProjectId, e.OldSolution),
+                            CancellationToken.None);
+                        break;
 
-                        case WorkspaceChangeKind.DocumentAdded:
-                            // This is the case when a component declaration file changes on disk. We have an MSBuild
-                            // generator configured by the SDK that will poke these files on disk when a component
-                            // is saved, or loses focus in the editor.
-                            project = e.NewSolution.GetRequiredProject(e.ProjectId);
-                            var newDocument = project.GetDocument(e.DocumentId!);
-
-                            if (newDocument?.FilePath is null)
-                            {
-                                break;
-                            }
-
-                            if (IsRazorFileOrRazorVirtual(newDocument))
-                            {
-                                EnqueueUpdateOnProjectAndDependencies(project, e.NewSolution);
-                                break;
-                            }
-
-                            // We now know we're not operating directly on a Razor file. However, it's possible the user
-                            // is operating on a partial class that is associated with a Razor file.
-                            if (IsPartialComponentClass(newDocument))
-                            {
-                                EnqueueUpdateOnProjectAndDependencies(project, e.NewSolution);
-                            }
-
-                            break;
-                        case WorkspaceChangeKind.DocumentRemoved:
-                            project = e.OldSolution.GetRequiredProject(e.ProjectId);
-                            var removedDocument = project.GetRequiredDocument(e.DocumentId);
-
-                            if (removedDocument.FilePath is null)
-                            {
-                                break;
-                            }
-
-                            if (IsRazorFileOrRazorVirtual(removedDocument))
-                            {
-                                EnqueueUpdateOnProjectAndDependencies(project, e.NewSolution);
-                                break;
-                            }
-
-                            // We now know we're not operating directly on a Razor file. However, it's possible the user
-                            // is operating on a partial class that is associated with a Razor file.
-
-                            if (IsPartialComponentClass(removedDocument))
-                            {
-                                EnqueueUpdateOnProjectAndDependencies(project, e.NewSolution);
-                            }
-
-                            break;
-                        case WorkspaceChangeKind.DocumentChanged:
-                        case WorkspaceChangeKind.DocumentReloaded:
+                    case WorkspaceChangeKind.DocumentAdded:
+                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
+                            static (state, _) =>
                             {
                                 // This is the case when a component declaration file changes on disk. We have an MSBuild
                                 // generator configured by the SDK that will poke these files on disk when a component
                                 // is saved, or loses focus in the editor.
-                                project = e.OldSolution.GetRequiredProject(e.ProjectId);
-                                var document = project.GetRequiredDocument(e.DocumentId);
+                                project = state.NewSolution.GetRequiredProject(state.ProjectId);
+                                var newDocument = project.GetDocument(state.DocumentId!);
+
+                                if (newDocument?.FilePath is null)
+                                {
+                                    return;
+                                }
+
+                                if (state.self.IsRazorFileOrRazorVirtual(newDocument))
+                                {
+                                    state.self.EnqueueUpdateOnProjectAndDependencies(project, state.NewSolution);
+                                    return;
+                                }
+
+                                // We now know we're not operating directly on a Razor file. However, it's possible the user
+                                // is operating on a partial class that is associated with a Razor file.
+                                if (state.self.IsPartialComponentClass(newDocument))
+                                {
+                                    state.self.EnqueueUpdateOnProjectAndDependencies(project, state.NewSolution);
+                                }
+                            },
+                            (self: this, e.ProjectId, e.DocumentId, e.NewSolution),
+                            CancellationToken.None);
+                        break;
+
+                    case WorkspaceChangeKind.DocumentRemoved:
+                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
+                            static (state, _) =>
+                            {
+                                project = state.OldSolution.GetRequiredProject(state.ProjectId);
+                                var removedDocument = project.GetRequiredDocument(state.DocumentId);
+
+                                if (removedDocument.FilePath is null)
+                                {
+                                    return;
+                                }
+
+                                if (state.self.IsRazorFileOrRazorVirtual(removedDocument))
+                                {
+                                    state.self.EnqueueUpdateOnProjectAndDependencies(project, state.NewSolution);
+                                    return;
+                                }
+
+                                // We now know we're not operating directly on a Razor file. However, it's possible the user
+                                // is operating on a partial class that is associated with a Razor file.
+
+                                if (state.self.IsPartialComponentClass(removedDocument))
+                                {
+                                    state.self.EnqueueUpdateOnProjectAndDependencies(project, state.NewSolution);
+                                }
+                            },
+                            (self: this, e.ProjectId, e.DocumentId, e.OldSolution),
+                            CancellationToken.None);
+                        break;
+
+                    case WorkspaceChangeKind.DocumentChanged:
+                    case WorkspaceChangeKind.DocumentReloaded:
+                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
+                            static (state, _) =>
+                            {
+                                // This is the case when a component declaration file changes on disk. We have an MSBuild
+                                // generator configured by the SDK that will poke these files on disk when a component
+                                // is saved, or loses focus in the editor.
+                                project = state.OldSolution.GetRequiredProject(state.ProjectId);
+                                var document = project.GetRequiredDocument(state.DocumentId);
 
                                 if (document.FilePath == null)
                                 {
-                                    break;
+                                    return;
                                 }
 
-                                if (IsRazorFileOrRazorVirtual(document))
+                                if (state.self.IsRazorFileOrRazorVirtual(document))
                                 {
-                                    var newProject = e.NewSolution.GetRequiredProject(e.ProjectId);
-                                    EnqueueUpdateOnProjectAndDependencies(newProject, e.NewSolution);
+                                    var newProject = e.NewSolution.GetRequiredProject(state.ProjectId);
+                                    state.self.EnqueueUpdateOnProjectAndDependencies(newProject, state.NewSolution);
                                     break;
                                 }
 
                                 // We now know we're not operating directly on a Razor file. However, it's possible the user is operating on a partial class that is associated with a Razor file.
 
-                                if (IsPartialComponentClass(document))
+                                if (state.self.IsPartialComponentClass(document))
                                 {
-                                    var newProject = e.NewSolution.GetRequiredProject(e.ProjectId);
-                                    EnqueueUpdateOnProjectAndDependencies(newProject, e.NewSolution);
+                                    var newProject = state.NewSolution.GetRequiredProject(state.ProjectId);
+                                    state.self.EnqueueUpdateOnProjectAndDependencies(newProject, state.NewSolution);
                                 }
+                            },
+                            (self: this, e.OldSolution, e.ProjectId, e.DocumentId, e.NewSolution),
+                            CancellationToken.None);
+                        break;
 
-                                break;
-                            }
-
-                        case WorkspaceChangeKind.SolutionAdded:
-                        case WorkspaceChangeKind.SolutionChanged:
-                        case WorkspaceChangeKind.SolutionCleared:
-                        case WorkspaceChangeKind.SolutionReloaded:
-                        case WorkspaceChangeKind.SolutionRemoved:
-
-                            if (e.OldSolution != null)
+                    case WorkspaceChangeKind.SolutionAdded:
+                    case WorkspaceChangeKind.SolutionChanged:
+                    case WorkspaceChangeKind.SolutionCleared:
+                    case WorkspaceChangeKind.SolutionReloaded:
+                    case WorkspaceChangeKind.SolutionRemoved:
+                        await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
+                            static (state, _) =>
                             {
-                                foreach (var p in e.OldSolution.Projects)
+                                if (state.oldProjectPaths != null)
                                 {
-                                    if (TryGetProjectSnapshot(p?.FilePath, out var projectSnapshot))
+                                    foreach (var p in state.oldProjectPaths)
                                     {
-                                        EnqueueUpdate(project: null, projectSnapshot!);
+                                        if (state.self.TryGetProjectSnapshot(p?.FilePath, out var projectSnapshot))
+                                        {
+                                            state.self.EnqueueUpdate(project: null, projectSnapshot!);
+                                        }
                                     }
                                 }
-                            }
 
-                            InitializeSolution(e.NewSolution);
-                            break;
-                    }
+                                InitializeSolution(state.NewSolution);
+                            },
+                            (self: this, oldProjectPaths: e.OldSolution?.Projects.Select(p => p?.FilePath), e.NewSolution),
+                            CancellationToken.None);
+                        break;
+                }
 
-                    // Let tests know that this event has completed
-                    if (NotifyWorkspaceChangedEventComplete != null)
-                    {
-                        NotifyWorkspaceChangedEventComplete.Set();
-                    }
-                }, CancellationToken.None);
+                // Let tests know that this event has completed
+                NotifyWorkspaceChangedEventComplete?.Set();
             }
             catch (Exception ex)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioFileChangeTracker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioFileChangeTracker.cs
@@ -72,22 +72,25 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
         {
             _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
-            if (_fileChangeUnadviseTask?.IsCompleted == false)
-            {
-                // An unadvise operation is still processing, block the project snapshot manager's thread until it completes.
-                _fileChangeUnadviseTask.Join();
-            }
-
             if (_fileChangeAdviseTask != null)
             {
                 // Already listening
                 return;
             }
 
+            // If an unadvise operation is still processing, we don't start listening until it completes.
+            if (_fileChangeUnadviseTask is not { IsCompleted: false } fileChangeUnadviseTaskToJoin)
+            {
+                fileChangeUnadviseTaskToJoin = null;
+            }
+
             _fileChangeAdviseTask = _joinableTaskContext.Factory.RunAsync(async () =>
             {
                 try
                 {
+                    if (fileChangeUnadviseTaskToJoin is not null)
+                        await fileChangeUnadviseTaskToJoin.JoinAsync().ConfigureAwait(true);
+
                     return await _fileChangeService.AdviseFileChangeAsync(FilePath, FileChangeFlags, this).ConfigureAwait(true);
                 }
                 catch (PathTooLongException)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioFileChangeTracker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioFileChangeTracker.cs
@@ -78,7 +78,6 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 return;
             }
 
-            // If an unadvise operation is still processing, we don't start listening until it completes.
             if (_fileChangeUnadviseTask is not { IsCompleted: false } fileChangeUnadviseTaskToJoin)
             {
                 fileChangeUnadviseTaskToJoin = null;
@@ -88,6 +87,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             {
                 try
                 {
+                    // If an unadvise operation is still processing, we don't start listening until it completes.
                     if (fileChangeUnadviseTaskToJoin is not null)
                         await fileChangeUnadviseTaskToJoin.JoinAsync().ConfigureAwait(true);
 


### PR DESCRIPTION
@sharwell  did this work already [here](https://github.com/dotnet/aspnetcore-tooling/pull/4157). I'm just rebasing / addressing some code review comments on his behalf since he's out.

* Join asynchronously instead of blocking the dispatcher thread
* Avoid capturing unnecessary solutions in WorkspaceProjectStateChangeDetector