### PR TITLE
Prioritize TagHelper/directive attribute completions when applicable.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -345,7 +345,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Label = razorCompletionItem.DisplayText,
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.DisplayText,
+                            SortText = razorCompletionItem.SortText,
                             Kind = CompletionItemKind.Struct,
                         };
 
@@ -373,7 +373,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Label = razorCompletionItem.DisplayText,
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.InsertText,
-                            SortText = razorCompletionItem.InsertText,
+                            SortText = razorCompletionItem.SortText,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -392,7 +392,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Label = razorCompletionItem.DisplayText,
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.InsertText,
-                            SortText = razorCompletionItem.InsertText,
+                            SortText = razorCompletionItem.SortText,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -406,7 +406,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Label = razorCompletionItem.DisplayText,
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.DisplayText,
+                            SortText = razorCompletionItem.SortText,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -425,7 +425,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Label = razorCompletionItem.DisplayText,
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.InsertText,
-                            SortText = razorCompletionItem.InsertText,
+                            SortText = razorCompletionItem.SortText,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -444,7 +444,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Label = razorCompletionItem.DisplayText,
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.InsertText,
-                            SortText = razorCompletionItem.InsertText,
+                            SortText = razorCompletionItem.SortText,
                             Kind = tagHelperCompletionItemKind,
                         };
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionSortTextHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionSortTextHelper.cs
@@ -3,10 +3,29 @@
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {
+    /// <summary>
+    /// Provides pre-filled sort text items to make setting <see cref="RazorCompletionItem.SortText"/> consistent.
+    /// </summary>
     internal static class CompletionSortTextHelper
     {
+        /// <summary>
+        /// The default sort priority. Typically this means an LSP client will fall-back to sorting the completion item
+        /// based off of the displayed label in the completion list.
+        /// </summary>
         public static string DefaultSortPriority => null;
 
+        /// <summary>
+        /// A high sort priority. Displayed above <see cref="DefaultSortPriority"/> items.
+        /// </summary>
+        /// <remarks>
+        /// Note how this property doesn't take into account the actual completion items content. Ultimately this property
+        /// simply returns whitespace. The reason it returns whitespace is that whitespace is alphabetically ordered at the
+        /// top of all other characters. Meaning, for a reasonable client to interpret this sort priority it'll sort by the
+        /// whitespace sort text then will need to fallback to something else to handle collisions (items that have the same
+        /// sort text). The only reasonable fallback will be the display text of a completion item; meaning, we'll have all
+        /// of our "high priority" completion items appear above any other completion item because it'll first sort by whitespace
+        /// and then by display text.
+        /// </remarks>
         public static string HighSortPriority => " ";
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionSortTextHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionSortTextHelper.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal static class CompletionSortTextHelper
+    {
+        public static string DefaultSortPriority => null;
+
+        public static string HighSortPriority => " ";
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     completion.Key,
                     insertText,
                     RazorCompletionItemKind.DirectiveAttribute,
-                    commitCharacters);
+                    commitCharacters: commitCharacters);
                 var completionDescription = new AggregateBoundAttributeDescription(attributeDescriptionInfos.ToArray());
                 razorCompletionItem.SetAttributeCompletionDescription(completionDescription);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                     completionDisplayText,
                     directive.Directive,
                     RazorCompletionItemKind.Directive,
-                    commitCharacters);
+                    commitCharacters: commitCharacters);
                 var completionDescription = new DirectiveCompletionDescription(directive.Description);
                 completionItem.SetDirectiveCompletionDescription(completionDescription);
                 completionItems.Add(completionItem);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                         completionDisplayText,
                         completionDisplayText,
                         RazorCompletionItemKind.MarkupTransition,
