### PR TITLE
Suppress TagHelper diagnostics on tag name.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
@@ -664,6 +664,64 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
         }
 
         [Fact]
+        public async Task Handle_ProcessDiagnostics_Html_TagHelperStartTag()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var addTagHelper = $"@addTagHelper *, TestAssembly{Environment.NewLine}";
+            var codeDocument = CreateCodeDocument(
+                $"{addTagHelper}<button></button>",
+                new[]
+                {
+                    GetButtonTagHelperDescriptor().Build()
+                });
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
+            var request = new RazorDiagnosticsParams()
+            {
+                Kind = RazorLanguageKind.Html,
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(1, 1), new Position(1, 7)) } },
+                RazorDocumentUri = new Uri(documentPath),
+            };
+
+            // Act
+            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+
+            // Assert
+            Assert.Empty(response.Diagnostics);
+            Assert.Equal(1337, response.HostDocumentVersion);
+        }
+
+        [Fact]
+        public async Task Handle_ProcessDiagnostics_Html_TagHelperEndTag()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var addTagHelper = $"@addTagHelper *, TestAssembly{Environment.NewLine}";
+            var codeDocument = CreateCodeDocument(
+                $"{addTagHelper}<button></button>",
+                new[]
+                {
+                    GetButtonTagHelperDescriptor().Build()
+                });
+            var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(Dispatcher, documentResolver, DocumentVersionCache, MappingService, LoggerFactory);
+            var request = new RazorDiagnosticsParams()
+            {
+                Kind = RazorLanguageKind.Html,
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(1, 10), new Position(1, 17)) } },
+                RazorDocumentUri = new Uri(documentPath),
+            };
+
+            // Act
+            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+
+            // Assert
+            Assert.Empty(response.Diagnostics);
+            Assert.Equal(1337, response.HostDocumentVersion);
+        }
+
+        [Fact]
         public async Task Handle_ProcessDiagnostics_Html_WithCSharpInAttribute_SingleDiagnostic()
         {
             // Arrange


### PR DESCRIPTION
- When users write TagHelper's or Components that override default HTML elements like `Input` the HTML stack can see that as an error because technically if a TagHelper allows body content to `Input` that is invalid in terms of a normal `input` HTML element. To account for this we suppress HTML diagnostics on TagHelper tag names.
- Added tests to validate that we suppress diagnostics on Component tag names

### Before
![image](https://user-images.githubusercontent.com/2008729/133857200-ddfb5079-192a-4229-ac73-ed4a724d51c4.png)

### After
![image](https://user-images.githubusercontent.com/2008729/133857077-e938443c-f5b4-40e3-8b1c-717f91c0ac12.png)

Fixes dotnet/aspnetcore#36569