### PR TITLE
Add issue filing link to aspnetcore repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐞 Bug report
 about: Create a report to help us improve
 title: ''
 labels: ''

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue with Razor compiler
+    url:  https://github.com/dotnet/aspnetcore/issues/new/choose
+    about: Please open issues relating to the Razor compiler in dotnet/aspnetcore.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: 💡 Feature request
 about: Suggest an idea for this project
 title: ''
 labels: ''
@@ -13,7 +13,7 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
-** Applicable Scenarios **
+**Applicable Scenarios**
 In what scenarios would the feature apply?
 
 **Describe alternatives you've considered**


### PR DESCRIPTION
Added config.yml, which should allow us to do something similar to below (screenshot taken from the aspnetcore repo):

![image](https://user-images.githubusercontent.com/16968319/136130084-d74a2336-4bf1-4208-aa96-5598351ee935.png)