-                        s_elementCommitCharacters);
+                        commitCharacters: s_elementCommitCharacters);
                     var completionDescription = new MarkupTransitionCompletionDescription(CodeAnalysisResources.MarkupTransition_Description);
                     s_markupTransitionCompletionItem.SetMarkupTransitionCompletionDescription(completionDescription);
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -13,10 +13,20 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     {
         private ItemCollection _items;
 
+        /// <summary>
+        /// Creates a new Razor completion item
+        /// </summary>
+        /// <param name="displayText">The text to display in the completion list</param>
+        /// <param name="insertText">Content to insert when completion item is committed</param>
+        /// <param name="kind">The type of completion item this is. Used for icons and resolving extra information like tooltip text.</param>
+        /// <param name="sortText">A string that is used to alphabetically sort the completion item. If omitted defaults to <paramref name="displayText"/>.</param>
+        /// <param name="commitCharacters">Characters that can be used to commit the completion item.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="displayText"/> or <paramref name="insertText"/> are <c>null</c>.</exception>
         public RazorCompletionItem(
             string displayText,
             string insertText,
             RazorCompletionItemKind kind,
+            string sortText = null,
             IReadOnlyCollection<string> commitCharacters = null)
         {
             if (displayText == null)
@@ -33,11 +43,17 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             InsertText = insertText;
             Kind = kind;
             CommitCharacters = commitCharacters;
+            SortText = sortText ?? displayText;
         }
 
         public string DisplayText { get; }
 
         public string InsertText { get; }
+
+        /// <summary>
+        /// A string that is used to alphabetically sort the completion item.
+        /// </summary>
+        public string SortText { get; }
 
         public RazorCompletionItemKind Kind { get; }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.DisplayText, converted.Label);
             Assert.Equal(completionItem.InsertText, converted.InsertText);
             Assert.Equal(completionItem.InsertText, converted.FilterText);
-            Assert.Equal(completionItem.InsertText, converted.SortText);
+            Assert.Equal(completionItem.DisplayText, converted.SortText);
             Assert.Equal(completionItem.CommitCharacters, converted.CommitCharacters);
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void TryConvert_DirectiveAttribute_ReturnsTrue()
         {
             // Arrange
-            var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, new[] { "=", ":" });
+            var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: new[] { "=", ":" });
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, _supportedCompletionItemKinds, out var converted);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -175,11 +175,36 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 {
                     Assert.Equal("bool-val", completion.InsertText);
                     Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
                 },
                 completion =>
                 {
                     Assert.Equal("int-val", completion.InsertText);
                     Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                });
+        }
+
+        [Fact]
+        public void GetCompletionAt_KnownHtmlElement_ReturnsCompletions_DefaultPriority()
+        {
+            // Arrange
+            var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<title  mutator />", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
+            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+
+            // Act
+            var completions = service.GetCompletionItems(context, sourceSpan);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("Extra", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal("Extra", completion.SortText);
                 });
         }
 
@@ -256,11 +281,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 {
                     Assert.Equal("bool-val", completion.InsertText);
                     Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
                 },
                 completion =>
                 {
                     Assert.Equal("int-val", completion.InsertText);
                     Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
                 });
         }
 
@@ -293,11 +320,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 {
                     Assert.Equal("bool-val", completion.InsertText);
                     Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
                 },
                 completion =>
                 {
                     Assert.Equal("bool-val-", completion.InsertText);
                     Assert.Empty(completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
                 });
         }
 
