### PR TITLE
Cache unchanged file responses

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
@@ -33,7 +34,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             }
 
             var normalizedPath = _filePathNormalizer.Normalize(filePath);
-            return new RemoteTextLoader(normalizedPath);
+            return new CachedTextLoader(normalizedPath, new RemoteTextLoader(normalizedPath));
         }
 
         private class RemoteTextLoader : TextLoader
@@ -52,7 +53,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
             public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
             {
-
                 TextAndVersion textAndVersion;
 
                 try

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CachedTextLoader.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CachedTextLoader.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces
+{
+    internal class CachedTextLoader : TextLoader
+    {
+        private record TextAndVersionCache(DateTime LastModified, Task<TextAndVersion> TextAndVersionTask);
+
+        private readonly string _filePath;
+
+        private readonly TextLoader _baseLoader;
+
+        private static readonly Dictionary<string, TextAndVersionCache> s_cache = new();
+
+        private static readonly object s_loadLock = new();
+
+        public CachedTextLoader(string filePath, TextLoader? baseLoader = null)
+        {
+            if (filePath is null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            if (baseLoader is null)
+            {
+                baseLoader = new FileTextLoader(filePath, defaultEncoding: null);
+            }
+
+            _filePath = filePath;
+            _baseLoader = baseLoader;
+        }
+
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+        {
+            var lastModified = GetLastWriteTimeUtc(_filePath);
+
+            lock (s_loadLock)
+            {
+                Task<TextAndVersion> textAndVersionTask;
+                if (s_cache.TryGetValue(_filePath, out var textAndVersionCache) &&
+                    lastModified is not null &&
+                    textAndVersionCache.LastModified == lastModified)
+                {
+                    textAndVersionTask = textAndVersionCache.TextAndVersionTask;
+                }
+                else
+                {
+                    textAndVersionTask = _baseLoader.LoadTextAndVersionAsync(workspace, documentId, cancellationToken);
+                    s_cache[_filePath] = new TextAndVersionCache(lastModified ?? DateTime.UtcNow, textAndVersionTask);
+                }
+
+                return textAndVersionTask;
+            }
+        }
+
+        internal virtual DateTime? GetLastWriteTimeUtc(string filePath)
+        {
+            var lastModified = File.GetLastWriteTimeUtc(filePath);
+
+            if (lastModified.Year == 1601)
+            {
+                return null;
+            }
+
+            return lastModified;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -208,466 +208,466 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
         }
 
-public override void DocumentRemoved(HostProject hostProject, HostDocument document)
-{
-    if (hostProject == null)
-    {
-        throw new ArgumentNullException(nameof(hostProject));
-    }
-
-    if (document == null)
-    {
-        throw new ArgumentNullException(nameof(document));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    if (_projects.TryGetValue(hostProject.FilePath, out var entry))
-    {
-        // if the solution is closing we don't need to bother computing new state
-        if (_solutionIsClosing)
+        public override void DocumentRemoved(HostProject hostProject, HostDocument document)
         {
-            var snapshot = entry.GetSnapshot();
-            NotifyListeners(snapshot, snapshot, document.FilePath, ProjectChangeKind.DocumentRemoved);
-        }
-        else
-        {
-            var state = entry.State.WithRemovedHostDocument(document);
-
-            // Document updates can no-op.
-            if (!object.ReferenceEquals(state, entry.State))
+            if (hostProject == null)
             {
-                var oldSnapshot = entry.GetSnapshot();
-                entry = new Entry(state);
-                _projects[hostProject.FilePath] = entry;
-                NotifyListeners(oldSnapshot, entry.GetSnapshot(), document.FilePath, ProjectChangeKind.DocumentRemoved);
+                throw new ArgumentNullException(nameof(hostProject));
             }
-        }
-    }
-}
 
-public override void DocumentOpened(string projectFilePath, string documentFilePath, SourceText sourceText)
-{
-    if (projectFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(projectFilePath));
-    }
-
-    if (documentFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(documentFilePath));
-    }
-
-    if (sourceText == null)
-    {
-        throw new ArgumentNullException(nameof(sourceText));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    if (_projects.TryGetValue(projectFilePath, out var entry) &&
-        entry.State.Documents.TryGetValue(documentFilePath, out var older))
-    {
-        // if the solution is closing we don't need to bother computing new state
-        if (_solutionIsClosing)
-        {
-            var oldSnapshot = entry.GetSnapshot();
-            NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath, ProjectChangeKind.DocumentChanged);
-        }
-        else
-        {
-            ProjectState state;
-
-            var currentText = sourceText;
-            if (older.TryGetText(out var olderText) &&
-                older.TryGetTextVersion(out var olderVersion))
+            if (document == null)
             {
-                var version = currentText.ContentEquals(olderText) ? olderVersion : olderVersion.GetNewerVersion();
-                state = entry.State.WithChangedHostDocument(older.HostDocument, currentText, version);
+                throw new ArgumentNullException(nameof(document));
             }
-            else
+
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            if (_projects.TryGetValue(hostProject.FilePath, out var entry))
             {
-                state = entry.State.WithChangedHostDocument(older.HostDocument, async () =>
+                // if the solution is closing we don't need to bother computing new state
+                if (_solutionIsClosing)
                 {
-                    olderText = await older.GetTextAsync().ConfigureAwait(false);
-                    olderVersion = await older.GetTextVersionAsync().ConfigureAwait(false);
-
-                    var version = currentText.ContentEquals(olderText) ? olderVersion : olderVersion.GetNewerVersion();
-                    return TextAndVersion.Create(currentText, version, documentFilePath);
-                });
-            }
-
-            _openDocuments.Add(documentFilePath);
-
-            // Document updates can no-op.
-            if (!object.ReferenceEquals(state, entry.State))
-            {
-                var oldSnapshot = entry.GetSnapshot();
-                entry = new Entry(state);
-                _projects[projectFilePath] = entry;
-                NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath, ProjectChangeKind.DocumentChanged);
-            }
-        }
-    }
-}
-
-public override void DocumentClosed(string projectFilePath, string documentFilePath, TextLoader textLoader)
-{
-    if (projectFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(projectFilePath));
-    }
-
-    if (documentFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(documentFilePath));
-    }
-
-    if (textLoader == null)
-    {
-        throw new ArgumentNullException(nameof(textLoader));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    if (_projects.TryGetValue(projectFilePath, out var entry) &&
-        entry.State.Documents.TryGetValue(documentFilePath, out var older))
-    {
-        // if the solution is closing we don't need to bother computing new state
-        if (_solutionIsClosing)
-        {
-            var oldSnapshot = entry.GetSnapshot();
-            NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath, ProjectChangeKind.DocumentChanged);
-        }
-        else
-        {
-            var state = entry.State.WithChangedHostDocument(
-            older.HostDocument,
-            async () => await textLoader.LoadTextAndVersionAsync(Workspace, default, default));
-
-            _openDocuments.Remove(documentFilePath);
-
-            // Document updates can no-op.
-            if (!object.ReferenceEquals(state, entry.State))
-            {
-                var oldSnapshot = entry.GetSnapshot();
-                entry = new Entry(state);
-                _projects[projectFilePath] = entry;
-                NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath, ProjectChangeKind.DocumentChanged);
-            }
-        }
-    }
-}
-
-public override void DocumentChanged(string projectFilePath, string documentFilePath, SourceText sourceText)
-{
-    if (projectFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(projectFilePath));
-    }
-
-    if (documentFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(documentFilePath));
-    }
-
-    if (sourceText == null)
-    {
-        throw new ArgumentNullException(nameof(sourceText));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    if (_projects.TryGetValue(projectFilePath, out var entry) &&
-        entry.State.Documents.TryGetValue(documentFilePath, out var older))
-    {
-        ProjectState state;
-
-        var currentText = sourceText;
-
-        // if the solution is closing we don't need to bother computing new state
-        if (_solutionIsClosing)
-        {
-            var oldSnapshot = entry.GetSnapshot();
-            NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath, ProjectChangeKind.DocumentChanged);
-        }
-        else
-        {
-            if (older.TryGetText(out var olderText) &&
-            older.TryGetTextVersion(out var olderVersion))
-            {
-                var version = currentText.ContentEquals(olderText) ? olderVersion : olderVersion.GetNewerVersion();
-                state = entry.State.WithChangedHostDocument(older.HostDocument, currentText, version);
-            }
-            else
-            {
-                state = entry.State.WithChangedHostDocument(older.HostDocument, async () =>
+                    var snapshot = entry.GetSnapshot();
+                    NotifyListeners(snapshot, snapshot, document.FilePath, ProjectChangeKind.DocumentRemoved);
+                }
+                else
                 {
-                    olderText = await older.GetTextAsync().ConfigureAwait(false);
-                    olderVersion = await older.GetTextVersionAsync().ConfigureAwait(false);
+                    var state = entry.State.WithRemovedHostDocument(document);
 
-                    var version = currentText.ContentEquals(olderText) ? olderVersion : olderVersion.GetNewerVersion();
-                    return TextAndVersion.Create(currentText, version, documentFilePath);
-                });
+                    // Document updates can no-op.
+                    if (!object.ReferenceEquals(state, entry.State))
+                    {
+                        var oldSnapshot = entry.GetSnapshot();
+                        entry = new Entry(state);
+                        _projects[hostProject.FilePath] = entry;
+                        NotifyListeners(oldSnapshot, entry.GetSnapshot(), document.FilePath, ProjectChangeKind.DocumentRemoved);
+                    }
+                }
             }
