### PR TITLE
Fix CSS diagnostic remapping

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Extensions/RazorLanguageKindExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Extensions/RazorLanguageKindExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions
     internal static class RazorLanguageKindExtensions
     {
         public static string ToContainedLanguageContentType(this RazorLanguageKind razorLanguageKind) =>
-            razorLanguageKind == RazorLanguageKind.CSharp ? RazorLSPConstants.CSharpContentTypeName : RazorLSPConstants.HtmlLSPContentTypeName;
+            razorLanguageKind == RazorLanguageKind.CSharp ? RazorLSPConstants.CSharpContentTypeName : RazorLSPConstants.HtmlLSPDelegationContentTypeName;
 
         public static string ToContainedLanguageServerName(this RazorLanguageKind razorLanguageKind)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -466,7 +466,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
 
                 if (IsCSharpApplicable(metadata) ||
-                    metadata.ContentTypes.Contains(RazorLSPConstants.HtmlLSPContentTypeName))
+                    metadata.ContentTypes.Contains(RazorLSPConstants.HtmlLSPDelegationContentTypeName))
                 {
                     relevantLanguageClients.Add(languageClientAndMetadata.Value);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LanguageServerKindExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/LanguageServerKindExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return languageServerKind switch
             {
                 LanguageServerKind.CSharp => RazorLSPConstants.CSharpContentTypeName,
-                LanguageServerKind.Html => RazorLSPConstants.HtmlLSPContentTypeName,
+                LanguageServerKind.Html => RazorLSPConstants.HtmlLSPDelegationContentTypeName,
                 _ => RazorLSPConstants.RazorLSPContentTypeName,
             };
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 if (s_htmlLSPContentType == null)
                 {
-                    s_htmlLSPContentType = ContentTypeRegistry.GetContentType(RazorLSPConstants.HtmlLSPContentTypeName);
+                    s_htmlLSPContentType = ContentTypeRegistry.GetContentType(RazorLSPConstants.HtmlLSPDelegationContentTypeName);
                 }
 
                 return s_htmlLSPContentType;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -19,7 +19,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
     [Export(typeof(MessageInterceptor))]
     [InterceptMethod(Methods.TextDocumentPublishDiagnosticsName)]
-    [ContentType(RazorLSPConstants.RazorLSPContentTypeName)]
+    [ContentType(RazorLSPConstants.HtmlLSPContentTypeName)]
+    [ContentType(RazorLSPConstants.CssLSPContentTypeName)]
+    [ContentType(RazorLSPConstants.TypeScriptLSPContentTypeName)]
     internal class RazorHtmlPublishDiagnosticsInterceptor : MessageInterceptor
     {
         private readonly LSPDocumentManager _documentManager;
@@ -79,13 +81,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 throw exception;
             }
 
-            _logger?.LogInformation($"Received HTML Publish diagnostic request for {diagnosticParams.Uri} with {diagnosticParams.Diagnostics.Length} diagnostics.");
-
             // We only support interception of Virtual HTML Files
             if (!RazorLSPConventions.IsVirtualHtmlFile(diagnosticParams.Uri))
             {
                 return CreateDefaultResponse(token);
             }
+
+            _logger?.LogInformation($"Received HTML Publish diagnostic request for {diagnosticParams.Uri} with {diagnosticParams.Diagnostics.Length} diagnostics.");
 
             var htmlDocumentUri = diagnosticParams.Uri;
             var razorDocumentUri = RazorLSPConventions.GetRazorDocumentUri(htmlDocumentUri);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -23,7 +23,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public const string CSharpContentTypeName = "CSharp";
 
-        public const string HtmlLSPContentTypeName = "html-delegation";
+        public const string HtmlLSPDelegationContentTypeName = "html-delegation";
+
+        public const string HtmlLSPContentTypeName = "htmlLSPClient";
+
+        public const string CssLSPContentTypeName = "cssLSPClient";
+
+        public const string TypeScriptLSPContentTypeName = "JavaScript";
 
         public const string VirtualCSharpFileNameSuffix = ".g.cs";
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         {
             var htmlContentType = Mock.Of<IContentType>(MockBehavior.Strict);
             ContentTypeRegistry = Mock.Of<IContentTypeRegistryService>(
-                registry => registry.GetContentType(RazorLSPConstants.HtmlLSPContentTypeName) == htmlContentType, MockBehavior.Strict);
+                registry => registry.GetContentType(RazorLSPConstants.HtmlLSPDelegationContentTypeName) == htmlContentType, MockBehavior.Strict);
             var textBufferFactory = new Mock<ITextBufferFactoryService>(MockBehavior.Strict);
             var factoryBuffer = Mock.Of<ITextBuffer>(buffer => buffer.CurrentSnapshot == Mock.Of<ITextSnapshot>(MockBehavior.Strict) && buffer.Properties == new PropertyCollection(), MockBehavior.Strict);
             Mock.Get(factoryBuffer).Setup(b => b.ChangeContentType(It.IsAny<IContentType>(), It.IsAny<object>())).Verifiable();


### PR DESCRIPTION
- When we re-did the publish diagnostic interceptor to not load in unexpected scenarios we had to then specify a content type for when we wanted to remap diagnostics. Only problem is that we need to remap JS/HTML/CSS diagnostics too and the middlelayer that intercepts publish diagnostics requests for those sub-languages passes along their language identifier (CSS, JavaScript etc.). Therefore, we were comparing "Razor" to "cssLSPClient" which would always fail resulting in our interceptor never running
- Updated to allow remapping from JavaScript / CSS / HTML; however, this has an unintended side effect of loading Razor bits in HTML LSP scenarios. This changeset most likely isn't the final bits required to fix this isseu because it re-introduces an assembly load regression on the HTML LSP front.
- Found that JavaScript doesn't seem to be publishing diagnostics when doing these code changes, following up.

### Before

![image](https://user-images.githubusercontent.com/2008729/133845004-bf57424f-cbd0-45b1-88bc-9fa371b4f9b2.png)

### After

![image](https://user-images.githubusercontent.com/2008729/133844747-6430b61b-01f4-4cd9-a7a1-2788394e8cc4.png)

Fixes dotnet/aspnetcore#36556
