### PR TITLE
Fix C# diagnostics clearing on close/delete.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -83,8 +83,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
-                return null;
+                _logger.LogInformation($"Document {request.TextDocument.Uri} closed or deleted, clearing diagnostics.");
+
+                var clearedDiagnosticReport = new VSInternalDiagnosticReport[]
+                {
+                    new VSInternalDiagnosticReport()
+                    {
+                        ResultId = null,
+                        Diagnostics = null
+                    }
+                };
+                return clearedDiagnosticReport;
             }
 
             if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         private HTMLCSharpLanguageServerLogHubLoggerProvider LoggerProvider { get; }
 
         [Fact]
-        public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
+        public async Task HandleRequestAsync_DocumentNotFound_ClearsDiagnostics()
         {
             // Arrange
             var documentManager = new TestDocumentManager();
@@ -128,7 +128,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var result = await documentDiagnosticsHandler.HandleRequestAsync(diagnosticRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            Assert.Null(result);
+            var report = Assert.Single(result);
+            Assert.Null(report.Diagnostics);
+            Assert.Null(report.ResultId);
         }
 
         [Fact]


### PR DESCRIPTION
- The platform sends one last pull diagnostic request on document close. Prior to this change we'd gracefully no-op if we couldn't find one of our documents; however, the expected behavior is to clear all diagnostics for that closed/deleted document. In the end this is a super simple change.
- Updated tests to reflect the new behavior.
- Added a CTI work item to expand our existing coverage of closed/deleted Razor documents in regards to C# diagnostics: https://github.com/aspnet/Tooling-ManualTests/issues/1503

### Before
![image](https://i.imgur.com/0Iq3b3z.gif)

### After
![image](https://i.imgur.com/HeZv3Ry.gif)

Fixes dotnet/aspnetcore#36940