+        }
 
-            // Document updates can no-op.
-            if (!object.ReferenceEquals(state, entry.State))
+        public override void DocumentOpened(string projectFilePath, string documentFilePath, SourceText sourceText)
+        {
+            if (projectFilePath == null)
             {
-                var oldSnapshot = entry.GetSnapshot();
-                entry = new Entry(state);
-                _projects[projectFilePath] = entry;
-                NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath, ProjectChangeKind.DocumentChanged);
+                throw new ArgumentNullException(nameof(projectFilePath));
             }
-        }
-    }
-}
 
-public override void DocumentChanged(string projectFilePath, string documentFilePath, TextLoader textLoader)
-{
-    if (projectFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(projectFilePath));
-    }
-
-    if (documentFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(documentFilePath));
-    }
-
-    if (textLoader == null)
-    {
-        throw new ArgumentNullException(nameof(textLoader));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    if (_projects.TryGetValue(projectFilePath, out var entry) &&
-        entry.State.Documents.TryGetValue(documentFilePath, out var older))
-    {
-        // if the solution is closing we don't need to bother computing new state
-        if (_solutionIsClosing)
-        {
-            var oldSnapshot = entry.GetSnapshot();
-            NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath, ProjectChangeKind.DocumentChanged);
-        }
-        else
-        {
-            var state = entry.State.WithChangedHostDocument(
-            older.HostDocument,
-            async () => await textLoader.LoadTextAndVersionAsync(Workspace, default, default));
-
-            // Document updates can no-op.
-            if (!ReferenceEquals(state, entry.State))
+            if (documentFilePath == null)
             {
-                var oldSnapshot = entry.GetSnapshot();
-                entry = new Entry(state);
-                _projects[projectFilePath] = entry;
-                NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath, ProjectChangeKind.DocumentChanged);
+                throw new ArgumentNullException(nameof(documentFilePath));
             }
-        }
-    }
-}
 
