### PR TITLE
Stop resolving stale TagHelpers on document removal.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Razor.Serialization;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.OperationProgress;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json;
 using Shared = System.Composition.SharedAttribute;
 using Task = System.Threading.Tasks.Task;
@@ -37,6 +36,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly IVsOperationProgressStatusService _operationProgressStatusService = null;
         private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
         private readonly Dictionary<string, ProjectSnapshot> _pendingProjectPublishes;
+        private readonly object _pendingProjectPublishesLock;
         private readonly object _publishLock;
 
         private readonly JsonSerializer _serializer = new();
@@ -72,6 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             DeferredPublishTasks = new Dictionary<string, Task>(FilePathComparer.Instance);
             _pendingProjectPublishes = new Dictionary<string, ProjectSnapshot>(FilePathComparer.Instance);
+            _pendingProjectPublishesLock = new();
             _publishLock = new object();
 
             _lspEditorFeatureDetector = lSPEditorFeatureDetector;
@@ -103,7 +104,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             // A race is not possible here because we use the main thread to synchronize the updates
             // by capturing the sync context.
-            _pendingProjectPublishes[projectSnapshot.FilePath] = projectSnapshot;
+            lock (_pendingProjectPublishesLock)
+            {
+                _pendingProjectPublishes[projectSnapshot.FilePath] = projectSnapshot;
+            }
 
             if (!DeferredPublishTasks.TryGetValue(projectSnapshot.FilePath, out var update) || update.IsCompleted)
             {
@@ -141,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     {
                         // Typically document open events don't result in us re-processing project state; however, given this is the first time a user opened a Razor document we should.
                         // Don't enqueue, just publish to get the most immediate result.
-                        Publish(args.Newer);
+                        ImmediatePublish(args.Newer);
                         return;
                     }
                 }
@@ -167,7 +171,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     {
                         // If our workspace state has changed since our last snapshot then this means pieces influencing
                         // TagHelper resolution have also changed. Fast path the TagHelper publish.
-                        Publish(args.Newer);
+                        ImmediatePublish(args.Newer);
                     }
                     else
                     {
@@ -191,7 +195,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
                     if (ProjectWorkspacePublishable(args))
                     {
-                        Publish(args.Newer);
+                        ImmediatePublish(args.Newer);
                     }
                     break;
 
@@ -252,10 +256,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     return;
                 }
 
-                if (_pendingProjectPublishes.TryGetValue(oldProjectFilePath, out _))
+
+                lock (_pendingProjectPublishesLock)
                 {
-                    // Project was removed while a delayed publish was in flight. Clear the in-flight publish so it noops.
-                    _pendingProjectPublishes.Remove(oldProjectFilePath);
+                    if (_pendingProjectPublishes.TryGetValue(oldProjectFilePath, out _))
+                    {
+                        // Project was removed while a delayed publish was in flight. Clear the in-flight publish so it noops.
+                        _pendingProjectPublishes.Remove(oldProjectFilePath);
+                    }
                 }
             }
         }
@@ -341,17 +349,32 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return !status.IsInProgress && _documentsProcessed;
         }
 
+        private void ImmediatePublish(ProjectSnapshot projectSnapshot)
+        {
+            lock (_pendingProjectPublishesLock)
+            {
+                // Clear any pending publish
+                _pendingProjectPublishes.Remove(projectSnapshot.FilePath);
+            }
+
+            Publish(projectSnapshot);
+        }
+
         private async Task PublishAfterDelayAsync(string projectFilePath)
         {
             await Task.Delay(EnqueueDelay).ConfigureAwait(false);
 
-            if (!_pendingProjectPublishes.TryGetValue(projectFilePath, out var projectSnapshot))
+            ProjectSnapshot projectSnapshot;
+            lock (_pendingProjectPublishesLock)
             {
-                // Project was removed while waiting for the publish delay.
-                return;
-            }
+                if (!_pendingProjectPublishes.TryGetValue(projectFilePath, out projectSnapshot))
+                {
+                    // Project was removed while waiting for the publish delay.
+                    return;
+                }
 
-            _pendingProjectPublishes.Remove(projectFilePath);
+                _pendingProjectPublishes.Remove(projectFilePath);
+            }
 
             Publish(projectSnapshot);
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -102,8 +102,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         // Internal for testing
         internal void EnqueuePublish(ProjectSnapshot projectSnapshot)
         {
-            // A race is not possible here because we use the main thread to synchronize the updates
-            // by capturing the sync context.
             lock (_pendingProjectPublishesLock)
             {
                 _pendingProjectPublishes[projectSnapshot.FilePath] = projectSnapshot;


### PR DESCRIPTION
- Found that after removing a document that TagHelper information for the removed document would briefly go away and then flicker back into existence. In the end this was due to how our `project.razor.json` publisher handled immediate/delayed updates.
- Had to lock around our `_pendingProjectPublishes` in order to prevent races in delayed/immediate project changes. Considered using a concurrent dictionary but they can fail to remove items and I didn't want to write the extra code that understands how to handle the failure case where a project publish fails to be removed.
- Added a test to validate this scenario.

### Before

![e2qlo6jkmp](https://user-images.githubusercontent.com/2008729/131446944-d6e0d458-cb1a-48a2-b64a-be422f31050c.gif)

### After

![ihadPrGEVX](https://user-images.githubusercontent.com/2008729/131446817-58365a6d-c7aa-43ed-9b14-2f79a1425d96.gif)

Fixes dotnet/aspnetcore#35945