### PR TITLE
Remove TM themes to prevent overcoloring

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -121,7 +121,7 @@
       </dict>
 
       <!-- <a> [href]="Hello"> -->
-      <dict>
+      <!-- <dict>
         <key>scope</key>
         <string>entity.other.attribute-name</string>
         <key>settings</key>
@@ -129,10 +129,10 @@
           <key>vsclassificationtype</key>
           <string>HTML Attribute Name</string>
         </dict>
-      </dict>
+      </dict> -->
 
       <!-- <a> href=["Hello"]> -->
-      <dict>
+      <!-- <dict>
         <key>scope</key>
         <string>meta.attribute, meta.attribute string.quoted</string>
         <key>settings</key>
@@ -140,7 +140,7 @@
           <key>vsclassificationtype</key>
           <string>HTML Attribute Value</string>
         </dict>
-      </dict>
+      </dict> -->
 
       <dict>
         <key>scope</key>


### PR DESCRIPTION
### Summary of the changes
 - We have proposed a more permanent fix for this against the platform, but due to resource constraints we're going to wait a bit to do that.
 - This prevents "overcoloring" by removing TM themes which are known to cause problems. This degrades the startup experience to improve correctness.

Fixes: https://github.com/dotnet/aspnetcore/issues/36614
