### PR TITLE
Add error logging to PSM dispatcher

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LSPProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LSPProjectSnapshotManagerDispatcher.cs
@@ -3,7 +3,9 @@
 
 #nullable enable
 
+using System;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -11,8 +13,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         private const string ThreadName = "Razor." + nameof(LSPProjectSnapshotManagerDispatcher);
 
-        public LSPProjectSnapshotManagerDispatcher() : base(ThreadName)
+        private readonly ILogger<LSPProjectSnapshotManagerDispatcher> _logger;
+
+        public LSPProjectSnapshotManagerDispatcher(ILoggerFactory loggerFactory) : base(ThreadName)
         {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<LSPProjectSnapshotManagerDispatcher>();
         }
+
+        public override void LogException(Exception ex) => _logger.LogError(ex, ThreadName + " encountered an exception.");
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/DefaultOmniSharpProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/DefaultOmniSharpProjectSnapshotManagerDispatcher.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
             public override void LogException(Exception ex)
             {
-                // ActivityLog and the LSP logger aren't applicable to O#. Do nothing.
+                // We don't currently have logging mechanisms in place for O#.
             }
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/DefaultOmniSharpProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/DefaultOmniSharpProjectSnapshotManagerDispatcher.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -24,6 +25,11 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
 
             public OmniSharpProjectSnapshotManagerDispatcher() : base(ThreadName)
             {
+            }
+
+            public override void LogException(Exception ex)
+            {
+                // ActivityLog and the LSP logger aren't applicable to O#. Do nothing.
             }
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcherBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcherBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         var task = _tasks.Take();
                         TryExecuteTask(task);
                     }
-                    catch (ThreadAbortException ex)
+                    catch (Exception ex)
                     {
                         // Fires when things shut down or in tests. Log exception and bail out.
                         _logException(ex);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcherBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcherBase.cs
@@ -78,11 +78,17 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         var task = _tasks.Take();
                         TryExecuteTask(task);
                     }
-                    catch (Exception ex)
+                    catch (ThreadAbortException ex)
                     {
                         // Fires when things shut down or in tests. Log exception and bail out.
                         _logException(ex);
                         return;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Unexpected exception. Log and throw.
+                        _logException(ex);
+                        throw;
                     }
                 }
             }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcherBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotManagerDispatcherBase.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         var task = _tasks.Take();
                         if (!TryExecuteTask(task))
                         {
-                            Debug.WriteLine("Task failed to execute on thread " + _thread + ".");
+                            Debug.WriteLine("Task failed to execute on thread " + _threadName + ".");
                         }
                     }
                     catch (ThreadAbortException e)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioFileChangeTrackerFactoryFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioFileChangeTrackerFactoryFactory.cs
@@ -45,6 +45,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
             _joinableTaskContext = joinableTaskContext;
         }
