### PR TITLE
Switch to 1ES servicing pools in release/3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,11 +54,11 @@ stages:
           displayName: Code check
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              name: NetCorePublic-Pool
-              queue: BuildPool.Server.Amd64.VS2019.Open
+              name: NetCore1ESPool-Svc-Public
+              demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              name: NetCoreInternal-Pool
-              queue: BuildPool.Server.Amd64.VS2019
+              name: NetCore1ESPool-Svc-Internal
+              demands: ImageOverride -equals Build.Server.Amd64.VS2019
           steps:
           - task: NodeTool@0
             displayName: Install Node 10.x
@@ -156,11 +156,11 @@ stages:
       - job: Windows
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Server.Amd64.VS2019.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Server.Amd64.VS2019
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019
         strategy:
           matrix:
             debug:


### PR DESCRIPTION
### Summary of the changes
 - We need to switch to the new 1ES servicing pools for all servicing branches. This does that for `release/3.1`.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276

cc/ @ulisesh @lpatalas 