### PR TITLE
Cancel pending TagHelper resolutions on solution close.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchingWorkQueue.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchingWorkQueue.cs
@@ -186,10 +186,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
         private void OnStartingBackgroundWork()
         {
-            if (NotifyBackgroundWorkStarting != null)
-            {
-                NotifyBackgroundWorkStarting.Set();
-            }
+            NotifyBackgroundWorkStarting?.Set();
 
             if (BlockBackgroundWorkStart != null)
             {
@@ -209,18 +206,12 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
         private void OnCompletedBackgroundWork()
         {
-            if (NotifyBackgroundWorkCompleted != null)
-            {
-                NotifyBackgroundWorkCompleted.Set();
-            }
+            NotifyBackgroundWorkCompleted?.Set();
         }
 
         private void OnBackgroundCapturedWorkload()
         {
-            if (NotifyBackgroundCapturedWorkload != null)
-            {
-                NotifyBackgroundCapturedWorkload.Set();
-            }
+            NotifyBackgroundCapturedWorkload?.Set();
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VsSolutionUpdatesProjectSnapshotChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VsSolutionUpdatesProjectSnapshotChangeTrigger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -17,14 +18,17 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     [Export(typeof(ProjectSnapshotChangeTrigger))]
-    internal class VsSolutionUpdatesProjectSnapshotChangeTrigger : ProjectSnapshotChangeTrigger, IVsUpdateSolutionEvents2
+    internal class VsSolutionUpdatesProjectSnapshotChangeTrigger : ProjectSnapshotChangeTrigger, IVsUpdateSolutionEvents2, IDisposable
     {
         private readonly IServiceProvider _services;
         private readonly TextBufferProjectService _projectService;
         private readonly ProjectWorkspaceStateGenerator _workspaceStateGenerator;
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
-        private ProjectSnapshotManagerBase _projectManager;
         private readonly JoinableTaskContext _joinableTaskContext;
+        private ProjectSnapshotManagerBase _projectManager;
+        private CancellationTokenSource _activeSolutionCancellationTokenSource;
+        private uint _updateCookie;
+        private IVsSolutionBuildManager _solutionBuildManager;
 
         [ImportingConstructor]
         public VsSolutionUpdatesProjectSnapshotChangeTrigger(
@@ -64,11 +68,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             _workspaceStateGenerator = workspaceStateGenerator;
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
             _joinableTaskContext = joinableTaskContext;
+            _activeSolutionCancellationTokenSource = new CancellationTokenSource();
         }
+
+        internal Task CurrentUpdateTaskForTests { get; private set; }
 
         public override void Initialize(ProjectSnapshotManagerBase projectManager)
         {
             _projectManager = projectManager;
+            _projectManager.Changed += ProjectManager_Changed;
 
             _ = _joinableTaskContext.Factory.RunAsync(async () =>
             {
@@ -77,49 +85,57 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 // Attach the event sink to solution update events.
                 if (_services.GetService(typeof(SVsSolutionBuildManager)) is IVsSolutionBuildManager solutionBuildManager)
                 {
+                    _solutionBuildManager = solutionBuildManager;
+
                     // We expect this to be called only once. So we don't need to Unadvise.
-                    var hr = solutionBuildManager.AdviseUpdateSolutionEvents(this, out _);
+                    var hr = _solutionBuildManager.AdviseUpdateSolutionEvents(this, out _updateCookie);
                     Marshal.ThrowExceptionForHR(hr);
                 }
             });
         }
 
-        public int UpdateSolution_Begin(ref int pfCancelUpdate)
-        {
-            return VSConstants.S_OK;
-        }
+        public int UpdateSolution_Begin(ref int pfCancelUpdate) => VSConstants.S_OK;
 
-        public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
-        {
-            return VSConstants.S_OK;
-        }
+        public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand) => VSConstants.S_OK;
 
-        public int UpdateSolution_StartUpdate(ref int pfCancelUpdate)
-        {
-            return VSConstants.S_OK;
-        }
+        public int UpdateSolution_StartUpdate(ref int pfCancelUpdate) => VSConstants.S_OK;
 
-        public int UpdateSolution_Cancel()
-        {
-            return VSConstants.S_OK;
-        }
+        public int UpdateSolution_Cancel() => VSConstants.S_OK;
 
-        public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy)
-        {
-            return VSConstants.S_OK;
-        }
+        public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy) => VSConstants.S_OK;
 
-        public int UpdateProjectCfg_Begin(IVsHierarchy pHierProj, IVsCfg pCfgProj, IVsCfg pCfgSln, uint dwAction, ref int pfCancel)
-        {
-            return VSConstants.S_OK;
-        }
+        public int UpdateProjectCfg_Begin(IVsHierarchy pHierProj, IVsCfg pCfgProj, IVsCfg pCfgSln, uint dwAction, ref int pfCancel) => VSConstants.S_OK;
 
         // This gets called when the project has finished building.
         public int UpdateProjectCfg_Done(IVsHierarchy pHierProj, IVsCfg pCfgProj, IVsCfg pCfgSln, uint dwAction, int fSuccess, int fCancel)
         {
-            _ = OnProjectBuiltAsync(pHierProj, CancellationToken.None);
+            Debug.Assert(_activeSolutionCancellationTokenSource != null, "We should not get build events when there is no active solution");
+
+            CurrentUpdateTaskForTests = OnProjectBuiltAsync(pHierProj, _activeSolutionCancellationTokenSource?.Token ?? CancellationToken.None);
 
             return VSConstants.S_OK;
+        }
+
+        public void Dispose()
+        {
+            _solutionBuildManager?.UnadviseUpdateSolutionEvents(_updateCookie);
+            _activeSolutionCancellationTokenSource?.Cancel();
+            _activeSolutionCancellationTokenSource?.Dispose();
+            _activeSolutionCancellationTokenSource = null;
+        }
+
+        private void ProjectManager_Changed(object sender, ProjectChangeEventArgs args)
+        {
+            if (args.SolutionIsClosing)
+            {
+                _activeSolutionCancellationTokenSource?.Cancel();
+                _activeSolutionCancellationTokenSource?.Dispose();
+                _activeSolutionCancellationTokenSource = null;
+            }
+            else if (_activeSolutionCancellationTokenSource == null)
+            {
+                _activeSolutionCancellationTokenSource = new CancellationTokenSource();
+            }
         }
 
         // Internal for testing

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestProjectWorkspaceStateGenerator.cs
@@ -11,14 +11,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Test
 {
     internal class TestProjectWorkspaceStateGenerator : ProjectWorkspaceStateGenerator
     {
-        private readonly List<(Project workspaceProject, ProjectSnapshot projectSnapshot)> _updates;
+        private readonly List<TestUpdate> _updates;
 
         public TestProjectWorkspaceStateGenerator()
         {
-            _updates = new List<(Project workspaceProject, ProjectSnapshot projectSnapshot)>();
+            _updates = new List<TestUpdate>();
         }
 
-        public IReadOnlyList<(Project workspaceProject, ProjectSnapshot projectSnapshot)> UpdateQueue => _updates;
+        public IReadOnlyList<TestUpdate> UpdateQueue => _updates;
 
         public override void Initialize(ProjectSnapshotManagerBase projectManager)
         {
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Test
 
         public override void Update(Project workspaceProject, ProjectSnapshot projectSnapshot, CancellationToken cancellationToken)
         {
-            var update = (workspaceProject, projectSnapshot);
+            var update = new TestUpdate(workspaceProject, projectSnapshot, cancellationToken);
             _updates.Add(update);
         }
 
@@ -34,5 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Test
         {
             _updates.Clear();
         }
+
+        public record TestUpdate(Project WorkspaceProject, ProjectSnapshot ProjectSnapshot, CancellationToken CancellationToken);
     }
 }


### PR DESCRIPTION
- There are two locations in which we resolve TagHelpers:
  1. WorkspaceProjectStateChangeDetector: This reacts to C# workspace and ProjectSnapshotManager changes and kicks off TagHelper resolution
  2. VsSolutionUpdatesProjectSnapshotChangeTrigger: This reacts to a user building their app and us forcing TagHelper resolution because of it.
  In both the above cases we need to understand when the solution is closing and cancel any active TagHelper resolution requests.
- In item 1 above we I decided to take the approach of throwing out the active work queue to cancel all in-flight work. This in turn revealed some fragilities to the pre-existing work queue so I made the work queue a little more resilient to teardown scenarios by adding some null checks / task cancellation exception understandings
- In item 2 above I hooked into our already pre-existing `ProjectSnapshotManager` eventing lifecycle to detect when the solution was closing down / being spun up. When we detect that a solution is closing down we cancel our solution cancellation token source which is tied to every resolution request.
 - Added tests for the two scenarios above and expanded some existing infra to make testing it easier.

Fixes dotnet/aspnetcore#36692
