### PR TITLE
Remove LSP.Protocol code bases / inclusion in VSIX.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyCodeBases.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyCodeBases.cs
@@ -3,9 +3,6 @@
 
 using Microsoft.VisualStudio.Shell;
 
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\MediatR.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\OmniSharp.Extensions.JsonRpc.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\OmniSharp.Extensions.LanguageProtocol.dll")]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -31,9 +31,6 @@
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="Microsoft.VisualStudio.Razor.TagHelperProvider64S.servicehub.service.json" />
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="ServiceHubCore\Microsoft.VisualStudio.Razor.TagHelperProviderCore64.servicehub.service.json" />
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="ServiceHubCore\Microsoft.VisualStudio.Razor.TagHelperProviderCore64S.servicehub.service.json" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll" />


### PR DESCRIPTION
- Platform will be providing our LSP.Protocol binary so for the interim we'll be removing our codebase for it.

/cc @matteo-prosperi