+
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
             if (workspaceServices == null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioErrorReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioErrorReporter.cs
@@ -2,18 +2,22 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
+    [Export(typeof(ErrorReporter))]
     internal class VisualStudioErrorReporter : ErrorReporter
     {
-        private readonly IServiceProvider _services;
+        private readonly SVsServiceProvider _services;
 
-        public VisualStudioErrorReporter(IServiceProvider services)
+        [ImportingConstructor]
+        public VisualStudioErrorReporter(SVsServiceProvider services)
         {
             if (services == null)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioErrorReporterFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioErrorReporterFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
     [ExportWorkspaceServiceFactory(typeof(ErrorReporter), ServiceLayer.Host)]
     internal class VisualStudioErrorReporterFactory : IWorkspaceServiceFactory
     {
-        private readonly IServiceProvider _serviceProvider;
+        private readonly SVsServiceProvider _serviceProvider;
 
         [ImportingConstructor]
         public VisualStudioErrorReporterFactory(SVsServiceProvider serviceProvider)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
@@ -12,9 +14,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
     {
         private const string ThreadName = "Razor." + nameof(VisualStudioProjectSnapshotManagerDispatcher);
 
-        public VisualStudioProjectSnapshotManagerDispatcher() : base(ThreadName)
-        {
+        private readonly ErrorReporter _errorReporter;
 
+        [ImportingConstructor]
+        public VisualStudioProjectSnapshotManagerDispatcher(SVsServiceProvider serviceProvider) : base(ThreadName)
+        {
+            _errorReporter = new VisualStudioErrorReporter(serviceProvider);
         }
+
+        public override void LogException(Exception ex) => _errorReporter.ReportError(ex);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
@@ -5,7 +5,6 @@ using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
@@ -17,9 +16,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         private readonly ErrorReporter _errorReporter;
 
         [ImportingConstructor]
-        public VisualStudioProjectSnapshotManagerDispatcher(SVsServiceProvider serviceProvider) : base(ThreadName)
+        public VisualStudioProjectSnapshotManagerDispatcher(ErrorReporter errorReporter) : base(ThreadName)
         {
-            _errorReporter = new VisualStudioErrorReporter(serviceProvider);
+            _errorReporter = errorReporter;
         }
 
         public override void LogException(Exception ex) => _errorReporter.ReportError(ex);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioSolutionCloseChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioSolutionCloseChangeTrigger.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.Shell;

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioErrorReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioErrorReporter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.Composition;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
@@ -10,6 +11,7 @@ using MonoDevelop.Core;
 
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
 {
+    [Export(typeof(ErrorReporter))]
     internal class VisualStudioErrorReporter : ErrorReporter
     {
         public override void ReportError(Exception exception)

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
@@ -14,15 +14,9 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
         private const string ThreadName = "Razor." + nameof(VisualStudioProjectSnapshotManagerDispatcher);
         private readonly ErrorReporter _errorReporter;
 
-        [ImportingConstructor]
-        public VisualStudioProjectSnapshotManagerDispatcher(ErrorReporter errorReporter) : base(ThreadName)
+        public VisualStudioProjectSnapshotManagerDispatcher() : base(ThreadName)
         {
-            if (errorReporter is null)
-            {
-                throw new ArgumentNullException(nameof(errorReporter));
-            }
-
-            _errorReporter = errorReporter;
+            _errorReporter = new VisualStudioErrorReporter();
         }
 
         public override void LogException(Exception ex) => _errorReporter.ReportError(ex);

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -11,10 +12,19 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
     internal class VisualStudioProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcherBase
     {
         private const string ThreadName = "Razor." + nameof(VisualStudioProjectSnapshotManagerDispatcher);
+        private readonly ErrorReporter _errorReporter;
 
-        public VisualStudioProjectSnapshotManagerDispatcher() : base(ThreadName)
+        [ImportingConstructor]
+        public VisualStudioProjectSnapshotManagerDispatcher(ErrorReporter errorReporter) : base(ThreadName)
         {
+            if (errorReporter is null)
+            {
+                throw new ArgumentNullException(nameof(errorReporter));
+            }
 
+            _errorReporter = errorReporter;
         }
+
+        public override void LogException(Exception ex) => _errorReporter.ReportError(ex);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioProjectSnapshotManagerDispatcher.cs
@@ -14,9 +14,10 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
         private const string ThreadName = "Razor." + nameof(VisualStudioProjectSnapshotManagerDispatcher);
         private readonly ErrorReporter _errorReporter;
 
-        public VisualStudioProjectSnapshotManagerDispatcher() : base(ThreadName)
+        [ImportingConstructor]
+        public VisualStudioProjectSnapshotManagerDispatcher(ErrorReporter errorReporter) : base(ThreadName)
         {
-            _errorReporter = new VisualStudioErrorReporter();
+            _errorReporter = errorReporter;
         }
 
         public override void LogException(Exception ex) => _errorReporter.ReportError(ex);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -20,7 +20,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     public class WorkspaceProjectStateChangeDetectorTest : WorkspaceTestBase, IDisposable
     {
-        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new VisualStudioProjectSnapshotManagerDispatcher(new TestSVsServiceProvider());
+        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new VisualStudioProjectSnapshotManagerDispatcher(
+            new VisualStudioErrorReporter(new TestSVsServiceProvider()));
 
         public WorkspaceProjectStateChangeDetectorTest()
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -4,22 +4,23 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Razor;
 using Microsoft.VisualStudio.LanguageServices.Razor.Test;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     public class WorkspaceProjectStateChangeDetectorTest : WorkspaceTestBase, IDisposable
     {
-        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new VisualStudioProjectSnapshotManagerDispatcher();
+        private static readonly ProjectSnapshotManagerDispatcher Dispatcher = new VisualStudioProjectSnapshotManagerDispatcher(new TestSVsServiceProvider());
 
         public WorkspaceProjectStateChangeDetectorTest()
         {
@@ -778,6 +779,11 @@ namespace Microsoft.AspNetCore.Components
                 : base(projectSnapshotManagerDispatcher, Mock.Of<ErrorReporter>(MockBehavior.Strict), triggers, workspace)
             {
             }
+        }
+
+        private class TestSVsServiceProvider : SVsServiceProvider
+        {
+            public object GetService(Type serviceType) => null;
         }
     }
 }


### PR DESCRIPTION
In an attempt to diagnose what's happening in https://github.com/dotnet/aspnetcore/issues/35787, I added some debug `WriteLine` outputs to the project snapshot manager dispatcher. Ideally these would be either (1) logs or (2) Debug.Fail, but the former doesn't apply to the Workspaces layer + not all the dispatchers support logging, and the latter will cause issues in tests.

I'm not sure how helpful these outputs would be so marking this PR as a draft for now. Any input would be appreciated.