@@ -330,11 +359,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 {
                     Assert.Equal("int-val", completion.InsertText);
                     Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
                 },
                 completion =>
                 {
                     Assert.Equal("int-val-", completion.InsertText);
                     Assert.Empty(completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
                 });
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -160,7 +160,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var htmlTagMutator = TagHelperDescriptorBuilder.Create("HtmlMutator", "TestAssembly");
             htmlTagMutator.TagMatchingRule(rule =>
             {
-                rule.TagName = "*";
+                rule.TagName = "title";
                 rule.RequireAttributeDescriptor(attributeRule =>
                 {
                     attributeRule.Name = "mutator";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -157,6 +157,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             directiveAttribute2.Metadata[ComponentMetadata.Component.NameMatchKey] = ComponentMetadata.Component.FullyQualifiedNameMatch;
             directiveAttribute2.SetTypeName("TestDirectiveAttribute");
 
+            var htmlTagMutator = TagHelperDescriptorBuilder.Create("HtmlMutator", "TestAssembly");
+            htmlTagMutator.TagMatchingRule(rule =>
+            {
+                rule.TagName = "*";
+                rule.RequireAttributeDescriptor(attributeRule =>
+                {
+                    attributeRule.Name = "mutator";
+                });
+            });
+            htmlTagMutator.SetTypeName("HtmlMutator");
+            htmlTagMutator.BindAttribute(attribute =>
+            {
+                attribute.Name = "Extra";
+                attribute.SetPropertyName("Extra");
+                attribute.TypeName = typeof(bool).FullName;
+            });
+
             DefaultTagHelpers = new[]
             {
                 builder1.Build(),
@@ -164,7 +181,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 builder2.Build(),
                 builder3.Build(),
                 directiveAttribute1.Build(),
-                directiveAttribute2.Build()
+                directiveAttribute2.Build(),
+                htmlTagMutator.Build()
             };
 
             HtmlFactsService = new DefaultHtmlFactsService();

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -317,10 +317,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             displayText ??= insertText;
 
-            Assert.Contains(completions, completion => insertText == completion.InsertText &&
-                    displayText == completion.DisplayText &&
-                    commitCharacters.SequenceEqual(completion.CommitCharacters) &&
-                    RazorCompletionItemKind.DirectiveAttribute == completion.Kind);
+            Assert.Contains(completions, completion =>
+                insertText == completion.InsertText &&
+                displayText == completion.DisplayText &&
+                commitCharacters.SequenceEqual(completion.CommitCharacters) &&
+                RazorCompletionItemKind.DirectiveAttribute == completion.Kind);
         }
 
         private static void AssertDoesNotContain(IReadOnlyList<RazorCompletionItem> completions, string insertText, string displayText)


### PR DESCRIPTION
- So unintentionally this issue ended up solving 2x issues at once, I apologize for the conflated concerns!! I'll leave comments in this description detailing how/why it did two.
- When a user is trying to get attribute completions today we show HTML & attribute completion items. Both of those completion item sets get weaved amongst each other and get shown as one jointly sorted list. Now the unfortunate side effect of this is that when you have a custom component / TagHelper we spit out every possible completion item which can lead to really confusing scenarios. To fix this I took the approach of adding `SortText` to our internal `RazorCompletionItem` type to allow us to sort TagHelper completion items prior to any HTML completions.
- Now similarly when trying to get directive attribute completions we have the same issue as above; however, that scenario is slightly different. Reason being in an ideal world for directive attribute completions i.e. `<strong @|>` we'd simply not request HTML completions because it's following an `@` symbol; however, with the Razor language servers current design this isn't easily done. We therefore can also utilize this sort text approach to prioritize directive attribute completions above HTML completions.

**Details:**
- Expanded `RazorCompletionItem` to support `SortText`.
- Added a `CompletionSortTextHelper` class to make picking `SortText`'s  simple. For now I've added 2 types, Default and High priority
- Updated our completion endpoint to utilize the `SortText` from our `RazorCompletionItem`s. This is where I unintentionally fixed issue dotnet/aspnetcore#30255. Reason being is that we had to pick a default for `SortText` when not provided. I chose the display text because technically that's what a user sees when typing. With this in mind a directive attribute completion USED to use `InsertText` for its sort text. Meaning, it'd display `@bind` but would be sorted off of `bind`. Now that `SortText` defaults to the display text it means the `@` in `@bind` sorts the item to the top of the list. I could take this one step further and be explicit in the `SortText` for directive attributes; however, we actually gain a little bit of perf here because if `DisplayText == SortText` then we can omit the `SortText` and platform will sort off of the display getting us our expected result.

## Directive Attribute Completion:

### Before
![image](https://i.imgur.com/NTLSBNr.gif)

### After
![image](https://i.imgur.com/W8yJDvB.gif)

## TagHelper Attribute Completion:

### Before
![image](https://i.imgur.com/1ohDsua.gif)

### After
![image](https://i.imgur.com/RdbJbtk.gif)

Fixes dotnet/aspnetcore#30255
Fixes dotnet/aspnetcore#35848

/cc @SteveSandersonMS since you were concerned a lot about this 😄