### PR TITLE
Catch IOException in DirectoryHelper

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal static class DirectoryHelper
     {
         /// <summary>
-        /// Finds all the files in  a directory which meet the given criteria.
+        /// Finds all the files in a directory which meet the given criteria.
         /// </summary>
         /// <param name="workspaceDirectory">The directory to be searched.</param>
         /// <param name="searchPattern">The pattern to apply when searching.</param>
@@ -67,6 +67,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 files = Array.Empty<string>();
             }
             catch (PathTooLongException ex)
+            {
+                logger?.LogWarning(ex.Message);
+                yield break;
+            }
+            catch (IOException ex)
             {
                 logger?.LogWarning(ex.Message);
                 yield break;


### PR DESCRIPTION
### Summary of the changes
 - Catches IOException which seems(?) to be out of our control. @ryanbrandenburg please let me know if this isn't the right fix.

Fixes: 
https://github.com/dotnet/aspnetcore/issues/35306

cc @NTaylorMullen, not sure if this should go into p5 - it seems like it's fairly uncommon although we've gotten two reports already.
