### PR TITLE
Fix closing HTML elements when nested and next to others.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SyntaxNodeExtensions.cs
@@ -14,6 +14,37 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
     internal static class SyntaxNodeExtensions
     {
+        internal static bool TryGetPreviousSibling(this SyntaxNode syntaxNode, out SyntaxNode previousSibling)
+        {
+            var syntaxNodeParent = syntaxNode.Parent;
+            if (syntaxNodeParent == null)
+            {
+                previousSibling = default;
+                return false;
+            }
+
+            var nodes = syntaxNodeParent.ChildNodes();
+            for (var i = 0; i < nodes.Count; i++)
+            {
+                if (nodes[i] == syntaxNode)
+                {
+                    if (i == 0)
+                    {
+                        previousSibling = default;
+                        return false;
+                    }
+                    else
+                    {
+                        previousSibling = nodes[i - 1];
+                        return true;
+                    }
+                }
+            }
+
+            previousSibling = default;
+            return false;
+        }
+
         public static bool ContainsOnlyWhitespace(this SyntaxNode node, bool includingNewLines = true)
         {
             if (node is null)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -237,6 +237,32 @@ expected: @"
 fileKind: FileKinds.Legacy,
 tagHelpers: new[] { NormalOrSelfClosingTagHelper, UnspecifiedInputTagHelper });
         }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/36906")]
+        public void OnTypeCloseAngle_TagHelperNextToTagHelper_NestedStatement()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<test>$$<input>
+}
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<test></test><input />
+}
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { NormalOrSelfClosingTagHelper, UnspecifiedInputTagHelper });
+        }
+
         [Fact]
         public void OnTypeCloseAngle_NormalOrSelfClosingTagHelperTagStructure_CodeBlock()
         {
@@ -423,6 +449,26 @@ expected: @"
 @if (true)
 {
     <div><p>$0</p></div>
+}
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/36906")]
+        public void OnTypeCloseAngle_TagNextToTag_NestedStatement()
+        {
+
+            RunAutoInsertTest(
+input: @"
+@if (true)
+{
+    <p>$$<div></div>
+}
+",
+expected: @"
+@if (true)
+{
+    <p>$0</p><div></div>
 }
 ");
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -240,6 +240,31 @@ tagHelpers: new[] { NormalOrSelfClosingTagHelper, UnspecifiedInputTagHelper });
 
         [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/36906")]
+        public void OnTypeCloseAngle_TagHelperNextToVoidTagHelper_NestedStatement()
+        {
+            RunAutoInsertTest(
+input: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<test>$$<input />
+}
+",
+expected: @"
+@addTagHelper *, TestAssembly
+
+@if (true)
+{
+<test>$0</test><input />
+}
+",
+fileKind: FileKinds.Legacy,
+tagHelpers: new[] { NormalOrSelfClosingTagHelper, UnspecifiedInputTagHelper });
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/36906")]
         public void OnTypeCloseAngle_TagHelperNextToTagHelper_NestedStatement()
         {
             RunAutoInsertTest(
@@ -248,7 +273,7 @@ input: @"
 
 @if (true)
 {
-<test>$$<input>
+<test>$$<input></input>
 }
 ",
 expected: @"
@@ -256,11 +281,11 @@ expected: @"
 
 @if (true)
 {
-<test></test><input />
+<test>$0</test><input></input>
 }
 ",
 fileKind: FileKinds.Legacy,
-tagHelpers: new[] { NormalOrSelfClosingTagHelper, UnspecifiedInputTagHelper });
+tagHelpers: new[] { NormalOrSelfClosingTagHelper, NormalOrSelfclosingInputTagHelper });
         }
 
         [Fact]
@@ -457,7 +482,6 @@ expected: @"
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/36906")]
         public void OnTypeCloseAngle_TagNextToTag_NestedStatement()
         {
-
             RunAutoInsertTest(
 input: @"
 @if (true)
@@ -469,6 +493,25 @@ expected: @"
 @if (true)
 {
     <p>$0</p><div></div>
+}
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/36906")]
+        public void OnTypeCloseAngle_TagNextToVoidTag_NestedStatement()
+        {
+            RunAutoInsertTest(
+input: @"
+@if (true)
+{
+    <p>$$<input />
+}
+",
+expected: @"
+@if (true)
+{
+    <p>$0</p><input />
 }
 ");
         }


### PR DESCRIPTION
- **Issue:** Found another compiler quirk since we can't rely on looking up specific SyntaxTokens by position :(. Gist is that since we can't lookup token by position and have to rely on `GetOwner` we can occasionally get a node that's in front of our cursor. In the nested HTML case of `<first>|<second>` you'd get `<second>` as the owner.
- **Fix:** Gist is I added two more sections to our compiler quirks helper in our auto-closing behavior method. It's sad but works.
- Updated tests to reflect this new scenario.

Fixes dotnet/aspnetcore#36906