-public override void ProjectAdded(HostProject hostProject)
-{
-    if (hostProject == null)
-    {
-        throw new ArgumentNullException(nameof(hostProject));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    // We don't expect to see a HostProject initialized multiple times for the same path. Just ignore it.
-    if (_projects.ContainsKey(hostProject.FilePath))
-    {
-        return;
-    }
-
-    var state = ProjectState.Create(Workspace.Services, hostProject);
-    var entry = new Entry(state);
-    _projects[hostProject.FilePath] = entry;
-
-    // We need to notify listeners about every project add.
-    NotifyListeners(older: null, entry.GetSnapshot(), documentFilePath: null, ProjectChangeKind.ProjectAdded);
-}
-
-public override void ProjectConfigurationChanged(HostProject hostProject)
-{
-    if (hostProject == null)
-    {
-        throw new ArgumentNullException(nameof(hostProject));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    if (_projects.TryGetValue(hostProject.FilePath, out var entry))
-    {
-        // if the solution is closing we don't need to bother computing new state
-        if (_solutionIsClosing)
-        {
-            var oldSnapshot = entry.GetSnapshot();
-            NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath: null, ProjectChangeKind.ProjectChanged);
-        }
-        else
-        {
-            var state = entry.State.WithHostProject(hostProject);
-
-            // HostProject updates can no-op.
-            if (!object.ReferenceEquals(state, entry.State))
+            if (sourceText == null)
             {
-                var oldSnapshot = entry.GetSnapshot();
-                entry = new Entry(state);
-                _projects[hostProject.FilePath] = entry;
-                NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath: null, ProjectChangeKind.ProjectChanged);
+                throw new ArgumentNullException(nameof(sourceText));
             }
-        }
-    }
-}
 
