### PR TITLE
Mark solution as open when we receive a new project

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -94,6 +94,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
         }
 
+        // internal for testing
+        internal bool IsSolutionClosing => _solutionIsClosing;
+
         public override IReadOnlyList<ProjectSnapshot> Projects
         {
             get

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/RazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/RazorProjectHostBase.cs
@@ -184,6 +184,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
             else if (Current == null && project != null)
             {
+                // Just in case we somehow got in a state where VS didn't tell us that solution close was finished, lets just
+                // ensure we're going to actually do something with the new project that we've just been told about.
+                // If VS did tell us, then this is a no-op.
+                projectManager.SolutionOpened();
+
                 projectManager.ProjectAdded(project);
             }
             else if (Current != null && project == null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioSolutionCloseChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioSolutionCloseChangeTrigger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     [Export(typeof(ProjectSnapshotChangeTrigger))]
     [System.Composition.Shared]
-    internal class VisualStudioSolutionCloseChangeTrigger : ProjectSnapshotChangeTrigger, IVsSolutionEvents, IDisposable
+    internal class VisualStudioSolutionCloseChangeTrigger : ProjectSnapshotChangeTrigger, IVsSolutionEvents3, IDisposable
     {
         private IVsSolution? _solution;
         private readonly IServiceProvider _serviceProvider;
@@ -54,6 +54,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             _solution?.UnadviseSolutionEvents(_cookie);
         }
 
+        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
+        {
+            _projectSnapshotManager?.SolutionOpened();
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeCloseSolution(object pUnkReserved)
+        {
+            _projectSnapshotManager?.SolutionClosed();
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterCloseSolution(object pUnkReserved)
+        {
+            _projectSnapshotManager?.SolutionOpened();
+            return VSConstants.S_OK;
+        }
+
+        #region Events we're not interested in
         public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
         {
             return HResult.NotImplemented;
@@ -84,27 +103,36 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             return HResult.NotImplemented;
         }
 
-        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
-        {
-            _projectSnapshotManager?.SolutionOpened();
-            return VSConstants.S_OK;
-        }
-
         public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
         {
             return HResult.NotImplemented;
         }
 
-        public int OnBeforeCloseSolution(object pUnkReserved)
+        public int OnAfterMergeSolution(object pUnkReserved)
         {
-            _projectSnapshotManager?.SolutionClosed();
-            return VSConstants.S_OK;
-        }
-
-        public int OnAfterCloseSolution(object pUnkReserved)
-        {
-            _projectSnapshotManager?.SolutionOpened();
             return HResult.NotImplemented;
         }
+
+        public int OnBeforeOpeningChildren(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnAfterOpeningChildren(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnBeforeClosingChildren(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnAfterClosingChildren(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/36697

A few things:
* I did see `OnAfterCloseSolution` not firing, but anecdotally it seemed like implementing `IVsSolutionEvents3` made this go away. I can provide no evidence for this though :)
* Yes the CPS stuff fires before `OnAfterOpenSolution` but that is expected. On my machine, under the debugger, however the actual dataflow event happened _afterwards_ so I didn't see any issues, but I can totally see how I would have, if I didn't get lucky
* Ultimately CPS is our "source of truth" here, since it initializes the project manager, which initializes the triggers, which is when we first get to hook up to the solution events so whilst this workaround seems a _little_ dodgy, it's not beyond reason IMO.

Happy to discuss further though if anyone has any better ideas.