### PR TITLE
Fix file change dispatcher leak on solution reopen

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,7 +12,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal class RazorFileChangeDetectorManager : IDisposable
     {
         private readonly WorkspaceDirectoryPathResolver _workspaceDirectoryPathResolver;
-        private readonly IEnumerable<IFileChangeDetector> _fileChangeDetectors;
+        private readonly IReadOnlyList<IFileChangeDetector> _fileChangeDetectors;
         private readonly object _disposeLock = new object();
         private bool _disposed;
 
@@ -30,7 +31,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             _workspaceDirectoryPathResolver = workspaceDirectoryPathResolver;
-            _fileChangeDetectors = fileChangeDetectors;
+            _fileChangeDetectors = fileChangeDetectors.ToArray();
         }
 
         public async Task InitializedAsync()


### PR DESCRIPTION
- Found a realllly interesting interaction with O# framework where if something imports an `IEnumerable` based service then when the outer service collection disposes it removes all entries from the imported `IEnumerable`. Because of this what would happen in our scenario is that we'd close a solution, the file change detector enumeration would be emptied and then in our file change detector manager's "Dispose" method we'd attempt to ` Stop` all active file change detectors; welllll in this situation the enumeration would be empty so `Stop` would never be called. All of those file watchers still had references to the old project snapshot manager dispatcher and would then enqueue tasks to be run on an old `ProjectSnapshotManagerDispatcher` that dispatcher would then operate in uncharted territory and ultimately leak loads of requests/information.
- The fix is rather simple, since the O# framework clears the imported enumeration we just need to `ToArray` it to ensure that the framework doesn't empty our collection.
- I have some doubts that this entirely fixes the below issue; however, It's most likely a part of it.

Part of dotnet/aspnetcore#35787

/cc @allisonchou, this might be part of the above issue. Most likely not all of it but something I came across in my travels 😄 
/cc @david-driscoll is it expected that the O# framework's disposal path would empty imported enumerable collections?