-public override void ProjectWorkspaceStateChanged(string projectFilePath, ProjectWorkspaceState projectWorkspaceState)
-{
-    if (projectFilePath == null)
-    {
-        throw new ArgumentNullException(nameof(projectFilePath));
-    }
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
-    if (projectWorkspaceState == null)
-    {
-        throw new ArgumentNullException(nameof(projectWorkspaceState));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    if (_projects.TryGetValue(projectFilePath, out var entry))
-    {
-        // if the solution is closing we don't need to bother computing new state
-        if (_solutionIsClosing)
-        {
-            var oldSnapshot = entry.GetSnapshot();
-            NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath: null, ProjectChangeKind.ProjectChanged);
-        }
-        else
-        {
-            var state = entry.State.WithProjectWorkspaceState(projectWorkspaceState);
-
-            // HostProject updates can no-op.
-            if (!object.ReferenceEquals(state, entry.State))
+            if (_projects.TryGetValue(projectFilePath, out var entry) &&
+                entry.State.Documents.TryGetValue(documentFilePath, out var older))
             {
-                var oldSnapshot = entry.GetSnapshot();
-                entry = new Entry(state);
-                _projects[projectFilePath] = entry;
-                NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath: null, ProjectChangeKind.ProjectChanged);
+                // if the solution is closing we don't need to bother computing new state
+                if (_solutionIsClosing)
+                {
+                    var oldSnapshot = entry.GetSnapshot();
+                    NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath, ProjectChangeKind.DocumentChanged);
+                }
+                else
+                {
+                    ProjectState state;
+
+                    var currentText = sourceText;
+                    if (older.TryGetText(out var olderText) &&
+                        older.TryGetTextVersion(out var olderVersion))
+                    {
+                        var version = currentText.ContentEquals(olderText) ? olderVersion : olderVersion.GetNewerVersion();
+                        state = entry.State.WithChangedHostDocument(older.HostDocument, currentText, version);
+                    }
+                    else
+                    {
+                        state = entry.State.WithChangedHostDocument(older.HostDocument, async () =>
+                        {
+                            olderText = await older.GetTextAsync().ConfigureAwait(false);
+                            olderVersion = await older.GetTextVersionAsync().ConfigureAwait(false);
+
+                            var version = currentText.ContentEquals(olderText) ? olderVersion : olderVersion.GetNewerVersion();
+                            return TextAndVersion.Create(currentText, version, documentFilePath);
+                        });
+                    }
+
+                    _openDocuments.Add(documentFilePath);
+
+                    // Document updates can no-op.
+                    if (!object.ReferenceEquals(state, entry.State))
+                    {
+                        var oldSnapshot = entry.GetSnapshot();
+                        entry = new Entry(state);
+                        _projects[projectFilePath] = entry;
+                        NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath, ProjectChangeKind.DocumentChanged);
+                    }
+                }
             }
         }
-    }
-}
 
-public override void ProjectRemoved(HostProject hostProject)
-{
-    if (hostProject == null)
-    {
-        throw new ArgumentNullException(nameof(hostProject));
-    }
-
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    if (_projects.TryGetValue(hostProject.FilePath, out var entry))
-    {
-        // We need to notify listeners about every project removal.
-        var oldSnapshot = entry.GetSnapshot();
-        _projects.Remove(hostProject.FilePath);
-        NotifyListeners(oldSnapshot, newer: null, documentFilePath: null, ProjectChangeKind.ProjectRemoved);
-    }
-}
-
-public override void SolutionOpened()
-{
-    _solutionIsClosing = false;
-}
-
-public override void SolutionClosed()
-{
-    _solutionIsClosing = true;
-}
-
-public override void ReportError(Exception exception)
-{
-    if (exception == null)
-    {
-        throw new ArgumentNullException(nameof(exception));
-    }
-
-    _errorReporter.ReportError(exception);
-}
-
-public override void ReportError(Exception exception, ProjectSnapshot project)
-{
-    if (exception == null)
-    {
-        throw new ArgumentNullException(nameof(exception));
-    }
-
-    _errorReporter.ReportError(exception, project);
-}
-
-public override void ReportError(Exception exception, HostProject hostProject)
-{
-    if (exception == null)
-    {
-        throw new ArgumentNullException(nameof(exception));
-    }
-
-    var snapshot = hostProject?.FilePath == null ? null : GetLoadedProject(hostProject.FilePath);
-    _errorReporter.ReportError(exception, snapshot);
-}
-
-private void NotifyListeners(ProjectSnapshot older, ProjectSnapshot newer, string documentFilePath, ProjectChangeKind kind)
-{
-    NotifyListeners(new ProjectChangeEventArgs(older, newer, documentFilePath, kind, _solutionIsClosing));
-}
-
-// virtual so it can be overridden in tests
-protected virtual void NotifyListeners(ProjectChangeEventArgs e)
-{
-    _projectSnapshotManagerDispatcher.AssertDispatcherThread();
-
-    _notificationWork.Enqueue(e);
-
-    if (_notificationWork.Count == 1)
-    {
-        // Only one notification, go ahead and start notifying. In the situation where Count > 1 it means an event was triggered as a response to another event.
-        // To ensure order we wont immediately re-invoke Changed here, we'll wait for the stack to unwind to notify others. This process still happens synchronously
-        // it just ensures that events happen in the correct order. For instance lets take the situation where a document is added to a project. That document will be
-        // added and then opened. However, if the result of "adding" causes an "open" to triger we want to ensure that "add" finishes prior to "open" being notified.
-
-        // Start unwinding the notification queue
-        do
+        public override void DocumentClosed(string projectFilePath, string documentFilePath, TextLoader textLoader)
         {
-            // Don't dequeue yet, we want the notification to sit in the queue until we've finished notifying to ensure other calls to NotifyListeners know there's a currently running event loop.
-            var args = _notificationWork.Peek();
-            Changed?.Invoke(this, args);
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
 
-            _notificationWork.Dequeue();
+            if (documentFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(documentFilePath));
+            }
+
+            if (textLoader == null)
+            {
+                throw new ArgumentNullException(nameof(textLoader));
+            }
+
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            if (_projects.TryGetValue(projectFilePath, out var entry) &&
+                entry.State.Documents.TryGetValue(documentFilePath, out var older))
+            {
+                // if the solution is closing we don't need to bother computing new state
+                if (_solutionIsClosing)
+                {
+                    var oldSnapshot = entry.GetSnapshot();
+                    NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath, ProjectChangeKind.DocumentChanged);
+                }
+                else
+                {
+                    var state = entry.State.WithChangedHostDocument(
+                    older.HostDocument,
+                    async () => await textLoader.LoadTextAndVersionAsync(Workspace, default, default));
+
+                    _openDocuments.Remove(documentFilePath);
+
+                    // Document updates can no-op.
+                    if (!object.ReferenceEquals(state, entry.State))
+                    {
+                        var oldSnapshot = entry.GetSnapshot();
+                        entry = new Entry(state);
+                        _projects[projectFilePath] = entry;
+                        NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath, ProjectChangeKind.DocumentChanged);
+                    }
+                }
+            }
         }
