### PR TITLE
Fix TagHelperProvider on ServiceHub Core hsot

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -68,10 +68,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(ServiceHubCoreSubPath)\Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="WebConfiguration.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json
@@ -1,3 +1,0 @@
-﻿[
-  "..\\..\\managedLanguages\\VBCSharp\\LanguageServices\\Core"
-]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json
@@ -7,5 +7,5 @@
     "fullClassName": "Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory",
     "AssemblySearchPathsConfig": "Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json"
   },
-  "friendServices": [ "roslynRemoteHostCore64" ]
+  "friendServices": [ "Microsoft.VisualStudio.LanguageServices.DiagnosticAnalyzerCore64" ]
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json
@@ -4,8 +4,7 @@
   "hostGroupAllowed": true,
   "entryPoint": {
     "assemblyPath": "Microsoft.CodeAnalysis.Remote.Razor.dll",
-    "fullClassName": "Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory",
-    "AssemblySearchPathsConfig": "Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json"
+    "fullClassName": "Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory"
   },
   "friendServices": [ "Microsoft.VisualStudio.LanguageServices.DiagnosticAnalyzerCore64" ]
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json
@@ -7,5 +7,5 @@
     "fullClassName": "Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory",
     "AssemblySearchPathsConfig": "Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json"
   },
-  "friendServices": [ "roslynRemoteHostCore64S" ]
+  "friendServices": [ "Microsoft.VisualStudio.LanguageServices.DiagnosticAnalyzerCore64S" ]
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/ServiceHubCore/Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json
@@ -4,8 +4,7 @@
   "hostGroupAllowed": true,
   "entryPoint": {
     "assemblyPath": "Microsoft.CodeAnalysis.Remote.Razor.dll",
-    "fullClassName": "Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory",
-    "AssemblySearchPathsConfig": "Microsoft.VisualStudio.Razor.TagHelperProvider.AssemblySearchPathsConfig.json"
+    "fullClassName": "Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory"
   },
   "friendServices": [ "Microsoft.VisualStudio.LanguageServices.DiagnosticAnalyzerCore64S" ]
 }


### PR DESCRIPTION
roslynRemoteHost service was removed in https://github.com/dotnet/roslyn/pull/56426, so switch to another roslyn service.