### PR TITLE
Format the whole document when doing range formatting

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -29,6 +29,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public const string RazorCodeActionRunnerCommand = "razor/runCodeAction";
 
+        public const string RazorDocumentFormattingEndpoint = "textDocument/formatting";
+
         // RZLS Custom Message Targets
         public const string RazorUpdateCSharpBufferEndpoint = "razor/updateCSharpBuffer";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             var uri = request.TextDocument.Uri;
             var position = request.Position;
 
-            using (var formattingContext = FormattingContext.Create(uri, document, codeDocument, request.Options, _workspaceFactory, new Range(position, position)))
+            using (var formattingContext = FormattingContext.Create(uri, document, codeDocument, request.Options, _workspaceFactory))
             {
                 for (var i = 0; i < applicableProviders.Count; i++)
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             };
 
             var response = await _server.SendRequestAsync(LanguageServerConstants.RazorRangeFormattingEndpoint, @params);
-            var result = await response.Returning<RazorDocumentRangeFormattingResponse>(cancellationToken);
+            var result = await response.Returning<RazorDocumentFormattingResponse>(cancellationToken);
 
             return result?.Edits ?? Array.Empty<TextEdit>();
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
-            using var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, _workspaceFactory, range);
+            using var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, _workspaceFactory);
 
             var result = new FormattingResult(Array.Empty<TextEdit>());
             foreach (var pass in _formattingPasses)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -225,7 +225,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             ValidateComponents(CodeDocument, codeDocument);
 
-            var newContext = Create(Uri, OriginalSnapshot, codeDocument, Options, _workspaceFactory, Range, IsFormatOnType);
+            var newContext = Create(Uri, OriginalSnapshot, codeDocument, Options, _workspaceFactory, IsFormatOnType);
             return newContext;
         }
 
@@ -248,7 +248,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             RazorCodeDocument codeDocument,
             FormattingOptions options,
             AdhocWorkspaceFactory workspaceFactory,
-            Range? range = null,
             bool isFormatOnType = false)
         {
             if (uri is null)
@@ -276,9 +275,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(workspaceFactory));
             }
 
-            var text = codeDocument.GetSourceText();
-            range ??= TextSpan.FromBounds(0, text.Length).AsRange(text);
-
             var syntaxTree = codeDocument.GetSyntaxTree();
             var formattingSpans = syntaxTree.GetFormattingSpans();
 
@@ -287,7 +283,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 Uri = uri,
                 OriginalSnapshot = originalSnapshot,
                 CodeDocument = codeDocument,
