### PR TITLE
Fix inaccurate HTML/CSS diagnostics on C#.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -193,13 +193,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 return false;
             }
 
-            var isCSharp = owner.Kind switch
-            {
-                SyntaxKind.CSharpExpressionLiteral => true,
-                SyntaxKind.CSharpStatementLiteral => true,
-                SyntaxKind.CSharpEphemeralTextLiteral => true,
-                _ => false,
-            };
+            var isCSharp = owner.Kind is SyntaxKind.CSharpExpressionLiteral or SyntaxKind.CSharpStatementLiteral or SyntaxKind.CSharpEphemeralTextLiteral;
 
             return isCSharp;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
@@ -655,7 +655,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Razor,
-                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 3), new Position(0, 4)) } },
+                Diagnostics = new[] { new OmniSharpVSDiagnostic() { Range = new Range(new Position(0, 1), new Position(0, 3)) } },
                 RazorDocumentUri = new Uri(documentPath),
             };
 


### PR DESCRIPTION
- The CSS diagnostic system didn't recognize the C# portions of the document and was then warning about those portions of the document. It's expected that we'd get a diagnostic in this case; however, we should be filtering HTML diagnostics that map to C# literals because they can't see the C# literals properly.
- Added a test to capture this case.

### Before
![image](https://user-images.githubusercontent.com/2008729/135360938-4f7af400-5675-4c5f-93bc-e37aebd0dad7.png)

### After
![image](https://user-images.githubusercontent.com/2008729/135360655-79d2fb12-3c38-4d25-97c7-fc8a71f57394.png)

Fixes dotnet/aspnetcore#36321