### PR TITLE
Don't return MarkupTextLiterals

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
         {
             if (!node.ContainsOnlyWhitespace())
             {
-                AddSemanticRange(node, RazorSemanticTokensLegend.MarkupTextLiteral);
+                // Don't return anything for MarkupTextLiterals. It translates to "text" on the VS side, which is the default color anyway
             }
         }
 


### PR DESCRIPTION
### Summary of the changes
 - Because Semantic tokens always "win" with competing classifications we were returning a "text" classification for JavaScript/TypeScript inside script blocks which had been colored by TextMate and they turned white instead of green.
 - By not returning anything for the MarkupTextLiteral nothing should change for the other cases, since it turned into the "text" or "Default" classification anyway.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1415312

FYI @gundermanc  and @amcasey.