-                Range = range,
                 Options = options,
                 IsFormatOnType = isFormatOnType,
                 FormattingSpans = formattingSpans

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
@@ -8,8 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
@@ -38,7 +38,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public async Task<TextEdit[]> FormatAsync(
             FormattingContext context,
-            Range rangeToFormat,
             CancellationToken cancellationToken)
         {
             if (context is null)
@@ -46,15 +45,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (rangeToFormat is null)
-            {
-                throw new ArgumentNullException(nameof(rangeToFormat));
-            }
+            var text = context.SourceText;
+            var range = TextSpan.FromBounds(0, text.Length).AsRange(text);
 
             var @params = new RazorDocumentRangeFormattingParams()
             {
                 Kind = RazorLanguageKind.Html,
-                ProjectedRange = rangeToFormat,
+                ProjectedRange = range,
                 HostDocumentFilePath = _filePathNormalizer.Normalize(context.Uri.GetAbsoluteOrUNCPath()),
                 Options = context.Options
             };

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
@@ -45,19 +44,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var text = context.SourceText;
-            var range = TextSpan.FromBounds(0, text.Length).AsRange(text);
-
-            var @params = new RazorDocumentRangeFormattingParams()
+            var @params = new DocumentFormattingParams()
             {
-                Kind = RazorLanguageKind.Html,
-                ProjectedRange = range,
-                HostDocumentFilePath = _filePathNormalizer.Normalize(context.Uri.GetAbsoluteOrUNCPath()),
+                TextDocument = new TextDocumentIdentifier { Uri = _filePathNormalizer.Normalize(context.Uri.GetAbsoluteOrUNCPath()) },
                 Options = context.Options
             };
 
-            var response = await _server.SendRequestAsync(LanguageServerConstants.RazorRangeFormattingEndpoint, @params);
-            var result = await response.Returning<RazorDocumentRangeFormattingResponse>(cancellationToken);
+            var response = await _server.SendRequestAsync(LanguageServerConstants.RazorDocumentFormattingEndpoint, @params);
+            var result = await response.Returning<RazorDocumentFormattingResponse>(cancellationToken);
 
             return result?.Edits ?? Array.Empty<TextEdit>();
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -57,8 +57,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             var originalText = context.SourceText;
 
-            var range = TextSpan.FromBounds(0, originalText.Length).AsRange(originalText);
-            var htmlEdits = await HtmlFormatter.FormatAsync(context, range, cancellationToken);
+            var htmlEdits = await HtmlFormatter.FormatAsync(context, cancellationToken);
             var normalizedEdits = NormalizeTextEdits(originalText, htmlEdits);
             var mappedEdits = RemapTextEdits(context.CodeDocument, normalizedEdits, RazorLanguageKind.Html);
             var changes = mappedEdits.Select(e => e.AsTextChange(originalText));

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -57,7 +57,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             var originalText = context.SourceText;
 
-            var htmlEdits = await HtmlFormatter.FormatAsync(context, context.Range, cancellationToken);
+            var range = TextSpan.FromBounds(0, originalText.Length).AsRange(originalText);
+            var htmlEdits = await HtmlFormatter.FormatAsync(context, range, cancellationToken);
             var normalizedEdits = NormalizeTextEdits(originalText, htmlEdits);
             var mappedEdits = RemapTextEdits(context.CodeDocument, normalizedEdits, RazorLanguageKind.Html);
             var changes = mappedEdits.Select(e => e.AsTextChange(originalText));

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentFormattingResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentFormattingResponse.cs
@@ -7,7 +7,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
-    internal class RazorDocumentRangeFormattingResponse
+    internal class RazorDocumentFormattingResponse
     {
         public TextEdit[]? Edits { get; set; }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingParams.cs
@@ -9,7 +9,7 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
-    internal class RazorDocumentRangeFormattingParams : IRequest<RazorDocumentRangeFormattingResponse>
+    internal class RazorDocumentRangeFormattingParams : IRequest<RazorDocumentFormattingResponse>
     {
         public RazorLanguageKind Kind { get; set; }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -27,6 +27,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         [JsonRpcMethod(LanguageServerConstants.RazorUpdateHtmlBufferEndpoint, UseSingleObjectParameterDeserialization = true)]
         public abstract Task UpdateHtmlBufferAsync(UpdateBufferRequest token, CancellationToken cancellationToken);
 
+        // Called by the Razor Language Server to invoke a textDocument/formatting request
+        // on the virtual Html/CSharp buffer.
+        [JsonRpcMethod(LanguageServerConstants.RazorDocumentFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<RazorDocumentRangeFormattingResponse> RazorDocumentFormattingAsync(DocumentFormattingParams token, CancellationToken cancellationToken);
+
         // Called by the Razor Language Server to invoke a textDocument/rangeFormatting request
         // on the virtual Html/CSharp buffer.
         [JsonRpcMethod(LanguageServerConstants.RazorRangeFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Text;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {
@@ -42,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             };
 
             var provider = CreateProvider();
-            var context = FormattingContext.Create(uri, Mock.Of<DocumentSnapshot>(MockBehavior.Strict), codeDocument, options, TestAdhocWorkspaceFactory.Instance, new Range(position, position));
+            var context = FormattingContext.Create(uri, Mock.Of<DocumentSnapshot>(MockBehavior.Strict), codeDocument, options, TestAdhocWorkspaceFactory.Instance);
 
             // Act
             if (!provider.TryResolveInsertion(position, context, out var edit, out _))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerClient.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerClient.cs
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 return Task.FromResult(Convert(response));
             }
             else if (@params is DocumentFormattingParams formattingParams &&
-                        string.Equals(method, "textDocument/formatting", StringComparison.Ordinal))
+                string.Equals(method, "textDocument/formatting", StringComparison.Ordinal))
             {
                 var response = Format(formattingParams);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerClient.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerClient.cs
@@ -65,10 +65,68 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public void AddCodeDocument(RazorCodeDocument codeDocument)
         {
             var path = _filePathNormalizer.Normalize(codeDocument.Source.FilePath);
-            _documents.TryAdd(path, codeDocument);
+            _documents.TryAdd("/" + path, codeDocument);
         }
 
-        private RazorDocumentRangeFormattingResponse Format(RazorDocumentRangeFormattingParams @params)
+        private RazorDocumentFormattingResponse Format(DocumentFormattingParams @params)
+        {
+            var options = @params.Options;
+            var response = new RazorDocumentFormattingResponse();
+
+            response.Edits = Array.Empty<TextEdit>();
+
+            var codeDocument = _documents[@params.TextDocument.Uri.GetAbsoluteOrUNCPath()];
+            var generatedHtml = codeDocument.GetHtmlDocument().GeneratedHtml;
+            generatedHtml = generatedHtml.Replace("\r", "", StringComparison.Ordinal).Replace("\n", "\r\n", StringComparison.Ordinal);
+            var generatedHtmlSource = SourceText.From(generatedHtml, Encoding.UTF8);
+
+            var editHandlerAssembly = Assembly.Load("Microsoft.WebTools.Languages.LanguageServer.Server, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+            var editHandlerType = editHandlerAssembly.GetType("Microsoft.WebTools.Languages.LanguageServer.Server.Html.OperationHandlers.ApplyFormatEditsHandler", throwOnError: true);
+            var bufferManagerType = editHandlerAssembly.GetType("Microsoft.WebTools.Languages.LanguageServer.Server.Shared.Buffer.BufferManager", throwOnError: true);
+
+            var exportProvider = EditorTestCompositions.Editor.ExportProviderFactory.CreateExportProvider();
+            var contentTypeService = exportProvider.GetExportedValue<IContentTypeRegistryService>();
+
+            contentTypeService.AddContentType(HtmlContentTypeDefinition.HtmlContentType, new[] { StandardContentTypeNames.Text });
+
+            var textBufferFactoryService = exportProvider.GetExportedValue<ITextBufferFactoryService>();
+            var textBufferListeners = Array.Empty<Lazy<IWebTextBufferListener, IOrderedComponentContentTypes>>();
+            var bufferManager = Activator.CreateInstance(bufferManagerType, new object[] { contentTypeService, textBufferFactoryService, textBufferListeners });
+            var joinableTaskFactoryThreadSwitcher = typeof(IdAttribute).Assembly.GetType("Microsoft.WebTools.Shared.Threading.JoinableTaskFactoryThreadSwitcher", throwOnError: true);
+            var threadSwitcher = (IThreadSwitcher)Activator.CreateInstance(joinableTaskFactoryThreadSwitcher, new object[] { new JoinableTaskContext().Factory });
+            var applyFormatEditsHandler = Activator.CreateInstance(editHandlerType, new object[] { bufferManager, threadSwitcher, textBufferFactoryService });
+
+            // Make sure the buffer manager knows about the source document
+            var documentUri = DocumentUri.From($"file:///{@params.TextDocument.Uri}");
+            var contentTypeName = HtmlContentTypeDefinition.HtmlContentType;
+            var initialContent = generatedHtml;
+            var snapshotVersionFromLSP = 0;
+            Assert.IsAssignableFrom<ITextSnapshot>(bufferManager.GetType().GetMethod("CreateBuffer").Invoke(bufferManager, new object[] { documentUri, contentTypeName, initialContent, snapshotVersionFromLSP }));
+
+            var requestType = editHandlerAssembly.GetType("Microsoft.WebTools.Languages.LanguageServer.Server.ContainedLanguage.ApplyFormatEditsParamForOmniSharp", throwOnError: true);
+            var serializedValue = $@"{{
+    ""Options"": {{
+        ""UseSpaces"": {(@params.Options.InsertSpaces ? "true" : "false")},
+        ""TabSize"": {@params.Options.TabSize},
+        ""IndentSize"": {@params.Options.TabSize}
+    }},
+    ""Uri"": ""file:///{@params.TextDocument.Uri}"",
+    ""GeneratedChanges"": [
+    ]
+}}
+";
+            var request = JsonConvert.DeserializeObject(serializedValue, requestType);
+            var resultTask = (Task)applyFormatEditsHandler.GetType().GetRuntimeMethod("Handle", new Type[] { requestType, typeof(CancellationToken) }).Invoke(applyFormatEditsHandler, new object[] { request, CancellationToken.None });
+            var result = resultTask.GetType().GetProperty(nameof(Task<int>.Result)).GetValue(resultTask);
+            var rawTextChanges = result.GetType().GetProperty("TextChanges").GetValue(result);
+            var serializedTextChanges = JsonConvert.SerializeObject(rawTextChanges, Newtonsoft.Json.Formatting.Indented);
+            var textChanges = JsonConvert.DeserializeObject<HtmlFormatterTextEdit[]>(serializedTextChanges);
+            response.Edits = textChanges.Select(change => change.AsTextEdit(SourceText.From(generatedHtml))).ToArray();
+
+            return response;
+        }
+
+        private RazorDocumentFormattingResponse Format(RazorDocumentRangeFormattingParams @params)
         {
             if (@params.Kind == RazorLanguageKind.Razor)
             {
@@ -76,7 +134,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             var options = @params.Options;
-            var response = new RazorDocumentRangeFormattingResponse();
+            var response = new RazorDocumentFormattingResponse();
 
             if (@params.Kind == RazorLanguageKind.CSharp)
             {
@@ -93,61 +151,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
                 response.Edits = changes.Select(c => c.AsTextEdit(csharpSourceText)).ToArray();
             }
-            else if (@params.Kind == RazorLanguageKind.Html)
+            else
             {
-                response.Edits = Array.Empty<TextEdit>();
-
-                var codeDocument = _documents[@params.HostDocumentFilePath];
-                var generatedHtml = codeDocument.GetHtmlDocument().GeneratedHtml;
-                generatedHtml = generatedHtml.Replace("\r", "", StringComparison.Ordinal).Replace("\n", "\r\n", StringComparison.Ordinal);
-                var generatedHtmlSource = SourceText.From(generatedHtml, Encoding.UTF8);
-
-                var editHandlerAssembly = Assembly.Load("Microsoft.WebTools.Languages.LanguageServer.Server, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-                var editHandlerType = editHandlerAssembly.GetType("Microsoft.WebTools.Languages.LanguageServer.Server.Html.OperationHandlers.ApplyFormatEditsHandler", throwOnError: true);
-                var bufferManagerType = editHandlerAssembly.GetType("Microsoft.WebTools.Languages.LanguageServer.Server.Shared.Buffer.BufferManager", throwOnError: true);
-
-                var exportProvider = EditorTestCompositions.Editor.ExportProviderFactory.CreateExportProvider();
-                var contentTypeService = exportProvider.GetExportedValue<IContentTypeRegistryService>();
-
-                contentTypeService.AddContentType(HtmlContentTypeDefinition.HtmlContentType, new[] { StandardContentTypeNames.Text });
-
-                var textBufferFactoryService = exportProvider.GetExportedValue<ITextBufferFactoryService>();
-                var textBufferListeners = Array.Empty<Lazy<IWebTextBufferListener, IOrderedComponentContentTypes>>();
-                var bufferManager = Activator.CreateInstance(bufferManagerType, new object[] { contentTypeService, textBufferFactoryService, textBufferListeners });
-                var joinableTaskFactoryThreadSwitcher = typeof(IdAttribute).Assembly.GetType("Microsoft.WebTools.Shared.Threading.JoinableTaskFactoryThreadSwitcher", throwOnError: true);
-                var threadSwitcher = (IThreadSwitcher)Activator.CreateInstance(joinableTaskFactoryThreadSwitcher, new object[] { new JoinableTaskContext().Factory });
-                var applyFormatEditsHandler = Activator.CreateInstance(editHandlerType, new object[] { bufferManager, threadSwitcher, textBufferFactoryService });
-
-                // Make sure the buffer manager knows about the source document
-                var documentUri = DocumentUri.From($"file:///{@params.HostDocumentFilePath}");
-                var contentTypeName = HtmlContentTypeDefinition.HtmlContentType;
-                var initialContent = generatedHtml;
-                var snapshotVersionFromLSP = 0;
-                Assert.IsAssignableFrom<ITextSnapshot>(bufferManager.GetType().GetMethod("CreateBuffer").Invoke(bufferManager, new object[] { documentUri, contentTypeName, initialContent, snapshotVersionFromLSP }));
-
-                var requestType = editHandlerAssembly.GetType("Microsoft.WebTools.Languages.LanguageServer.Server.ContainedLanguage.ApplyFormatEditsParamForOmniSharp", throwOnError: true);
-                var serializedValue = $@"{{
-    ""Options"": {{
-        ""UseSpaces"": {(@params.Options.InsertSpaces ? "true" : "false")},
-        ""TabSize"": {@params.Options.TabSize},
-        ""IndentSize"": {@params.Options.TabSize}
-    }},
-    ""SpanToFormat"": {{
-        ""start"": {@params.ProjectedRange.AsTextSpan(generatedHtmlSource).Start},
-        ""length"": {@params.ProjectedRange.AsTextSpan(generatedHtmlSource).Length},
-    }},
-    ""Uri"": ""file:///{@params.HostDocumentFilePath}"",
-    ""GeneratedChanges"": [
-    ]
-}}
-";
-                var request = JsonConvert.DeserializeObject(serializedValue, requestType);
-                var resultTask = (Task)applyFormatEditsHandler.GetType().GetRuntimeMethod("Handle", new Type[] { requestType, typeof(CancellationToken) }).Invoke(applyFormatEditsHandler, new object[] { request, CancellationToken.None });
-                var result = resultTask.GetType().GetProperty(nameof(Task<int>.Result)).GetValue(resultTask);
-                var rawTextChanges = result.GetType().GetProperty("TextChanges").GetValue(result);
-                var serializedTextChanges = JsonConvert.SerializeObject(rawTextChanges, Newtonsoft.Json.Formatting.Indented);
-                var textChanges = JsonConvert.DeserializeObject<HtmlFormatterTextEdit[]>(serializedTextChanges);
-                response.Edits = textChanges.Select(change => change.AsTextEdit(SourceText.From(generatedHtml))).ToArray();
+                throw new InvalidOperationException($"We shouldn't be asked to format {@params.Kind} language kind.");
             }
 
             return response;
@@ -227,15 +233,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public override Task<IResponseRouterReturns> SendRequestAsync<T>(string method, T @params)
         {
-            if (!(@params is RazorDocumentRangeFormattingParams formattingParams) ||
-                !string.Equals(method, "razor/rangeFormatting", StringComparison.Ordinal))
+            if (@params is RazorDocumentRangeFormattingParams rangeFormattingParams &&
+               string.Equals(method, "razor/rangeFormatting", StringComparison.Ordinal))
             {
-                throw new NotImplementedException();
+                var response = Format(rangeFormattingParams);
+
+                return Task.FromResult(Convert(response));
             }
+            else if (@params is DocumentFormattingParams formattingParams &&
+                        string.Equals(method, "textDocument/formatting", StringComparison.Ordinal))
+            {
+                var response = Format(formattingParams);
 
-            var response = Format(formattingParams);
-
-            return Task.FromResult(Convert<RazorDocumentRangeFormattingResponse>(response));
+                return Task.FromResult(Convert(response));
+            }
+            throw new NotImplementedException();
         }
 
         public override Task<IResponseRouterReturns> SendRequestAsync(string method)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -48,6 +48,34 @@ expected: @"
         }
 
         [Fact]
+        public async Task FormatsSimpleHtmlTag_Range()
+        {
+            await RunFormattingTestAsync(
+input: @"
+<html>
+<head>
+    <title>Hello</title>
+</head>
+<body>
+        [|<div>
+        </div>|]
+</body>
+</html>
+",
+expected: @"
+<html>
+<head>
+    <title>Hello</title>
+</head>
+<body>
+    <div>
+    </div>
+</body>
+</html>
+");
+        }
+
+        [Fact]
         public async Task FormatsRazorHtmlBlock()
         {
             await RunFormattingTestAsync(
@@ -639,6 +667,142 @@ expected: @"
     </ChildContent>
 </GridTable>
 ", tagHelpers: GetComponents());
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/30382")]
+        public async Task FormatNestedComponents2_Range()
+        {
+            await RunFormattingTestAsync(
+input: @"
+<GridTable>
+<ChildContent>
+<GridRow>
+<ChildContent>
+<GridCell>
+<ChildContent>
+<strong></strong>
+@if (true)
+{
+[|<strong></strong>|]
+}
+<strong></strong>
+</ChildContent>
+</GridCell>
+</ChildContent>
+</GridRow>
+</ChildContent>
+</GridTable>
+",
+expected: @"
+<GridTable>
+<ChildContent>
+<GridRow>
+<ChildContent>
+<GridCell>
+<ChildContent>
+<strong></strong>
+@if (true)
+{
+                            <strong></strong>
+}
+<strong></strong>
+</ChildContent>
+</GridCell>
+</ChildContent>
+</GridRow>
+</ChildContent>
+</GridTable>
+", tagHelpers: GetComponents());
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/29645")]
+        public async Task FormatHtmlInIf()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@if (true)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class=""table"">
+        <thead>
+            <tr>
+        <th>Date</th>
+        <th>Temp. (C)</th>
+        <th>Temp. (F)</th>
+        <th>Summary</th>
+            </tr>
+        </thead>
+    </table>
+}
+",
+expected: @"@if (true)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class=""table"">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Temp. (C)</th>
+                <th>Temp. (F)</th>
+                <th>Summary</th>
+            </tr>
+        </thead>
+    </table>
+}
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/29645")]
+        public async Task FormatHtmlInIf_Range()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@if (true)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class=""table"">
+        <thead>
+            <tr>
+[|      <th>Date</th>
+        <th>Temp. (C)</th>
+        <th>Temp. (F)</th>
+        <th>Summary</th>|]
+            </tr>
+        </thead>
+    </table>
+}
+",
+expected: @"
+@if (true)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class=""table"">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Temp. (C)</th>
+                <th>Temp. (F)</th>
+                <th>Summary</th>
+            </tr>
+        </thead>
+    </table>
+}
+");
         }
 
         private IReadOnlyList<TagHelperDescriptor> GetSurveyPrompt()


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/29645

When doing range formatting in C# the relevant lines are put into the right position as if the whole document was formatted. When doing range formatting in HTML it looks like the HTML formatter does not behave the same way. This is problematic for two reasons: Firstly, and most importantly, the Razor formatter makes assumptions about line start positions being correct, and formats based on that, which is why this bug existed, and secondly, it means that format range followed by format document would fight over where things should be.

I decided consistency between formatting methods made more sense, and consistency with C# formatting, and so range formatting now just means "format, but only change this range".