-        while (_notificationWork.Count > 0);
-    }
-}
 
-private class Entry
-{
-    private ProjectSnapshot _snapshotUnsafe;
-    public readonly ProjectState State;
+        public override void DocumentChanged(string projectFilePath, string documentFilePath, SourceText sourceText)
+        {
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
 
-    public Entry(ProjectState state)
-    {
-        State = state;
-    }
+            if (documentFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(documentFilePath));
+            }
 
-    public ProjectSnapshot GetSnapshot()
-    {
-        return _snapshotUnsafe ??= new DefaultProjectSnapshot(State);
-    }
-}
+            if (sourceText == null)
+            {
+                throw new ArgumentNullException(nameof(sourceText));
+            }
+
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            if (_projects.TryGetValue(projectFilePath, out var entry) &&
+                entry.State.Documents.TryGetValue(documentFilePath, out var older))
+            {
+                ProjectState state;
+
+                var currentText = sourceText;
+
+                // if the solution is closing we don't need to bother computing new state
+                if (_solutionIsClosing)
+                {
+                    var oldSnapshot = entry.GetSnapshot();
+                    NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath, ProjectChangeKind.DocumentChanged);
+                }
+                else
+                {
+                    if (older.TryGetText(out var olderText) &&
+                    older.TryGetTextVersion(out var olderVersion))
+                    {
+                        var version = currentText.ContentEquals(olderText) ? olderVersion : olderVersion.GetNewerVersion();
+                        state = entry.State.WithChangedHostDocument(older.HostDocument, currentText, version);
+                    }
+                    else
+                    {
+                        state = entry.State.WithChangedHostDocument(older.HostDocument, async () =>
+                        {
+                            olderText = await older.GetTextAsync().ConfigureAwait(false);
+                            olderVersion = await older.GetTextVersionAsync().ConfigureAwait(false);
+
+                            var version = currentText.ContentEquals(olderText) ? olderVersion : olderVersion.GetNewerVersion();
+                            return TextAndVersion.Create(currentText, version, documentFilePath);
+                        });
+                    }
+
+                    // Document updates can no-op.
+                    if (!object.ReferenceEquals(state, entry.State))
+                    {
+                        var oldSnapshot = entry.GetSnapshot();
+                        entry = new Entry(state);
+                        _projects[projectFilePath] = entry;
+                        NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath, ProjectChangeKind.DocumentChanged);
+                    }
+                }
+            }
+        }
+
+        public override void DocumentChanged(string projectFilePath, string documentFilePath, TextLoader textLoader)
+        {
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
+
+            if (documentFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(documentFilePath));
+            }
+
+            if (textLoader == null)
+            {
+                throw new ArgumentNullException(nameof(textLoader));
+            }
+
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            if (_projects.TryGetValue(projectFilePath, out var entry) &&
+                entry.State.Documents.TryGetValue(documentFilePath, out var older))
+            {
+                // if the solution is closing we don't need to bother computing new state
+                if (_solutionIsClosing)
+                {
+                    var oldSnapshot = entry.GetSnapshot();
+                    NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath, ProjectChangeKind.DocumentChanged);
+                }
+                else
+                {
+                    var state = entry.State.WithChangedHostDocument(
+                    older.HostDocument,
+                    async () => await textLoader.LoadTextAndVersionAsync(Workspace, default, default));
+
+                    // Document updates can no-op.
+                    if (!ReferenceEquals(state, entry.State))
+                    {
+                        var oldSnapshot = entry.GetSnapshot();
+                        entry = new Entry(state);
+                        _projects[projectFilePath] = entry;
+                        NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath, ProjectChangeKind.DocumentChanged);
+                    }
+                }
+            }
+        }
+
+        public override void ProjectAdded(HostProject hostProject)
+        {
+            if (hostProject == null)
+            {
+                throw new ArgumentNullException(nameof(hostProject));
+            }
+
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            // We don't expect to see a HostProject initialized multiple times for the same path. Just ignore it.
+            if (_projects.ContainsKey(hostProject.FilePath))
+            {
+                return;
+            }
+
+            var state = ProjectState.Create(Workspace.Services, hostProject);
+            var entry = new Entry(state);
+            _projects[hostProject.FilePath] = entry;
+
+            // We need to notify listeners about every project add.
+            NotifyListeners(older: null, entry.GetSnapshot(), documentFilePath: null, ProjectChangeKind.ProjectAdded);
+        }
+
+        public override void ProjectConfigurationChanged(HostProject hostProject)
+        {
+            if (hostProject == null)
+            {
+                throw new ArgumentNullException(nameof(hostProject));
+            }
+
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            if (_projects.TryGetValue(hostProject.FilePath, out var entry))
+            {
+                // if the solution is closing we don't need to bother computing new state
+                if (_solutionIsClosing)
+                {
+                    var oldSnapshot = entry.GetSnapshot();
+                    NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath: null, ProjectChangeKind.ProjectChanged);
+                }
+                else
+                {
+                    var state = entry.State.WithHostProject(hostProject);
+
+                    // HostProject updates can no-op.
+                    if (!object.ReferenceEquals(state, entry.State))
+                    {
+                        var oldSnapshot = entry.GetSnapshot();
+                        entry = new Entry(state);
+                        _projects[hostProject.FilePath] = entry;
+                        NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath: null, ProjectChangeKind.ProjectChanged);
+                    }
+                }
+            }
+        }
+
+        public override void ProjectWorkspaceStateChanged(string projectFilePath, ProjectWorkspaceState projectWorkspaceState)
+        {
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
+
+            if (projectWorkspaceState == null)
+            {
+                throw new ArgumentNullException(nameof(projectWorkspaceState));
+            }
+
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            if (_projects.TryGetValue(projectFilePath, out var entry))
+            {
+                // if the solution is closing we don't need to bother computing new state
+                if (_solutionIsClosing)
+                {
+                    var oldSnapshot = entry.GetSnapshot();
+                    NotifyListeners(oldSnapshot, oldSnapshot, documentFilePath: null, ProjectChangeKind.ProjectChanged);
+                }
+                else
+                {
+                    var state = entry.State.WithProjectWorkspaceState(projectWorkspaceState);
+
+                    // HostProject updates can no-op.
+                    if (!object.ReferenceEquals(state, entry.State))
+                    {
+                        var oldSnapshot = entry.GetSnapshot();
+                        entry = new Entry(state);
+                        _projects[projectFilePath] = entry;
+                        NotifyListeners(oldSnapshot, entry.GetSnapshot(), documentFilePath: null, ProjectChangeKind.ProjectChanged);
+                    }
+                }
+            }
+        }
+
+        public override void ProjectRemoved(HostProject hostProject)
+        {
+            if (hostProject == null)
+            {
+                throw new ArgumentNullException(nameof(hostProject));
+            }
+
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            if (_projects.TryGetValue(hostProject.FilePath, out var entry))
+            {
+                // We need to notify listeners about every project removal.
+                var oldSnapshot = entry.GetSnapshot();
+                _projects.Remove(hostProject.FilePath);
+                NotifyListeners(oldSnapshot, newer: null, documentFilePath: null, ProjectChangeKind.ProjectRemoved);
+            }
+        }
+
+        public override void SolutionOpened()
+        {
+            _solutionIsClosing = false;
+        }
+
+        public override void SolutionClosed()
+        {
+            _solutionIsClosing = true;
+        }
+
+        public override void ReportError(Exception exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            _errorReporter.ReportError(exception);
+        }
+
+        public override void ReportError(Exception exception, ProjectSnapshot project)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            _errorReporter.ReportError(exception, project);
+        }
+
+        public override void ReportError(Exception exception, HostProject hostProject)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            var snapshot = hostProject?.FilePath == null ? null : GetLoadedProject(hostProject.FilePath);
+            _errorReporter.ReportError(exception, snapshot);
+        }
+
+        private void NotifyListeners(ProjectSnapshot older, ProjectSnapshot newer, string documentFilePath, ProjectChangeKind kind)
+        {
+            NotifyListeners(new ProjectChangeEventArgs(older, newer, documentFilePath, kind, _solutionIsClosing));
+        }
+
+        // virtual so it can be overridden in tests
+        protected virtual void NotifyListeners(ProjectChangeEventArgs e)
+        {
+            _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+            _notificationWork.Enqueue(e);
+
+            if (_notificationWork.Count == 1)
+            {
+                // Only one notification, go ahead and start notifying. In the situation where Count > 1 it means an event was triggered as a response to another event.
+                // To ensure order we wont immediately re-invoke Changed here, we'll wait for the stack to unwind to notify others. This process still happens synchronously
+                // it just ensures that events happen in the correct order. For instance lets take the situation where a document is added to a project. That document will be
+                // added and then opened. However, if the result of "adding" causes an "open" to triger we want to ensure that "add" finishes prior to "open" being notified.
+
+                // Start unwinding the notification queue
+                do
+                {
+                    // Don't dequeue yet, we want the notification to sit in the queue until we've finished notifying to ensure other calls to NotifyListeners know there's a currently running event loop.
+                    var args = _notificationWork.Peek();
+                    Changed?.Invoke(this, args);
+
+                    _notificationWork.Dequeue();
+                }
+                while (_notificationWork.Count > 0);
+            }
+        }
+
+        private class Entry
+        {
+            private ProjectSnapshot _snapshotUnsafe;
+            public readonly ProjectState State;
+
+            public Entry(ProjectState state)
+            {
+                State = state;
+            }
+
+            public ProjectSnapshot GetSnapshot()
+            {
+                return _snapshotUnsafe ??= new DefaultProjectSnapshot(State);
+            }
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
@@ -118,7 +119,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                     JoinableTaskContext,
                     key.ProjectFilePath,
                     key.DocumentFilePath,
-                    new FileTextLoader(key.DocumentFilePath, defaultEncoding: null),
+                    new CachedTextLoader(key.DocumentFilePath),
                     _fileChangeTrackerFactory.Create(key.DocumentFilePath),
                     textBuffer,
                     changedOnDisk,

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/RazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/RazorProjectHostBase.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Threading;
 using MonoDevelop.Projects;
 
@@ -175,7 +176,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             }
 
             var hostDocument = new HostDocument(filePath, relativeFilePath);
