### PR TITLE
Fix bug in LinkedEditingRange span calculation

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -95,7 +95,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
 
             // We only care if the user is within a TagHelper or HTML tag with a valid start and end tag.
             if (TryGetNearestMarkupNameTokens(codeDocument, location, out var startTagNameToken, out var endTagNameToken) &&
-                (startTagNameToken.Span.Contains(location.AbsoluteIndex) || endTagNameToken.Span.Contains(location.AbsoluteIndex)))
+                (startTagNameToken.Span.Contains(location.AbsoluteIndex) || endTagNameToken.Span.Contains(location.AbsoluteIndex) ||
+                startTagNameToken.Span.End == location.AbsoluteIndex || endTagNameToken.Span.End == location.AbsoluteIndex))
             {
                 var startSpan = startTagNameToken.GetLinePositionSpan(codeDocument.Source);
                 var endSpan = endTagNameToken.GetLinePositionSpan(codeDocument.Source);


### PR DESCRIPTION
### Summary of the changes
 - Missed a case in the original PR (https://github.com/dotnet/aspnetcore-tooling/pull/4125) which caused the end boundary of the span to not be respected. For example, we should still return results to LSP if the cursor is somewhere like `<test1[||]></test1>`.

Fixes: 
https://github.com/dotnet/aspnetcore/issues/35951