### PR TITLE
Fix auto-closing behavior of mirrored components.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
     internal class AutoClosingTagOnAutoInsertProvider : RazorOnAutoInsertProvider
     {
         // From http://dev.w3.org/html5/spec/Overview.html#elements-0
-        public static readonly HashSet<string> VoidElements = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        public static readonly HashSet<string> VoidElements = new HashSet<string>(StringComparer.Ordinal)
         {
             "area",
             "base",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
     internal class AutoClosingTagOnAutoInsertProvider : RazorOnAutoInsertProvider
     {
         // From http://dev.w3.org/html5/spec/Overview.html#elements-0
-        public static readonly HashSet<string> VoidElements = new HashSet<string>(StringComparer.Ordinal)
+        private static readonly IReadOnlyList<string> VoidElements = new[]
         {
             "area",
             "base",
@@ -145,7 +146,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
                 if (!TryGetTagHelperAutoClosingBehavior(tagHelperElement.TagHelperInfo.BindingResult, out autoClosingBehavior))
                 {
-                    autoClosingBehavior = InferAutoClosingBehavior(name);
+                    autoClosingBehavior = InferAutoClosingBehavior(name, tagNameComparer: StringComparer.Ordinal);
                 }
 
                 return true;
@@ -238,9 +239,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             return true;
         }
 
-        private static AutoClosingBehavior InferAutoClosingBehavior(string name)
+        private static AutoClosingBehavior InferAutoClosingBehavior(string name, StringComparer tagNameComparer = null)
         {
-            if (VoidElements.Contains(name))
+            tagNameComparer ??= StringComparer.OrdinalIgnoreCase;
+
+            if (VoidElements.Contains(name, tagNameComparer))
             {
                 return AutoClosingBehavior.SelfClosing;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.Extensions.Options;
@@ -86,6 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/36568")]
         public void OnTypeCloseAngle_VoidElementMirroringTagHelper()
         {
             RunAutoInsertTest(
@@ -101,6 +103,17 @@ expected: @"
 ",
 fileKind: FileKinds.Legacy,
 tagHelpers: new[] { UnspecifiedInputMirroringTagHelper });
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/36568")]
+        public void OnTypeCloseAngle_VoidHtmlElementCapitalized_SelfCloses()
+        {
+            RunAutoInsertTest(
+input: "<Input>$$",
+expected: "<Input />",
+fileKind: FileKinds.Legacy,
+tagHelpers: Array.Empty<TagHelperDescriptor>());
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -13,6 +13,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
     {
         private RazorLSPOptions Options { get; set; } = RazorLSPOptions.Default;
 
+        private static TagHelperDescriptor UnspecifiedInputMirroringTagHelper
+        {
+            get
+            {
+                var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
+                descriptor.SetTypeName("TestNamespace.TestTagHelper");
+                descriptor.TagMatchingRule(builder => builder.RequireTagName("Input").RequireTagStructure(TagStructure.Unspecified));
+
+                return descriptor.Build();
+            }
+        }
+
         private static TagHelperDescriptor UnspecifiedTagHelper
         {
             get
@@ -71,6 +83,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
                 return descriptor.Build();
             }
+        }
+
+        [Fact]
+        public void OnTypeCloseAngle_VoidElementMirroringTagHelper()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+<Input>$$
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+<Input>$0</Input>
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { UnspecifiedInputMirroringTagHelper });
         }
 
         [Fact]


### PR DESCRIPTION
- Found that we were treating TagHelper components as basic void HTML elements which auto-close as self-closing; however, there wasn't an easy way to fix this issue. Technically TagHelpers can also apply to void elements so we can't simply check "is it void and a TagHelper then do something different". Therefore I felt it was a reasonable trade to say if a user misstypes their HTML element (and avoids using our completion items) then they wont get auto-closing behavior. This in turn allows us to detect cases when a user has a more component looking HTML element like `Input` (pascal cased) and default to open/close or whatever the TagHelper specifies as its auto-closing behavior.
- Added a test to validate the new behavior.

### Before

![image](https://i.imgur.com/v0QrjlR.gif)_

### After

![image](https://i.imgur.com/9nYqVVj.gif)

Fixes dotnet/aspnetcore#36568