### PR TITLE
Switch to dispatcher thread in VS Mac

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultDotNetProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultDotNetProjectHost.cs
@@ -90,11 +90,11 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 
         private void Project_Disposing(object sender, EventArgs e)
         {
+            _project.ProjectCapabilitiesChanged -= Project_ProjectCapabilitiesChanged;
+            _project.Disposing -= Project_Disposing;
+
             _ = _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() =>
                 {
-                    _project.ProjectCapabilitiesChanged -= Project_ProjectCapabilitiesChanged;
-                    _project.Disposing -= Project_Disposing;
-
                     DetachCurrentRazorProjectHost();
                 }, CancellationToken.None);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35952

The `DotNetProject` class that is firing the events here is a VS Mac class, so has no idea about dispatcher threads. It does helpfully switch to the UI thread before firing these events though 😛