### PR TITLE
Switch to dispatcher thread on Mac

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectBuildChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectBuildChangeTrigger.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Editor.Razor;
@@ -95,42 +96,47 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             }
         }
 
-        // Internal for testing
-        internal void ProjectOperations_EndBuild(object sender, BuildEventArgs args)
+        private void ProjectOperations_EndBuild(object sender, BuildEventArgs args)
         {
             if (args == null)
             {
                 throw new ArgumentNullException(nameof(args));
             }
 
+            _ = HandleEndBuildAsync(args);
+        }
+
+        // Internal for testing
+        internal Task HandleEndBuildAsync(BuildEventArgs args)
+        {
             if (!args.Success)
             {
                 // Build failed
-                return;
+                return Task.CompletedTask;
             }
 
-            _ = _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync((projectItem, ct) =>
-            {
-                if (!_projectService.IsSupportedProject(projectItem))
-                {
-                    // We're hooked into all build events, it's possible to get called with an unsupported project item type.
-                    return;
-                }
+            return _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync((projectItem, ct) =>
+                   {
+                       if (!_projectService.IsSupportedProject(projectItem))
+                       {
+                           // We're hooked into all build events, it's possible to get called with an unsupported project item type.
+                           return;
+                       }
 
-                var projectPath = _projectService.GetProjectPath(projectItem);
-                var projectSnapshot = _projectManager.GetLoadedProject(projectPath);
-                if (projectSnapshot != null)
-                {
-                    var workspaceProject = _projectManager.Workspace.CurrentSolution?.Projects.FirstOrDefault(
-                        project => FilePathComparer.Instance.Equals(project.FilePath, projectSnapshot.FilePath));
-                    if (workspaceProject != null)
-                    {
-                        // Trigger a tag helper update by forcing the project manager to see the workspace Project
-                        // from the current solution.
-                        _workspaceStateGenerator.Update(workspaceProject, projectSnapshot, CancellationToken.None);
-                    }
-                }
-            }, args.SolutionItem, CancellationToken.None);
+                       var projectPath = _projectService.GetProjectPath(projectItem);
+                       var projectSnapshot = _projectManager.GetLoadedProject(projectPath);
+                       if (projectSnapshot != null)
+                       {
+                           var workspaceProject = _projectManager.Workspace.CurrentSolution?.Projects.FirstOrDefault(
+                               project => FilePathComparer.Instance.Equals(project.FilePath, projectSnapshot.FilePath));
+                           if (workspaceProject != null)
+                           {
+                               // Trigger a tag helper update by forcing the project manager to see the workspace Project
+                               // from the current solution.
+                               _workspaceStateGenerator.Update(workspaceProject, projectSnapshot, CancellationToken.None);
+                           }
+                       }
+                   }, args.SolutionItem, CancellationToken.None);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectBuildChangeTriggerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectBuildChangeTriggerTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -40,7 +42,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
         private Workspace Workspace { get; }
 
         [UIFact]
-        public void ProjectOperations_EndBuild_EnqueuesProjectStateUpdate()
+        public async Task ProjectOperations_EndBuild_EnqueuesProjectStateUpdate()
         {
             // Arrange
             var expectedProjectPath = SomeProject.FilePath;
@@ -58,7 +60,9 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             var trigger = new ProjectBuildChangeTrigger(Dispatcher, projectService, workspaceStateGenerator, projectManager.Object);
 
             // Act
-            trigger.ProjectOperations_EndBuild(null, args);
+            await trigger.HandleEndBuildAsync(args);
+
+            Thread.Sleep(500);
 
             // Assert
             var update = Assert.Single(workspaceStateGenerator.UpdateQueue);
@@ -66,7 +70,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
         }
 
         [UIFact]
-        public void ProjectOperations_EndBuild_ProjectWithoutWorkspaceProject_Noops()
+        public async Task ProjectOperations_EndBuild_ProjectWithoutWorkspaceProject_Noops()
         {
             // Arrange
             var expectedPath = "Path/To/Project.csproj";
@@ -87,14 +91,14 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             var trigger = new ProjectBuildChangeTrigger(Dispatcher, projectService, workspaceStateGenerator, projectManager.Object);
 
             // Act
-            trigger.ProjectOperations_EndBuild(null, args);
+            await trigger.HandleEndBuildAsync(args);
 
             // Assert
             Assert.Empty(workspaceStateGenerator.UpdateQueue);
         }
 
         [UIFact]
-        public void ProjectOperations_EndBuild_UntrackedProject_Noops()
+        public async Task ProjectOperations_EndBuild_UntrackedProject_NoopsAsync()
         {
             // Arrange
             var projectService = CreateProjectService(SomeProject.FilePath);
@@ -110,14 +114,14 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             var trigger = new ProjectBuildChangeTrigger(Dispatcher, projectService, workspaceStateGenerator, projectManager.Object);
 
             // Act
-            trigger.ProjectOperations_EndBuild(null, args);
+            await trigger.HandleEndBuildAsync(args);
 
             // Assert
             Assert.Empty(workspaceStateGenerator.UpdateQueue);
         }
 
         [UIFact]
-        public void ProjectOperations_EndBuild_BuildFailed_Noops()
+        public async Task ProjectOperations_EndBuild_BuildFailed_Noops()
         {
             // Arrange
             var args = new BuildEventArgs(monitor: null, success: false);
@@ -129,14 +133,14 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             var trigger = new ProjectBuildChangeTrigger(Dispatcher, projectService.Object, workspaceStateGenerator, projectManager.Object);
 
             // Act
-            trigger.ProjectOperations_EndBuild(null, args);
+            await trigger.HandleEndBuildAsync(args);
 
             // Assert
             Assert.Empty(workspaceStateGenerator.UpdateQueue);
         }
 
         [UIFact]
-        public void ProjectOperations_EndBuild_UnsupportedProject_Noops()
+        public async Task ProjectOperations_EndBuild_UnsupportedProject_Noops()
         {
             // Arrange
             var args = new BuildEventArgs(monitor: null, success: true);
@@ -148,7 +152,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             var trigger = new ProjectBuildChangeTrigger(Dispatcher, projectService.Object, workspaceStateGenerator, projectManager.Object);
 
             // Act
-            trigger.ProjectOperations_EndBuild(null, args);
+            await trigger.HandleEndBuildAsync(args);
 
             // Assert
             Assert.Empty(workspaceStateGenerator.UpdateQueue);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391658
Whitespace off recommended.

Last time I looked for all events on `DotNetProject`, but this time I searched for all event handlers and found only these two, which match was reported.

I was going to make `RunOnDispatcherAsync` do a check for the right thread, and just not use `AssertDispatcherThread` at all in the Mac project, but since most of these are sync-over-async I'm not 100% sure of the impact in doing that, so left it for now.