### PR TITLE
Switch to 1ES R&D pools on main

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -31,8 +31,8 @@ stages:
       jobs:
       - job: Windows
         pool:
-          name: NetCorePublic-Pool
-          queue: buildpool.windows.10.amd64.vs2019.pre.open
+          name: NetCore1ESPool-Public
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre.open
 
         steps:
         - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,11 +62,11 @@ stages:
           displayName: Code check
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              name: NetCorePublic-Pool
-              queue: buildpool.windows.10.amd64.vs2019.pre.open
+              name: NetCore1ESPool-Public
+              demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              name: NetCoreInternal-Pool
-              queue: buildpool.windows.10.amd64.vs2019.pre
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre
           steps:
           - task: NodeTool@0
             displayName: Install Node 10.x
@@ -107,11 +107,11 @@ stages:
       - job: Windows
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCorePublic-Pool
-            queue: buildpool.windows.10.amd64.vs2019.pre.open
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2019.pre
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre
         strategy:
           matrix:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
### Summary of the changes
 - Same as https://github.com/dotnet/aspnetcore-tooling/pull/4239 but on main

Related to: https://github.com/dotnet/core-eng/issues/14276

cc/ @lpatalas @ulisesh 