-            _projectSnapshotManager.DocumentAdded(hostProject, hostDocument, new FileTextLoader(filePath, defaultEncoding: null));
+            _projectSnapshotManager.DocumentAdded(hostProject, hostDocument, new CachedTextLoader(filePath));
 
             _currentDocuments[filePath] = hostDocument;
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/CachedTextLoaderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/CachedTextLoaderTest.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces.Test
+{
+    public class CachedTextLoaderTest
+    {
+        private class TestCachedTextLoader : CachedTextLoader
+        {
+            private readonly DateTime _time;
+
+            public TestCachedTextLoader(DateTime time, string filePath, TextLoader? baseLoader = null) : base(filePath, baseLoader)
+            {
+                _time = time;
+            }
+
+            internal override DateTime? GetLastWriteTimeUtc(string filePath)
+            {
+                return _time;
+            }
+        }
+
+        [Fact]
+        public async Task CachedTextLoader_FileModified()
+        {
+            // Arrange
+            var filePath = "Z:\\location\\file.razor";
+            var sourceText = SourceText.From("sourceText");
+            var firstVersion = VersionStamp.Default;
+            var secondVersion = VersionStamp.Create(DateTime.UtcNow.AddHours(1));
+
+            using var workspace = TestWorkspace.Create();
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            var firstMockTextLoader = new Mock<TextLoader>(MockBehavior.Strict);
+            firstMockTextLoader.Setup(t => t.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(TextAndVersion.Create(sourceText, firstVersion, filePath)));
+            var secondMockTextLoader = new Mock<TextLoader>(MockBehavior.Strict);
+            secondMockTextLoader.Setup(t => t.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(TextAndVersion.Create(sourceText, secondVersion, filePath)));
+
+            var firstTextLoader = new TestCachedTextLoader(DateTime.Now, filePath, firstMockTextLoader.Object);
+            var secondTextLoader = new TestCachedTextLoader(DateTime.Now.AddHours(1), filePath, secondMockTextLoader.Object);
+
+            // Act
+            var firstTextAndVersionTask = firstTextLoader.LoadTextAndVersionAsync(workspace, documentId, CancellationToken.None);
+            var secondTextAndVersionTask = secondTextLoader.LoadTextAndVersionAsync(workspace, documentId, CancellationToken.None);
+
+            var firstTextAndVersion = await firstTextAndVersionTask;
+            var secondTextAndVersion = await secondTextAndVersionTask;
+
+            // Assert
+            Assert.NotSame(firstTextAndVersionTask, secondTextAndVersionTask);
+            Assert.NotSame(firstTextAndVersion, secondTextAndVersion);
+        }
+
+        [Fact]
+        public async Task CachedTextLoader_ReUsesTask()
+        {
+            // Arrange
+            var filePath = "Z:\\location\\file.razor";
+            var sourceText = SourceText.From("sourceText");
+            var version = VersionStamp.Default;
+
+            using var workspace = TestWorkspace.Create();
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            var mockTextLoader = new Mock<TextLoader>(MockBehavior.Strict);
+            mockTextLoader.Setup(t => t.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(TextAndVersion.Create(sourceText, version, filePath)));
+
+            var now = DateTime.Now;
+
+            var firstTextLoader = new TestCachedTextLoader(now, filePath, mockTextLoader.Object);
+            var secondTextLoader = new TestCachedTextLoader(now, filePath, mockTextLoader.Object);
+
+            // Act
+            var firstTextAndVersionTask = firstTextLoader.LoadTextAndVersionAsync(workspace, documentId, CancellationToken.None);
+            var firstTextAndVersion = await firstTextAndVersionTask;
+
+            var secondTextAndVersionTask = secondTextLoader.LoadTextAndVersionAsync(workspace, documentId, CancellationToken.None);
+            var secondTextAndVersion = await secondTextAndVersionTask;
+
+            // Assert
+            Assert.Same(firstTextAndVersionTask, secondTextAndVersionTask);
+            Assert.Equal(filePath, firstTextAndVersion.FilePath);
+        }
+
+        [Fact]
+        public async Task CachedTextLoader_DifferentPaths()
+        {
+            // Arrange
+            var firstFilePath = "Z:\\location\\file.razor";
+            var secondFilePath = "Z:\\other\\location\\file.razor";
+
+            var sourceText = SourceText.From("sourceText");
+            var version = VersionStamp.Default;
+
+            using var workspace = TestWorkspace.Create();
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            var firstMockTextLoader = new Mock<TextLoader>(MockBehavior.Strict);
+            firstMockTextLoader.Setup(t => t.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(TextAndVersion.Create(sourceText, version, firstFilePath)));
+            var secondMockTextLoader = new Mock<TextLoader>(MockBehavior.Strict);
+            secondMockTextLoader.Setup(t => t.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(TextAndVersion.Create(sourceText, version, secondFilePath)));
+
+            var now = DateTime.Now;
+
+            var firstCachedLoader = new TestCachedTextLoader(now, firstFilePath, firstMockTextLoader.Object);
+            var secondCachedLoader = new TestCachedTextLoader(now, secondFilePath, secondMockTextLoader.Object);
+
+            // Act
+            var firstTextAndVersion = firstCachedLoader.LoadTextAndVersionAsync(workspace, documentId, CancellationToken.None);
+            var secondTextAndVersion = secondCachedLoader.LoadTextAndVersionAsync(workspace, documentId, CancellationToken.None);
+
+            // Assert
+            Assert.NotSame(firstTextAndVersion, secondTextAndVersion);
+            Assert.Equal(firstFilePath, (await firstTextAndVersion).FilePath);
+            Assert.Equal(secondFilePath, (await secondTextAndVersion).FilePath);
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the changes
 - This issue is experimental because I've not yet been able to reproduce the situation which causes high file reads. It's possible that this has been resolved somewhere further down the stack (they may already be caching).
 - This trades "static" memory for memory churn.

Fixes: https://github.com/dotnet/aspnetcore/issues/35313
