### PR TITLE
Allow synchronizer to handle removed documents.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             {
                 if (!_virtualDocumentContexts.TryGetValue(virtualDocument.Uri, out var documentContext))
                 {
-                    // Document was delted/removed in mid-synchronization
+                    // Document was deleted/removed in mid-synchronization
                     return Task.FromResult(false);
                 }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
@@ -48,7 +48,8 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             {
                 if (!_virtualDocumentContexts.TryGetValue(virtualDocument.Uri, out var documentContext))
                 {
-                    throw new InvalidOperationException("Document context should never be null here.");
+                    // Document was delted/removed in mid-synchronization
+                    return Task.FromResult(false);
                 }
 
                 if (requiredHostDocumentVersion == documentContext.SeenHostDocumentVersion)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultLSPDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultLSPDocumentSynchronizerTest.cs
@@ -28,6 +28,24 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         private ITextBuffer VirtualDocumentTextBuffer { get; }
 
         [Fact]
+        public async Task TrySynchronizeVirtualDocumentAsync_RemovedDocument_ReturnsFalse()
+        {
+            // Arrange
+            var (lspDocument, virtualDocument) = CreateDocuments(lspDocumentVersion: 123, virtualDocumentSyncVersion: 123);
+            var fileUriProvider = CreateUriProviderFor(VirtualDocumentTextBuffer, virtualDocument.Uri);
+            var synchronizer = new DefaultLSPDocumentSynchronizer(fileUriProvider);
+            NotifyLSPDocumentAdded(lspDocument, synchronizer);
+            NotifyBufferVersionUpdated(VirtualDocumentTextBuffer, virtualDocument.HostDocumentSyncVersion.Value);
+            NotifyLSPDocumentRemoved(lspDocument, synchronizer);
+
+            // Act
+            var result = await synchronizer.TrySynchronizeVirtualDocumentAsync(lspDocument.Version, virtualDocument, CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
         public async Task TrySynchronizeVirtualDocumentAsync_SynchronizedDocument_ReturnsTrue()
         {
             // Arrange


### PR DESCRIPTION
- Occasionally virtual documents get removed in the midst of trying to synchronize. I found that after deleting a Razor file we'd throw because we couldn't lookup the HTML virtual document. Updated the synchronizer to respect this scenario and added a test as well.
- Found this when investigating https://github.com/dotnet/aspnetcore-tooling/pull/4251