### PR TITLE
Add support for basic `RenderFragment` completion.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -83,7 +83,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 }
 
                 var stringifiedAttributes = _tagHelperFactsService.StringifyAttributes(attributes);
-                var elementCompletions = GetElementCompletions(parent, containingTagNameToken.Content, stringifiedAttributes, context.TagHelperDocumentContext);
+                var containingElement = parent.Parent;
+                var elementCompletions = GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context.TagHelperDocumentContext);
                 return elementCompletions;
             }
 
@@ -188,12 +189,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         private IReadOnlyList<RazorCompletionItem> GetElementCompletions(
-            SyntaxNode containingTag,
+            SyntaxNode containingElement,
             string containingTagName,
             IEnumerable<KeyValuePair<string, string>> attributes,
             TagHelperDocumentContext tagHelperDocumentContext)
         {
-            var ancestors = containingTag.Ancestors();
+            var ancestors = containingElement.Ancestors();
             var (ancestorTagName, ancestorIsTagHelper) = _tagHelperFactsService.GetNearestAncestorTagInfo(ancestors);
             var elementCompletionContext = new ElementCompletionContext(
                 tagHelperDocumentContext,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperCompletionService.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             var catchAllDescriptors = new HashSet<TagHelperDescriptor>();
             var prefix = completionContext.DocumentContext.Prefix ?? string.Empty;
-            var possibleChildDescriptors = _tagHelperFactsService.GetTagHelpersGivenParent(completionContext.DocumentContext, completionContext.ContainingTagName);
+            var possibleChildDescriptors = _tagHelperFactsService.GetTagHelpersGivenParent(completionContext.DocumentContext, completionContext.ContainingParentTagName);
             possibleChildDescriptors = FilterFullyQualifiedCompletions(possibleChildDescriptors);
             foreach (var possibleDescriptor in possibleChildDescriptors)
             {
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
                 foreach (var rule in possibleDescriptor.TagMatchingRules)
                 {
-                    if (!TagHelperMatchingConventions.SatisfiesParentTag(completionContext.ContainingTagName, rule))
+                    if (!TagHelperMatchingConventions.SatisfiesParentTag(completionContext.ContainingParentTagName, rule))
                     {
                         continue;
                     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -184,6 +184,60 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        public void GetCompletionAt_InBody_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2><</test2>", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(37 + Environment.NewLine.Length, 0);
+            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+
+            // Act
+            var completions = service.GetCompletionItems(context, sourceSpan);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("test1", completion.InsertText);
+                },
+                completion =>
+                {
+                    Assert.Equal("test2", completion.InsertText);
+                });
+        }
+
+        [Fact]
+        public void GetCompletionAt_InBody_ParentRequiring_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><</test1>", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(37 + Environment.NewLine.Length, 0);
+            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+
+            // Act
+            var completions = service.GetCompletionItems(context, sourceSpan);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("test1", completion.InsertText);
+                },
+                completion =>
+                {
+                    Assert.Equal("SomeChild", completion.InsertText);
+                },
+                completion =>
+                {
+                    Assert.Equal("test2", completion.InsertText);
+                });
+        }
+
+        [Fact]
         public void GetCompletionAt_AtAttributeEdge_BoolAttribute_ReturnsCompletionsWithout()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -40,6 +40,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 attribute.TypeName = typeof(int).FullName;
             });
 
+            var builder1WithRequiredParent = TagHelperDescriptorBuilder.Create("Test1TagHelper.SomeChild", "TestAssembly");
+            builder1WithRequiredParent.TagMatchingRule(rule =>
+            {
+                rule.TagName = "SomeChild";
+                rule.ParentTag = "test1";
+            });
+            builder1WithRequiredParent.SetTypeName("Test1TagHelper.SomeChild");
+
             var builder2 = TagHelperDescriptorBuilder.Create("Test2TagHelper", "TestAssembly");
             builder2.TagMatchingRule(rule => rule.TagName = "test2");
             builder2.SetTypeName("Test2TagHelper");
@@ -149,7 +157,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             directiveAttribute2.Metadata[ComponentMetadata.Component.NameMatchKey] = ComponentMetadata.Component.FullyQualifiedNameMatch;
             directiveAttribute2.SetTypeName("TestDirectiveAttribute");
 
-            DefaultTagHelpers = new[] { builder1.Build(), builder2.Build(), builder3.Build(), directiveAttribute1.Build(), directiveAttribute2.Build() };
+            DefaultTagHelpers = new[]
+            {
+                builder1.Build(),
+                builder1WithRequiredParent.Build(),
+                builder2.Build(),
+                builder3.Build(),
+                directiveAttribute1.Build(),
+                directiveAttribute2.Build()
+            };
 
             HtmlFactsService = new DefaultHtmlFactsService();
             TagHelperFactsService = new DefaultTagHelperFactsService();


### PR DESCRIPTION
- Turns out we were passing in the wrong information to our completion engine so it couldn't apply proper "parent tag" restrictions. TagHelpers have the ability to specify a required tag name and our completion engine wasn't capturing the proper "parent tag" name. Instead we were capturing the active tag name so when you would type `<|` we'd think the parent tag name was the empty string. After fixing which tag we were inspecting I also then found that we were blatantly passing in the wrong criteria to our matching conventions for parent tag restrictions.
- This wasn't an issue in the old editor because the old editor did not use our completion engine and instead had its own (which also had its own flaws).
- Mentioning that this issue is for "basic" completion because there's a lot more we can improve in this area. I've filed [this](https://github.com/dotnet/aspnetcore/issues/36634) to capture fully filling out `RenderFragment` completion support.
- Added tests that also had TagHelpers with parent tag restrictions.

### Before

![image](https://i.imgur.com/JxYSTi1.gif)

### After

![image](https://i.imgur.com/PsrFY9R.gif)

Fixes dotnet/aspnetcore#36120