### PR TITLE
Cleanup: Normalize project file paths when absorbing project.razor.json.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -146,6 +146,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             void EnqueueUpdateProject(string projectFilePath, FullProjectSnapshotHandle snapshotHandle)
             {
+                projectFilePath = _filePathNormalizer.Normalize(projectFilePath);
                 if (!ProjectInfoMap.ContainsKey(projectFilePath))
                 {
                     ProjectInfoMap[projectFilePath] = new DelayedProjectInfo();


### PR DESCRIPTION
- I found that different project paths would be stored in our `ProjectInfoMap`. This cleans that up:
![image](https://i.imgur.com/6XwTSyR.png)

- This doesn't actually have any end-user impact because we do a few publishes and then things just normalize to one of the paths.